### PR TITLE
Added sublibs file telling regression tools that subdirs contain library tests

### DIFF
--- a/sublibs
+++ b/sublibs
@@ -1,0 +1,1 @@
+The existance of this file tells the regression reporting programs that the directory contains sub-directories which are libraries.


### PR DESCRIPTION
The feature is documented only in [regression code](https://github.com/boostorg/regression/blob/35d42b5d50dff7008374807aa136ddf26a97a2fd/common/src/process_jam_log.cpp#L228-L238), but widely used in boost.