### PR TITLE
Various documentation fixes.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -56,13 +56,20 @@ matrix:
       ARCH: x86
       VARIANT: release
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - TOOLSET: msvc-14.1
+      ARCH: x86_64
+      VARIANT: debug
+      GENERATOR: "Visual Studio 15 2017 Win64"
+      CMAKE_CONFIG: Debug
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      APPVEYOR_SAVE_CACHE_ON_ERROR: true
 
 cache:
   - c:\tools\vcpkg\installed\
 
 install:
   - ps: 'Write-Host "Installing CMake module FindBoost.cmake for Boost 1.67+" -ForegroundColor Magenta'
-  - appveyor DownloadFile https://raw.githubusercontent.com/Kitware/CMake/master/Modules/FindBoost.cmake -FileName "C:\Program Files (x86)\CMake\share\cmake-3.10\Modules\FindBoost.cmake"
+  - appveyor DownloadFile https://raw.githubusercontent.com/Kitware/CMake/master/Modules/FindBoost.cmake -FileName "C:\Program Files (x86)\CMake\share\cmake-3.11\Modules\FindBoost.cmake"
   # FIXME: To be removed https://help.appveyor.com/discussions/problems/13000-cmake_toolchain_filevcpkgcmake-conflicts-with-cmake-native-findboostcmake"
   - ps: 'Write-Host "Installing latest vcpkg.cmake module" -ForegroundColor Magenta'
   - appveyor DownloadFile https://raw.githubusercontent.com/Microsoft/vcpkg/master/scripts/buildsystems/vcpkg.cmake -FileName "c:\tools\vcpkg\scripts\buildsystems\vcpkg.cmake"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -69,7 +69,7 @@ cache:
 
 install:
   - ps: 'Write-Host "Installing CMake module FindBoost.cmake for Boost 1.67+" -ForegroundColor Magenta'
-  - appveyor DownloadFile https://raw.githubusercontent.com/Kitware/CMake/master/Modules/FindBoost.cmake -FileName "C:\Program Files (x86)\CMake\share\cmake-3.11\Modules\FindBoost.cmake"
+  - if DEFINED GENERATOR appveyor DownloadFile https://raw.githubusercontent.com/Kitware/CMake/master/Modules/FindBoost.cmake -FileName "C:\Program Files (x86)\CMake\share\cmake-3.11\Modules\FindBoost.cmake"
   # FIXME: To be removed https://help.appveyor.com/discussions/problems/13000-cmake_toolchain_filevcpkgcmake-conflicts-with-cmake-native-findboostcmake"
   - ps: 'Write-Host "Installing latest vcpkg.cmake module" -ForegroundColor Magenta'
   - appveyor DownloadFile https://raw.githubusercontent.com/Microsoft/vcpkg/master/scripts/buildsystems/vcpkg.cmake -FileName "c:\tools\vcpkg\scripts\buildsystems\vcpkg.cmake"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -24,7 +24,7 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = []
+extensions = ['sphinx.ext.autosectionlabel']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -64,6 +64,10 @@ release = '1.0'
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 exclude_patterns = ['_build']
+
+# disambiguate auto-generated section anchors by prefixing
+# them with the document name
+autosectionlabel_prefix_document = True
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 #default_role = None

--- a/doc/design_guide.rst
+++ b/doc/design_guide.rst
@@ -54,7 +54,7 @@ recommended to read the sections in order.
 About Concepts
 --------------
 
-All constructs in GIL are models of GIL concepts. A \em concept is a
+All constructs in GIL are models of GIL concepts. A *concept* is a
 set of requirements that a type (or a set of related types) must
 fulfill to be used correctly in generic algorithms. The requirements
 include syntactic and algorithmic guarantees.  For example, GIL's
@@ -149,11 +149,9 @@ GIL uses a two-dimensional point, which is a refinement of
     value_type x,y;
   };
 
-Related Concepts
-~~~~~~~~~~~~~~~~
-
-- `PointNDConcept`
-- `Point2DConcept`
+.. seealso::
+   - `PointNDConcept <reference/structboost_1_1gil_1_1_point_n_d_concept.html>`_
+   - `Point2DConcept <reference/structboost_1_1gil_1_1_point2_d_concept.html>`_
 
 Models
 ~~~~~~
@@ -235,14 +233,12 @@ not have a default constructor.
 Note also that algorithms may impose additional requirements on
 channels, such as support for arithmetic operations.
 
-Related Concepts
-~~~~~~~~~~~~~~~~
-
-- `ChannelConcept<T>`
-- `ChannelValueConcept<T>`
-- `MutableChannelConcept<T>`
-- `ChannelsCompatibleConcept<T1,T2>`
-- `ChannelConvertibleConcept<SrcChannel,DstChannel>`
+.. seealso::
+   - `ChannelConcept<T> <reference/structboost_1_1gil_1_1_channel_concept.html>`_
+   - `ChannelValueConcept<T> <reference/structboost_1_1gil_1_1_channel_value_concept.html>`_
+   - `MutableChannelConcept<T> <reference/structboost_1_1gil_1_1_mutable_channel_concept.html>`_
+   - `ChannelsCompatibleConcept<T1,T2> <reference/structboost_1_1gil_1_1_channels_compatible_concept.html>`_
+   - `ChannelConvertibleConcept<SrcChannel,DstChannel> <reference/structboost_1_1gil_1_1_channel_convertible_concept.html>`_
 
 Models
 ~~~~~~
@@ -361,12 +357,10 @@ sequence containing the types of all elements in the color space.
 Two color spaces are considered *compatible* if they are equal
 (i.e. have the same set of colors in the same order).
 
-Related Concepts
-~~~~~~~~~~~~~~~~
-
-- `ColorSpaceConcept<ColorSpace>`
-- `ColorSpacesCompatibleConcept<ColorSpace1,ColorSpace2>`
-- `ChannelMappingConcept<Mapping>`
+.. seealso::
+   - `ColorSpaceConcept<ColorSpace> <reference/structboost_1_1gil_1_1_color_space_concept.html>`_
+   - `ColorSpacesCompatibleConcept<ColorSpace1,ColorSpace2> <reference/structboost_1_1gil_1_1_color_spaces_compatible_concept.html>`_
+   - `ChannelMappingConcept<Mapping> <reference/structboost_1_1gil_1_1_channel_mapping_concept.html>`_
 
 Models
 ~~~~~~
@@ -536,7 +530,7 @@ elements all have the same type). ::
 It is used in the implementation of GIL's pixel, planar pixel
 reference and planar pixel iterator.  Another model of
 ``ColorBaseConcept`` is ``packed_pixel`` - it is a pixel whose
-channels are bit ranges. See the \ref PixelSectionDG section for more.
+channels are bit ranges. See the :ref:`Pixel` section for more.
 
 Algorithms
 ~~~~~~~~~~
@@ -758,18 +752,17 @@ The distinction between ``PixelConcept`` and ``PixelValueConcept`` is
 analogous to that for channels and color bases - pixel reference
 proxies model both, but only pixel values model the latter.
 
-Related Concepts
-~~~~~~~~~~~~~~~~
+.. seealso::
 
-- `PixelBasedConcept<P>`
-- `PixelConcept<Pixel>`
-- `MutablePixelConcept<Pixel>`
-- `PixelValueConcept<Pixel>`
-- `HomogeneousPixelConcept<Pixel>`
-- `MutableHomogeneousPixelConcept<Pixel>`
-- `HomogeneousPixelValueConcept<Pixel>`
-- `PixelsCompatibleConcept<Pixel1, Pixel2>`
-- `PixelConvertibleConcept<SrcPixel, DstPixel>`
+   - `PixelBasedConcept<P> <reference/structboost_1_1gil_1_1_pixel_based_concept.html>`_
+   - `PixelConcept<Pixel> <reference/structboost_1_1gil_1_1_pixel_concept.html>`_
+   - `MutablePixelConcept<Pixel> <reference/structboost_1_1gil_1_1_mutable_pixel_concept.html>`_
+   - `PixelValueConcept<Pixel> <reference/structboost_1_1gil_1_1_pixel_value_concept.html>`_
+   - `HomogeneousPixelConcept<Pixel> <reference/structboost_1_1gil_1_1_homogeneous_pixel_based_concept.html>`_
+   - `MutableHomogeneousPixelConcept<Pixel> <reference/structboost_1_1gil_1_1_mutable_homogeneous_pixel_concept.html>`_
+   - `HomogeneousPixelValueConcept<Pixel> <reference/structboost_1_1gil_1_1_homogeneous_pixel_value_concept.html>`_
+   - `PixelsCompatibleConcept<Pixel1, Pixel2> <reference/structboost_1_1gil_1_1_pixels_compatible_concept.html>`_
+   - `PixelConvertibleConcept<SrcPixel, DstPixel> <reference/structboost_1_1gil_1_1_pixel_convertible_concept.html>`_
 
 Models
 ~~~~~~
@@ -942,11 +935,10 @@ iterators or adaptors over another pixel iterator::
   template <typename Iterator>
   concept MutablePixelIteratorConcept : PixelIteratorConcept<Iterator>, MutableRandomAccessIteratorConcept<Iterator> {};
 
-Related Concepts
-++++++++++++++++
+.. seealso::
 
-- `PixelIteratorConcept<Iterator>`
-- `MutablePixelIteratorConcept<Iterator>`
+   - `PixelIteratorConcept<Iterator> <reference/group___pixel_iterator_concept_pixel_iterator.html>`_
+   - `MutablePixelIteratorConcept<Iterator> <reference/structboost_1_1gil_1_1_mutable_pixel_iterator_concept.html>`_
 
 Models
 ++++++
@@ -970,7 +962,7 @@ iterators over unsigned char are defined::
 ``planar_pixel_iterator`` also models ``HomogeneousColorBaseConcept``
 (it subclasses from ``homogeneous_color_base``) and, as a result, all
 color base algorithms apply to it. The element type of its color base
-is a channel iterator. For example, GIL implements \p operator++ of
+is a channel iterator. For example, GIL implements ``operator++`` of
 planar iterators approximately like this::
 
   template <typename T>
@@ -1021,11 +1013,10 @@ to another base iterator::
   template <boost_concepts::Mutable_ForwardIteratorConcept Iterator>
   concept MutableIteratorAdaptorConcept : IteratorAdaptorConcept<Iterator> {};
 
-Related Concepts
-++++++++++++++++
-
-- `IteratorAdaptorConcept<Iterator>`
-- `MutableIteratorAdaptorConcept<Iterator>`
+.. seealso::
+   
+   - `IteratorAdaptorConcept<Iterator> <reference/structboost_1_1gil_1_1_iterator_adaptor_concept.html>`_
+   - `MutableIteratorAdaptorConcept<Iterator> <reference/structboost_1_1gil_1_1_mutable_iterator_adaptor_concept.html>`_
 
 Models
 ++++++
@@ -1033,13 +1024,12 @@ Models
 GIL provides several models of ``IteratorAdaptorConcept``:
 
 * ``memory_based_step_iterator<Iterator>``: An iterator adaptor that
-  changes the fundamental step of the base iterator (see \ref
-  StepIteratorDG)
+  changes the fundamental step of the base iterator (see :ref:`Step Iterator`)
 * ``dereference_iterator_adaptor<Iterator,Fn>``: An iterator that
   applies a unary function ``Fn`` upon dereferencing. It is used, for
   example, for on-the-fly color conversion. It can be used to construct
   a shallow image "view" that pretends to have a different color space
-  or channel depth. See \ref ImageViewFrowImageViewDG for more. The
+  or channel depth. See :ref:`Image View` for more. The
   unary function ``Fn`` must model ``PixelDereferenceAdaptorConcept``
   (see below).
 
@@ -1151,13 +1141,12 @@ horizontal step::
 All models of pixel iterators, locators and image views that GIL
 provides support ``HasDynamicXStepTypeConcept``.
 
-Related Concepts
-++++++++++++++++
+.. seealso::
 
-- `StepIteratorConcept<Iterator>`
-- `MutableStepIteratorConcept<Iterator>`
-- `MemoryBasedIteratorConcept<Iterator>`
-- `HasDynamicXStepTypeConcept<T>`
+   - `StepIteratorConcept<Iterator> <reference/structboost_1_1gil_1_1_step_iterator_concept.html>`_
+   - `MutableStepIteratorConcept<Iterator> <reference/structboost_1_1gil_1_1_mutable_step_iterator_concept.html>`_
+   - `MemoryBasedIteratorConcept<Iterator> <reference/structboost_1_1gil_1_1_memory_based_iterator_concept.html>`_
+   - `HasDynamicXStepTypeConcept<T> <reference/structboost_1_1gil_1_1_has_dynamic_x_step_type_concept.html>`_
 
 Models
 ++++++
@@ -1283,7 +1272,7 @@ Two-dimensional locators have additional requirements::
   concept MutableRandomAccess2DLocatorConcept<RandomAccess2DLocatorConcept Loc> : MutableRandomAccessNDLocatorConcept<Loc> {};
 
 2D locators can have a dynamic step not just horizontally, but also
-vertically. This gives rise to the Y equivalent of \p
+vertically. This gives rise to the Y equivalent of
 HasDynamicXStepTypeConcept::
 
   concept HasDynamicYStepTypeConcept<typename T>
@@ -1324,17 +1313,16 @@ concept::
 
   concept MutablePixelLocatorConcept<PixelLocatorConcept Loc> : MutableRandomAccess2DLocatorConcept<Loc> {};
 
-Related Concepts
-++++++++++++++++
+.. seealso::
 
-- `HasDynamicYStepTypeConcept<T>`
-- `HasTransposedTypeConcept<T>`
-- `RandomAccessNDLocatorConcept<Locator>`
-- `MutableRandomAccessNDLocatorConcept<Locator>`
-- `RandomAccess2DLocatorConcept<Locator>`
-- `MutableRandomAccess2DLocatorConcept<Locator>`
-- `PixelLocatorConcept<Locator>`
-- `MutablePixelLocatorConcept<Locator>`
+   - `HasDynamicYStepTypeConcept<T> <reference/structboost_1_1gil_1_1_has_dynamic_y_step_type_concept.html>`_
+   - `HasTransposedTypeConcept<T> <reference/structboost_1_1gil_1_1_has_transposed_type_concept.html>`_
+   - `RandomAccessNDLocatorConcept<Locator> <reference/structboost_1_1gil_1_1_random_access_n_d_locator_concept.html>`_
+   - `MutableRandomAccessNDLocatorConcept<Locator> <reference/structboost_1_1gil_1_1_mutable_random_access_n_d_locator_concept.html>`_
+   - `RandomAccess2DLocatorConcept<Locator> <reference/structboost_1_1gil_1_1_random_access2_d_locator_concept.html>`_
+   - `MutableRandomAccess2DLocatorConcept<Locator> <reference/structboost_1_1gil_1_1_mutable_random_access2_d_locator_concept.html>`_
+   - `PixelLocatorConcept<Locator> <reference/structboost_1_1gil_1_1_pixel_locator_concept.html>`_
+   - `MutablePixelLocatorConcept<Locator> <reference/structboost_1_1gil_1_1_mutable_pixel_locator_concept.html>`_
 
 Models
 ++++++
@@ -1455,7 +1443,7 @@ inside ``iterator_from_2d::operator++`` to determine whether we are at
 the end of a row. For fast operations, such as pixel copy, this second
 check adds about 15% performance delay (measured for interleaved
 images on Intel platform). GIL overrides some STL algorithms, such as
-\p std::copy and ``std::fill``, when invoked with
+ ``std::copy`` and ``std::fill``, when invoked with
 ``iterator_from_2d``-s, to go through each row using their base
 x-iterators, and, if the image has no padding
 (i.e. ``iterator_from_2d::is_1d_traversable()`` returns true) to
@@ -1597,16 +1585,15 @@ Compatible views must also have the same dimensions (i.e. the same
 width and height). Many algorithms taking multiple views require that
 they be pairwise compatible.
 
-Related Concepts
-~~~~~~~~~~~~~~~~
+.. seealso::
 
-- `RandomAccessNDImageViewConcept<View>`
-- `MutableRandomAccessNDImageViewConcept<View>`
-- `RandomAccess2DImageViewConcept<View>`
-- `MutableRandomAccess2DImageViewConcept<View>`
-- `ImageViewConcept<View>`
-- `MutableImageViewConcept<View>`
-- `ViewsCompatibleConcept<View1,View2>`
+   - `RandomAccessNDImageViewConcept<View> <reference/structboost_1_1gil_1_1_random_access_n_d_image_view_concept.html>`_
+   - `MutableRandomAccessNDImageViewConcept<View> <reference/structboost_1_1gil_1_1_mutable_random_access_n_d_image_view_concept.html>`_
+   - `RandomAccess2DImageViewConcept<View> <reference/structboost_1_1gil_1_1_random_access2_d_image_view_concept.html>`_
+   - `MutableRandomAccess2DImageViewConcept<View> <reference/structboost_1_1gil_1_1_mutable_random_access2_d_image_view_concept.html>`_
+   - `ImageViewConcept<View> <reference/structboost_1_1gil_1_1_image_view_concept.html>`_
+   - `MutableImageViewConcept<View> <reference/structboost_1_1gil_1_1_mutable_image_view_concept.html>`_
+   - `ViewsCompatibleConcept<View1,View2> <reference/structboost_1_1gil_1_1_views_compatible_concept.html>`_
 
 Models
 ~~~~~~
@@ -1745,7 +1732,7 @@ because there is a significant increase in compile time when using
 concept checks. We will skip ``gil_function_requires`` in the code
 examples in this guide for the sake of succinctness.
 
-Image views can be freely composed (see section \ref MetafunctionsDG
+Image views can be freely composed (see section :ref:`Useful Metafunctions and Typedefs`
 for the typedefs ``rgb16_image_t`` and ``gray16_step_view_t)``::
 
   rgb16_image_t img(100,100);    // an RGB interleaved image
@@ -1857,7 +1844,7 @@ algorithms. For example, ``std::copy`` for planar iterators is
 overloaded to perform ``std::copy`` for each of the
 planes. ``std::copy`` over bitwise-copyable pixels results in
 ``std::copy`` over unsigned char, which STL typically implements via
-\p memmove.
+``memmove``.
 
 As a result ``copy_pixels`` may result in a single call to ``memmove``
 for interleaved 1D-traversable views, or one per each plane of planar
@@ -1931,12 +1918,11 @@ operate on pixels.::
 Images, unlike locators and image views, don't have 'mutable' set of
 concepts because immutable images are not very useful.
 
-Related Concepts
-~~~~~~~~~~~~~~~~
+.. seealso::
 
-- `RandomAccessNDImageConcept<Image>`
-- `RandomAccess2DImageConcept<Image>`
-- `ImageConcept<Image>`
+   - `RandomAccessNDImageConcept<Image> <reference/structboost_1_1gil_1_1_random_access_n_d_image_concept.html>`_
+   - `RandomAccess2DImageConcept<Image> <reference/structboost_1_1gil_1_1_random_access2_d_image_concept.html>`_
+   - `ImageConcept<Image> <reference/structboost_1_1gil_1_1_image_concept.html>`_
 
 Models
 ~~~~~~
@@ -2402,7 +2388,7 @@ be evaluated like this::
   BOOST_STATIC_ASSERT(is_planar<rgb8_planar_view_t>::value == true);
 
 GIL also supports type analysis metafunctions of the form:
-[pixel_reference/iterator/locator/view/image] + \p "_is_" +
+[pixel_reference/iterator/locator/view/image] + "_is_" +
 [basic/mutable/step]. For example::
 
   if (view_is_mutable<View>::value)

--- a/doc/io.rst
+++ b/doc/io.rst
@@ -60,16 +60,9 @@ on how to use this boost::gil extension. For more details please refer to sectio
 Since this is an extension to boost::gil I expect the user to have some very basic
 understanding of the gil ( generic image library ). Please see here for the help.
 
-[h2 Header Files]
-The header files to be included all have the same format. For instance, tiff_all.hpp will
-allow to read and write. Whereas, tiff_read.hpp only allows for reading. If the user only
-wants to write jpeg's include jpeg_write.hpp. All formats provide these three types of header files:
-
-* xxx_all.hpp
-* xxx_read.hpp
-* xxx_write.hpp
-
-xxx stands for image format.
+For each supported IO format a single top-level header file is provided.
+For instance, include `boost/gil/extension/io/tiff.hpp` to be able
+to read or write TIFF files.
 
 Reading An Image
 ~~~~~~~~~~~~~~~~

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -7,15 +7,9 @@ Tutorial
 Installation
 ------------
 
-The latest version of GIL can be downloaded from
-http://boostorg.github.com/gilGIL's web page,
-at http://stlab.adobe.com/gil.
-
-The GIL is approved for integration into Boost and in the future will be
-installed simply by installing Boost from http://www.boost.org.
-GIL consists of header files only and does not require any libraries to
-link against. It does not require Boost to be built.
-Including ``boost/gil/gil_all.hpp`` will be sufficient for most projects.
+The latest version of GIL can be downloaded from http://boostorg.github.com/gil.
+GIL consists of header files only and does not require any libraries to link against. It does not require Boost to be built.
+Including ``boost/gil.hpp`` will be sufficient for most projects.
 
 Example - Computing the Image Gradient
 --------------------------------------
@@ -40,7 +34,7 @@ Let us first start with 8-bit unsigned grayscale image as the input and
 8-bit signed grayscale image as the output.
 Here is how the interface to our algorithm looks like::
 
-  #include <boost/gil/gil_all.hpp>
+  #include <boost/gil.hpp>
   using namespace boost::gil;
 
   void x_gradient(const gray8c_view_t& src, const gray8s_view_t& dst)

--- a/include/boost/gil.hpp
+++ b/include/boost/gil.hpp
@@ -1,0 +1,31 @@
+// Copyright 2005-2007 Adobe Systems Incorporated
+// Copyright 2018 Stefan Seefeld
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef boost_gil_hpp_
+#define boost_gil_hpp_
+
+#include <boost/gil/version.hpp>
+#include <boost/gil/gil_config.hpp>
+#include <boost/gil/channel_algorithm.hpp>
+#include <boost/gil/algorithm.hpp>
+#include <boost/gil/pixel.hpp>
+#include <boost/gil/packed_pixel.hpp>
+#include <boost/gil/planar_pixel_reference.hpp>
+#include <boost/gil/planar_pixel_iterator.hpp>
+#include <boost/gil/pixel_iterator_adaptor.hpp>
+#include <boost/gil/step_iterator.hpp>
+#include <boost/gil/iterator_from_2d.hpp>
+#include <boost/gil/image.hpp>
+#include <boost/gil/image_view_factory.hpp>
+#include <boost/gil/typedefs.hpp>
+#include <boost/gil/metafunctions.hpp>
+#include <boost/gil/color_convert.hpp>
+#include <boost/gil/device_n.hpp>
+#include <boost/gil/virtual_locator.hpp>
+#include <boost/gil/bit_aligned_pixel_iterator.hpp>
+
+#endif

--- a/io/test/bmp_old_test.cpp
+++ b/io/test/bmp_old_test.cpp
@@ -8,7 +8,7 @@
 //#define BOOST_TEST_MODULE bmp_old_test_module
 #include <boost/test/unit_test.hpp>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/io/bmp_io_old.hpp>
 
 #include "mandel_view.hpp"

--- a/io/test/bmp_read_test.cpp
+++ b/io/test/bmp_read_test.cpp
@@ -9,7 +9,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/type_traits/is_same.hpp>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/io/bmp_all.hpp>
 
 #include "scanline_read_test.hpp"

--- a/io/test/bmp_test.cpp
+++ b/io/test/bmp_test.cpp
@@ -12,7 +12,7 @@
 
 #include <fstream>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/io/bmp_all.hpp>
 
 #define BOOST_FILESYSTEM_VERSION 3

--- a/io/test/bmp_write_test.cpp
+++ b/io/test/bmp_write_test.cpp
@@ -8,7 +8,7 @@
 //#define BOOST_TEST_MODULE bmp_write_test_module
 #include <boost/test/unit_test.hpp>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 
 #include <boost/gil/extension/io/detail/typedefs.hpp>
 #include <boost/gil/extension/io/bmp_all.hpp>

--- a/io/test/cmp_view.hpp
+++ b/io/test/cmp_view.hpp
@@ -18,7 +18,7 @@
 ////////////////////////////////////////////////////////////////////////////////////////
 
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 
 template< typename View_1, typename View_2 >
 void cmp_view( const View_1& v1

--- a/io/test/color_space_write_test.hpp
+++ b/io/test/color_space_write_test.hpp
@@ -10,7 +10,7 @@
 
 #include <string>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 
 #include "cmp_view.hpp"
 

--- a/io/test/jpeg_old_test.cpp
+++ b/io/test/jpeg_old_test.cpp
@@ -8,7 +8,7 @@
 //#define BOOST_TEST_MODULE jpeg_old_test_module
 #include <boost/test/unit_test.hpp>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/io/jpeg_io_old.hpp>
 
 #include "mandel_view.hpp"

--- a/io/test/jpeg_read_test.cpp
+++ b/io/test/jpeg_read_test.cpp
@@ -8,7 +8,7 @@
 //#define BOOST_TEST_MODULE jpeg_read_test_module
 #include <boost/test/unit_test.hpp>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/io/jpeg_all.hpp>
 
 #include "paths.hpp"

--- a/io/test/jpeg_test.cpp
+++ b/io/test/jpeg_test.cpp
@@ -12,7 +12,7 @@
 
 #include <fstream>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 
 #define BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 #include <boost/gil/extension/io/jpeg_all.hpp>

--- a/io/test/jpeg_write_test.cpp
+++ b/io/test/jpeg_write_test.cpp
@@ -8,7 +8,7 @@
 //#define BOOST_TEST_MODULE jpeg_write_test_module
 #include <boost/test/unit_test.hpp>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/io/jpeg_all.hpp>
 
 #include "color_space_write_test.hpp"

--- a/io/test/make.cpp
+++ b/io/test/make.cpp
@@ -14,7 +14,7 @@
 #define BOOST_FILESYSTEM_VERSION 3
 #include <boost/filesystem/convenience.hpp>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/io/bmp_all.hpp>
 
 #include "paths.hpp"

--- a/io/test/mandel_view.hpp
+++ b/io/test/mandel_view.hpp
@@ -8,7 +8,7 @@
 #ifndef BOOST_GIL_IO_UNIT_TEST_MANDEL_HPP
 #define BOOST_GIL_IO_UNIT_TEST_MANDEL_HPP
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 
 using namespace std;
 using namespace boost;

--- a/io/test/png_old_test.cpp
+++ b/io/test/png_old_test.cpp
@@ -8,7 +8,7 @@
 //#define BOOST_TEST_MODULE png_old_test_module
 #include <boost/test/unit_test.hpp>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/io/png_io_old.hpp>
 
 #include "mandel_view.hpp"

--- a/io/test/png_test.cpp
+++ b/io/test/png_test.cpp
@@ -10,7 +10,7 @@
 
 #include <fstream>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 
 //#define BOOST_GIL_IO_PNG_FLOATING_POINT_SUPPORTED
 //#define BOOST_GIL_IO_PNG_FIXED_POINT_SUPPORTED

--- a/io/test/pnm_old_test.cpp
+++ b/io/test/pnm_old_test.cpp
@@ -8,7 +8,7 @@
 //#define BOOST_TEST_MODULE pnm_old_test_module
 #include <boost/test/unit_test.hpp>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/io/pnm_io_old.hpp>
 
 #include "paths.hpp"

--- a/io/test/pnm_test.cpp
+++ b/io/test/pnm_test.cpp
@@ -10,7 +10,7 @@
 
 #include <fstream>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/io/pnm_all.hpp>
 
 #include <boost/type_traits/is_same.hpp>

--- a/io/test/raw_test.cpp
+++ b/io/test/raw_test.cpp
@@ -12,7 +12,7 @@
 
 #include <fstream>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/io/raw_all.hpp>
 
 #define BOOST_FILESYSTEM_VERSION 3

--- a/io/test/scanline_read_test.hpp
+++ b/io/test/scanline_read_test.hpp
@@ -8,7 +8,7 @@
 #ifndef BOOST_GIL_IO_UNIT_TEST_SCANLINE_READ_TEST_HPP
 #define BOOST_GIL_IO_UNIT_TEST_SCANLINE_READ_TEST_HPP
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 
 #include "cmp_view.hpp"
 

--- a/io/test/subimage_test.hpp
+++ b/io/test/subimage_test.hpp
@@ -8,7 +8,7 @@
 #ifndef BOOST_GIL_IO_UNIT_TEST_SUBIMAGE_TEST_HPP
 #define BOOST_GIL_IO_UNIT_TEST_SUBIMAGE_TEST_HPP
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 
 using namespace std;
 using namespace boost;

--- a/io/test/targa_old_test.cpp
+++ b/io/test/targa_old_test.cpp
@@ -8,7 +8,7 @@
 //#define BOOST_TEST_MODULE targa_old_test_module
 #include <boost/test/unit_test.hpp>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/io/targa_io_old.hpp>
 
 #include "mandel_view.hpp"

--- a/io/test/targa_read_test.cpp
+++ b/io/test/targa_read_test.cpp
@@ -9,7 +9,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/type_traits/is_same.hpp>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/io/targa_all.hpp>
 
 #include "paths.hpp"

--- a/io/test/targa_test.cpp
+++ b/io/test/targa_test.cpp
@@ -12,7 +12,7 @@
 
 #include <fstream>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/io/targa_all.hpp>
 
 #include <boost/filesystem/convenience.hpp>

--- a/io/test/targa_write_test.cpp
+++ b/io/test/targa_write_test.cpp
@@ -8,7 +8,7 @@
 //#define BOOST_TEST_MODULE targa_write_test_module
 #include <boost/test/unit_test.hpp>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 
 #include <boost/gil/extension/io/detail/typedefs.hpp>
 #include <boost/gil/extension/io/targa_all.hpp>

--- a/io/test/tiff_old_test.cpp
+++ b/io/test/tiff_old_test.cpp
@@ -16,7 +16,7 @@
 //#define BOOST_TEST_MODULE tiff_old_test_module
 #include <boost/test/unit_test.hpp>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/io/tiff_io_old.hpp>
 
 #include "paths.hpp"

--- a/io/test/tiff_tiled_read_macros.hpp
+++ b/io/test/tiff_tiled_read_macros.hpp
@@ -15,7 +15,7 @@
 #include <boost/preprocessor/repetition/repeat_from_to.hpp>
 
 #include <boost/mpl/vector.hpp>
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/io/tiff_read.hpp>
 
 #include "paths.hpp"

--- a/io/test/tiff_tiled_write_macros.hpp
+++ b/io/test/tiff_tiled_write_macros.hpp
@@ -9,7 +9,7 @@
 #define BOOST_GIL_TIFF_TILED_WRITE_MACROS_HPP
 
 #include <boost/mpl/vector.hpp>
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/io/tiff_all.hpp>
 
 #include "paths.hpp"

--- a/io/test/tiff_write_test.cpp
+++ b/io/test/tiff_write_test.cpp
@@ -8,7 +8,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 
 #include <boost/gil/extension/io/detail/typedefs.hpp>
 #include <boost/gil/extension/io/tiff_all.hpp>

--- a/test/sample_image.cpp
+++ b/test/sample_image.cpp
@@ -8,7 +8,7 @@
     See http://opensource.adobe.com/gil for most recent version including documentation.
 */
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 
 unsigned char halfdome[][3174]={
 {

--- a/toolbox/test/channel_view.cpp
+++ b/toolbox/test/channel_view.cpp
@@ -9,7 +9,7 @@
 
 #include <boost/type_traits/is_same.hpp>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/toolbox/metafunctions/channel_view.hpp>
 
 using namespace boost;

--- a/toolbox/test/get_num_bits.cpp
+++ b/toolbox/test/get_num_bits.cpp
@@ -9,7 +9,7 @@
 
 #include <boost/type_traits/is_same.hpp>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/toolbox/metafunctions/channel_type.hpp>
 #include <boost/gil/extension/toolbox/metafunctions/get_num_bits.hpp>
 

--- a/toolbox/test/get_pixel_type.cpp
+++ b/toolbox/test/get_pixel_type.cpp
@@ -9,7 +9,7 @@
 
 #include <boost/type_traits/is_same.hpp>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/toolbox/metafunctions/get_pixel_type.hpp>
 
 using namespace boost;

--- a/toolbox/test/gray_to_rgba.cpp
+++ b/toolbox/test/gray_to_rgba.cpp
@@ -9,7 +9,7 @@
 
 #include <boost/type_traits/is_same.hpp>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/toolbox/color_converters/gray_to_rgba.hpp>
 
 using namespace boost;

--- a/toolbox/test/hsl_hsv_test.cpp
+++ b/toolbox/test/hsl_hsv_test.cpp
@@ -7,7 +7,7 @@
 
 /// \brief Unit test for hsl and hsv color spaces 
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/toolbox/color_spaces/hsl.hpp>
 #include <boost/gil/extension/toolbox/color_spaces/hsv.hpp>
 

--- a/toolbox/test/indexed_image_test.cpp
+++ b/toolbox/test/indexed_image_test.cpp
@@ -9,7 +9,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/toolbox/image_types/indexed_image.hpp>
 
 

--- a/toolbox/test/is_bit_aligned.cpp
+++ b/toolbox/test/is_bit_aligned.cpp
@@ -9,7 +9,7 @@
 
 #include <boost/type_traits/is_same.hpp>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/toolbox/metafunctions/is_bit_aligned.hpp>
 
 using namespace boost;

--- a/toolbox/test/is_homogeneous.cpp
+++ b/toolbox/test/is_homogeneous.cpp
@@ -7,7 +7,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/toolbox/metafunctions/is_homogeneous.hpp>
 
 using namespace boost;

--- a/toolbox/test/is_similar.cpp
+++ b/toolbox/test/is_similar.cpp
@@ -7,7 +7,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/toolbox/metafunctions/is_similar.hpp>
 
 using namespace boost;

--- a/toolbox/test/lab_test.cpp
+++ b/toolbox/test/lab_test.cpp
@@ -15,7 +15,7 @@
     BOOST_CHECK_CLOSE(a, b, 0.0005f)
 
 #include <iostream>
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/toolbox/color_spaces/lab.hpp>
 
 using namespace boost;

--- a/toolbox/test/pixel_bit_size.cpp
+++ b/toolbox/test/pixel_bit_size.cpp
@@ -7,7 +7,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/toolbox/metafunctions/pixel_bit_size.hpp>
 
 using namespace boost;

--- a/toolbox/test/rgb_to_luminance.cpp
+++ b/toolbox/test/rgb_to_luminance.cpp
@@ -7,7 +7,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/toolbox/color_converters/rgb_to_luminance.hpp>
 
 using namespace boost;

--- a/toolbox/test/subchroma_image.cpp
+++ b/toolbox/test/subchroma_image.cpp
@@ -7,7 +7,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 
 #include <boost/gil/extension/toolbox/color_spaces/ycbcr.hpp>
 #include <boost/gil/extension/toolbox/image_types/subchroma_image.hpp>

--- a/toolbox/test/xyz_test.cpp
+++ b/toolbox/test/xyz_test.cpp
@@ -12,7 +12,7 @@
 #include <iostream>
 #include <limits>
 #include <boost/cstdint.hpp>
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/toolbox/color_spaces/xyz.hpp>
 
 #include <boost/test/unit_test.hpp>


### PR DESCRIPTION
Referencing auto-generated docs unfortunately is a bit messy, as doxygen doesn't provide an official mapping from referenced language artefacts to URLs. So, all of this is a bit fragile. Still, I expect the referenced entities to be stable, and as long as doxygen doesn't change its mapping, this should be fine.