### PR TITLE
Fix some warnings reported by clang

### DIFF
--- a/include/boost/gil/algorithm.hpp
+++ b/include/boost/gil/algorithm.hpp
@@ -127,7 +127,7 @@ private:
 
     // function with distinct name - it can be overloaded by subclasses
     template <typename V1, typename V2>
-    BOOST_FORCEINLINE result_type apply_incompatible(const V1& v1, const V2& v2) const {
+    BOOST_FORCEINLINE result_type apply_incompatible(const V1&, const V2&) const {
         throw std::bad_cast();
     }
 };
@@ -199,7 +199,6 @@ struct copier_n<iterator_from_2d<IL>,O> {
         gil_function_requires<PixelLocatorConcept<IL> >();
         gil_function_requires<MutablePixelIteratorConcept<O> >();
         while (n>0) {
-            typedef typename iterator_from_2d<IL>::difference_type diff_t;
             diff_t l=src.width()-src.x_pos();
             diff_t numToCopy=(n<l ? n:l);
             detail::copy_n(src.x(), numToCopy, dst);

--- a/include/boost/gil/channel_algorithm.hpp
+++ b/include/boost/gil/channel_algorithm.hpp
@@ -333,14 +333,14 @@ template <> struct channel_convert_to_unsigned<bits8s> {
     typedef bits8s argument_type;
     typedef bits8 result_type;
     typedef bits8 type;
-    type operator()(bits8s  val) const { return val+128; }
+    type operator()(bits8s  val) const { return static_cast<bits8>(val+128); }
 };
 
 template <> struct channel_convert_to_unsigned<bits16s> {
     typedef bits16s argument_type;
     typedef bits16 result_type;
     typedef bits16 type;
-    type operator()(bits16s  val) const { return val+32768; }
+    type operator()(bits16s  val) const { return static_cast<bits16>(val+32768); }
 };
 
 template <> struct channel_convert_to_unsigned<bits32s> {
@@ -362,14 +362,14 @@ template <> struct channel_convert_from_unsigned<bits8s> {
     typedef bits8 argument_type;
     typedef bits8s result_type;
     typedef bits8s type;
-    type  operator()(bits8  val) const { return val-128; }
+    type  operator()(bits8  val) const { return static_cast<bits8s>(val-128); }
 };
 
 template <> struct channel_convert_from_unsigned<bits16s> {
     typedef bits16 argument_type;
     typedef bits16s result_type;
     typedef bits16s type;
-    type operator()(bits16 val) const { return val-32768; }
+    type operator()(bits16 val) const { return static_cast<bits16s>(val-32768); }
 };
 
 template <> struct channel_convert_from_unsigned<bits32s> {

--- a/include/boost/gil/gil_concept.hpp
+++ b/include/boost/gil/gil_concept.hpp
@@ -109,7 +109,7 @@ template <typename T> struct transposed_type;
 
 namespace detail {
 template <typename T>
-void initialize_it(T& x) {}
+void initialize_it(T&) {}
 } // namespace detail
 
 template <typename T>
@@ -1127,7 +1127,7 @@ struct PixelDereferenceAdaptorArchetype {
     typedef typename add_reference<P>::type reference;
     typedef reference const_reference;
     static const bool is_mutable=false;
-    P operator()(P x) const { throw; }
+    P operator()(P) const { throw; }
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/include/boost/gil/virtual_locator.hpp
+++ b/include/boost/gil/virtual_locator.hpp
@@ -72,7 +72,7 @@ public:
     y_iterator const& y()                         const { return _p; }
 
     // Returns the y distance between two x_iterators given the difference of their x positions
-    y_coord_t y_distance_to(const this_t& it2, x_coord_t xDiff) const { return (it2.pos()[1-IsTransposed] - pos()[1-IsTransposed])/step()[1-IsTransposed]; }
+    y_coord_t y_distance_to(const this_t& it2, x_coord_t) const { return (it2.pos()[1-IsTransposed] - pos()[1-IsTransposed])/step()[1-IsTransposed]; }
     bool      is_1d_traversable(x_coord_t)        const { return false; }   // is there no gap at the end of each row? I.e. can we use x_iterator to visit every pixel instead of nested loops?
 
     // Methods specific for virtual 2D locator


### PR DESCRIPTION
### Description

Cleans up a bunch of warnings reported for minimalistic

```
#include <boost/gil.hpp>
int main() {}
```

namely:

- unused parameter
- shadowed typedef
- implicit conversion changes signedness:
  int to signed <int>
  int to unsigned <int>

Note, arithmetic op is performed on `int` as higher rank type with result is in range of return type, safe to cast.

### Tasklist

- [ ] Review
- [ ] Adjust for comments
- [ ] All CI builds and checks have passed

### Environment

All relevant information like:

- Compiler version: clang 6

