### PR TITLE
Remove #if _MSC_VER > 1310 as always true since switch to C++11

### DIFF
--- a/include/boost/gil/gil_concept.hpp
+++ b/include/boost/gil/gil_concept.hpp
@@ -80,7 +80,6 @@ typename add_reference<E>::type                           at_c(      detail::hom
 template <int K, typename E, typename L, int N>
 typename add_reference<typename add_const<E>::type>::type at_c(const detail::homogeneous_color_base<E,L,N>& p);
 
-#if !defined(_MSC_VER)  || _MSC_VER > 1310
 template <typename P, typename C, typename L> struct packed_pixel;
 template <int K, typename P, typename C, typename L>
 typename kth_element_reference_type<packed_pixel<P,C,L>, K>::type 
@@ -95,7 +94,6 @@ template <typename B, typename C, typename L, bool M> struct bit_aligned_pixel_r
 template <int K, typename B, typename C, typename L, bool M> inline
 typename kth_element_reference_type<bit_aligned_pixel_reference<B,C,L,M>, K>::type
 at_c(const bit_aligned_pixel_reference<B,C,L,M>& p);
-#endif
 
 // Forward-declare semantic_at_c
 template <int K, typename ColorBase>
@@ -627,12 +625,10 @@ struct ColorBaseConcept {
 
         static const std::size_t num_elements = size<ColorBase>::value;
 
-        typedef typename kth_element_type<ColorBase,num_elements-1>::type TN; 
-        typedef typename kth_element_const_reference_type<ColorBase,num_elements-1>::type CR; 
+        typedef typename kth_element_type<ColorBase,num_elements-1>::type TN;
+        typedef typename kth_element_const_reference_type<ColorBase,num_elements-1>::type CR;
 
-#if !defined(_MSC_VER) || _MSC_VER > 1310
         CR cr=gil::at_c<num_elements-1>(cb);  ignore_unused_variable_warning(cr);
-#endif
 
         // functions that work for every pixel (no need to require them)
         semantic_at_c<0>(cb);
@@ -667,10 +663,8 @@ struct MutableColorBaseConcept {
 
         typedef typename kth_element_reference_type<ColorBase, 0>::type CR; 
 
-#if !defined(_MSC_VER) || _MSC_VER > 1310
         CR r=gil::at_c<0>(cb);
         gil::at_c<0>(cb)=r;
-#endif
     }
 
     ColorBase cb;


### PR DESCRIPTION
### Description

Clean up old MSVC cruft.

### Tasklist

- [x] All CI builds and checks have passed

### References

Follows #77
