### PR TITLE
Require C++11 or later

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,6 +7,8 @@
 #
 version: 1.0.{build}-{branch}
 
+# Current Boost.GIL develop branch (future Boost 1.68) requires C++11
+# Since VS2017, MSVC default is /std:c++14, so no explicit switch is required.
 image: Visual Studio 2017
 
 platform: x64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@
 cmake_minimum_required(VERSION 3.10)
 project(Boost.GIL CXX)
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 include(CMakeDependentOption)
 option(GIL_BUILD_TESTS "Build GIL tests" ON)
 option(GIL_BUILD_EXAMPLES "Build GIL examples" OFF) # FIXME: Switch to ON after https://github.com/boostorg/gil/issues/40

--- a/Jamfile
+++ b/Jamfile
@@ -9,13 +9,14 @@
 project boost-gil
     :
     requirements
-        <toolset>intel:<debug-symbols>off
+        # MSVC: Since VS2017, default is -std:c++14, so no explicit switch is required.
         <toolset>msvc:<asynch-exceptions>on
         <toolset>msvc:<cxxflags>"/W4"
         <toolset>msvc:<define>_SCL_SECURE_NO_DEPRECATE <define>_CRT_SECURE_NO_WARNINGS <define>_CRT_NONSTDC_NO_DEPRECATE
-        <toolset>gcc:<cxxflags>"-pedantic -Wstrict-aliasing -fstrict-aliasing -Wextra -Wsign-promo -Wunused-parameter -Wconversion -Wfloat-equal -Wshadow"
-        <toolset>darwin:<cxxflags>"-pedantic -Wstrict-aliasing -fstrict-aliasing -Wextra -Wsign-promo -Wunused-parameter -Wconversion -Wfloat-equal -Wshadow"
-        <toolset>clang:<cxxflags>"-pedantic -Wstrict-aliasing -fstrict-aliasing -Wextra -Wsign-promo -Wunused-parameter -Wsign-conversion -Wconversion -Wfloat-equal -Wshadow"
+        <toolset>intel:<debug-symbols>off
+        <toolset>gcc:<cxxflags>"-std=c++11 -pedantic -Wstrict-aliasing -fstrict-aliasing -Wextra -Wsign-promo -Wunused-parameter -Wconversion -Wfloat-equal -Wshadow"
+        <toolset>darwin:<cxxflags>"-std=c++11 -pedantic -Wstrict-aliasing -fstrict-aliasing -Wextra -Wsign-promo -Wunused-parameter -Wconversion -Wfloat-equal -Wshadow"
+        <toolset>clang:<cxxflags>"-std=c++11 -pedantic -Wstrict-aliasing -fstrict-aliasing -Wextra -Wsign-promo -Wunused-parameter -Wsign-conversion -Wconversion -Wfloat-equal -Wshadow"
     ;
 
 build-project example ;


### PR DESCRIPTION
Add necessary flags to Boost.Build and CMake configurations as well as CI builds.

### Description

Following the agreement about [C++11 requirement in develop branch](https://lists.boost.org/boost-gil/2018/04/0015.php), Boost.GIL now officially requires compiler with support for C++11 or later.

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed
