### PR TITLE
Add basic CMake configuration for Boost.GIL

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,86 +1,96 @@
 # Copyright 2016, 2017 Peter Dimov
+# Copyright 2018 Mateusz Loskot <mateusz at loskot dot net>
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
-
+#
 version: 1.0.{build}-{branch}
 
-shallow_clone: true
+image: Visual Studio 2017
+
+platform: x64
 
 branches:
   only:
     - master
     - develop
     - ci
+    - ml/add-cmake
+
+shallow_clone: true
 
 environment:
   matrix:
-    #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
-    #  TOOLSET: msvc-9.0
-    #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
-    #  TOOLSET: msvc-10.0
-    #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
-    #  TOOLSET: msvc-11.0
-    #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
-    #  TOOLSET: msvc-12.0
-    #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
-    #  ADDPATH: C:\cygwin\bin;
-    #  TOOLSET: gcc
-    #  CXXFLAGS: cxxflags=-std=c++03
-    #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
-    #  ADDPATH: C:\cygwin\bin;
-    #  TOOLSET: gcc
-    #  CXXFLAGS: cxxflags=-std=c++11
-    #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
-    #  ADDPATH: C:\mingw\bin;
-    #  TOOLSET: gcc
-    #  CXXFLAGS: cxxflags=-std=c++03
-    #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
-    #  ADDPATH: C:\mingw\bin;
-    #  TOOLSET: gcc
-    #  CXXFLAGS: cxxflags=-std=c++11
-    #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
-    #  ADDPATH: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin;
-    #  TOOLSET: gcc
-    #  CXXFLAGS: cxxflags=-std=c++03
-    #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
-    #  ADDPATH: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin;
-    #  TOOLSET: gcc
-    #  CXXFLAGS: cxxflags=-std=c++11
-    #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-    #  TOOLSET: msvc-14.0
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      TOOLSET: msvc-14.1
+    - TOOLSET: msvc-14.1
       ARCH: x86_64
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      TOOLSET: msvc-14.1
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - TOOLSET: msvc-14.1
       ARCH: x86
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - TOOLSET: msvc-14.1
+      ARCH: x86_64
+      GENERATOR: "Visual Studio 15 2017 Win64"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      APPVEYOR_SAVE_CACHE_ON_ERROR: true
+    - TOOLSET: msvc-14.1
+      ARCH: x86
+      GENERATOR: "Visual Studio 15 2017"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      APPVEYOR_SAVE_CACHE_ON_ERROR: true
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - TOOLSET: msvc-14.1
+      ARCH: x86_64
+      GENERATOR: "Visual Studio 15 2017 Win64"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      APPVEYOR_SAVE_CACHE_ON_ERROR: true
+    - TOOLSET: msvc-14.1
+      ARCH: x86
+      GENERATOR: "Visual Studio 15 2017"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      APPVEYOR_SAVE_CACHE_ON_ERROR: true
 
 cache:
   - c:\tools\vcpkg\installed\
 
 install:
+  - ps: 'Write-Host "Installing CMake module FindBoost.cmake for Boost 1.67+" -ForegroundColor Magenta'
+  - appveyor DownloadFile https://raw.githubusercontent.com/Kitware/CMake/master/Modules/FindBoost.cmake -FileName "C:\Program Files (x86)\CMake\share\cmake-3.10\Modules\FindBoost.cmake"
+  # FIXME: To be removed https://help.appveyor.com/discussions/problems/13000-cmake_toolchain_filevcpkgcmake-conflicts-with-cmake-native-findboostcmake"
+  - ps: 'Write-Host "Installing latest vcpkg.cmake module" -ForegroundColor Magenta'
+  - appveyor DownloadFile https://raw.githubusercontent.com/Microsoft/vcpkg/master/scripts/buildsystems/vcpkg.cmake -FileName "c:\tools\vcpkg\scripts\buildsystems\vcpkg.cmake"
   - if %ARCH% == x86 ( set "TRIPLET=x86-windows" ) else ( set "TRIPLET=x64-windows" )
   - if %ARCH% == x86 ( set AM=32 ) else ( set AM=64 )
   - vcpkg --triplet %TRIPLET% install libjpeg-turbo libpng tiff
-  - cd ..
-  - git clone -b develop --depth 1 https://github.com/boostorg/boost.git boost-root
-  - cd boost-root
-  - git submodule update --init tools/build
-  - git submodule update --init libs/config
-  - git submodule update --init tools/boostdep
+  - if NOT DEFINED GENERATOR set PATH=c:\Tools\vcpkg\installed\%TRIPLET%\bin;%PATH%
+  - if NOT DEFINED GENERATOR set VCPKG_I=C:\Tools\vcpkg\installed\%TRIPLET%\include
+  - if NOT DEFINED GENERATOR set VCPKG_L=C:\Tools\vcpkg\installed\%TRIPLET%\lib
+  - if NOT DEFINED GENERATOR set LIBPNG_NAME=libpng16
+
+before_build:
+  - git clone --quiet -b develop --depth 1 https://github.com/boostorg/boost.git c:\projects\boost
+  - cd c:\projects\boost
+  - git submodule --quiet update --init tools/build
+  - git submodule --quiet update --init libs/config
+  - git submodule --quiet update --init tools/boostdep
   - xcopy /s /e /q %APPVEYOR_BUILD_FOLDER% libs\gil
   - python tools/boostdep/depinst/depinst.py gil
   - cmd /c bootstrap
-  - b2 address-model=64 headers
+  - .\b2 headers
+  - if DEFINED GENERATOR .\b2 address-model=%AM% toolset=%TOOLSET% variant=release --with-filesystem --with-test stage
 
 build: off
 
+build_script:
+  - cd c:\projects\boost
+  - if NOT DEFINED GENERATOR b2 address-model=%AM% toolset=%TOOLSET% variant=release libs/gil/test
+  - if NOT DEFINED GENERATOR b2 address-model=%AM% toolset=%TOOLSET% variant=release libs/gil/toolbox/test
+  - if NOT DEFINED GENERATOR b2 address-model=%AM% toolset=%TOOLSET% variant=release libs/gil/numeric/test
+  - if NOT DEFINED GENERATOR b2 address-model=%AM% toolset=%TOOLSET% variant=release include=%VCPKG_I% library-path=%VCPKG_L% libs/gil/io/test//simple
+  - if DEFINED GENERATOR cd libs\gil && md build && cd build
+  - if DEFINED GENERATOR cmake -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake ..
+  - if DEFINED GENERATOR cmake --build . --config Release
+
 test_script:
-  - set PATH=c:\Tools\vcpkg\installed\%TRIPLET%\bin;%PATH%
-  - set I=C:\Tools\vcpkg\installed\%TRIPLET%\include
-  - set L=C:\Tools\vcpkg\installed\%TRIPLET%\lib
-  - set LIBPNG_NAME=libpng16
-  - b2 address-model=%AM% libs/gil/test toolset=%TOOLSET% %CXXFLAGS%
-  - b2 address-model=%AM% libs/gil/toolbox/test toolset=%TOOLSET% %CXXFLAGS%
-  - b2 address-model=%AM% libs/gil/numeric/test toolset=%TOOLSET% %CXXFLAGS%
-  - b2 address-model=%AM% libs/gil/io/test//simple toolset=%TOOLSET% %CXXFLAGS% include=%I% library-path=%L%
+  - if DEFINED GENERATOR ctest -V --output-on-failure -C Release

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# EditorConfig is awesome: http://EditorConfig.org
+#
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_size = 4
+indent_style = space
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[{CMakeLists.txt,CMakeSettings.json,*.cmake}]
+indent_size = 2
+indent_style = space
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[{.travis.yml,.appveyor.yml,Vagrantfile}]
+indent_size = 2
+indent_style = space
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,113 @@
+#
+# Copyright (c) 2017 Mateusz Loskot <mateusz at loskot dot net>
+# All rights reserved.
+#
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+#
+cmake_minimum_required(VERSION 3.5.1)
+project(GIL CXX)
+
+include(CMakeDependentOption)
+option(GIL_BUILD_TESTS "Build GIL tests" ON)
+option(GIL_BUILD_EXAMPLES "Build GIL examples" OFF) # FIXME: Switch to ON after https://github.com/boostorg/gil/issues/40
+option(GIL_USE_BOOST_STAGE "Use Boost from current source tree and libraries from stage, unless BOOST_ROOT specified." ON)
+option(GIL_USE_CONAN "Use Conan to install dependencies" OFF)
+
+#-----------------------------------------------------------------------------
+# Dependency: Boost
+# - look for stage Build
+# - look for default installation location
+# - look for location specified with BOOST_ROOT
+#-----------------------------------------------------------------------------
+if(GIL_USE_BOOST_STAGE AND NOT DEFINED BOOST_ROOT AND NOT DEFINED ENV{BOOST_ROOT})
+  get_filename_component(_boost_root ../../ ABSOLUTE)
+  if(EXISTS ${_boost_root}/boost-build.jam)
+    set(BOOST_ROOT ${_boost_root})
+    message(STATUS "Using Boost libraries from stage directory in BOOST_ROOT=${BOOST_ROOT}")
+  endif()
+endif()
+
+set(BOOST_COMPONENTS)
+if(GIL_BUILD_TESTS)
+  list(APPEND BOOST_COMPONENTS unit_test_framework filesystem)
+endif()
+
+set(Boost_DETAILED_FAILURE_MSG ON)
+if(MSVC)
+  set(Boost_USE_STATIC_LIBS ON)
+  set(Boost_USE_STATIC_RUNTIME OFF)
+endif()
+
+find_package(Boost 1.66.0 REQUIRED COMPONENTS ${BOOST_COMPONENTS})
+
+# The boostorg/gil repository includes must come first,
+# before Boost includes from cloned Boost superproject or installed distribution.
+# Otherwise the IDE sees the wrong file (ie. due to boost/ symlinks or
+# GIL headers from installed Boost instead of this clone of boostog/gil).
+include_directories(include)
+
+#-----------------------------------------------------------------------------
+# Dependency: libpng, libjpeg, libtiff via Vcpkg or Conan
+#-----------------------------------------------------------------------------
+if(GIL_USE_CONAN)
+  # Download automatically, you can also just copy the conan.cmake file
+  if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
+    message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
+    file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/v0.9/conan.cmake"
+      "${CMAKE_BINARY_DIR}/conan.cmake")
+  endif()
+
+  # NOTE: See RelWithDebInfo for Release builds, http://docs.conan.io/en/latest/howtos/vs2017_cmake.html
+  set(_build_type_saved ${CMAKE_BUILD_TYPE})
+  if(CMAKE_BUILD_TYPE STREQUAL "MinSizeRel" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+    set(CMAKE_BUILD_TYPE "Release")
+  endif()
+
+  include(${CMAKE_BINARY_DIR}/conan.cmake)
+  conan_cmake_run(CONANFILE conanfile.txt BASIC_SETUP CMAKE_TARGETS)
+
+  set(CMAKE_BUILD_TYPE ${_build_type_saved})
+else()
+  find_package(JPEG)
+  find_package(PNG)
+  find_package(TIFF)
+endif()
+
+#-----------------------------------------------------------------------------
+# Compiler
+#-----------------------------------------------------------------------------
+if(MSVC)
+  string(REGEX REPLACE "/W3" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+  add_compile_options(/W4)
+else()
+  add_compile_options(-Wall)
+  add_compile_options(-pedantic)
+endif()
+
+if(MSVC)
+  add_definitions(-D_CRT_NONSTDC_NO_DEPRECATE=1)
+  add_definitions(-D_SCL_SECURE_NO_DEPRECATE=1)
+  add_definitions(-D_CRT_SECURE_NO_WARNINGS=1)
+  add_definitions(-D_SCL_SECURE_NO_WARNINGS=1)
+  add_definitions(-DBOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE=1)
+endif()
+
+#-----------------------------------------------------------------------------
+# Tests
+#-----------------------------------------------------------------------------
+if(GIL_BUILD_TESTS)
+  enable_testing()
+  add_subdirectory(test)
+  add_subdirectory(io/test)
+  add_subdirectory(numeric/test)
+  add_subdirectory(toolbox/test)
+endif()
+
+#-----------------------------------------------------------------------------
+# Examples
+#-----------------------------------------------------------------------------
+if(GIL_BUILD_EXAMPLES)
+  add_subdirectory(example)
+endif()

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,133 @@
+{
+  "_comment": "CMakeSettings.json for building Boost.GIL tests and examples. See https://go.microsoft.com//fwlink//?linkid=834763 for more information about CMake integration with Visual Studio 2017 and this file.",
+  "environments": [
+    {
+      "BuildDir": "${workspaceRoot}\\_build"
+    },
+    {
+      "InstallDir": "${workspaceRoot}\\_install"
+    }
+  ],
+  "configurations": [
+    {
+      "name": "x64-Debug-Ninja",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${env.BuildDir}\\${name}",
+      "installRoot": "${env.InstallDir}\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": "",
+      "variables": [
+        { "name": "GIL_USE_CONAN", "value": "ON" }
+      ]
+    },
+    {
+      "name": "x64-Release-Ninja",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${env.BuildDir}\\${name}",
+      "installRoot": "${env.InstallDir}\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": "",
+      "variables": [
+        { "name": "GIL_USE_CONAN", "value": "ON" }
+      ]
+    },
+    {
+      "name": "x86-Debug-Ninja",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "msvc_x86" ],
+      "buildRoot": "${env.BuildDir}\\${name}",
+      "installRoot": "${env.InstallDir}\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": "",
+      "variables": [
+        { "name": "GIL_USE_CONAN", "value": "ON" }
+      ]
+    },
+    {
+      "name": "x86-Release-Ninja",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "inheritEnvironments": [ "msvc_x86" ],
+      "buildRoot": "${env.BuildDir}\\${name}",
+      "installRoot": "${env.InstallDir}\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": "",
+      "variables": [
+        { "name": "GIL_USE_CONAN", "value": "ON" }
+      ]
+    },
+    {
+      "name": "x64-Debug",
+      "generator": "Visual Studio 15 2017 Win64",
+      "configurationType": "Debug",
+      "buildRoot": "${env.BuildDir}\\${name}",
+      "installRoot": "${env.InstallDir}\\${name}",
+      "buildCommandArgs": "-m",
+      "cmakeCommandArgs": "",
+      "ctestCommandArgs": "",
+      "variables": [
+        {
+          "name": "CMAKE_TOOLCHAIN_FILE",
+          "value": "C:\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake"
+        }
+      ]
+    },
+    {
+      "name": "x64-Release",
+      "generator": "Visual Studio 15 2017 Win64",
+      "configurationType": "Release",
+      "buildRoot": "${env.BuildDir}\\${name}",
+      "installRoot": "${env.InstallDir}\\${name}",
+      "buildCommandArgs": "-m",
+      "cmakeCommandArgs": "",
+      "ctestCommandArgs": "",
+      "variables": [
+        {
+          "name": "CMAKE_TOOLCHAIN_FILE",
+          "value": "C:\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake"
+        }
+      ]
+    },
+    {
+      "name": "x86-Debug",
+      "generator": "Visual Studio 15 2017",
+      "configurationType": "Debug",
+      "buildRoot": "${env.BuildDir}\\${name}",
+      "installRoot": "${env.InstallDir}\\${name}",
+      "buildCommandArgs": "-m",
+      "cmakeCommandArgs": "",
+      "ctestCommandArgs": "",
+      "variables": [
+        {
+          "name": "CMAKE_TOOLCHAIN_FILE",
+          "value": "C:\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake"
+        }
+      ]
+    },
+    {
+      "name": "x86-Release",
+      "generator": "Visual Studio 15 2017",
+      "configurationType": "Release",
+      "buildRoot": "${env.BuildDir}\\${name}",
+      "installRoot": "${env.InstallDir}\\${name}",
+      "buildCommandArgs": "-m",
+      "cmakeCommandArgs": "",
+      "ctestCommandArgs": "",
+      "variables": [
+        {
+          "name": "CMAKE_TOOLCHAIN_FILE",
+          "value": "C:\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake"
+        }
+      ]
+    }
+  ]
+}

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,7 @@
+[requires]
+libpng/1.6.34@bincrafters/stable
+libjpeg/9c@bincrafters/stable
+libtiff/4.0.9@bincrafters/stable
+
+[generators]
+cmake

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2017 Mateusz Loskot <mateusz at loskot dot net>
+# All rights reserved.
+#
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+#
+foreach(name affine convolution dynamic_image histogram interleaved_ptr mandelbrot packed_pixel resize x_gradient)
+  add_executable(gil_example_${name} ${name}.cpp)
+  target_compile_definitions(gil_example_${name} PRIVATE BOOST_GIL_USE_CONCEPT_CHECK=1)
+  # Unfortunately, ALIAS of imported target is not supported
+  # see https://github.com/conan-io/conan/issues/2125
+  if (GIL_USE_CONAN)
+    target_link_libraries(gil_example_${name}
+      PRIVATE
+      Boost::disable_autolinking
+      Boost::filesystem
+      CONAN_PKG::libjpeg
+      CONAN_PKG::libpng
+      CONAN_PKG::libtiff)
+  else()
+    target_link_libraries(gil_example_${name}
+      PRIVATE
+      Boost::disable_autolinking
+      Boost::filesystem
+      PNG::PNG
+      TIFF::TIFF
+      ${JPEG_LIBRARIES})
+    target_include_directories(gil_example_${name} ${JPEG_INCLUDE_DIR})
+  endif()
+endforeach()

--- a/io/test/CMakeLists.txt
+++ b/io/test/CMakeLists.txt
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2017 Mateusz Loskot <mateusz at loskot dot net>
+# All rights reserved.
+#
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+#
+add_definitions(-DBOOST_GIL_IO_TEST_ALLOW_READING_IMAGES=1)
+add_definitions(-DBOOST_GIL_IO_TEST_ALLOW_WRITING_IMAGES=1)
+
+add_executable(gil_test_ext_io_simple all_formats_test.cpp)
+# Unfortunately, ALIAS of imported target is not supported
+# see https://github.com/conan-io/conan/issues/2125
+if (GIL_USE_CONAN)
+  target_link_libraries(gil_test_ext_io_simple
+    PRIVATE
+    Boost::disable_autolinking
+    Boost::filesystem
+    Boost::unit_test_framework
+    CONAN_PKG::libjpeg
+    CONAN_PKG::libpng
+    CONAN_PKG::libtiff)
+else()
+  target_link_libraries(gil_test_ext_io_simple
+    PRIVATE
+    Boost::disable_autolinking
+    Boost::filesystem
+    Boost::unit_test_framework
+    PNG::PNG
+    TIFF::TIFF
+    ${JPEG_LIBRARIES})
+  target_include_directories(gil_test_ext_io_simple PRIVATE ${JPEG_INCLUDE_DIR})
+endif()
+add_test(tests.ext.io.simple gil_test_ext_io_simple)

--- a/numeric/test/CMakeLists.txt
+++ b/numeric/test/CMakeLists.txt
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2017 Mateusz Loskot <mateusz at loskot dot net>
+# All rights reserved.
+#
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+#
+add_executable(gil_test_ext_numeric test.cpp numeric.cpp)
+target_link_libraries(gil_test_ext_numeric
+    PRIVATE
+    Boost::disable_autolinking
+    Boost::unit_test_framework)
+add_test(gil.tests.ext.numeric gil_test_ext_numeric)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2017 Mateusz Loskot <mateusz at loskot dot net>
+# All rights reserved.
+#
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+#
+foreach(name channel pixel pixel_iterator)
+  add_executable(gil_test_core_${name} ${name}.cpp error_if.cpp)
+  target_link_libraries(gil_test_core_${name}
+    PRIVATE
+    Boost::disable_autolinking
+    Boost::filesystem
+    Boost::unit_test_framework)
+  add_test(gil.tests.core.${name} gil_test_core_${name})
+endforeach()
+
+add_executable(gil_test_core_image image.cpp sample_image.cpp error_if.cpp)
+target_link_libraries(gil_test_core_image
+    PRIVATE
+    Boost::disable_autolinking
+    Boost::filesystem
+    Boost::unit_test_framework)
+add_test(gil.tests.core.image gil_test_core_image ${CMAKE_CURRENT_SOURCE_DIR}/gil_reference_checksums.txt)

--- a/toolbox/test/CMakeLists.txt
+++ b/toolbox/test/CMakeLists.txt
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2017 Mateusz Loskot <mateusz at loskot dot net>
+# All rights reserved.
+#
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+#
+add_executable(gil_test_ext_toolbox
+  test.cpp
+  channel_type.cpp
+  channel_view.cpp
+  cmyka.cpp
+  get_num_bits.cpp
+  get_pixel_type.cpp
+  gray_alpha.cpp
+  gray_to_rgba.cpp
+  hsl_hsv_test.cpp
+  indexed_image_test.cpp
+  is_bit_aligned.cpp
+  is_homogeneous.cpp
+  is_similar.cpp
+  lab_test.cpp
+  pixel_bit_size.cpp
+  rgb_to_luminance.cpp
+  xyz_test.cpp)
+target_link_libraries(gil_test_ext_toolbox
+    PRIVATE
+    Boost::disable_autolinking
+    Boost::unit_test_framework)
+add_test(gil.tests.ext.toolbox gil_test_ext_toolbox)


### PR DESCRIPTION
Add basic CMake configuration for Boost.GIL

First stab at collection of `CMakeLists.txt` for Boost.GIL
- Allow building and testing boostorg/gil against Boost from cloned superproject or installed distribution.

Add `CMakeSettings.json` config file for VS2017 integration with CMake
- Defines build configurations for VS and Ninja generators.
- Can be used as is or as a template ready to customise.

Add `conanfile.txt `for Conan package manager (eg. for `cmake -DGIL_USE_CONAN=ON`).
Add `.editignore` file to with basic encoding of CMake and CI scripts.
Update `.appveyor.yml` with two extra CMake-based builds (allowed to fail).

-----
## Motivation

Provide CMake build configuration for convenient development, building and debugging using CMake-based IDEs.

Allow building and testing Boost.GIL against staged build of Boost as well as in lightweight scenario where only `boostorg/gil` repository is cloned and tested against pre-preinstalled Boost binaries:

1. Install Boost from released distribution or clone the Boost superproject (see [Boost Wiki](https://github.com/boostorg/boost/wiki/Getting-Started)).
2. `git clone https://github.com/boostorg/gil.git`
3. `cd gil`
4. `mkdir _build && cd  _build`
5. `cmake -DBOOST_ROOT=/path/to/boost/aimed/to/target ..`

## Tasklist

 - [x] Add `CMakeLists.txt` for core tests
 - [x] Add `CMakeLists.txt` for numeric tests
 - [x] Add `CMakeLists.txt` for toolbox tests
 - [x] Add `CMakeLists.txt` for IO tests, including look-up for libjpeg, libpng, etc. dependencies (allow use of Conan and Vcpkg).
 - [x] Enable building tests against Boost
        - from stage (implicit `BOOST_ROOT` points to root of current source tree)
        - installed Boost (eg. `C:\local\boost_1_66_0`) found without `BOOST_ROOT` specified
        - Boost found in specified `BOOST_ROOT` location
 - [x] Add CMake-based build to CI (eg. AppVeyor or new CircleCI)
 - [ ] Review
 - [ ] Adjust for comments