### PR TITLE
Take input filename on the command line to test/image.

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -15,7 +15,7 @@ test-suite gil :
            sample_image.cpp
            error_if.cpp
         :
-        :
+        : gil_reference_checksums.txt
         : <include>$(BOOST_ROOT) <define>BOOST_GIL_NO_IO <define>_SCL_SECURE_NO_WARNINGS ]
     [ run  channel.cpp 
            error_if.cpp

--- a/test/image.cpp
+++ b/test/image.cpp
@@ -568,21 +568,17 @@ void test_image(const char* ref_checksum) {
 }
 
 int main(int argc, char* argv[]) {
-
-    const char* local_name = "gil_reference_checksums.txt";
-    const char* name_from_status = "../libs/gil/test/gil_reference_checksums.txt";
-
-    std::ifstream file_is_there(local_name);
+    if(argc != 2)
+    {
+        std::cerr << "Checksum file name argument missing" << std::endl;
+        return 1;
+    }
+    std::ifstream file_is_there(argv[1]);
     if (file_is_there) {
-        test_image(local_name);
+        test_image(argv[1]);
     } else {
-        std::ifstream file_is_there(name_from_status);
-        if (file_is_there)
-            test_image(name_from_status);
-        else {
-            std::cerr << "Unable to open gil_reference_checksums.txt"<<std::endl;
-            return 1;
-        }
+        std::cerr << "Unable to open " << argv[1] << std::endl;
+        return 1;
     }
 
     return 0;


### PR DESCRIPTION
This enables test runners to copy the file to the target. It also makes the code that looks for the file in a different path unnecessary since Boost.Build will pass the proper relative path.

This should fix failures for test runners NA-QNX650-SP1-ARM and CrystaX.NET\* on master. Note that this fix is irrelevant for develop as the test no longer uses an input file there.

It may be more appropriate to merge develop to master since that hasn't been done in over four years.
