### PR TITLE
Fixes of potential UB due to overflowing bit-shift operation

### DIFF
--- a/include/boost/gil/channel_algorithm.hpp
+++ b/include/boost/gil/channel_algorithm.hpp
@@ -329,7 +329,7 @@ template <> struct channel_convert_to_unsigned<bits16s> : public std::unary_func
 
 template <> struct channel_convert_to_unsigned<bits32s> : public std::unary_function<bits32s,bits32> {
     typedef bits32 type;
-    type operator()(bits32s x) const { return static_cast<bits32>(x+(1<<31)); }
+    type operator()(bits32s x) const { return static_cast<bits32>(x)+(1u<<31); }
 };
 
 
@@ -352,7 +352,7 @@ template <> struct channel_convert_from_unsigned<bits16s> : public std::unary_fu
 
 template <> struct channel_convert_from_unsigned<bits32s> : public std::unary_function<bits32,bits32s> {
     typedef bits32s type;
-    type operator()(bits32 x) const { return static_cast<bits32s>(x-(1<<31)); }
+    type operator()(bits32 x) const { return static_cast<bits32s>(x-(1u<<31)); }
 };
 
 }   // namespace detail

--- a/include/boost/gil/extension/io/formats/bmp/reader_backend.hpp
+++ b/include/boost/gil/extension/io/formats/bmp/reader_backend.hpp
@@ -189,7 +189,7 @@ public:
 
         if( entries == 0 )
         {
-            entries = 1 << this->_info._bits_per_pixel;
+            entries = 1u << this->_info._bits_per_pixel;
         }
 
         _palette.resize( entries, rgba8_pixel_t(0, 0, 0, 0));

--- a/include/boost/gil/extension/io/formats/bmp/scanline_read.hpp
+++ b/include/boost/gil/extension/io/formats/bmp/scanline_read.hpp
@@ -289,7 +289,7 @@ private:
 
         if( entries == 0 )
         {
-            entries = 1 << this->_info._bits_per_pixel;
+            entries = 1u << this->_info._bits_per_pixel;
         }
 
 		this->_palette.resize( entries, rgba8_pixel_t(0,0,0,0) );

--- a/include/boost/gil/extension/io/formats/bmp/write.hpp
+++ b/include/boost/gil/extension/io/formats/bmp/write.hpp
@@ -111,7 +111,7 @@ private:
         ///        in this context.
         if( bpp <= 8 )
         {
-            entries = 1 << bpp;
+            entries = 1u << bpp;
         }
 */
 

--- a/include/boost/gil/extension/io/formats/png/writer_backend.hpp
+++ b/include/boost/gil/extension/io/formats/png/writer_backend.hpp
@@ -355,7 +355,7 @@ protected:
 
         if( _info._valid_transparency_factors )
         {
-            int sample_max = ( 1 << _info._bit_depth );
+            int sample_max = ( 1u << _info._bit_depth );
 
             /* libpng doesn't reject a tRNS chunk with out-of-range samples */
             if( !(  (  _info._color_type == PNG_COLOR_TYPE_GRAY 


### PR DESCRIPTION
### Description

 More fixes of potential UB due to overflowing bit-shift operation

Patch courtesy of @Lastique via Boost ML.
Continuation of SHA-1: 90c2deb725db4dda408b065e130f19553574953d

### Tasklist

- [ ] Review
- [ ] Adjust for comments
- [ ] All CI builds and checks have passed

### References (eg. other issues, pull requests)

#46, #50, #51 and hopefully it also fixes the checksum bug #49
