### PR TITLE
fix removal of include file

### DIFF
--- a/include/boost/gil/extension/toolbox/color_spaces/hsv.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/hsv.hpp
@@ -19,6 +19,8 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////////////
 
+#include <boost/numeric/conversion/cast.hpp>
+
 namespace boost{ namespace gil {
 
 /// \addtogroup ColorNameModel


### PR DESCRIPTION
Add <boost/numeric/conversion/cast.hpp> inclusion to a single file that does numeric_cast
