### PR TITLE
Remove uncommented raw URL

### DIFF
--- a/include/boost/gil/extension/io/formats/targa/reader_backend.hpp
+++ b/include/boost/gil/extension/io/formats/targa/reader_backend.hpp
@@ -108,7 +108,6 @@ public:
                 io_error("Unsupported descriptor for targa file");
             }
 
-            http://www.paulbourke.net/dataformats/tga/
             if (_info._descriptor & 32)
             {
                 _info._screen_origin_bit = true;


### PR DESCRIPTION
Likely, committed by accident as part of fix of #33 

-----

This cruft was added in https://github.com/boostorg/gil/commit/fe8dcea00d4ae393ddbe0c92909026e39731375b
@chhenning  I have no idea how this slipped through CI builds :)

