### PR TITLE
Add AppVeyor jobs for b2 variant=release

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,3 +1,5 @@
+# AppVeyor for Boost.GIL
+#
 # Copyright 2016, 2017 Peter Dimov
 # Copyright 2018 Mateusz Loskot <mateusz at loskot dot net>
 # Distributed under the Boost Software License, Version 1.0.

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,9 +21,19 @@ environment:
   matrix:
     - TOOLSET: msvc-14.1
       ARCH: x86_64
+      VARIANT: debug
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - TOOLSET: msvc-14.1
+      ARCH: x86_64
+      VARIANT: release
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     - TOOLSET: msvc-14.1
       ARCH: x86
+      VARIANT: debug
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - TOOLSET: msvc-14.1
+      ARCH: x86
+      VARIANT: release
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     - TOOLSET: msvc-14.1
       ARCH: x86_64
@@ -83,10 +93,10 @@ build: off
 
 build_script:
   - cd c:\projects\boost
-  - if NOT DEFINED GENERATOR b2 address-model=%AM% toolset=%TOOLSET% variant=release libs/gil/test
-  - if NOT DEFINED GENERATOR b2 address-model=%AM% toolset=%TOOLSET% variant=release libs/gil/toolbox/test
-  - if NOT DEFINED GENERATOR b2 address-model=%AM% toolset=%TOOLSET% variant=release libs/gil/numeric/test
-  - if NOT DEFINED GENERATOR b2 address-model=%AM% toolset=%TOOLSET% variant=release include=%VCPKG_I% library-path=%VCPKG_L% libs/gil/io/test//simple
+  - if NOT DEFINED GENERATOR b2 address-model=%AM% toolset=%TOOLSET% variant=%VARIANT% libs/gil/test
+  - if NOT DEFINED GENERATOR b2 address-model=%AM% toolset=%TOOLSET% variant=%VARIANT% libs/gil/toolbox/test
+  - if NOT DEFINED GENERATOR b2 address-model=%AM% toolset=%TOOLSET% variant=%VARIANT% libs/gil/numeric/test
+  - if NOT DEFINED GENERATOR b2 address-model=%AM% toolset=%TOOLSET% variant=%VARIANT% include=%VCPKG_I% library-path=%VCPKG_L% libs/gil/io/test//simple
   - if DEFINED GENERATOR cd libs\gil && md build && cd build
   - if DEFINED GENERATOR cmake -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake ..
   - if DEFINED GENERATOR cmake --build . --config Release

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,11 +39,13 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     - TOOLSET: msvc-14.1
       ARCH: x86_64
+      VARIANT: Debug
       GENERATOR: "Visual Studio 15 2017 Win64"
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       APPVEYOR_SAVE_CACHE_ON_ERROR: true
     - TOOLSET: msvc-14.1
       ARCH: x86
+      VARIANT: Debug
       GENERATOR: "Visual Studio 15 2017"
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       APPVEYOR_SAVE_CACHE_ON_ERROR: true
@@ -89,7 +91,7 @@ before_build:
   - python tools/boostdep/depinst/depinst.py gil
   - cmd /c bootstrap
   - .\b2 headers
-  - if DEFINED GENERATOR .\b2 address-model=%AM% toolset=%TOOLSET% variant=release --with-filesystem --with-test stage
+  - if DEFINED GENERATOR .\b2 address-model=%AM% toolset=%TOOLSET% variant=%VARIANT% --with-filesystem --with-test stage
 
 build: off
 
@@ -101,10 +103,10 @@ build_script:
   - if NOT DEFINED GENERATOR b2 address-model=%AM% toolset=%TOOLSET% variant=%VARIANT% include=%VCPKG_I% library-path=%VCPKG_L% libs/gil/io/test//simple
   - if DEFINED GENERATOR cd libs\gil && md build && cd build
   - if DEFINED GENERATOR cmake -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake ..
-  - if DEFINED GENERATOR cmake --build . --config Release
+  - if DEFINED GENERATOR cmake --build . --config %VARIANT%
 
 test_script:
-  - if DEFINED GENERATOR ctest -V --output-on-failure -C Release
+  - if DEFINED GENERATOR ctest -V --output-on-failure -C %VARIANT%
 
 notifications:
   - provider: Webhook

--- a/include/boost/gil/channel_algorithm.hpp
+++ b/include/boost/gil/channel_algorithm.hpp
@@ -329,7 +329,7 @@ template <> struct channel_convert_to_unsigned<bits16s> : public std::unary_func
 
 template <> struct channel_convert_to_unsigned<bits32s> : public std::unary_function<bits32s,bits32> {
     typedef bits32 type;
-    type operator()(bits32s x) const { return static_cast<bits32>(x+(1<<31)); }
+    type operator()(bits32s x) const { return static_cast<bits32>(x)+(static_cast<bits32>(1)<<31); }
 };
 
 

--- a/test/image.cpp
+++ b/test/image.cpp
@@ -34,8 +34,8 @@ namespace fs = boost::filesystem;
 extern rgb8c_planar_view_t sample_view;
 void error_if(bool condition);
 
-#if BOOST_WORKAROUND(BOOST_MSVC, >= 1400) 
-#pragma warning(push) 
+#if BOOST_WORKAROUND(BOOST_MSVC, >= 1400)
+#pragma warning(push)
 #pragma warning(disable:4127) //conditional expression is constant
 #endif
 


### PR DESCRIPTION
/cc @chhenning, @stefanseefeld yet another curious case :)

For `variant-debug` all tests pass - this is the default AppVeyor builds variant for current the master.

For `variant=release`, run for `test/image.cpp` will likely fail due to mismatch of CRC calculated `bgr121_basic_red_x` image.