### PR TITLE
Extend GCC and clang cxxflags for detailed warnings

### DIFF
--- a/Jamfile.v2
+++ b/Jamfile.v2
@@ -9,7 +9,13 @@
 project boost-gil
     :
     requirements
+        <toolset>intel:<debug-symbols>off
         <toolset>msvc:<asynch-exceptions>on
+        <toolset>msvc:<cxxflags>"/W4"
+        <toolset>msvc:<define>_SCL_SECURE_NO_DEPRECATE <define>_CRT_SECURE_NO_WARNINGS <define>_CRT_NONSTDC_NO_DEPRECATE
+        <toolset>gcc:<cxxflags>"-pedantic -Wstrict-aliasing -fstrict-aliasing -Wextra -Wsign-promo -Wunused-parameter -Wconversion -Wfloat-equal -Wshadow"
+        <toolset>darwin:<cxxflags>"-pedantic -Wstrict-aliasing -fstrict-aliasing -Wextra -Wsign-promo -Wunused-parameter -Wconversion -Wfloat-equal -Wshadow"
+        <toolset>clang:<cxxflags>"-pedantic -Wstrict-aliasing -fstrict-aliasing -Wextra -Wsign-promo -Wunused-parameter -Wsign-conversion -Wconversion -Wfloat-equal -Wshadow"
     ;
 
 build-project example ;

--- a/io/test/Jamfile
+++ b/io/test/Jamfile
@@ -18,16 +18,10 @@ using libtiff : : : : true ;
 
 project
     : requirements
-        <toolset>intel:<debug-symbols>off
-        <toolset>msvc-7.1:<debug-symbols>off
-        <toolset>msvc-8.0:<define>_SCL_SECURE_NO_DEPRECATE <define>_CRT_SECURE_NO_DEPRECATE <define>_CRT_NONSTDC_NO_DEPRECATE
-        <toolset>msvc-9.0:<define>_SCL_SECURE_NO_DEPRECATE <define>_CRT_SECURE_NO_WARNINGS <define>_CRT_NONSTDC_NO_DEPRECATE
-        <toolset>msvc-10.0:<define>_SCL_SECURE_NO_DEPRECATE <define>_CRT_SECURE_NO_WARNINGS <define>_CRT_NONSTDC_NO_DEPRECATE
-        <toolset>msvc-14.0:<define>_SCL_SECURE_NO_DEPRECATE <define>_CRT_SECURE_NO_WARNINGS <define>_CRT_NONSTDC_NO_DEPRECATE
-	<define>BOOST_TEST_DYN_LINK
-	<library>/boost/test//boost_unit_test_framework
-	<library>/boost/system//boost_system
-	<library>/boost/filesystem//boost_filesystem
+    <include>$(BOOST_ROOT)
+    <library>/boost/test//boost_unit_test_framework
+    <library>/boost/system//boost_system
+    <library>/boost/filesystem//boost_filesystem
     ;
 
 test-suite simple
@@ -35,8 +29,8 @@ test-suite simple
       : # args
       : # input files
       : # requirements
-	<define>BOOST_GIL_IO_TEST_ALLOW_READING_IMAGES
-	<define>BOOST_GIL_IO_TEST_ALLOW_WRITING_IMAGES
+    <define>BOOST_GIL_IO_TEST_ALLOW_READING_IMAGES
+    <define>BOOST_GIL_IO_TEST_ALLOW_WRITING_IMAGES
         [ ac.check-library /libjpeg//libjpeg : <library>/libjpeg//libjpeg : <build>no ]
         [ ac.check-library /zlib//zlib : <library>/zlib//zlib : <build>no ]
         [ ac.check-library /libpng//libpng : <library>/libpng//libpng : <build>no ]
@@ -45,26 +39,26 @@ test-suite simple
 ;
 
 test-suite full :
-	[ run bmp_test.cpp bmp_old_test.cpp bmp_read_test.cpp bmp_write_test.cpp ]
-	[ run jpeg_test.cpp jpeg_old_test.cpp jpeg_read_test.cpp jpeg_write_test.cpp
-	  :
-	  :
+    [ run bmp_test.cpp bmp_old_test.cpp bmp_read_test.cpp bmp_write_test.cpp ]
+    [ run jpeg_test.cpp jpeg_old_test.cpp jpeg_read_test.cpp jpeg_write_test.cpp
+      :
+      :
           : [ ac.check-library /libjpeg//libjpeg : <library>/libjpeg//libjpeg : <build>no ] ]
         #make.cpp
-	[ run png_test.cpp png_old_test.cpp png_file_format_test.cpp png_read_test.cpp
-	  :
-	  :
-	  :
+    [ run png_test.cpp png_old_test.cpp png_file_format_test.cpp png_read_test.cpp
+      :
+      :
+      :
           [ ac.check-library /zlib//zlib : <library>/zlib//zlib : <build>no ]
           [ ac.check-library /libpng//libpng : <library>/libpng//libpng : <build>no ]
-	]
-	[ run pnm_test.cpp pnm_old_test.cpp pnm_read_test.cpp pnm_write_test.cpp ]
-	#raw_test.cpp
+    ]
+    [ run pnm_test.cpp pnm_old_test.cpp pnm_read_test.cpp pnm_write_test.cpp ]
+    #raw_test.cpp
         [ run targa_test.cpp targa_old_test.cpp targa_read_test.cpp targa_write_test.cpp ]
-	[ run
+    [ run
           tiff_test.cpp
           tiff_old_test.cpp
-	  tiff_file_format_test.cpp
+      tiff_file_format_test.cpp
           tiff_subimage_test.cpp
           tiff_tiled_float_test.cpp
           tiff_tiled_minisblack_test_1-10.cpp
@@ -88,8 +82,8 @@ test-suite full :
           tiff_tiled_rgb_planar_test_21-31_32_64.cpp
           tiff_tiled_test.cpp
           tiff_write_test.cpp
-	  :
-	  :
+      :
+      :
           : [ ac.check-library /libtiff//libtiff : <library>/libtiff//libtiff : <build>no ]
-	]
+    ]
     ;

--- a/numeric/test/Jamfile
+++ b/numeric/test/Jamfile
@@ -10,25 +10,15 @@ import testing ;
 
 project
     : requirements
-        <library>/boost/test//boost_unit_test_framework
-        <link>static
-        <include>../../../..
-        <toolset>intel:<debug-symbols>off
-        <toolset>msvc-7.1:<debug-symbols>off
-        <toolset>msvc-8.0:<define>_SCL_SECURE_NO_DEPRECATE <define>_CRT_SECURE_NO_DEPRECATE <define>_CRT_NONSTDC_NO_DEPRECATE
-        <toolset>msvc-9.0:<define>_SCL_SECURE_NO_DEPRECATE <define>_CRT_SECURE_NO_WARNINGS <define>_CRT_NONSTDC_NO_DEPRECATE
-        <toolset>msvc-10.0:<define>_SCL_SECURE_NO_DEPRECATE <define>_CRT_SECURE_NO_WARNINGS <define>_CRT_NONSTDC_NO_DEPRECATE
-        <link>static
-        <library>/boost/test//boost_unit_test_framework
-#		<library>/boost/system//boost_system
+    <include>$(BOOST_ROOT)
+    <library>/boost/test//boost_unit_test_framework
     ;
 
 test-suite "gil::numeric"
-	:
-	[ run
+    :
+    [ run
         # sources
         test.cpp
         numeric.cpp
-	]
-
+    ]
     ;

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -10,13 +10,8 @@ import testing ;
 
 project
     : requirements
-        <toolset>intel:<debug-symbols>off
-        <toolset>msvc-7.1:<debug-symbols>off
-        <toolset>msvc-8.0:<define>_SCL_SECURE_NO_DEPRECATE <define>_CRT_SECURE_NO_DEPRECATE <define>_CRT_NONSTDC_NO_DEPRECATE
-        <toolset>msvc-9.0:<define>_SCL_SECURE_NO_DEPRECATE <define>_CRT_SECURE_NO_WARNINGS <define>_CRT_NONSTDC_NO_DEPRECATE
-        <toolset>msvc-10.0:<define>_SCL_SECURE_NO_DEPRECATE <define>_CRT_SECURE_NO_WARNINGS <define>_CRT_NONSTDC_NO_DEPRECATE
-	<include>$(BOOST_ROOT)
-	<library>/boost/filesystem//boost_filesystem
+    <include>$(BOOST_ROOT)
+    <library>/boost/filesystem//boost_filesystem
     ;
 
 test-suite gil :
@@ -24,4 +19,4 @@ test-suite gil :
     [ run channel.cpp error_if.cpp ]
     [ run pixel.cpp error_if.cpp ]
     [ run pixel_iterator.cpp error_if.cpp ]
-;
+    ;

--- a/toolbox/test/Jamfile
+++ b/toolbox/test/Jamfile
@@ -10,19 +10,12 @@ import testing ;
 
 project
     : requirements
-        <include>../../../..
-        <toolset>intel:<debug-symbols>off
-        <toolset>msvc-7.1:<debug-symbols>off
-        <toolset>msvc-8.0:<define>_SCL_SECURE_NO_DEPRECATE <define>_CRT_SECURE_NO_DEPRECATE <define>_CRT_NONSTDC_NO_DEPRECATE
-        <toolset>msvc-9.0:<define>_SCL_SECURE_NO_DEPRECATE <define>_CRT_SECURE_NO_WARNINGS <define>_CRT_NONSTDC_NO_DEPRECATE
-        <toolset>msvc-10.0:<define>_SCL_SECURE_NO_DEPRECATE <define>_CRT_SECURE_NO_WARNINGS <define>_CRT_NONSTDC_NO_DEPRECATE
-	<define>BOOST_TEST_DYN_LINK
-        <library>/boost/test//boost_unit_test_framework
-#		<library>/boost/system//boost_system
+    <include>$(BOOST_ROOT)
+    <library>/boost/test//boost_unit_test_framework
     ;
 
 test-suite "gil::toolbox" :
-	[ run
+    [ run
         # sources
         test.cpp
         channel_type.cpp
@@ -47,6 +40,5 @@ test-suite "gil::toolbox" :
         : # target-name
         gil_io_new_tests
         : # default-build
-	]
-
+    ]
     ;


### PR DESCRIPTION
### Description

- Group compilation flags and defines in common top-level Jamfile - relies on Boost.Build feature of referring parent Jamfile-s.
- Bump MSVC warning level to W4
- Preparing for detailed warnings clean up based on:
https://svn.boost.org/trac10/wiki/Guidelines/WarningsGuidelines

## Tasklist
- [x] All CI builds and checks have passed

# References

I'm hopeful it will also help to investigate #49