### PR TITLE
Add vcpkg bin folder to PATH

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -76,7 +76,7 @@ install:
 build: off
 
 test_script:
-  - set PATH=%ADDPATH%%PATH%
+  - set PATH=c:\Tools\vcpkg\installed\%TRIPLET%\bin;%PATH%
   - set I=C:\Tools\vcpkg\installed\%TRIPLET%\include
   - set L=C:\Tools\vcpkg\installed\%TRIPLET%\lib
   - set LIBPNG_NAME=libpng16


### PR DESCRIPTION
Fix GIL IO tests issue with dependency DLLs not found.

-----

/cc @chhenning, @stefanseefeld 

```
D:\dev\boost\boost\libs\gil (ml/add-vcpkg-bin-to-path) b2 address-model=32 include=%I% library-path=%L% io/test//simple
..\..\libs\log\build\Jamfile.v2:45: Unescaped special character in argument <define>$(flag)=1
D:/dev/boost/boost/libs/predef/check/../tools/check\predef.jam:46: Unescaped special character in argument $(language)::$(expression)
Performing configuration checks

    - default address-model    : 32-bit (cached)
    - default architecture     : x86 (cached)
    - symlinks supported       : yes (cached)
    - BOOST_COMP_GNUC >= 4.3.0 : no  (cached)
    - libjpeg                  : yes (cached)
    - zlib                     : yes (cached)
    - libpng                   : yes (cached)
    - libtiff                  : yes (cached)
...patience...
...patience...
...found 3397 targets...
...updating 2 targets...
testing.capture-output ..\..\bin.v2\libs\gil\io\test\all_formats_test.test\msvc-14.1\debug\threading-multi\all_formats_test.run
====== BEGIN OUTPUT ======
Running 1 test case...
unknown location(0): fatal error: in "gil_io_tests/non_bit_aligned_image_test": class std::ios_base::failure: Unsupported descriptor for targa file: iostream stream error
io\test\all_formats_test.cpp(30): last checkpoint: "non_bit_aligned_image_test" test entry

*** 1 failure is detected in the test module "all_formats_test"

EXIT STATUS: 201
====== END OUTPUT ======

    set Path=D:\dev\boost\boost\bin.v2\libs\chrono\build\msvc-14.1\debug\threading-multi;D:\dev\boost\boost\bin.v2\libs\filesystem\build\msvc-14.1\debug\threading-multi;D:\dev\boost\boost\bin.v2\libs\system\build\msvc-14.1\debug\threading-multi;D:\dev\boost\boost\bin.v2\libs\test\build\msvc-14.1\debug\threading-multi;D:\dev\boost\boost\bin.v2\libs\timer\build\msvc-14.1\debug\threading-multi;%Path%

    set status=0
    if %status% NEQ 0 (
        echo Skipping test execution due to testing.execute=off
        exit 0
    )
     "..\..\bin.v2\libs\gil\io\test\all_formats_test.test\msvc-14.1\debug\threading-multi\all_formats_test.exe"   > "..\..\bin.v2\libs\gil\io\test\all_formats_test.test\msvc-14.1\debug\threading-multi\all_formats_test.output" 2>&1
    set status=%ERRORLEVEL%
    echo. >> "..\..\bin.v2\libs\gil\io\test\all_formats_test.test\msvc-14.1\debug\threading-multi\all_formats_test.output"
    echo EXIT STATUS: %status% >> "..\..\bin.v2\libs\gil\io\test\all_formats_test.test\msvc-14.1\debug\threading-multi\all_formats_test.output"
    if %status% EQU 0 (
        copy "..\..\bin.v2\libs\gil\io\test\all_formats_test.test\msvc-14.1\debug\threading-multi\all_formats_test.output" "..\..\bin.v2\libs\gil\io\test\all_formats_test.test\msvc-14.1\debug\threading-multi\all_formats_test.run"
    )
    set verbose=0
    if %status% NEQ 0 (
        set verbose=1
    )
    if %verbose% EQU 1 (
        echo ====== BEGIN OUTPUT ======
        type "..\..\bin.v2\libs\gil\io\test\all_formats_test.test\msvc-14.1\debug\threading-multi\all_formats_test.output"
        echo ====== END OUTPUT ======
    )
    exit %status%

...failed testing.capture-output ..\..\bin.v2\libs\gil\io\test\all_formats_test.test\msvc-14.1\debug\threading-multi\all_formats_test.run...
...failed updating 1 target...
...skipped 1 target...
```

Next, merging #42 should fix the 'new' TARGA issue.