### PR TITLE
Fix test of TARGA header descriptor for 24bpp file

### DIFF
--- a/include/boost/gil/extension/io/formats/targa/reader_backend.hpp
+++ b/include/boost/gil/extension/io/formats/targa/reader_backend.hpp
@@ -95,14 +95,25 @@ public:
         
         _info._descriptor = _io_dev.read_uint8();
 
-
-
-        if(_info._bits_per_pixel == 24 && _info._descriptor != 0 ) 
+        // According to TGA specs, http://www.gamers.org/dEngine/quake3/TGA.txt,
+        // the image descriptor byte is:
+        //
+        // For Data Type 1, This entire byte should be set to 0.
+        if (_info._image_type == 1 && _info._descriptor != 0)
         {
-            io_error( "Unsupported descriptor for targa file" );
+            io_error("Unsupported descriptor for targa file");
+        }
+        else if (_info._bits_per_pixel == 24)
+        {
+            // Bits 3-0 - For the Targa 24, it should be 0.
+            if ((_info._descriptor & 0x0FU) != 0)
+            {
+                io_error("Unsupported descriptor for targa file");
+            }
         }
         else if (_info._bits_per_pixel == 32)
         {
+            // Bits 3-0 - For Targa 32, it should be 8.
             if (_info._descriptor != 8 && _info._descriptor != 40)
             {
                 io_error("Unsupported descriptor for targa file");


### PR DESCRIPTION
Ensure that for TARGA Data Type 1, entire descriptor byte is set to 0.

-----

/cc @chhenning, @stefanseefeld 

## Issue

According to the TGA Specification, http://www.paulbourke.net/dataformats/tga/, regardless of the Data Type (apart from Data Type 1):

> For the Targa 24, it should be 0.

For Targa 24bpp images, the original of `if(_info._bits_per_pixel == 24 && _info._descriptor != 0 )` is false and skips directly to the following `else` clause which throws `io_error("Unsupported descriptor for targa file")`.

This caused failures of `non_bit_aligned_image_test` in `all_formats_test.cpp`.

## References

Might be related to #33

This also cleans up garbage URL removed in #41