### PR TITLE
Improve casts in channel_convert_from_unsigned (refines PR #74)

### DIFF
--- a/include/boost/gil/channel_algorithm.hpp
+++ b/include/boost/gil/channel_algorithm.hpp
@@ -333,21 +333,27 @@ template <> struct channel_convert_to_unsigned<bits8s> {
     typedef bits8s argument_type;
     typedef bits8 result_type;
     typedef bits8 type;
-    type operator()(bits8s  val) const { return static_cast<bits8>(val+128); }
+    type operator()(bits8s val) const {
+        return static_cast<bits8>(static_cast<bits32>(val) + 128u);
+    }
 };
 
 template <> struct channel_convert_to_unsigned<bits16s> {
     typedef bits16s argument_type;
     typedef bits16 result_type;
     typedef bits16 type;
-    type operator()(bits16s  val) const { return static_cast<bits16>(val+32768); }
+    type operator()(bits16s val) const {
+        return static_cast<bits16>(static_cast<bits32>(val) + 32768u);
+    }
 };
 
 template <> struct channel_convert_to_unsigned<bits32s> {
     typedef bits32s argument_type;
     typedef bits32 result_type;
     typedef bits32 type;
-    type operator()(bits32s x) const { return static_cast<bits32>(x)+(1u<<31); }
+    type operator()(bits32s val) const {
+        return static_cast<bits32>(val)+(1u<<31);
+    }
 };
 
 
@@ -362,21 +368,27 @@ template <> struct channel_convert_from_unsigned<bits8s> {
     typedef bits8 argument_type;
     typedef bits8s result_type;
     typedef bits8s type;
-    type  operator()(bits8  val) const { return static_cast<bits8s>(val-128); }
+    type  operator()(bits8 val) const {
+        return static_cast<bits8s>(static_cast<bits32s>(val) - 128);
+    }
 };
 
 template <> struct channel_convert_from_unsigned<bits16s> {
     typedef bits16 argument_type;
     typedef bits16s result_type;
     typedef bits16s type;
-    type operator()(bits16 val) const { return static_cast<bits16s>(val-32768); }
+    type operator()(bits16 val) const {
+        return static_cast<bits16s>(static_cast<bits32s>(val) - 32768);
+    }
 };
 
 template <> struct channel_convert_from_unsigned<bits32s> {
     typedef bits32 argument_type;
     typedef bits32s result_type;
     typedef bits32s type;
-    type operator()(bits32 x) const { return static_cast<bits32s>(x-(1u<<31)); }
+    type operator()(bits32 val) const {
+        return static_cast<bits32s>(val - (1u<<31));
+    }
 };
 
 }   // namespace detail


### PR DESCRIPTION
### Description

Add cast to explicitly indicate `val` promotion to at least 32-bit integer.

The arithmetic operations are performed on `int` of higher rank type.
Finally, since the result value is guaranteed to fit range of `8/16-bit` result integer type, it is safe to cast.
This should make it clearer for a reader that subtleties of implicit promotions and conversions have been considered.

### Tasklist

- [ ] Review
- [ ] Adjust for comments
- [ ] All CI builds and checks have passed

### References (eg. other issues, pull requests)

Refines #74 