### PR TITLE
Remove redundant local num_values in packed_channel_reference_base::set()

### DIFF
--- a/include/boost/gil/channel.hpp
+++ b/include/boost/gil/channel.hpp
@@ -351,7 +351,6 @@ protected:
 
 private:
     void set(integer_t value) const {     // can this be done faster??
-        const integer_t num_values = max_val+1;
         this->derived().set_unsafe(((value % num_values) + num_values) % num_values); 
     }
     integer_t get() const { return derived().get(); }


### PR DESCRIPTION
Pre-defined packed_channel_reference_base::set::num_values already
represents the value.
Fixes warning C4458: declaration of 'num_values' hides class member

### Tasklist

- [x] All CI builds and checks have passed

### Environment

All relevant information like:
- Compiler version: VS2017
