### PR TITLE
Remove duplicate definition of this_t in pnm format's scanline_reader

### DIFF
--- a/include/boost/gil/extension/io/formats/pnm/scanline_read.hpp
+++ b/include/boost/gil/extension/io/formats/pnm/scanline_read.hpp
@@ -50,12 +50,6 @@ class scanline_reader< Device
                            , pnm_tag
                            >
 {
-private:
-
-    typedef scanline_reader< Device
-                           , pnm_tag
-                           > this_t;
-
 public:
 
     typedef pnm_tag tag_t;


### PR DESCRIPTION
Fixes https://svn.boost.org/trac/boost/ticket/10054 
