### PR TITLE
Suppress concept-related compiler warnings.

### DIFF
--- a/include/boost/gil/extension/io/formats/bmp/scanline_read.hpp
+++ b/include/boost/gil/extension/io/formats/bmp/scanline_read.hpp
@@ -372,7 +372,6 @@ private:
     void read_15_bits_row( byte_t* dst )
     {
         typedef rgb8_view_t dst_view_t;
-        typedef typename dst_view_t::x_iterator it_t;
 
         dst_view_t dst_view = interleaved_view( this->_info._width
                                               , 1

--- a/include/boost/gil/extension/io/formats/bmp/write.hpp
+++ b/include/boost/gil/extension/io/formats/bmp/write.hpp
@@ -88,10 +88,10 @@ private:
     template< typename View >
     void write( const View& view )
     {
-        typedef typename channel_type<
-                    typename get_pixel_type< View >::type >::type channel_t;
+        // typedef typename channel_type<
+        //             typename get_pixel_type< View >::type >::type channel_t;
 
-        typedef typename color_space_type< View >::type color_space_t;
+        // typedef typename color_space_type< View >::type color_space_t;
 
         // check if supported
 /*

--- a/include/boost/gil/extension/io/formats/png/read.hpp
+++ b/include/boost/gil/extension/io/formats/png/read.hpp
@@ -246,7 +246,6 @@ private:
     {        
         typedef detail::row_buffer_helper_view< ImagePixel > row_buffer_helper_t;
 
-        typedef typename row_buffer_helper_t::buffer_t   buffer_t;
         typedef typename row_buffer_helper_t::iterator_t it_t;
 
         typedef typename is_same< ConversionPolicy

--- a/include/boost/gil/extension/io/formats/pnm/write.hpp
+++ b/include/boost/gil/extension/io/formats/pnm/write.hpp
@@ -188,7 +188,7 @@ private:
                           >
                    > buf( src.width() );
 
-        typedef typename View::value_type pixel_t;
+        // typedef typename View::value_type pixel_t;
         // typedef typename view_type_from_pixel< pixel_t >::type view_t;
 
         //view_t row = interleaved_view( src.width()

--- a/include/boost/gil/extension/io/formats/pnm/write.hpp
+++ b/include/boost/gil/extension/io/formats/pnm/write.hpp
@@ -189,7 +189,7 @@ private:
                    > buf( src.width() );
 
         typedef typename View::value_type pixel_t;
-        typedef typename view_type_from_pixel< pixel_t >::type view_t;
+        // typedef typename view_type_from_pixel< pixel_t >::type view_t;
 
         //view_t row = interleaved_view( src.width()
         //                             , 1

--- a/include/boost/gil/extension/io/formats/targa/reader_backend.hpp
+++ b/include/boost/gil/extension/io/formats/targa/reader_backend.hpp
@@ -46,9 +46,9 @@ public:
                   , const image_read_settings< targa_tag >& settings
                   )
     : _io_dev  ( io_dev   )
+    , _scanline_length(0)
     , _settings( settings )
     , _info()
-    , _scanline_length(0)
     {
         read_header();    
 

--- a/include/boost/gil/extension/io/formats/tiff/read.hpp
+++ b/include/boost/gil/extension/io/formats/tiff/read.hpp
@@ -448,7 +448,6 @@ private:
        /// read_stripped_data IS working.
        typedef detail::row_buffer_helper_view< View > row_buffer_helper_t;
 
-       typedef typename row_buffer_helper_t::buffer_t   buffer_t;
        typedef typename row_buffer_helper_t::iterator_t it_t;
 
        tiff_image_width::type  image_width  = this->_info._width;
@@ -572,7 +571,6 @@ private:
        /// read_stripped_data IS working.
        typedef detail::row_buffer_helper_view< View > row_buffer_helper_t;
 
-       typedef typename row_buffer_helper_t::buffer_t   buffer_t;
        typedef typename row_buffer_helper_t::iterator_t it_t;
 
        tiff_image_width::type  image_width  = this->_info._width;
@@ -634,7 +632,6 @@ private:
       //typedef detail::row_buffer_helper_view< View > row_buffer_helper_t;
       typedef Buffer row_buffer_helper_t;
 
-      typedef typename row_buffer_helper_t::buffer_t   buffer_t;
       typedef typename row_buffer_helper_t::iterator_t it_t;
 
       std::size_t size_to_allocate = buffer_size< typename View::value_type >( dst_view.width()

--- a/include/boost/gil/extension/toolbox/color_spaces/hsl.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/hsl.hpp
@@ -66,7 +66,7 @@ struct default_color_converter_impl< rgb_t, hsl_t >
       bits32f min_color = (std::min)( temp_red, (std::min)( temp_green, temp_blue ));
       bits32f max_color = (std::max)( temp_red, (std::max)( temp_green, temp_blue ));
 
-      if( abs( min_color - max_color ) < 0.001 )
+      if( std::abs( min_color - max_color ) < 0.001 )
       {
          // rgb color is gray
 
@@ -100,14 +100,14 @@ struct default_color_converter_impl< rgb_t, hsl_t >
          }
 
          // hue calculation
-         if( abs( max_color - temp_red ) < 0.0001f )
+         if( std::abs( max_color - temp_red ) < 0.0001f )
          {
             // max_color is red
             hue = ( temp_green - temp_blue ) 
                 / diff;
 
          }
-         else if( abs( max_color - temp_green) < 0.0001f )
+         else if( std::abs( max_color - temp_green) < 0.0001f )
          {
             // max_color is green
             // 2.0 + (b - r) / (maxColor - minColor);
@@ -150,7 +150,7 @@ struct default_color_converter_impl<hsl_t,rgb_t>
 
       bits32f red, green, blue;
 
-      if( abs( get_color( src, saturation_t() )) < 0.0001  )
+      if( std::abs( get_color( src, saturation_t() )) < 0.0001  )
       {
          // If saturation is 0, the color is a shade of gray
          red   = get_color( src, lightness_t() );

--- a/include/boost/gil/gil_concept.hpp
+++ b/include/boost/gil/gil_concept.hpp
@@ -33,6 +33,9 @@
 
 namespace boost { namespace gil {
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
+
 #if BOOST_WORKAROUND(BOOST_MSVC, >= 1400) 
 #pragma warning(push) 
 #pragma warning(disable:4510) //default constructor could not be generated
@@ -2195,6 +2198,7 @@ struct ImageConcept {
 #pragma warning(pop) 
 #endif 
 
+#pragma GCC diagnostic pop
 
 } }  // namespace boost::gil
 

--- a/include/boost/gil/gil_concept.hpp
+++ b/include/boost/gil/gil_concept.hpp
@@ -33,8 +33,10 @@
 
 namespace boost { namespace gil {
 
+#if defined(__GNUC__) && (__GNUC__ >= 4)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
+#endif
 
 #if BOOST_WORKAROUND(BOOST_MSVC, >= 1400) 
 #pragma warning(push) 
@@ -2198,7 +2200,9 @@ struct ImageConcept {
 #pragma warning(pop) 
 #endif 
 
+#if defined(__GNUC__) && (__GNUC__ >= 4)
 #pragma GCC diagnostic pop
+#endif
 
 } }  // namespace boost::gil
 


### PR DESCRIPTION
This change suppresses lots of warnings on GCC all stemming from the use of (pseudo-)concepts to validate the use of template parameters in GIL code.