### PR TITLE
Fix implicit int to libjpeg boolean conversion

### DIFF
--- a/include/boost/gil/extension/io/formats/jpeg/writer_backend.hpp
+++ b/include/boost/gil/extension/io/formats/jpeg/writer_backend.hpp
@@ -154,7 +154,7 @@ protected:
                                   );
 
         writer<Device,jpeg_tag>::init_device( cinfo );
-        return 1;
+        return static_cast<boolean>(TRUE);
     }
 
     static void close_device( jpeg_compress_struct* cinfo )


### PR DESCRIPTION
Apparently, clang-802.0.42 (Apple LLVM version 8.1.0) is complaining as per the recent Travis CI build failures.