### PR TITLE
jpeg reading: allow the user to specify scale_num/scale_denum in image_r...

### DIFF
--- a/include/boost/gil/extension/io/formats/jpeg/reader_backend.hpp
+++ b/include/boost/gil/extension/io/formats/jpeg/reader_backend.hpp
@@ -149,6 +149,9 @@ public:
         {
             _settings._dim.y = _info._height;
         }
+
+        get()->scale_num = settings._scale_num;
+        get()->scale_denom = settings._scale_denom;
     }
 
     /// Read image header.
@@ -200,21 +203,21 @@ public:
     {
         if( _settings._dim.x > 0 )
         {
-            if( img_dim.x < _settings._dim.x ) { io_error( "Supplied image is too small" ); }
+            if( img_dim.x < _settings._dim.x * _settings._scale_num / _settings._scale_denom ) { io_error( "Supplied image is too small" ); }
         }
         else
         {
-            if( (jpeg_image_width::type) img_dim.x < _info._width ) { io_error( "Supplied image is too small" ); }
+            if( (jpeg_image_width::type) img_dim.x < _info._width * _settings._scale_num / _settings._scale_denom ) { io_error( "Supplied image is too small" ); }
         }
 
 
         if( _settings._dim.y > 0 )
         {
-            if( img_dim.y < _settings._dim.y ) { io_error( "Supplied image is too small" ); }
+            if( img_dim.y < _settings._dim.y * _settings._scale_num / _settings._scale_denom ) { io_error( "Supplied image is too small" ); }
         }
         else
         {
-            if( (jpeg_image_height::type) img_dim.y < _info._height ) { io_error( "Supplied image is too small" ); }
+            if( (jpeg_image_height::type) img_dim.y < _info._height * _settings._scale_num / _settings._scale_denom ) { io_error( "Supplied image is too small" ); }
         }
     }
 

--- a/include/boost/gil/extension/io/jpeg_tags.hpp
+++ b/include/boost/gil/extension/io/jpeg_tags.hpp
@@ -156,6 +156,8 @@ struct image_read_settings< jpeg_tag > : public image_read_settings_base
     image_read_settings<jpeg_tag>()
     : image_read_settings_base()
     , _dct_method( jpeg_dct_method::default_value )
+    , _scale_num(1)
+    , _scale_denom(1)
     {}
 
     /// Constructor
@@ -170,10 +172,13 @@ struct image_read_settings< jpeg_tag > : public image_read_settings_base
                               , dim
                               )
     , _dct_method( dct_method )
+    , _scale_num(1)
+    , _scale_denom(1)
     {}
 
     /// The dct ( discrete cosine transformation ) method. 
     jpeg_dct_method::type _dct_method;
+    unsigned int _scale_num, _scale_denom;
 };
 
 /// Write information for jpeg images.


### PR DESCRIPTION
libjpeg downscale images by a factor of n/m during image reading/decompression whenever scale_num and scale_denom are specified in the read options. This pull requests adds parameters to the gil jpeg settings structure to enable the user setting these values.

n/m are integer values, for m = 8, n may be in the range 1...16, the downscaling is very efficient as libjpeg directly accesses the respective coefficent(s) on the 8x8 pixel DCT.