### PR TITLE
Replace bitsN[s] aliases with C++11 fixed width integer types

### DIFF
--- a/example/x_gradient.cpp
+++ b/example/x_gradient.cpp
@@ -53,7 +53,7 @@ int main() {
     jpeg_read_image("test.jpg",img);
     
     gray8s_image_t img_out(img.dimensions());
-    fill_pixels(view(img_out),bits8s(0));
+    fill_pixels(view(img_out),int8_t(0));
 
     x_luminosity_gradient(const_view(img), view(img_out));
     jpeg_write_view("out-x_gradient.jpg",color_converted_view<gray8_pixel_t>(const_view(img_out)));

--- a/include/boost/gil/channel_algorithm.hpp
+++ b/include/boost/gil/channel_algorithm.hpp
@@ -32,6 +32,7 @@
 
 #include "gil_config.hpp"
 #include "channel.hpp"
+#include "typedefs.hpp"
 
 namespace boost { namespace gil {
 
@@ -99,12 +100,12 @@ and \p detail::channel_convert_from_unsigned to convert between the signed and u
 
 Example:
 \code
-// bits32f is a floating point channel with range [0.0f ... 1.0f]
-bits32f src_channel = channel_traits<bits32f>::max_value();
+// float32_t is a floating point channel with range [0.0f ... 1.0f]
+float32_t src_channel = channel_traits<float32_t>::max_value();
 assert(src_channel == 1);
 
-// bits8 is 8-bit unsigned integral channel (typedef-ed from unsigned char)
-bits8 dst_channel = channel_convert<bits8>(src_channel);
+// uint8_t is 8-bit unsigned integral channel (typedef-ed from unsigned char)
+uint8_t dst_channel = channel_convert<uint8_t>(src_channel);
 assert(dst_channel == 255);     // max value goes to max value
 \endcode
 */
@@ -206,7 +207,7 @@ struct channel_converter_unsigned_integral_impl<SrcChannelV,DstChannelV,false,tr
 template <typename DstChannelV> 
 struct channel_converter_unsigned_integral_impl<uintmax_t,DstChannelV,false,true> {
     DstChannelV operator()(uintmax_t src) const { 
-        static const uintmax_t div = unsigned_integral_max_value<bits32>::value / unsigned_integral_max_value<DstChannelV>::value;
+        static const uintmax_t div = unsigned_integral_max_value<uint32_t>::value / unsigned_integral_max_value<DstChannelV>::value;
         static const uintmax_t div2 = div/2;
         if (src > unsigned_integral_max_value<uintmax_t>::value - div2)
             return unsigned_integral_max_value<DstChannelV>::value;
@@ -272,50 +273,50 @@ struct channel_converter_unsigned_integral_nondivisible<SrcChannelV,DstChannelV,
 } // namespace detail
 
 /////////////////////////////////////////////////////
-///  bits32f conversion
+///  float32_t conversion
 /////////////////////////////////////////////////////
 
-template <typename DstChannelV> struct channel_converter_unsigned<bits32f,DstChannelV> {
-    typedef bits32f argument_type;
+template <typename DstChannelV> struct channel_converter_unsigned<float32_t,DstChannelV> {
+    typedef float32_t argument_type;
     typedef DstChannelV result_type;
-    DstChannelV operator()(bits32f x) const
+    DstChannelV operator()(float32_t x) const
     {
         typedef typename detail::unsigned_integral_max_value< DstChannelV >::value_type dst_integer_t;
         return DstChannelV( static_cast< dst_integer_t >(x*channel_traits<DstChannelV>::max_value()+0.5f ));
     }
 };
 
-template <typename SrcChannelV> struct channel_converter_unsigned<SrcChannelV,bits32f> {
-    typedef bits32f argument_type;
+template <typename SrcChannelV> struct channel_converter_unsigned<SrcChannelV,float32_t> {
+    typedef float32_t argument_type;
     typedef SrcChannelV result_type;
-    bits32f operator()(SrcChannelV   x) const { return bits32f(x/float(channel_traits<SrcChannelV>::max_value())); }
+    float32_t operator()(SrcChannelV   x) const { return float32_t(x/float(channel_traits<SrcChannelV>::max_value())); }
 };
 
-template <> struct channel_converter_unsigned<bits32f,bits32f> {
-    typedef bits32f argument_type;
-    typedef bits32f result_type;
-    bits32f operator()(bits32f   x) const { return x; }
+template <> struct channel_converter_unsigned<float32_t,float32_t> {
+    typedef float32_t argument_type;
+    typedef float32_t result_type;
+    float32_t operator()(float32_t   x) const { return x; }
 };
 
 
 /// \brief 32 bit <-> float channel conversion
-template <> struct channel_converter_unsigned<bits32,bits32f> {
-    typedef bits32 argument_type;
-    typedef bits32f result_type;
-    bits32f operator()(bits32 x) const {
-        // unfortunately without an explicit check it is possible to get a round-off error. We must ensure that max_value of bits32 matches max_value of bits32f
-        if (x>=channel_traits<bits32>::max_value()) return channel_traits<bits32f>::max_value();
-        return float(x) / float(channel_traits<bits32>::max_value());
+template <> struct channel_converter_unsigned<uint32_t,float32_t> {
+    typedef uint32_t argument_type;
+    typedef float32_t result_type;
+    float32_t operator()(uint32_t x) const {
+        // unfortunately without an explicit check it is possible to get a round-off error. We must ensure that max_value of uint32_t matches max_value of float32_t
+        if (x>=channel_traits<uint32_t>::max_value()) return channel_traits<float32_t>::max_value();
+        return float(x) / float(channel_traits<uint32_t>::max_value());
     }
 };
 /// \brief 32 bit <-> float channel conversion
-template <> struct channel_converter_unsigned<bits32f,bits32> {
-    typedef bits32f argument_type;
-    typedef bits32 result_type;
-    bits32 operator()(bits32f x) const {
-        // unfortunately without an explicit check it is possible to get a round-off error. We must ensure that max_value of bits32 matches max_value of bits32f
-        if (x>=channel_traits<bits32f>::max_value()) return channel_traits<bits32>::max_value();
-        return bits32(x * channel_traits<bits32>::max_value() + 0.5f);
+template <> struct channel_converter_unsigned<float32_t,uint32_t> {
+    typedef float32_t argument_type;
+    typedef uint32_t result_type;
+    uint32_t operator()(float32_t x) const {
+        // unfortunately without an explicit check it is possible to get a round-off error. We must ensure that max_value of uint32_t matches max_value of float32_t
+        if (x>=channel_traits<float32_t>::max_value()) return channel_traits<uint32_t>::max_value();
+        return uint32_t(x * channel_traits<uint32_t>::max_value() + 0.5f);
     }
 };
 
@@ -329,30 +330,30 @@ struct channel_convert_to_unsigned : public detail::identity<ChannelValue> {
     typedef ChannelValue type;
 };
 
-template <> struct channel_convert_to_unsigned<bits8s> {
-    typedef bits8s argument_type;
-    typedef bits8 result_type;
-    typedef bits8 type;
-    type operator()(bits8s val) const {
-        return static_cast<bits8>(static_cast<bits32>(val) + 128u);
+template <> struct channel_convert_to_unsigned<int8_t> {
+    typedef int8_t argument_type;
+    typedef uint8_t result_type;
+    typedef uint8_t type;
+    type operator()(int8_t val) const {
+        return static_cast<uint8_t>(static_cast<uint32_t>(val) + 128u);
     }
 };
 
-template <> struct channel_convert_to_unsigned<bits16s> {
-    typedef bits16s argument_type;
-    typedef bits16 result_type;
-    typedef bits16 type;
-    type operator()(bits16s val) const {
-        return static_cast<bits16>(static_cast<bits32>(val) + 32768u);
+template <> struct channel_convert_to_unsigned<int16_t> {
+    typedef int16_t argument_type;
+    typedef uint16_t result_type;
+    typedef uint16_t type;
+    type operator()(int16_t val) const {
+        return static_cast<uint16_t>(static_cast<uint32_t>(val) + 32768u);
     }
 };
 
-template <> struct channel_convert_to_unsigned<bits32s> {
-    typedef bits32s argument_type;
-    typedef bits32 result_type;
-    typedef bits32 type;
-    type operator()(bits32s val) const {
-        return static_cast<bits32>(val)+(1u<<31);
+template <> struct channel_convert_to_unsigned<int32_t> {
+    typedef int32_t argument_type;
+    typedef uint32_t result_type;
+    typedef uint32_t type;
+    type operator()(int32_t val) const {
+        return static_cast<uint32_t>(val)+(1u<<31);
     }
 };
 
@@ -364,30 +365,30 @@ struct channel_convert_from_unsigned : public detail::identity<ChannelValue> {
     typedef ChannelValue type;
 };
 
-template <> struct channel_convert_from_unsigned<bits8s> {
-    typedef bits8 argument_type;
-    typedef bits8s result_type;
-    typedef bits8s type;
-    type  operator()(bits8 val) const {
-        return static_cast<bits8s>(static_cast<bits32s>(val) - 128);
+template <> struct channel_convert_from_unsigned<int8_t> {
+    typedef uint8_t argument_type;
+    typedef int8_t result_type;
+    typedef int8_t type;
+    type  operator()(uint8_t val) const {
+        return static_cast<int8_t>(static_cast<int32_t>(val) - 128);
     }
 };
 
-template <> struct channel_convert_from_unsigned<bits16s> {
-    typedef bits16 argument_type;
-    typedef bits16s result_type;
-    typedef bits16s type;
-    type operator()(bits16 val) const {
-        return static_cast<bits16s>(static_cast<bits32s>(val) - 32768);
+template <> struct channel_convert_from_unsigned<int16_t> {
+    typedef uint16_t argument_type;
+    typedef int16_t result_type;
+    typedef int16_t type;
+    type operator()(uint16_t val) const {
+        return static_cast<int16_t>(static_cast<int32_t>(val) - 32768);
     }
 };
 
-template <> struct channel_convert_from_unsigned<bits32s> {
-    typedef bits32 argument_type;
-    typedef bits32s result_type;
-    typedef bits32s type;
-    type operator()(bits32 val) const {
-        return static_cast<bits32s>(val - (1u<<31));
+template <> struct channel_convert_from_unsigned<int32_t> {
+    typedef uint32_t argument_type;
+    typedef int32_t result_type;
+    typedef int32_t type;
+    type operator()(uint32_t val) const {
+        return static_cast<int32_t>(val - (1u<<31));
     }
 };
 
@@ -441,9 +442,9 @@ namespace detail {
 
 Example:
 \code
-bits8 x=128;
-bits8 y=128;
-bits8 mul = channel_multiply(x,y);
+uint8_t x=128;
+uint8_t y=128;
+uint8_t mul = channel_multiply(x,y);
 assert(mul == 64);    // 64 = 128 * 128 / 255
 \endcode
 */
@@ -461,27 +462,27 @@ struct channel_multiplier_unsigned {
 };
 
 /// \brief Specialization of channel_multiply for 8-bit unsigned channels
-template<> struct channel_multiplier_unsigned<bits8> {
-    typedef bits8 first_argument_type;
-    typedef bits8 second_argument_type;
-    typedef bits8 result_type;
-    bits8 operator()(bits8 a, bits8 b) const { return bits8(detail::div255(uint32_t(a) * uint32_t(b))); }
+template<> struct channel_multiplier_unsigned<uint8_t> {
+    typedef uint8_t first_argument_type;
+    typedef uint8_t second_argument_type;
+    typedef uint8_t result_type;
+    uint8_t operator()(uint8_t a, uint8_t b) const { return uint8_t(detail::div255(uint32_t(a) * uint32_t(b))); }
 };
 
 /// \brief Specialization of channel_multiply for 16-bit unsigned channels
-template<> struct channel_multiplier_unsigned<bits16> {
-    typedef bits16 first_argument_type;
-    typedef bits16 second_argument_type;
-    typedef bits16 result_type;
-    bits16 operator()(bits16 a, bits16 b) const { return bits16((uint32_t(a) * uint32_t(b))/65535); }
+template<> struct channel_multiplier_unsigned<uint16_t> {
+    typedef uint16_t first_argument_type;
+    typedef uint16_t second_argument_type;
+    typedef uint16_t result_type;
+    uint16_t operator()(uint16_t a, uint16_t b) const { return uint16_t((uint32_t(a) * uint32_t(b))/65535); }
 };
 
 /// \brief Specialization of channel_multiply for float 0..1 channels
-template<> struct channel_multiplier_unsigned<bits32f> {
-    typedef bits32f first_argument_type;
-    typedef bits32f second_argument_type;
-    typedef bits32f result_type;
-    bits32f operator()(bits32f a, bits32f b) const { return a*b; }
+template<> struct channel_multiplier_unsigned<float32_t> {
+    typedef float32_t first_argument_type;
+    typedef float32_t second_argument_type;
+    typedef float32_t result_type;
+    float32_t operator()(float32_t a, float32_t b) const { return a*b; }
 };
 
 /// \brief A function object to multiply two channels. result = a * b / max_value
@@ -512,9 +513,9 @@ inline typename channel_traits<Channel>::value_type channel_multiply(Channel a, 
 
 Example:
 \code
-// bits8 == uint8_t == unsigned char
-bits8 x=255;
-bits8 inv = channel_invert(x);
+// uint8_t == uint8_t == unsigned char
+uint8_t x=255;
+uint8_t inv = channel_invert(x);
 assert(inv == 0);
 \endcode
 */

--- a/include/boost/gil/cmyk.hpp
+++ b/include/boost/gil/cmyk.hpp
@@ -32,7 +32,6 @@
 
 namespace boost { namespace gil {
 
-
 /// \addtogroup ColorNameModel
 /// \{
 

--- a/include/boost/gil/color_base_algorithm.hpp
+++ b/include/boost/gil/color_base_algorithm.hpp
@@ -207,7 +207,7 @@ typename color_element_const_reference_type<ColorBase,Color>::type get_color(con
 Example:
 \code
 typedef element_type<rgb8c_planar_ptr_t>::type element_t;
-BOOST_STATIC_ASSERT((boost::is_same<element_t, const bits8*>::value));
+BOOST_STATIC_ASSERT((boost::is_same<element_t, const uint8_t*>::value));
 \endcode
 */
 /// \brief Specifies the element type of a homogeneous color base
@@ -637,7 +637,7 @@ void increment_elements(ColorBase& cb) {
     static_for_each(cb, increment());
 }
 
-bits8 red[2], green[2], blue[2];
+uint8_t red[2], green[2], blue[2];
 rgb8c_planar_ptr_t p1(red,green,blue);
 rgb8c_planar_ptr_t p2=p1;
 increment_elements(p1);

--- a/include/boost/gil/color_convert.hpp
+++ b/include/boost/gil/color_convert.hpp
@@ -73,10 +73,10 @@ namespace detail {
 template <typename RedChannel, typename GreenChannel, typename BlueChannel, typename GrayChannelValue>
 struct rgb_to_luminance_fn {
     GrayChannelValue operator()(const RedChannel& red, const GreenChannel& green, const BlueChannel& blue) const {
-        return channel_convert<GrayChannelValue>( bits32f(
-            channel_convert<bits32f>(red  )*0.30f + 
-            channel_convert<bits32f>(green)*0.59f + 
-            channel_convert<bits32f>(blue )*0.11f) );
+        return channel_convert<GrayChannelValue>(float32_t(
+            channel_convert<float32_t>(red  )*0.30f +
+            channel_convert<float32_t>(green)*0.59f +
+            channel_convert<float32_t>(blue )*0.11f) );
     }
 };
 

--- a/include/boost/gil/extension/dynamic_image/reduce.hpp
+++ b/include/boost/gil/extension/dynamic_image/reduce.hpp
@@ -699,11 +699,11 @@ namespace detail {
     struct any_type_get_num_channels;
     template <typename View> struct reduce_view_basic<any_type_get_num_channels,View,true> { 
         typedef typename View::color_space_t::base Cs;
-        typedef typename view_type<bits8,typename reduce_color_space<Cs>::type>::type type; 
+        typedef typename view_type<uint8_t,typename reduce_color_space<Cs>::type>::type type;
     };
     template <typename Img>  struct reduce_image_basic<any_type_get_num_channels,Img,true> { 
         typedef typename Img::color_space_t::base Cs;
-        typedef typename image_type<bits8,typename reduce_color_space<Cs>::type>::type type; 
+        typedef typename image_type<uint8_t,typename reduce_color_space<Cs>::type>::type type;
     };
 
     ////////////////////////////////////////////////////////

--- a/include/boost/gil/extension/io/bmp/detail/supported_types.hpp
+++ b/include/boost/gil/extension/io/bmp/detail/supported_types.hpp
@@ -70,7 +70,7 @@ struct bmp_read_support< packed_dynamic_channel_reference< BitField
 
 
 template<>
-struct bmp_read_support< bits8
+struct bmp_read_support<uint8_t
                        , gray_t
                        > : read_support_true
 {
@@ -80,7 +80,7 @@ struct bmp_read_support< bits8
 
 
 template<>
-struct bmp_read_support< bits8
+struct bmp_read_support<uint8_t
                        , rgb_t
                        > : read_support_true
 {
@@ -89,7 +89,7 @@ struct bmp_read_support< bits8
 
 
 template<>
-struct bmp_read_support< bits8
+struct bmp_read_support<uint8_t
                        , rgba_t
                        > : read_support_true
 {
@@ -106,12 +106,12 @@ struct bmp_write_support : write_support_false
 {};
 
 template<>
-struct bmp_write_support< bits8
+struct bmp_write_support<uint8_t
                         , rgb_t
                         > : write_support_true {};
 
 template<>
-struct bmp_write_support< bits8
+struct bmp_write_support<uint8_t
                         , rgba_t
                         > : write_support_true {};
 

--- a/include/boost/gil/extension/io/jpeg/detail/supported_types.hpp
+++ b/include/boost/gil/extension/io/jpeg/detail/supported_types.hpp
@@ -42,19 +42,19 @@ struct jpeg_read_support : read_support_false
                          , jpeg_rw_support_base< JCS_UNKNOWN > {};
 
 template<>
-struct jpeg_read_support< bits8
+struct jpeg_read_support<uint8_t
                         , rgb_t
                         > : read_support_true
                           , jpeg_rw_support_base< JCS_RGB > {};
 
 template<>
-struct jpeg_read_support< bits8
+struct jpeg_read_support<uint8_t
                         , cmyk_t
                         > : read_support_true
                           , jpeg_rw_support_base< JCS_CMYK > {};
 
 template<>
-struct jpeg_read_support< bits8
+struct jpeg_read_support<uint8_t
                         , gray_t
                         > : read_support_true
                           , jpeg_rw_support_base< JCS_GRAYSCALE > {};
@@ -68,19 +68,19 @@ struct jpeg_write_support : write_support_false
                           , jpeg_rw_support_base< JCS_UNKNOWN > {};
 
 template<>
-struct jpeg_write_support< bits8
+struct jpeg_write_support<uint8_t
                          , gray_t
                          > : write_support_true
                           , jpeg_rw_support_base< JCS_GRAYSCALE > {};
 
 template<>
-struct jpeg_write_support< bits8
+struct jpeg_write_support<uint8_t
                          , rgb_t
                          > : write_support_true
                           , jpeg_rw_support_base< JCS_RGB > {};
 
 template<>
-struct jpeg_write_support< bits8
+struct jpeg_write_support<uint8_t
                          , cmyk_t
                          > : write_support_true
                           , jpeg_rw_support_base< JCS_CMYK > {};

--- a/include/boost/gil/extension/io/png/detail/supported_types.hpp
+++ b/include/boost/gil/extension/io/png/detail/supported_types.hpp
@@ -85,7 +85,7 @@ struct png_read_support< packed_dynamic_channel_reference< BitField
                                               > {};
 
 template<>
-struct png_read_support< bits8
+struct png_read_support<uint8_t
                        , gray_t
                        > : read_support_true
                          , png_rw_support_base< 8
@@ -94,7 +94,7 @@ struct png_read_support< bits8
 
 #ifdef BOOST_GIL_IO_ENABLE_GRAY_ALPHA
 template<>
-struct png_read_support< bits8
+struct png_read_support<uint8_t
                        , gray_alpha_t
                        > : read_support_true
                          , png_rw_support_base< 8
@@ -103,7 +103,7 @@ struct png_read_support< bits8
 #endif // BOOST_GIL_IO_ENABLE_GRAY_ALPHA
 
 template<>
-struct png_read_support< bits8
+struct png_read_support<uint8_t
                        , rgb_t
                        > : read_support_true
                          , png_rw_support_base< 8
@@ -111,7 +111,7 @@ struct png_read_support< bits8
                                               > {};
 
 template<>
-struct png_read_support< bits8
+struct png_read_support<uint8_t
                        , rgba_t
                        > : read_support_true
                          , png_rw_support_base< 8
@@ -119,7 +119,7 @@ struct png_read_support< bits8
                                               > {};
 
 template<>
-struct png_read_support< bits16
+struct png_read_support<uint16_t
                        , gray_t
                        > : read_support_true
                          , png_rw_support_base< 16
@@ -127,7 +127,7 @@ struct png_read_support< bits16
                                               > {};
 
 template<>
-struct png_read_support< bits16
+struct png_read_support<uint16_t
                        , rgb_t
                        > : read_support_true
                          , png_rw_support_base< 16
@@ -135,7 +135,7 @@ struct png_read_support< bits16
                                               > {};
 
 template<>
-struct png_read_support< bits16
+struct png_read_support<uint16_t
                        , rgba_t
                        > : read_support_true
                          , png_rw_support_base< 16
@@ -144,7 +144,7 @@ struct png_read_support< bits16
 
 #ifdef BOOST_GIL_IO_ENABLE_GRAY_ALPHA
 template<>
-struct png_read_support< bits16
+struct png_read_support<uint16_t
                        , gray_alpha_t
                        > : read_support_true
                          , png_rw_support_base< 16
@@ -247,7 +247,7 @@ struct png_write_support< packed_dynamic_channel_reference< BitField
 {};
 
 template<>
-struct png_write_support< bits8
+struct png_write_support<uint8_t
                         , gray_t
                         > : write_support_true
                           , png_rw_support_base< 8
@@ -257,7 +257,7 @@ struct png_write_support< bits8
 
 #ifdef BOOST_GIL_IO_ENABLE_GRAY_ALPHA
 template<>
-struct png_write_support< bits8
+struct png_write_support<uint8_t
                         , gray_alpha_t
                         > : write_support_true
                           , png_rw_support_base< 8
@@ -267,7 +267,7 @@ struct png_write_support< bits8
 #endif // BOOST_GIL_IO_ENABLE_GRAY_ALPHA
 
 template<>
-struct png_write_support< bits8
+struct png_write_support<uint8_t
                         , rgb_t
                         > : write_support_true
                           , png_rw_support_base< 8
@@ -276,7 +276,7 @@ struct png_write_support< bits8
 {};
 
 template<>
-struct png_write_support< bits8
+struct png_write_support<uint8_t
                         , rgba_t
                         > : write_support_true
                           , png_rw_support_base< 8
@@ -285,7 +285,7 @@ struct png_write_support< bits8
 {};
 
 template<>
-struct png_write_support< bits16
+struct png_write_support<uint16_t
                         , gray_t
                         > : write_support_true
                           , png_rw_support_base< 16
@@ -294,7 +294,7 @@ struct png_write_support< bits16
 {};
 
 template<>
-struct png_write_support< bits16
+struct png_write_support<uint16_t
                         , rgb_t
                         > : write_support_true
                           , png_rw_support_base< 16
@@ -303,7 +303,7 @@ struct png_write_support< bits16
 {};
 
 template<>
-struct png_write_support< bits16
+struct png_write_support<uint16_t
                         , rgba_t
                         > : write_support_true
                           , png_rw_support_base< 16
@@ -313,7 +313,7 @@ struct png_write_support< bits16
 
 #ifdef BOOST_GIL_IO_ENABLE_GRAY_ALPHA
 template<>
-struct png_write_support< bits16
+struct png_write_support<uint16_t
                         , gray_alpha_t
                         > : write_support_true
                           , png_rw_support_base< 16

--- a/include/boost/gil/extension/io/pnm/detail/supported_types.hpp
+++ b/include/boost/gil/extension/io/pnm/detail/supported_types.hpp
@@ -58,7 +58,7 @@ struct pnm_read_support< packed_dynamic_channel_reference< BitField
                                               > {};
 
 template<>
-struct pnm_read_support< bits8
+struct pnm_read_support<uint8_t
                        , gray_t
                        > : read_support_true
                          , pnm_rw_support_base< pnm_image_type::gray_asc_t::value
@@ -67,7 +67,7 @@ struct pnm_read_support< bits8
 
 
 template<>
-struct pnm_read_support< bits8
+struct pnm_read_support<uint8_t
                        , rgb_t
                        > : read_support_true
                          , pnm_rw_support_base< pnm_image_type::color_asc_t::value
@@ -95,7 +95,7 @@ struct pnm_write_support< packed_dynamic_channel_reference< BitField
 
 
 template<>
-struct pnm_write_support< bits8
+struct pnm_write_support<uint8_t
                         , gray_t
                         > : write_support_true
                           , pnm_rw_support_base< pnm_image_type::gray_asc_t::value
@@ -104,7 +104,7 @@ struct pnm_write_support< bits8
 
 
 template<>
-struct pnm_write_support< bits8
+struct pnm_write_support<uint8_t
                         , rgb_t
                         > : write_support_true
                           , pnm_rw_support_base< pnm_image_type::color_asc_t::value

--- a/include/boost/gil/extension/io/raw/detail/supported_types.hpp
+++ b/include/boost/gil/extension/io/raw/detail/supported_types.hpp
@@ -37,22 +37,22 @@ template< typename Channel
 struct raw_read_support : read_support_false {};
 
 template<>
-struct raw_read_support< bits8
+struct raw_read_support<uint8_t
                        , gray_t
                        > : read_support_true {};
 
 template<>
-struct raw_read_support< bits16
+struct raw_read_support<uint16_t
                        , gray_t
                        > : read_support_true {};
 
 template<>
-struct raw_read_support< bits8
+struct raw_read_support<uint8_t
                        , rgb_t
                        > : read_support_true {};
 
 template<>
-struct raw_read_support< bits16
+struct raw_read_support<uint16_t
                        , rgb_t
                        > : read_support_true {};
 

--- a/include/boost/gil/extension/io/targa/detail/supported_types.hpp
+++ b/include/boost/gil/extension/io/targa/detail/supported_types.hpp
@@ -40,7 +40,7 @@ struct targa_read_support : read_support_false
 };
 
 template<>
-struct targa_read_support< bits8
+struct targa_read_support<uint8_t
                          , rgb_t
                          > : read_support_true
 {
@@ -49,7 +49,7 @@ struct targa_read_support< bits8
 
 
 template<>
-struct targa_read_support< bits8
+struct targa_read_support<uint8_t
                          , rgba_t
                          > : read_support_true
 {
@@ -66,12 +66,12 @@ struct targa_write_support : write_support_false
 {};
 
 template<>
-struct targa_write_support< bits8
+struct targa_write_support<uint8_t
                           , rgb_t
                           > : write_support_true {};
 
 template<>
-struct targa_write_support< bits8
+struct targa_write_support<uint8_t
                           , rgba_t
                           > : write_support_true {};
 

--- a/include/boost/gil/extension/io/tiff/detail/device.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/device.hpp
@@ -466,14 +466,14 @@ struct is_adaptable_output_device< FormatTag
 
 
 template < typename Channel > struct sample_format : public mpl::int_<SAMPLEFORMAT_UINT> {};
-template<> struct sample_format<bits8>   : public mpl::int_<SAMPLEFORMAT_UINT> {};
-template<> struct sample_format<bits16>  : public mpl::int_<SAMPLEFORMAT_UINT> {};
-template<> struct sample_format<bits32>  : public mpl::int_<SAMPLEFORMAT_UINT> {};
-template<> struct sample_format<bits32f> : public mpl::int_<SAMPLEFORMAT_IEEEFP> {};
+template<> struct sample_format<uint8_t>   : public mpl::int_<SAMPLEFORMAT_UINT> {};
+template<> struct sample_format<uint16_t>  : public mpl::int_<SAMPLEFORMAT_UINT> {};
+template<> struct sample_format<uint32_t>  : public mpl::int_<SAMPLEFORMAT_UINT> {};
+template<> struct sample_format<float32_t> : public mpl::int_<SAMPLEFORMAT_IEEEFP> {};
 template<> struct sample_format<double>  : public mpl::int_<SAMPLEFORMAT_IEEEFP> {};
-template<> struct sample_format<bits8s>  : public mpl::int_<SAMPLEFORMAT_INT> {};
-template<> struct sample_format<bits16s> : public mpl::int_<SAMPLEFORMAT_INT> {};
-template<> struct sample_format<bits32s> : public mpl::int_<SAMPLEFORMAT_INT> {};
+template<> struct sample_format<int8_t>  : public mpl::int_<SAMPLEFORMAT_INT> {};
+template<> struct sample_format<int16_t> : public mpl::int_<SAMPLEFORMAT_INT> {};
+template<> struct sample_format<int32_t> : public mpl::int_<SAMPLEFORMAT_INT> {};
 
 template <typename Channel> struct photometric_interpretation {};
 template<> struct photometric_interpretation< gray_t > : public mpl::int_< PHOTOMETRIC_MINISBLACK > {};

--- a/include/boost/gil/extension/io/tiff/detail/read.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/read.hpp
@@ -349,7 +349,7 @@ private:
                                                    , red
                                                    , green
                                                    , blue
-                                                   , sizeof( bits16 ) * num_colors );
+                                                   , sizeof(uint16_t) * num_colors );
 
       for( typename rgb16_view_t::y_coord_t y = 0; y < dst_view.height(); ++y )
       {
@@ -360,7 +360,7 @@ private:
 
          for( ; it != end; ++it, ++indices_it )
          {
-            bits16 i = gil::at_c<0>( *indices_it );
+            uint16_t i = gil::at_c<0>( *indices_it );
 
             *it = palette[i];
          }

--- a/include/boost/gil/extension/io/tiff/detail/scanline_read.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/scanline_read.hpp
@@ -134,7 +134,7 @@ private:
                                               , this->_red
                                               , this->_green
                                               , this->_blue
-                                              , sizeof( bits16 ) * num_colors
+                                              , sizeof(uint16_t) * num_colors
                                               );
 
                     _read_function = boost::mem_fn( &this_t::read_1_bit_index_image );
@@ -153,7 +153,7 @@ private:
                                               , this->_red
                                               , this->_green
                                               , this->_blue
-                                              , sizeof( bits16 ) * num_colors
+                                              , sizeof(uint16_t) * num_colors
                                               );
 
                     _read_function = boost::mem_fn( &this_t::read_2_bits_index_image );
@@ -171,7 +171,7 @@ private:
                                               , this->_red
                                               , this->_green
                                               , this->_blue
-                                              , sizeof( bits16 ) * num_colors
+                                              , sizeof(uint16_t) * num_colors
                                               );
 
                     _read_function = boost::mem_fn( &this_t::read_4_bits_index_image );
@@ -190,7 +190,7 @@ private:
                                               , this->_red
                                               , this->_green
                                               , this->_blue
-                                              , sizeof( bits16 ) * num_colors
+                                              , sizeof(uint16_t) * num_colors
                                               );
 
                     _read_function = boost::mem_fn( &this_t::read_8_bits_index_image );
@@ -209,7 +209,7 @@ private:
                                               , this->_red
                                               , this->_green
                                               , this->_blue
-                                              , sizeof( bits16 ) * num_colors
+                                              , sizeof(uint16_t) * num_colors
                                               );
 
                     _read_function = boost::mem_fn( &this_t::read_16_bits_index_image );
@@ -228,7 +228,7 @@ private:
                                               , this->_red
                                               , this->_green
                                               , this->_blue
-                                              , sizeof( bits16 ) * num_colors
+                                              , sizeof(uint16_t) * num_colors
                                               );
 
                     _read_function = boost::mem_fn( &this_t::read_24_bits_index_image );
@@ -247,7 +247,7 @@ private:
                                               , this->_red
                                               , this->_green
                                               , this->_blue
-                                              , sizeof( bits16 ) * num_colors
+                                              , sizeof(uint16_t) * num_colors
                                               );
 
                     _read_function = boost::mem_fn( &this_t::read_32_bits_index_image );
@@ -402,7 +402,7 @@ private:
            ; ++i, src_it++, dst_it++
            )
         {
-            boost::uint16_t c = static_cast< boost::uint16_t >( get_color( *src_it, gray_color_t() ));
+            auto const c = static_cast<std::uint16_t>(get_color(*src_it, gray_color_t()));
             *dst_it = this->_palette[c];
         }
     }

--- a/include/boost/gil/extension/toolbox/color_spaces/cmyka.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/cmyka.hpp
@@ -28,19 +28,18 @@
 namespace boost{ namespace gil {
 
 /// \ingroup ColorSpaceModel
-typedef mpl::vector5<cyan_t,magenta_t,yellow_t,black_t,alpha_t> cmyka_t;
+using cmyka_t = mpl::vector5<cyan_t, magenta_t, yellow_t, black_t, alpha_t>;
 
 /// \ingroup LayoutModel
-typedef layout<cmyka_t> cmyka_layout_t;
+using cmyka_layout_t = layout<cmyka_t>;
 
-
-GIL_DEFINE_ALL_TYPEDEFS(8,  cmyka)
-GIL_DEFINE_ALL_TYPEDEFS(8s, cmyka)
-GIL_DEFINE_ALL_TYPEDEFS(16, cmyka)
-GIL_DEFINE_ALL_TYPEDEFS(16s,cmyka)
-GIL_DEFINE_ALL_TYPEDEFS(32 ,cmyka)
-GIL_DEFINE_ALL_TYPEDEFS(32s,cmyka)
-GIL_DEFINE_ALL_TYPEDEFS(32f,cmyka)
+GIL_DEFINE_ALL_TYPEDEFS(8, uint8_t, cmyka)
+GIL_DEFINE_ALL_TYPEDEFS(8s, int8_t, cmyka)
+GIL_DEFINE_ALL_TYPEDEFS(16, uint16_t, cmyka)
+GIL_DEFINE_ALL_TYPEDEFS(16s, int16_t, cmyka)
+GIL_DEFINE_ALL_TYPEDEFS(32, uint32_t, cmyka)
+GIL_DEFINE_ALL_TYPEDEFS(32s, int32_t, cmyka)
+GIL_DEFINE_ALL_TYPEDEFS(32f, float32_t, cmyka)
 
 ///// \ingroup ColorConvert
 ///// \brief Converting CMYKA to any pixel type. Note: Supports homogeneous pixels only.

--- a/include/boost/gil/extension/toolbox/color_spaces/gray_alpha.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/gray_alpha.hpp
@@ -33,21 +33,21 @@ typedef mpl::vector2<gray_color_t,alpha_t> gray_alpha_t;
 typedef layout<gray_alpha_t> gray_alpha_layout_t;
 typedef layout<gray_alpha_layout_t, mpl::vector2_c<int,1,0> > alpha_gray_layout_t;
 
-GIL_DEFINE_BASE_TYPEDEFS(8,  alpha_gray)
-GIL_DEFINE_BASE_TYPEDEFS(8s, alpha_gray)
-GIL_DEFINE_BASE_TYPEDEFS(16, alpha_gray)
-GIL_DEFINE_BASE_TYPEDEFS(16s,alpha_gray)
-GIL_DEFINE_BASE_TYPEDEFS(32 ,alpha_gray)
-GIL_DEFINE_BASE_TYPEDEFS(32s,alpha_gray)
-GIL_DEFINE_BASE_TYPEDEFS(32f,alpha_gray)
+GIL_DEFINE_BASE_TYPEDEFS(8, uint8_t, alpha_gray)
+GIL_DEFINE_BASE_TYPEDEFS(8s, int8_t, alpha_gray)
+GIL_DEFINE_BASE_TYPEDEFS(16, uint16_t, alpha_gray)
+GIL_DEFINE_BASE_TYPEDEFS(16s, int16_t, alpha_gray)
+GIL_DEFINE_BASE_TYPEDEFS(32, uint32_t, alpha_gray)
+GIL_DEFINE_BASE_TYPEDEFS(32s, int32_t, alpha_gray)
+GIL_DEFINE_BASE_TYPEDEFS(32f, float32_t, alpha_gray)
 
-GIL_DEFINE_ALL_TYPEDEFS(8,  gray_alpha)
-GIL_DEFINE_ALL_TYPEDEFS(8s, gray_alpha)
-GIL_DEFINE_ALL_TYPEDEFS(16, gray_alpha)
-GIL_DEFINE_ALL_TYPEDEFS(16s,gray_alpha)
-GIL_DEFINE_ALL_TYPEDEFS(32 ,gray_alpha)
-GIL_DEFINE_ALL_TYPEDEFS(32s,gray_alpha)
-GIL_DEFINE_ALL_TYPEDEFS(32f,gray_alpha)
+GIL_DEFINE_ALL_TYPEDEFS(8, uint8_t, gray_alpha)
+GIL_DEFINE_ALL_TYPEDEFS(8s, int8_t, gray_alpha)
+GIL_DEFINE_ALL_TYPEDEFS(16, uint16_t, gray_alpha)
+GIL_DEFINE_ALL_TYPEDEFS(16s, int16_t, gray_alpha)
+GIL_DEFINE_ALL_TYPEDEFS(32, uint32_t, gray_alpha)
+GIL_DEFINE_ALL_TYPEDEFS(32s, int32_t, gray_alpha)
+GIL_DEFINE_ALL_TYPEDEFS(32f, float32_t, gray_alpha)
 
 /// \ingroup ColorConvert
 /// \brief Gray Alpha to RGBA

--- a/include/boost/gil/extension/toolbox/color_spaces/hsl.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/hsl.hpp
@@ -19,6 +19,8 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////////////
 
+#include <boost/gil/typedefs.hpp>
+
 namespace boost{ namespace gil {
 
 /// \addtogroup ColorNameModel
@@ -44,7 +46,7 @@ typedef mpl::vector3< hsl_color_space::hue_t
 typedef layout<hsl_t> hsl_layout_t;
 
 
-GIL_DEFINE_ALL_TYPEDEFS( 32f, hsl );
+GIL_DEFINE_ALL_TYPEDEFS(32f, float32_t, hsl);
 
 /// \ingroup ColorConvert
 /// \brief RGB to HSL
@@ -56,15 +58,15 @@ struct default_color_converter_impl< rgb_t, hsl_t >
    {
       using namespace hsl_color_space;
 
-      // only bits32f for hsl is supported
-      bits32f temp_red   = channel_convert<bits32f>( get_color( src, red_t()   ));
-      bits32f temp_green = channel_convert<bits32f>( get_color( src, green_t() ));
-      bits32f temp_blue  = channel_convert<bits32f>( get_color( src, blue_t()  ));
+      // only float32_t for hsl is supported
+      float32_t temp_red   = channel_convert<float32_t>( get_color( src, red_t()   ));
+      float32_t temp_green = channel_convert<float32_t>( get_color( src, green_t() ));
+      float32_t temp_blue  = channel_convert<float32_t>( get_color( src, blue_t()  ));
 
-      bits32f hue, saturation, lightness;
+      float32_t hue, saturation, lightness;
 
-      bits32f min_color = (std::min)( temp_red, (std::min)( temp_green, temp_blue ));
-      bits32f max_color = (std::max)( temp_red, (std::max)( temp_green, temp_blue ));
+      float32_t min_color = (std::min)( temp_red, (std::min)( temp_green, temp_blue ));
+      float32_t max_color = (std::max)( temp_red, (std::max)( temp_green, temp_blue ));
 
       if( std::abs( min_color - max_color ) < 0.001 )
       {
@@ -79,7 +81,7 @@ struct default_color_converter_impl< rgb_t, hsl_t >
       else
       {
 
-         bits32f diff = max_color - min_color;
+         float32_t diff = max_color - min_color;
 
          // lightness calculation
 
@@ -148,7 +150,7 @@ struct default_color_converter_impl<hsl_t,rgb_t>
    {
       using namespace hsl_color_space;
 
-      bits32f red, green, blue;
+      float32_t red, green, blue;
 
       if( std::abs( get_color( src, saturation_t() )) < 0.0001  )
       {

--- a/include/boost/gil/extension/toolbox/color_spaces/hsv.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/hsv.hpp
@@ -21,6 +21,8 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 
+#include <boost/gil/typedefs.hpp>
+
 namespace boost{ namespace gil {
 
 /// \addtogroup ColorNameModel
@@ -45,7 +47,7 @@ typedef mpl::vector3< hsv_color_space::hue_t
 /// \ingroup LayoutModel
 typedef layout<hsv_t> hsv_layout_t;
 
-GIL_DEFINE_ALL_TYPEDEFS( 32f, hsv )
+GIL_DEFINE_ALL_TYPEDEFS(32f, float32_t, hsv)
 
 /// \ingroup ColorConvert
 /// \brief RGB to HSV
@@ -57,19 +59,19 @@ struct default_color_converter_impl< rgb_t, hsv_t >
    {
       using namespace hsv_color_space;
 
-      // only bits32f for hsv is supported
-      bits32f temp_red   = channel_convert<bits32f>( get_color( src, red_t()   ));
-      bits32f temp_green = channel_convert<bits32f>( get_color( src, green_t() ));
-      bits32f temp_blue  = channel_convert<bits32f>( get_color( src, blue_t()  ));
+      // only float32_t for hsv is supported
+      float32_t temp_red   = channel_convert<float32_t>( get_color( src, red_t()   ));
+      float32_t temp_green = channel_convert<float32_t>( get_color( src, green_t() ));
+      float32_t temp_blue  = channel_convert<float32_t>( get_color( src, blue_t()  ));
 
-      bits32f hue, saturation, value;
+      float32_t hue, saturation, value;
 
-      bits32f min_color = (std::min)( temp_red, (std::min)( temp_green, temp_blue ));
-      bits32f max_color = (std::max)( temp_red, (std::max)( temp_green, temp_blue ));
+      float32_t min_color = (std::min)( temp_red, (std::min)( temp_green, temp_blue ));
+      float32_t max_color = (std::max)( temp_red, (std::max)( temp_green, temp_blue ));
 
       value = max_color;
 
-      bits32f diff = max_color - min_color;
+      float32_t diff = max_color - min_color;
 
       if( max_color < 0.0001f )
       {  
@@ -88,7 +90,7 @@ struct default_color_converter_impl< rgb_t, hsv_t >
       }   
       else
       { 
-         if( (std::abs)( boost::numeric_cast<bits32f>(temp_red - max_color) ) < 0.0001f )
+         if( (std::abs)( boost::numeric_cast<float32_t>(temp_red - max_color) ) < 0.0001f )
          {
             hue = ( temp_green - temp_blue )
                 / diff;
@@ -129,7 +131,7 @@ struct default_color_converter_impl<hsv_t,rgb_t>
    {
       using namespace hsv_color_space;
 
-      bits32f red, green, blue;
+      float32_t red, green, blue;
 
       //If saturation is 0, the color is a shade of gray
       if( abs( get_color( src, saturation_t() )) < 0.0001f  )
@@ -141,14 +143,14 @@ struct default_color_converter_impl<hsv_t,rgb_t>
       }
       else
       {
-         bits32f frac, p, q, t, h;
-         bits32 i;
+         float32_t frac, p, q, t, h;
+         uint32_t i;
 
          //to bring hue to a number between 0 and 6, better for the calculations
          h = get_color( src, hue_t() );
          h *= 6.f;
 
-         i = static_cast<bits32>( floor( h ));
+         i = static_cast<uint32_t>(floor(h));
 
          frac = h - i;
 

--- a/include/boost/gil/extension/toolbox/color_spaces/lab.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/lab.hpp
@@ -19,7 +19,7 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////////////
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil/gil_all.hpp> // FIXME: Include what you use, not everything, even in extensions!
 #include <boost/gil/extension/toolbox/color_spaces/xyz.hpp>
 
 namespace boost{ namespace gil {
@@ -46,7 +46,7 @@ typedef mpl::vector3< lab_color_space::luminance_t
 /// \ingroup LayoutModel
 typedef layout<lab_t> lab_layout_t;
 
-GIL_DEFINE_ALL_TYPEDEFS( 32f, lab );
+GIL_DEFINE_ALL_TYPEDEFS(32f, float32_t, lab)
 
 /// \ingroup ColorConvert
 /// \brief LAB to XYZ
@@ -59,7 +59,7 @@ struct default_color_converter_impl< lab_t, xyz_t >
         using namespace lab_color_space;
         using namespace xyz_color_space;
 
-        bits32f p = ((get_color(src, luminance_t()) + 16.f)/116.f);
+        float32_t p = ((get_color(src, luminance_t()) + 16.f)/116.f);
 
         get_color(dst, y_t()) =
                 1.f * powf(p, 3.f);
@@ -84,7 +84,7 @@ struct default_color_converter_impl< xyz_t, lab_t >
 private:
     /// \ref http://www.brucelindbloom.com/index.html?Eqn_XYZ_to_Lab.html
     BOOST_FORCEINLINE
-    bits32f forward_companding(bits32f value) const
+    float32_t forward_companding(float32_t value) const
     {
         if (value > 216.f/24389.f)
         {
@@ -102,26 +102,26 @@ public:
     {
         using namespace lab_color_space;
 
-        bits32f f_y =
+        float32_t f_y =
                 forward_companding(
-                    channel_convert<bits32f>(
+                    channel_convert<float32_t>(
                         get_color(src, xyz_color_space::y_t())
                         )
                     // / 1.f
                     );
 
-        bits32f f_x =
+        float32_t f_x =
                 forward_companding(
-                    channel_convert<bits32f>(
+                    channel_convert<float32_t>(
                         get_color(src, xyz_color_space::x_t())
                         )
                     * (1.f / 0.95047f)  // if the compiler is smart, it should
                                         // precalculate this, no?
                     );
 
-        bits32f f_z =
+        float32_t f_z =
                 forward_companding(
-                    channel_convert<bits32f>(
+                    channel_convert<float32_t>(
                         get_color(src, xyz_color_space::z_t())
                         )
                     * (1.f / 1.08883f)  // if the compiler is smart, it should

--- a/include/boost/gil/extension/toolbox/color_spaces/xyz.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/xyz.hpp
@@ -19,6 +19,8 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////////////
 
+#include <boost/gil/typedefs.hpp>
+
 namespace boost{ namespace gil {
 
 /// \addtogroup ColorNameModel
@@ -43,7 +45,7 @@ typedef mpl::vector3< xyz_color_space::x_t
 /// \ingroup LayoutModel
 typedef layout<xyz_t> xyz_layout_t;
 
-GIL_DEFINE_ALL_TYPEDEFS( 32f, xyz );
+GIL_DEFINE_ALL_TYPEDEFS(32f, float32_t, xyz);
 
 /// \ingroup ColorConvert
 /// \brief RGB to XYZ
@@ -54,7 +56,7 @@ struct default_color_converter_impl< rgb_t, xyz_t >
 {
 private:
     BOOST_FORCEINLINE
-    bits32f inverse_companding(bits32f sample) const
+    float32_t inverse_companding(float32_t sample) const
     {
         if ( sample > 0.04045f )
         {
@@ -72,21 +74,15 @@ public:
     {
         using namespace xyz_color_space;
 
-        bits32f red(
-                    inverse_companding(
-                        channel_convert<bits32f>( get_color( src, red_t() ))
-                        )
-                    );
-        bits32f green(
-                    inverse_companding(
-                        channel_convert<bits32f>( get_color( src, green_t() ))
-                        )
-                    );
-        bits32f blue(
-                    inverse_companding(
-                        channel_convert<bits32f>( get_color( src, blue_t() ))
-                        )
-                    );
+        float32_t red(
+            inverse_companding(
+                channel_convert<float32_t>(get_color(src, red_t()))));
+        float32_t green(
+            inverse_companding(
+                channel_convert<float32_t>(get_color(src, green_t()))));
+        float32_t blue(
+            inverse_companding(
+                channel_convert<float32_t>(get_color(src, blue_t()))));
 
         get_color( dst, x_t() ) =
                 red * 0.4124564f +
@@ -110,7 +106,7 @@ struct default_color_converter_impl<xyz_t,rgb_t>
 {
 private:
     BOOST_FORCEINLINE
-    bits32f companding(bits32f sample) const
+    float32_t companding(float32_t sample) const
     {
         if ( sample > 0.0031308f )
         {
@@ -129,10 +125,10 @@ public:
         using namespace xyz_color_space;
 
         // Note: ideally channel_convert should be compiled out, because xyz_t
-        // is bits32f natively only
-        bits32f x( channel_convert<bits32f>( get_color( src, x_t() ) ) );
-        bits32f y( channel_convert<bits32f>( get_color( src, y_t() ) ) );
-        bits32f z( channel_convert<bits32f>( get_color( src, z_t() ) ) );
+        // is float32_t natively only
+        float32_t x( channel_convert<float32_t>( get_color( src, x_t() ) ) );
+        float32_t y( channel_convert<float32_t>( get_color( src, y_t() ) ) );
+        float32_t z( channel_convert<float32_t>( get_color( src, z_t() ) ) );
 
         get_color(dst,red_t())  =
                 channel_convert<typename color_element_type<P2, red_t>::type>(

--- a/include/boost/gil/extension/toolbox/color_spaces/ycbcr.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/ycbcr.hpp
@@ -19,6 +19,7 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////////////
 
+#include <cstdint>
 #include <boost/algorithm/clamp.hpp>
 #include <boost/mpl/range_c.hpp>
 #include <boost/mpl/vector_c.hpp>
@@ -60,8 +61,8 @@ typedef boost::gil::layout<ycbcr_601__t> ycbcr_601__layout_t;
 typedef boost::gil::layout<ycbcr_709__t> ycbcr_709__layout_t;
 
 //The channel depth is ALWAYS 8bits ofr YCbCr!
-GIL_DEFINE_ALL_TYPEDEFS(8,  ycbcr_601_)
-GIL_DEFINE_ALL_TYPEDEFS(8,  ycbcr_709_)
+GIL_DEFINE_ALL_TYPEDEFS(8, uint8_t, ycbcr_601_)
+GIL_DEFINE_ALL_TYPEDEFS(8, uint8_t, ycbcr_709_)
 
 /*
  * 601 Source: http://en.wikipedia.org/wiki/YCbCr#ITU-R_BT.601_conversion
@@ -76,7 +77,7 @@ GIL_DEFINE_ALL_TYPEDEFS(8,  ycbcr_709_)
 template<>
 struct default_color_converter_impl<ycbcr_601__t, rgb_t>
 {
-	// Note: the RGB_t channels range can be set later on by the users. We dont want to cast to bits8 or anything here.
+	// Note: the RGB_t channels range can be set later on by the users. We dont want to cast to uint8_t or anything here.
 	template < typename SRCP, typename DSTP >
 	void operator()( const SRCP& src, DSTP& dst ) const
 	{
@@ -110,12 +111,12 @@ private:
 		src_channel_t cr = channel_convert<src_channel_t>( get_color(src, cr_t()));
 
 		// The intermediate results of the formulas require at least 16bits of precission.
-		boost::int_fast16_t c = y  - 16;
-		boost::int_fast16_t d = cb - 128;
-		boost::int_fast16_t e = cr - 128;
-		boost::int_fast16_t red   = clamp((( 298 * c + 409 * e + 128) >> 8), 0, 255);
-		boost::int_fast16_t green = clamp((( 298 * c - 100 * d - 208 * e + 128) >> 8), 0, 255);
-		boost::int_fast16_t blue  = clamp((( 298 * c + 516 * d + 128) >> 8), 0, 255);
+		std::int_fast16_t c = y  - 16;
+		std::int_fast16_t d = cb - 128;
+		std::int_fast16_t e = cr - 128;
+		std::int_fast16_t red   = clamp((( 298 * c + 409 * e + 128) >> 8), 0, 255);
+		std::int_fast16_t green = clamp((( 298 * c - 100 * d - 208 * e + 128) >> 8), 0, 255);
+		std::int_fast16_t blue  = clamp((( 298 * c + 516 * d + 128) >> 8), 0, 255);
 
 		get_color( dst,  red_t() )  = (dst_channel_t) red;
 		get_color( dst, green_t() ) = (dst_channel_t) green;

--- a/include/boost/gil/gil_concept.hpp
+++ b/include/boost/gil/gil_concept.hpp
@@ -514,7 +514,7 @@ struct ChannelValueConcept {
 Example:
 
 \code
-BOOST_STATIC_ASSERT((channels_are_compatible<bits8, const bits8&>::value));
+BOOST_STATIC_ASSERT((channels_are_compatible<uint8_t, const uint8_t&>::value));
 \endcode
 */
 template <typename T1, typename T2>  // Models GIL Pixel

--- a/include/boost/gil/io/typedefs.hpp
+++ b/include/boost/gil/io/typedefs.hpp
@@ -35,8 +35,6 @@ namespace boost { namespace gil {
 struct double_zero { static double apply() { return 0.0; } };
 struct double_one  { static double apply() { return 1.0; } };
 
-typedef scoped_channel_value< double, double_zero, double_one > bits64f;
-
 typedef unsigned char byte_t;
 typedef std::vector< byte_t > byte_vector_t;
 
@@ -47,8 +45,8 @@ typedef point2< std::ptrdiff_t > point_t;
 
 namespace boost { 
 
-template<> struct is_floating_point< gil::bits32f > : mpl::true_ {};
-template<> struct is_floating_point< gil::bits64f > : mpl::true_ {};
+template<> struct is_floating_point<gil::float32_t> : mpl::true_ {};
+template<> struct is_floating_point<gil::float64_t> : mpl::true_ {};
 
 } // namespace boost
 

--- a/include/boost/gil/packed_pixel.hpp
+++ b/include/boost/gil/packed_pixel.hpp
@@ -57,7 +57,7 @@ assert(r565 == rgb565_pixel_t((uint16_t)0xFFFF));
 /// \ingroup ColorBaseModelPackedPixel PixelModelPackedPixel PixelBasedModel
 /// \brief Heterogeneous pixel value whose channel references can be constructed from the pixel bitfield and their index. Models ColorBaseValueConcept, PixelValueConcept, PixelBasedConcept
 /// Typical use for this is a model of a packed pixel (like 565 RGB)
-template <typename BitField,      // A type that holds the bits of the pixel. Typically an integral type, like boost::uint16_t
+template <typename BitField,      // A type that holds the bits of the pixel. Typically an integral type, like std::uint16_t
           typename ChannelRefVec, // An MPL vector whose elements are packed channels. They must be constructible from BitField. GIL uses packed_channel_reference
           typename Layout>        // Layout defining the color space and ordering of the channels. Example value: rgb_layout_t
 struct packed_pixel {

--- a/include/boost/gil/pixel.hpp
+++ b/include/boost/gil/pixel.hpp
@@ -73,7 +73,7 @@ BOOST_STATIC_ASSERT((is_planar<rgb16_planar_image_t>::value));
 BOOST_STATIC_ASSERT((is_same<color_space_type<rgb8_planar_ref_t>::type, rgb_t>::value));
 BOOST_STATIC_ASSERT((is_same<channel_mapping_type<cmyk8_pixel_t>::type, 
                              channel_mapping_type<rgba8_pixel_t>::type>::value));
-BOOST_STATIC_ASSERT((is_same<channel_type<bgr8_pixel_t>::type, bits8>::value));
+BOOST_STATIC_ASSERT((is_same<channel_type<bgr8_pixel_t>::type, uint8_t>::value));
 \endcode
 */
 

--- a/include/boost/gil/typedefs.hpp
+++ b/include/boost/gil/typedefs.hpp
@@ -1,196 +1,237 @@
-/*
-    Copyright 2005-2007 Adobe Systems Incorporated
-   
-    Use, modification and distribution are subject to the Boost Software License,
-    Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
-    http://www.boost.org/LICENSE_1_0.txt).
+//
+// Copyright 2005-2007 Adobe Systems Incorporated
+// Copyright 2018 Mateusz Loskot <mateusz@loskot.net>
+//
+// Use, modification and distribution are subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+#ifndef BOOST_GIL_TYPEDEFS_HPP
+#define BOOST_GIL_TYPEDEFS_HPP
 
-    See http://opensource.adobe.com/gil for most recent version including documentation.
-*/
-
-/*************************************************************************************************/
-
-#ifndef GIL_TYPEDEFS_H
-#define GIL_TYPEDEFS_H
-
-////////////////////////////////////////////////////////////////////////////////////////
-/// \file               
-/// \brief Useful typedefs
+/// \file
+/// \brief Useful public typedefs
 /// \author Lubomir Bourdev and Hailin Jin \n
 ///         Adobe Systems Incorporated
-/// \date 2005-2007 \n Last updated on March 8, 2006
-///
-////////////////////////////////////////////////////////////////////////////////////////
 
 #include "gil_config.hpp"
-#include <boost/cstdint.hpp>
+
+#include <cstdint>
+#include <memory>
+
+#include "cmyk.hpp"
+#include "device_n.hpp"
 #include "gray.hpp"
 #include "rgb.hpp"
 #include "rgba.hpp"
-#include "cmyk.hpp"
-#include "device_n.hpp"
-#include <memory>
 
-// CS = 'bgr' LAYOUT='bgr_layout_t'
-#define GIL_DEFINE_BASE_TYPEDEFS_INTERNAL(T,CS,LAYOUT)                                              \
-    template <typename, typename>    struct pixel;                                                \
-    template <typename, typename>    struct planar_pixel_reference;                                            \
-    template <typename, typename>    struct planar_pixel_iterator;                                            \
-    template <typename>                class memory_based_step_iterator;                                    \
-    template <typename>                class point2;                                                \
-    template <typename>                class memory_based_2d_locator;                                    \
-    template <typename>                class image_view;                                            \
-    template <typename, bool, typename>    class image;                                                \
-    typedef pixel<bits##T, LAYOUT >                        CS##T##_pixel_t;        \
-    typedef const pixel<bits##T, LAYOUT >                   CS##T##c_pixel_t;        \
-    typedef pixel<bits##T, LAYOUT >&                      CS##T##_ref_t;            \
-    typedef const pixel<bits##T, LAYOUT >&                CS##T##c_ref_t;            \
-    typedef CS##T##_pixel_t*                                               CS##T##_ptr_t;            \
-    typedef CS##T##c_pixel_t*                                               CS##T##c_ptr_t;            \
-    typedef memory_based_step_iterator<CS##T##_ptr_t>                               CS##T##_step_ptr_t;        \
-    typedef memory_based_step_iterator<CS##T##c_ptr_t>                               CS##T##c_step_ptr_t;    \
-    typedef memory_based_2d_locator<memory_based_step_iterator<CS##T##_ptr_t> >       CS##T##_loc_t;            \
-    typedef memory_based_2d_locator<memory_based_step_iterator<CS##T##c_ptr_t> >       CS##T##c_loc_t;            \
-    typedef memory_based_2d_locator<memory_based_step_iterator<CS##T##_step_ptr_t> >  CS##T##_step_loc_t;        \
-    typedef memory_based_2d_locator<memory_based_step_iterator<CS##T##c_step_ptr_t> > CS##T##c_step_loc_t;    \
-    typedef image_view<CS##T##_loc_t>                                        CS##T##_view_t;            \
-    typedef image_view<CS##T##c_loc_t>                                        CS##T##c_view_t;        \
-    typedef image_view<CS##T##_step_loc_t>                                    CS##T##_step_view_t;    \
-    typedef image_view<CS##T##c_step_loc_t>                                   CS##T##c_step_view_t;    \
-    typedef image<CS##T##_pixel_t,false,std::allocator<unsigned char> >           CS##T##_image_t;
+// B - bits size/signedness, CM - channel model, CS - colour space, LAYOUT - pixel layout
+// Example: B = '8', CM = 'uint8_t', CS = 'bgr,  LAYOUT='bgr_layout_t'
+#define GIL_DEFINE_BASE_TYPEDEFS_INTERNAL(B, CM, CS, LAYOUT)                             \
+    template <typename, typename> struct pixel;                                          \
+    template <typename, typename> struct planar_pixel_reference;                         \
+    template <typename, typename> struct planar_pixel_iterator;                          \
+    template <typename> class memory_based_step_iterator;                                \
+    template <typename> class point2;                                                    \
+    template <typename> class memory_based_2d_locator;                                   \
+    template <typename> class image_view;                                                \
+    template <typename, bool, typename> class image;                                     \
+    using CS##B##_pixel_t     = pixel<CM, LAYOUT>;                                       \
+    using CS##B##c_pixel_t    = pixel<CM, LAYOUT> const;                                 \
+    using CS##B##_ref_t       = pixel<CM, LAYOUT>&;                                      \
+    using CS##B##c_ref_t      = pixel<CM, LAYOUT> const&;                                \
+    using CS##B##_ptr_t       = CS##B##_pixel_t*;                                        \
+    using CS##B##c_ptr_t      = CS##B##c_pixel_t*;                                       \
+    using CS##B##_step_ptr_t  = memory_based_step_iterator<CS##B##_ptr_t>;               \
+    using CS##B##c_step_ptr_t = memory_based_step_iterator<CS##B##c_ptr_t>;              \
+    using CS##B##_loc_t                                                                  \
+        = memory_based_2d_locator<memory_based_step_iterator<CS##B##_ptr_t>>;            \
+    using CS##B##c_loc_t                                                                 \
+        = memory_based_2d_locator<memory_based_step_iterator<CS##B##c_ptr_t>>;           \
+    using CS##B##_step_loc_t                                                             \
+        = memory_based_2d_locator<memory_based_step_iterator<CS##B##_step_ptr_t>>;       \
+    using CS##B##c_step_loc_t                                                            \
+        = memory_based_2d_locator<memory_based_step_iterator<CS##B##c_step_ptr_t>>;      \
+    using CS##B##_view_t       = image_view<CS##B##_loc_t>;                              \
+    using CS##B##c_view_t      = image_view<CS##B##c_loc_t>;                             \
+    using CS##B##_step_view_t  = image_view<CS##B##_step_loc_t>;                         \
+    using CS##B##c_step_view_t = image_view<CS##B##c_step_loc_t>;                        \
+    using CS##B##_image_t = image<CS##B##_pixel_t, false, std::allocator<unsigned char>>;
 
-// CS = 'bgr' CS_FULL = 'rgb_t' LAYOUT='bgr_layout_t'
-#define GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(T,CS,CS_FULL,LAYOUT)                                                                \
-    GIL_DEFINE_BASE_TYPEDEFS_INTERNAL(T,CS,LAYOUT)                                                                    \
-    typedef planar_pixel_reference<bits##T&,CS_FULL >                                          CS##T##_planar_ref_t;        \
-    typedef planar_pixel_reference<const bits##T&,CS_FULL >                                      CS##T##c_planar_ref_t;        \
-    typedef planar_pixel_iterator<bits##T*,CS_FULL >                                          CS##T##_planar_ptr_t;        \
-    typedef planar_pixel_iterator<const bits##T*,CS_FULL >                                      CS##T##c_planar_ptr_t;        \
-    typedef memory_based_step_iterator<CS##T##_planar_ptr_t>                              CS##T##_planar_step_ptr_t;    \
-    typedef memory_based_step_iterator<CS##T##c_planar_ptr_t>                              CS##T##c_planar_step_ptr_t;    \
-    typedef memory_based_2d_locator<memory_based_step_iterator<CS##T##_planar_ptr_t> >          CS##T##_planar_loc_t;        \
-    typedef memory_based_2d_locator<memory_based_step_iterator<CS##T##c_planar_ptr_t> >      CS##T##c_planar_loc_t;        \
-    typedef memory_based_2d_locator<memory_based_step_iterator<CS##T##_planar_step_ptr_t> >  CS##T##_planar_step_loc_t;    \
-    typedef memory_based_2d_locator<memory_based_step_iterator<CS##T##c_planar_step_ptr_t> > CS##T##c_planar_step_loc_t;    \
-    typedef image_view<CS##T##_planar_loc_t>                                      CS##T##_planar_view_t;        \
-    typedef image_view<CS##T##c_planar_loc_t>                                      CS##T##c_planar_view_t;        \
-    typedef image_view<CS##T##_planar_step_loc_t>                                  CS##T##_planar_step_view_t;    \
-    typedef image_view<CS##T##c_planar_step_loc_t>                                  CS##T##c_planar_step_view_t;\
-    typedef image<CS##T##_pixel_t,true,std::allocator<unsigned char> >              CS##T##_planar_image_t;    
+// Example: B = '8', CM = 'uint8_t', CS = 'bgr' CS_FULL = 'rgb_t' LAYOUT='bgr_layout_t'
+#define GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(B, CM, CS, CS_FULL, LAYOUT)                        \
+    GIL_DEFINE_BASE_TYPEDEFS_INTERNAL(B, CM, CS, LAYOUT)                                    \
+    using CS##B##_planar_ref_t      = planar_pixel_reference<CM&, CS_FULL>;                 \
+    using CS##B##c_planar_ref_t     = planar_pixel_reference<CM const&, CS_FULL>;           \
+    using CS##B##_planar_ptr_t      = planar_pixel_iterator<CM*, CS_FULL>;                  \
+    using CS##B##c_planar_ptr_t     = planar_pixel_iterator<CM const*, CS_FULL>;            \
+    using CS##B##_planar_step_ptr_t = memory_based_step_iterator<CS##B##_planar_ptr_t>;     \
+    using CS##B##c_planar_step_ptr_t                                                        \
+        = memory_based_step_iterator<CS##B##c_planar_ptr_t>;                                \
+    using CS##B##_planar_loc_t                                                              \
+        = memory_based_2d_locator<memory_based_step_iterator<CS##B##_planar_ptr_t>>;        \
+    using CS##B##c_planar_loc_t                                                             \
+        = memory_based_2d_locator<memory_based_step_iterator<CS##B##c_planar_ptr_t>>;       \
+    using CS##B##_planar_step_loc_t                                                         \
+        = memory_based_2d_locator<memory_based_step_iterator<CS##B##_planar_step_ptr_t>>;   \
+    using CS##B##c_planar_step_loc_t                                                        \
+        = memory_based_2d_locator<memory_based_step_iterator<CS##B##c_planar_step_ptr_t>>;  \
+    using CS##B##_planar_view_t       = image_view<CS##B##_planar_loc_t>;                   \
+    using CS##B##c_planar_view_t      = image_view<CS##B##c_planar_loc_t>;                  \
+    using CS##B##_planar_step_view_t  = image_view<CS##B##_planar_step_loc_t>;              \
+    using CS##B##c_planar_step_view_t = image_view<CS##B##c_planar_step_loc_t>;             \
+    using CS##B##_planar_image_t                                                            \
+        = image<CS##B##_pixel_t, true, std::allocator<unsigned char>>;
 
-#define GIL_DEFINE_BASE_TYPEDEFS(T,CS)        \
-    GIL_DEFINE_BASE_TYPEDEFS_INTERNAL(T,CS,CS##_layout_t)
+#define GIL_DEFINE_BASE_TYPEDEFS(B, CM, CS)                                                  \
+    GIL_DEFINE_BASE_TYPEDEFS_INTERNAL(B, CM, CS, CS##_layout_t)
 
-#define GIL_DEFINE_ALL_TYPEDEFS(T,CS)         \
-    GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(T,CS,CS##_t,CS##_layout_t)
+#define GIL_DEFINE_ALL_TYPEDEFS(B, CM, CS)                                                   \
+    GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(B, CM, CS, CS##_t, CS##_layout_t)
+
 
 namespace boost { namespace gil {
 
 // forward declarations
 template <typename B, typename Mn, typename Mx> struct scoped_channel_value;
-struct float_zero;
-struct float_one;
-typedef scoped_channel_value<float,float_zero,float_one> bits32f;
-typedef uint8_t  bits8;
-typedef uint16_t bits16;
-typedef uint32_t bits32;
-typedef int8_t   bits8s;
-typedef int16_t  bits16s;
-typedef int32_t  bits32s;
+template <typename T> struct float_point_zero;
+template <typename T> struct float_point_one;
 
-GIL_DEFINE_BASE_TYPEDEFS(8,  gray)
-GIL_DEFINE_BASE_TYPEDEFS(8s, gray)
-GIL_DEFINE_BASE_TYPEDEFS(16, gray)
-GIL_DEFINE_BASE_TYPEDEFS(16s,gray)
-GIL_DEFINE_BASE_TYPEDEFS(32 ,gray)
-GIL_DEFINE_BASE_TYPEDEFS(32s,gray)
-GIL_DEFINE_BASE_TYPEDEFS(32f,gray)
-GIL_DEFINE_BASE_TYPEDEFS(8,  bgr)
-GIL_DEFINE_BASE_TYPEDEFS(8s, bgr)
-GIL_DEFINE_BASE_TYPEDEFS(16, bgr)
-GIL_DEFINE_BASE_TYPEDEFS(16s,bgr)
-GIL_DEFINE_BASE_TYPEDEFS(32 ,bgr)
-GIL_DEFINE_BASE_TYPEDEFS(32s,bgr)
-GIL_DEFINE_BASE_TYPEDEFS(32f,bgr)
-GIL_DEFINE_BASE_TYPEDEFS(8,  argb)
-GIL_DEFINE_BASE_TYPEDEFS(8s, argb)
-GIL_DEFINE_BASE_TYPEDEFS(16, argb)
-GIL_DEFINE_BASE_TYPEDEFS(16s,argb)
-GIL_DEFINE_BASE_TYPEDEFS(32, argb)
-GIL_DEFINE_BASE_TYPEDEFS(32s,argb)
-GIL_DEFINE_BASE_TYPEDEFS(32f,argb)
-GIL_DEFINE_BASE_TYPEDEFS(8,  abgr)
-GIL_DEFINE_BASE_TYPEDEFS(8s, abgr)
-GIL_DEFINE_BASE_TYPEDEFS(16, abgr)
-GIL_DEFINE_BASE_TYPEDEFS(16s,abgr)
-GIL_DEFINE_BASE_TYPEDEFS(32 ,abgr)
-GIL_DEFINE_BASE_TYPEDEFS(32s,abgr)
-GIL_DEFINE_BASE_TYPEDEFS(32f,abgr)
-GIL_DEFINE_BASE_TYPEDEFS(8,  bgra)
-GIL_DEFINE_BASE_TYPEDEFS(8s, bgra)
-GIL_DEFINE_BASE_TYPEDEFS(16, bgra)
-GIL_DEFINE_BASE_TYPEDEFS(16s,bgra)
-GIL_DEFINE_BASE_TYPEDEFS(32 ,bgra)
-GIL_DEFINE_BASE_TYPEDEFS(32s,bgra)
-GIL_DEFINE_BASE_TYPEDEFS(32f,bgra)
+//////////////////////////////////////////////////////////////////////////////////////////
+///  Built-in channel models
+//////////////////////////////////////////////////////////////////////////////////////////
 
-GIL_DEFINE_ALL_TYPEDEFS(8,  rgb)
-GIL_DEFINE_ALL_TYPEDEFS(8s, rgb)
-GIL_DEFINE_ALL_TYPEDEFS(16, rgb)
-GIL_DEFINE_ALL_TYPEDEFS(16s,rgb)
-GIL_DEFINE_ALL_TYPEDEFS(32 ,rgb)
-GIL_DEFINE_ALL_TYPEDEFS(32s,rgb)
-GIL_DEFINE_ALL_TYPEDEFS(32f,rgb)
-GIL_DEFINE_ALL_TYPEDEFS(8,  rgba)
-GIL_DEFINE_ALL_TYPEDEFS(8s, rgba)
-GIL_DEFINE_ALL_TYPEDEFS(16, rgba)
-GIL_DEFINE_ALL_TYPEDEFS(16s,rgba)
-GIL_DEFINE_ALL_TYPEDEFS(32 ,rgba)
-GIL_DEFINE_ALL_TYPEDEFS(32s,rgba)
-GIL_DEFINE_ALL_TYPEDEFS(32f,rgba)
-GIL_DEFINE_ALL_TYPEDEFS(8,  cmyk)
-GIL_DEFINE_ALL_TYPEDEFS(8s, cmyk)
-GIL_DEFINE_ALL_TYPEDEFS(16, cmyk)
-GIL_DEFINE_ALL_TYPEDEFS(16s,cmyk)
-GIL_DEFINE_ALL_TYPEDEFS(32 ,cmyk)
-GIL_DEFINE_ALL_TYPEDEFS(32s,cmyk)
-GIL_DEFINE_ALL_TYPEDEFS(32f,cmyk)
+/// \ingroup ChannelModel
+/// \brief 8-bit unsigned integral channel type (typedef from uint8_t). Models ChannelValueConcept
+using std::uint8_t;
 
+/// \ingroup ChannelModel
+/// \brief 16-bit unsigned integral channel type (typedef from uint16_t). Models ChannelValueConcept
+using std::uint16_t;
+
+/// \ingroup ChannelModel
+/// \brief 32-bit unsigned integral channel type  (typedef from uint32_t). Models ChannelValueConcept
+using std::uint32_t;
+
+/// \ingroup ChannelModel
+/// \brief 8-bit signed integral channel type (typedef from int8_t). Models ChannelValueConcept
+using std::int8_t;
+
+/// \ingroup ChannelModel
+/// \brief 16-bit signed integral channel type (typedef from int16_t). Models ChannelValueConcept
+using std::int16_t;
+
+/// \ingroup ChannelModel
+/// \brief 32-bit signed integral channel type (typedef from int32_t). Models ChannelValueConcept
+using std::int32_t;
+
+/// \ingroup ChannelModel
+/// \brief 32-bit floating point channel type with range [0.0f ... 1.0f]. Models ChannelValueConcept
+using float32_t = scoped_channel_value<float, float_point_zero<float>, float_point_one<float>>;
+
+/// \ingroup ChannelModel
+/// \brief 64-bit floating point channel type with range [0.0f ... 1.0f]. Models ChannelValueConcept
+using float64_t = scoped_channel_value<double, float_point_zero<double>, float_point_one<double>>;
+
+GIL_DEFINE_BASE_TYPEDEFS(8, uint8_t, gray)
+GIL_DEFINE_BASE_TYPEDEFS(8s, int8_t, gray)
+GIL_DEFINE_BASE_TYPEDEFS(16, uint16_t, gray)
+GIL_DEFINE_BASE_TYPEDEFS(16s, int16_t, gray)
+GIL_DEFINE_BASE_TYPEDEFS(32, uint32_t, gray)
+GIL_DEFINE_BASE_TYPEDEFS(32s, int32_t, gray)
+GIL_DEFINE_BASE_TYPEDEFS(32f, float32_t, gray)
+
+GIL_DEFINE_BASE_TYPEDEFS(8, uint8_t, bgr)
+GIL_DEFINE_BASE_TYPEDEFS(8s, int8_t, bgr)
+GIL_DEFINE_BASE_TYPEDEFS(16, uint16_t, bgr)
+GIL_DEFINE_BASE_TYPEDEFS(16s, int16_t, bgr)
+GIL_DEFINE_BASE_TYPEDEFS(32, uint32_t, bgr)
+GIL_DEFINE_BASE_TYPEDEFS(32s, int32_t, bgr)
+GIL_DEFINE_BASE_TYPEDEFS(32f, float32_t, bgr)
+
+GIL_DEFINE_BASE_TYPEDEFS(8, uint8_t, argb)
+GIL_DEFINE_BASE_TYPEDEFS(8s, int8_t, argb)
+GIL_DEFINE_BASE_TYPEDEFS(16, uint16_t, argb)
+GIL_DEFINE_BASE_TYPEDEFS(16s, int16_t, argb)
+GIL_DEFINE_BASE_TYPEDEFS(32, uint32_t, argb)
+GIL_DEFINE_BASE_TYPEDEFS(32s, int32_t, argb)
+GIL_DEFINE_BASE_TYPEDEFS(32f, float32_t, argb)
+
+GIL_DEFINE_BASE_TYPEDEFS(8, uint8_t, abgr)
+GIL_DEFINE_BASE_TYPEDEFS(8s, int8_t, abgr)
+GIL_DEFINE_BASE_TYPEDEFS(16, uint16_t, abgr)
+GIL_DEFINE_BASE_TYPEDEFS(16s, int16_t, abgr)
+GIL_DEFINE_BASE_TYPEDEFS(32, uint32_t, abgr)
+GIL_DEFINE_BASE_TYPEDEFS(32s, int32_t, abgr)
+GIL_DEFINE_BASE_TYPEDEFS(32f, float32_t, abgr)
+
+GIL_DEFINE_BASE_TYPEDEFS(8, uint8_t, bgra)
+GIL_DEFINE_BASE_TYPEDEFS(8s, int8_t, bgra)
+GIL_DEFINE_BASE_TYPEDEFS(16, uint16_t, bgra)
+GIL_DEFINE_BASE_TYPEDEFS(16s, int16_t, bgra)
+GIL_DEFINE_BASE_TYPEDEFS(32, uint32_t, bgra)
+GIL_DEFINE_BASE_TYPEDEFS(32s, int32_t, bgra)
+GIL_DEFINE_BASE_TYPEDEFS(32f, float32_t, bgra)
+
+GIL_DEFINE_ALL_TYPEDEFS(8, uint8_t, rgb)
+GIL_DEFINE_ALL_TYPEDEFS(8s, int8_t, rgb)
+GIL_DEFINE_ALL_TYPEDEFS(16, uint16_t, rgb)
+GIL_DEFINE_ALL_TYPEDEFS(16s, int16_t, rgb)
+GIL_DEFINE_ALL_TYPEDEFS(32, uint32_t, rgb)
+GIL_DEFINE_ALL_TYPEDEFS(32s, int32_t, rgb)
+GIL_DEFINE_ALL_TYPEDEFS(32f, float32_t, rgb)
+
+GIL_DEFINE_ALL_TYPEDEFS(8, uint8_t, rgba)
+GIL_DEFINE_ALL_TYPEDEFS(8s, int8_t, rgba)
+GIL_DEFINE_ALL_TYPEDEFS(16, uint16_t, rgba)
+GIL_DEFINE_ALL_TYPEDEFS(16s, int16_t, rgba)
+GIL_DEFINE_ALL_TYPEDEFS(32, uint32_t, rgba)
+GIL_DEFINE_ALL_TYPEDEFS(32s, int32_t, rgba)
+GIL_DEFINE_ALL_TYPEDEFS(32f, float32_t, rgba)
+
+GIL_DEFINE_ALL_TYPEDEFS(8, uint8_t, cmyk)
+GIL_DEFINE_ALL_TYPEDEFS(8s, int8_t, cmyk)
+GIL_DEFINE_ALL_TYPEDEFS(16, uint16_t, cmyk)
+GIL_DEFINE_ALL_TYPEDEFS(16s, int16_t, cmyk)
+GIL_DEFINE_ALL_TYPEDEFS(32, uint32_t, cmyk)
+GIL_DEFINE_ALL_TYPEDEFS(32s, int32_t, cmyk)
+GIL_DEFINE_ALL_TYPEDEFS(32f, float32_t, cmyk)
 
 template <int N> struct devicen_t;
 template <int N> struct devicen_layout_t;
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(8,  dev2n, devicen_t<2>, devicen_layout_t<2>)
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(8s, dev2n, devicen_t<2>, devicen_layout_t<2>)
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(16, dev2n, devicen_t<2>, devicen_layout_t<2>)
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(16s,dev2n, devicen_t<2>, devicen_layout_t<2>)
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(32 ,dev2n, devicen_t<2>, devicen_layout_t<2>)
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(32s,dev2n, devicen_t<2>, devicen_layout_t<2>)
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(32f,dev2n, devicen_t<2>, devicen_layout_t<2>)
 
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(8,  dev3n, devicen_t<3>, devicen_layout_t<3>)
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(8s, dev3n, devicen_t<3>, devicen_layout_t<3>)
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(16, dev3n, devicen_t<3>, devicen_layout_t<3>)
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(16s,dev3n, devicen_t<3>, devicen_layout_t<3>)
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(32 ,dev3n, devicen_t<3>, devicen_layout_t<3>)
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(32s,dev3n, devicen_t<3>, devicen_layout_t<3>)
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(32f,dev3n, devicen_t<3>, devicen_layout_t<3>)
+GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(8, uint8_t, dev2n, devicen_t<2>, devicen_layout_t<2>)
+GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(8s, int8_t, dev2n, devicen_t<2>, devicen_layout_t<2>)
+GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(16, uint16_t, dev2n, devicen_t<2>, devicen_layout_t<2>)
+GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(16s, int16_t, dev2n, devicen_t<2>, devicen_layout_t<2>)
+GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(32, uint32_t, dev2n, devicen_t<2>, devicen_layout_t<2>)
+GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(32s, int32_t, dev2n, devicen_t<2>, devicen_layout_t<2>)
+GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(32f, float32_t, dev2n, devicen_t<2>, devicen_layout_t<2>)
 
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(8,  dev4n, devicen_t<4>, devicen_layout_t<4>)
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(8s, dev4n, devicen_t<4>, devicen_layout_t<4>)
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(16, dev4n, devicen_t<4>, devicen_layout_t<4>)
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(16s,dev4n, devicen_t<4>, devicen_layout_t<4>)
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(32 ,dev4n, devicen_t<4>, devicen_layout_t<4>)
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(32s,dev4n, devicen_t<4>, devicen_layout_t<4>)
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(32f,dev4n, devicen_t<4>, devicen_layout_t<4>)
+GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(8, uint8_t, dev3n, devicen_t<3>, devicen_layout_t<3>)
+GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(8s, int8_t, dev3n, devicen_t<3>, devicen_layout_t<3>)
+GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(16, uint16_t, dev3n, devicen_t<3>, devicen_layout_t<3>)
+GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(16s, int16_t, dev3n, devicen_t<3>, devicen_layout_t<3>)
+GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(32, uint32_t, dev3n, devicen_t<3>, devicen_layout_t<3>)
+GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(32s, int32_t, dev3n, devicen_t<3>, devicen_layout_t<3>)
+GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(32f, float32_t, dev3n, devicen_t<3>, devicen_layout_t<3>)
 
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(8,  dev5n, devicen_t<5>, devicen_layout_t<5>)
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(8s, dev5n, devicen_t<5>, devicen_layout_t<5>)
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(16, dev5n, devicen_t<5>, devicen_layout_t<5>)
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(16s,dev5n, devicen_t<5>, devicen_layout_t<5>)
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(32 ,dev5n, devicen_t<5>, devicen_layout_t<5>)
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(32s,dev5n, devicen_t<5>, devicen_layout_t<5>)
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(32f,dev5n, devicen_t<5>, devicen_layout_t<5>)
+GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(8, uint8_t, dev4n, devicen_t<4>, devicen_layout_t<4>)
+GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(8s, int8_t, dev4n, devicen_t<4>, devicen_layout_t<4>)
+GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(16, uint16_t, dev4n, devicen_t<4>, devicen_layout_t<4>)
+GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(16s, int16_t, dev4n, devicen_t<4>, devicen_layout_t<4>)
+GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(32, uint32_t, dev4n, devicen_t<4>, devicen_layout_t<4>)
+GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(32s, int32_t, dev4n, devicen_t<4>, devicen_layout_t<4>)
+GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(32f, float32_t, dev4n, devicen_t<4>, devicen_layout_t<4>)
 
-} }  // namespace boost::gil
+GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(8, uint8_t, dev5n, devicen_t<5>, devicen_layout_t<5>)
+GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(8s, int8_t, dev5n, devicen_t<5>, devicen_layout_t<5>)
+GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(16, uint16_t, dev5n, devicen_t<5>, devicen_layout_t<5>)
+GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(16s, int16_t, dev5n, devicen_t<5>, devicen_layout_t<5>)
+GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(32, uint32_t, dev5n, devicen_t<5>, devicen_layout_t<5>)
+GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(32s, int32_t, dev5n, devicen_t<5>, devicen_layout_t<5>)
+GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(32f, float32_t, dev5n, devicen_t<5>, devicen_layout_t<5>)
+
+}} // namespace boost::gil
 
 #endif

--- a/io/test/png_read_test.cpp
+++ b/io/test/png_read_test.cpp
@@ -11,13 +11,12 @@
 #define BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 #define BOOST_GIL_IO_ENABLE_GRAY_ALPHA
 
-#include <boost/cstdint.hpp>
-
 #define BOOST_FILESYSTEM_VERSION 3
 #include <boost/filesystem/convenience.hpp>
 
 #include <boost/gil/extension/io/png.hpp>
 
+#include <cstdint>
 #include <iostream>
 
 #include "paths.hpp"

--- a/io/test/png_write_test.cpp
+++ b/io/test/png_write_test.cpp
@@ -11,13 +11,13 @@
 #define BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 #define BOOST_GIL_IO_ENABLE_GRAY_ALPHA
 
-#include <boost/cstdint.hpp>
 
 #define BOOST_FILESYSTEM_VERSION 3
 #include <boost/filesystem/convenience.hpp>
 
 #include <boost/gil/extension/io/png.hpp>
 
+#include <cstdint>
 #include <iostream>
 
 #include "color_space_write_test.hpp"

--- a/io/test/tiff_tiled_minisblack_test_11-20.cpp
+++ b/io/test/tiff_tiled_minisblack_test_11-20.cpp
@@ -14,7 +14,7 @@
 //#define BOOST_TEST_MODULE tiff_tiled_miniblack_test_11_20_module
 #include <boost/test/unit_test.hpp>
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
 #include "tiff_tiled_read_macros.hpp"
 
 BOOST_AUTO_TEST_SUITE( gil_io_tiff_tests )

--- a/io/test/tiff_tiled_minisblack_test_21-31_32-64.cpp
+++ b/io/test/tiff_tiled_minisblack_test_21-31_32-64.cpp
@@ -14,7 +14,7 @@
 //#define BOOST_TEST_MODULE tiff_tiled_miniblack_test_21_31_32_64_module
 #include <boost/test/unit_test.hpp>
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
 #include "tiff_tiled_read_macros.hpp"
 
 BOOST_AUTO_TEST_SUITE( gil_io_tiff_tests )

--- a/test/channel.cpp
+++ b/test/channel.cpp
@@ -10,11 +10,14 @@
 // channel.cpp : Tests channel
 //
 
+#include <cstdint>
 #include <exception>
 #include <iostream>
 #include <boost/gil/gil_config.hpp>
-#include <boost/gil/channel_algorithm.hpp>
 #include <boost/gil/gil_concept.hpp>
+#include <boost/gil/channel.hpp>
+#include <boost/gil/channel_algorithm.hpp>
+#include <boost/gil/typedefs.hpp>
 
 #if BOOST_WORKAROUND(BOOST_MSVC, >= 1400) 
 #pragma warning(push) 
@@ -27,20 +30,20 @@ using namespace std;
 
 void error_if(bool);
 
-bits8   c8_min   =  channel_traits<bits8  >::min_value();
-bits8   c8_max   =  channel_traits<bits8  >::max_value();
-bits8s  c8s_min  =  channel_traits<bits8s >::min_value();
-bits8s  c8s_max  =  channel_traits<bits8s >::max_value();
-bits16  c16_min  =  channel_traits<bits16 >::min_value();
-bits16  c16_max  =  channel_traits<bits16 >::max_value();
-bits16s c16s_min =  channel_traits<bits16s>::min_value();
-bits16s c16s_max =  channel_traits<bits16s>::max_value();
-bits32  c32_min  =  channel_traits<bits32 >::min_value();
-bits32  c32_max  =  channel_traits<bits32 >::max_value();
-bits32s c32s_min =  channel_traits<bits32s>::min_value();
-bits32s c32s_max =  channel_traits<bits32s>::max_value();
-bits32f c32f_min =  channel_traits<bits32f>::min_value();
-bits32f c32f_max =  channel_traits<bits32f>::max_value();
+auto c8_min   = channel_traits<uint8_t>::min_value();
+auto c8_max   = channel_traits<uint8_t>::max_value();
+auto c8s_min  = channel_traits<int8_t>::min_value();
+auto c8s_max  = channel_traits<int8_t>::max_value();
+auto c16_min  = channel_traits<uint16_t>::min_value();
+auto c16_max  = channel_traits<uint16_t>::max_value();
+auto c16s_min = channel_traits<int16_t>::min_value();
+auto c16s_max = channel_traits<int16_t>::max_value();
+auto c32_min  = channel_traits<uint32_t>::min_value();
+auto c32_max  = channel_traits<uint32_t>::max_value();
+auto c32s_min = channel_traits<int32_t>::min_value();
+auto c32s_max = channel_traits<int32_t>::max_value();
+auto c32f_min = channel_traits<float32_t>::min_value();
+auto c32f_max = channel_traits<float32_t>::max_value();
 
 
 template <typename ChannelTestCore>
@@ -270,7 +273,7 @@ struct channel_archetype {
     // less-than comparable
     friend bool operator<(const channel_archetype&,const channel_archetype&) { return false; }
     // convertible to a scalar
-    operator bits8() const { return 0; }
+    operator std::uint8_t() const { return 0; }
 
     
     channel_archetype& operator++() { return *this; }
@@ -299,7 +302,7 @@ struct channel_value_archetype : public channel_archetype {
     channel_value_archetype() {}                                        // default constructible
     channel_value_archetype(const channel_value_archetype&) {}          // copy constructible
     channel_value_archetype& operator=(const channel_value_archetype&){return *this;} // assignable
-    channel_value_archetype(bits8) {}
+    channel_value_archetype(std::uint8_t) {}
 };
 
 channel_value_archetype channel_archetype::min_value() { return channel_value_archetype(); }
@@ -307,11 +310,11 @@ channel_value_archetype channel_archetype::max_value() { return channel_value_ar
 
 
 void test_packed_channel_reference() {
-    typedef packed_channel_reference<boost::uint16_t, 0,5,true> channel16_0_5_reference_t;
-    typedef packed_channel_reference<boost::uint16_t, 5,6,true> channel16_5_6_reference_t;
-    typedef packed_channel_reference<boost::uint16_t, 11,5,true> channel16_11_5_reference_t;
+    typedef packed_channel_reference<std::uint16_t, 0,5,true> channel16_0_5_reference_t;
+    typedef packed_channel_reference<std::uint16_t, 5,6,true> channel16_5_6_reference_t;
+    typedef packed_channel_reference<std::uint16_t, 11,5,true> channel16_11_5_reference_t;
 
-    boost::uint16_t data=0;
+    std::uint16_t data=0;
     channel16_0_5_reference_t   channel1(&data);
     channel16_5_6_reference_t   channel2(&data);
     channel16_11_5_reference_t  channel3(&data);
@@ -327,10 +330,10 @@ void test_packed_channel_reference() {
 }
 
 void test_packed_dynamic_channel_reference() {
-    typedef packed_dynamic_channel_reference<boost::uint16_t,5,true> channel16_5_reference_t;
-    typedef packed_dynamic_channel_reference<boost::uint16_t,6,true> channel16_6_reference_t;
+    typedef packed_dynamic_channel_reference<std::uint16_t,5,true> channel16_5_reference_t;
+    typedef packed_dynamic_channel_reference<std::uint16_t,6,true> channel16_6_reference_t;
 
-    boost::uint16_t data=0;
+    std::uint16_t data=0;
     channel16_5_reference_t  channel1(&data,0);
     channel16_6_reference_t  channel2(&data,5);
     channel16_5_reference_t  channel3(&data,11);
@@ -344,14 +347,14 @@ void test_packed_dynamic_channel_reference() {
 }
 
 void test_channel() {
-    test_channel_value_impl<bits8>();
-    test_channel_value_impl<bits8s>();
-    test_channel_value_impl<bits16>();
-    test_channel_value_impl<bits16s>();
-    test_channel_value_impl<bits32>();
-    test_channel_value_impl<bits32s>();
+    test_channel_value_impl<uint8_t>();
+    test_channel_value_impl<int8_t>();
+    test_channel_value_impl<uint16_t>();
+    test_channel_value_impl<int16_t>();
+    test_channel_value_impl<uint32_t>();
+    test_channel_value_impl<int16_t>();
 
-    test_channel_value_impl<bits32f>();
+    test_channel_value_impl<float32_t>();
 
     test_packed_channel_reference();
     test_packed_dynamic_channel_reference();
@@ -389,4 +392,4 @@ int main()
 // - What to do about pointer types?!
 // - Performance!!
 //      - is channel_convert the same as native?
-//      - is operator++ on bits32f the same as native? How about if operator++ is defined in scoped_channel to do _value++?
+//      - is operator++ on float32_t the same as native? How about if operator++ is defined in scoped_channel to do _value++?

--- a/test/image.cpp
+++ b/test/image.cpp
@@ -496,7 +496,7 @@ void static_checks() {
     BOOST_STATIC_ASSERT(view_is_mutable<rgb8_planar_view_t>::value);
 
     BOOST_STATIC_ASSERT((boost::is_same<derived_view_type<cmyk8c_planar_step_view_t>::type, cmyk8c_planar_step_view_t>::value));
-    BOOST_STATIC_ASSERT((boost::is_same<derived_view_type<cmyk8c_planar_step_view_t, bits16, rgb_layout_t>::type,  rgb16c_planar_step_view_t>::value));
+    BOOST_STATIC_ASSERT((boost::is_same<derived_view_type<cmyk8c_planar_step_view_t, std::uint16_t, rgb_layout_t>::type,  rgb16c_planar_step_view_t>::value));
     BOOST_STATIC_ASSERT((boost::is_same<derived_view_type<cmyk8c_planar_step_view_t, use_default, rgb_layout_t, mpl::false_, use_default, mpl::false_>::type,  rgb8c_step_view_t>::value));
 
     // test view get raw data (mostly compile-time test)

--- a/test/performance.cpp
+++ b/test/performance.cpp
@@ -468,11 +468,11 @@ BOOST_AUTO_TEST_CASE(performance_test)
 
     // for_each()
     std::cout<<"test for_each_pixel() on rgb8_image_t"<<std::endl;
-    test_for_each<rgb8_view_t,rgb_fr_t<bits8> >(num_trials);
+    test_for_each<rgb8_view_t,rgb_fr_t<uint8_t> >(num_trials);
     std::cout<<std::endl;
 
     std::cout<<"test for_each_pixel() on rgb8_planar_image_t"<<std::endl;
-    test_for_each<rgb8_planar_view_t,rgb_fr_t<bits8> >(num_trials);
+    test_for_each<rgb8_planar_view_t,rgb_fr_t<uint8_t> >(num_trials);
     std::cout<<std::endl;
 
     // copy()
@@ -498,19 +498,19 @@ BOOST_AUTO_TEST_CASE(performance_test)
 
     // transform()
     std::cout<<"test transform_pixels() between rgb8_image_t and rgb8_image_t"<<std::endl;
-    test_transform<rgb8_view_t,rgb8_view_t,bgr_to_rgb_t<bits8,pixel<bits8,rgb_layout_t> > >(num_trials);
+    test_transform<rgb8_view_t,rgb8_view_t,bgr_to_rgb_t<uint8_t,pixel<uint8_t,rgb_layout_t> > >(num_trials);
     std::cout<<std::endl;
 
     std::cout<<"test transform_pixels() between rgb8_planar_image_t and rgb8_planar_image_t"<<std::endl;
-    test_transform<rgb8_planar_view_t,rgb8_planar_view_t,bgr_to_rgb_t<bits8,planar_pixel_reference<bits8,rgb_t> > >(num_trials);
+    test_transform<rgb8_planar_view_t,rgb8_planar_view_t,bgr_to_rgb_t<uint8_t,planar_pixel_reference<uint8_t,rgb_t> > >(num_trials);
     std::cout<<std::endl;
 
     std::cout<<"test transform_pixels() between rgb8_image_t and rgb8_planar_image_t"<<std::endl;
-    test_transform<rgb8_view_t,rgb8_planar_view_t,bgr_to_rgb_t<bits8,pixel<bits8,rgb_layout_t> > >(num_trials);
+    test_transform<rgb8_view_t,rgb8_planar_view_t,bgr_to_rgb_t<uint8_t,pixel<uint8_t,rgb_layout_t> > >(num_trials);
     std::cout<<std::endl;
 
     std::cout<<"test transform_pixels() between rgb8_planar_image_t and rgb8_image_t"<<std::endl;
-    test_transform<rgb8_planar_view_t,rgb8_view_t,bgr_to_rgb_t<bits8,planar_pixel_reference<bits8,rgb_t> > >(num_trials);
+    test_transform<rgb8_planar_view_t,rgb8_view_t,bgr_to_rgb_t<uint8_t,planar_pixel_reference<uint8_t,rgb_t> > >(num_trials);
     std::cout<<std::endl;
 }
 

--- a/test/pixel.cpp
+++ b/test/pixel.cpp
@@ -272,8 +272,8 @@ void test_packed_pixel() {
     color_convert(rgb_full,r565);
 
     // Test bit-aligned pixel reference
-    typedef const bit_aligned_pixel_reference<boost::uint8_t, boost::mpl::vector3_c<int,1,2,1>, bgr_layout_t, true>  bgr121_ref_t;
-    typedef const bit_aligned_pixel_reference<boost::uint8_t, boost::mpl::vector3_c<int,1,2,1>, rgb_layout_t, true>  rgb121_ref_t;
+    typedef const bit_aligned_pixel_reference<std::uint8_t, boost::mpl::vector3_c<int,1,2,1>, bgr_layout_t, true>  bgr121_ref_t;
+    typedef const bit_aligned_pixel_reference<std::uint8_t, boost::mpl::vector3_c<int,1,2,1>, rgb_layout_t, true>  rgb121_ref_t;
     typedef rgb121_ref_t::value_type rgb121_pixel_t;
     rgb121_pixel_t p121;
     do_basic_test<reference_core<bgr121_ref_t,0>, reference_core<rgb121_ref_t,1> >(p121).test_heterogeneous();     
@@ -322,7 +322,7 @@ void test_pixel() {
     // Assigning a grayscale channel to a pixel
     gray16_pixel_t g16(34);
     g16 = 8;
-    bits16 g = get_color(g16,gray_color_t());
+    uint16_t g = get_color(g16,gray_color_t());
     error_if(g != 8);
     error_if(g16 != 8);
 }

--- a/test/pixel_iterator.cpp
+++ b/test/pixel_iterator.cpp
@@ -48,7 +48,7 @@ void test_pixel_iterator() {
 
     boost::function_requires<MutablePixelLocatorConcept<memory_based_2d_locator<rgb8_step_ptr_t> > >();
 
-    typedef const bit_aligned_pixel_reference<boost::uint8_t, boost::mpl::vector3_c<int,1,2,1>, bgr_layout_t, true>  bgr121_ref_t;
+    typedef const bit_aligned_pixel_reference<std::uint8_t, boost::mpl::vector3_c<int,1,2,1>, bgr_layout_t, true>  bgr121_ref_t;
     typedef bit_aligned_pixel_iterator<bgr121_ref_t> bgr121_ptr_t;
 
     boost::function_requires<MutablePixelIteratorConcept<bgr121_ptr_t> >();
@@ -60,7 +60,7 @@ void test_pixel_iterator() {
     BOOST_STATIC_ASSERT(( boost::is_same<cmyk16_step_ptr_t,dynamic_x_step_type<cmyk16_step_ptr_t>::type>::value ));
     BOOST_STATIC_ASSERT(( boost::is_same<cmyk16_planar_step_ptr_t,dynamic_x_step_type<cmyk16_planar_ptr_t>::type>::value ));
 
-    BOOST_STATIC_ASSERT(( boost::is_same<iterator_type<bits8,gray_layout_t,false,false,false>::type,gray8c_ptr_t>::value ));
+    BOOST_STATIC_ASSERT(( boost::is_same<iterator_type<uint8_t,gray_layout_t,false,false,false>::type,gray8c_ptr_t>::value ));
 
 // TEST iterator_is_step
     BOOST_STATIC_ASSERT(iterator_is_step< cmyk16_step_ptr_t >::value);
@@ -92,7 +92,7 @@ void test_pixel_iterator() {
 // bit_aligned iterators test
 
     // Mutable reference to a BGR232 pixel
-    typedef const bit_aligned_pixel_reference<boost::uint8_t, boost::mpl::vector3_c<unsigned,2,3,2>, bgr_layout_t, true>  bgr232_ref_t;
+    typedef const bit_aligned_pixel_reference<std::uint8_t, boost::mpl::vector3_c<unsigned,2,3,2>, bgr_layout_t, true>  bgr232_ref_t;
 
     // A mutable iterator over BGR232 pixels
     typedef bit_aligned_pixel_iterator<bgr232_ref_t> bgr232_ptr_t;
@@ -187,7 +187,7 @@ void test_pixel_iterator() {
 
 //    planarPtr2=&rgba8;
 
-    planar_pixel_reference<bits8&,rgb_t> pxl=*(planarPtr1+5);
+    planar_pixel_reference<uint8_t&,rgb_t> pxl=*(planarPtr1+5);
   rgb8_pixel_t pv2=pxl;
   rgb8_pixel_t pv3=*(planarPtr1+5);
      rgb8_pixel_t pv=planarPtr1[5];

--- a/toolbox/test/channel_type.cpp
+++ b/toolbox/test/channel_type.cpp
@@ -20,8 +20,9 @@ BOOST_AUTO_TEST_CASE( channel_type_test )
 {
     BOOST_STATIC_ASSERT(( is_same< unsigned char, channel_type< rgb8_pixel_t >::type >::value ));
 
-    // bits32f is a scoped_channel_value object
-    BOOST_STATIC_ASSERT(( is_same< bits32f, channel_type< rgba32f_pixel_t >::type >::value ));
+    // float32_t is a scoped_channel_value object
+    BOOST_STATIC_ASSERT((
+        is_same<float32_t, channel_type<rgba32f_pixel_t>::type>::value));
 
     // channel_type for bit_aligned images doesn't work with standard gil.
     typedef bit_aligned_image4_type<4, 4, 4, 4, rgb_layout_t>::type image_t;

--- a/toolbox/test/rgb_to_luminance.cpp
+++ b/toolbox/test/rgb_to_luminance.cpp
@@ -16,8 +16,6 @@ using namespace gil;
 struct double_zero { static double apply() { return 0.0; } };
 struct double_one  { static double apply() { return 1.0; } };
 
-typedef scoped_channel_value< double, double_zero, double_one > bits64f;
-
 typedef pixel< double, gray_layout_t > gray64f_pixel_t;
 typedef pixel< double, rgb_layout_t  > rgb64f_pixel_t;
 

--- a/toolbox/test/xyz_test.cpp
+++ b/toolbox/test/xyz_test.cpp
@@ -9,9 +9,9 @@
 /// \brief Unit test for XYZ Colorspace
 /// \author Davide Anastasia <davideanastasia@users.sourceforge.net>
 
+#include <cstdint>
 #include <iostream>
 #include <limits>
-#include <boost/cstdint.hpp>
 #include <boost/gil.hpp>
 #include <boost/gil/extension/toolbox/color_spaces/xyz.hpp>
 


### PR DESCRIPTION
### Description

- Replace bitsN[s] aliases with C++11 fixed width integer types
- Import the selection of integer types into `boost::gil` namespace, and move from `channel.hpp` to `typedefs.hpp` for easier access.
- Replace `bits32f` with `float32_t` and `bits64f` with `float64_t` - kept as alias of scoped_channel_value.
- Move `float64_t` (`bits64f`) to typedefs.hpp.
- Replace the four `{float|double}_{zero|one}` min/max channel values
  with `float_point_zero` and `float_point_one` templates.
- Replace `<boost/cstdint,hpp>` with C++11 `<cstdint>`.

- Introduce preference of `using` declaration instead of `typedef`.
- Reformat typedefs.hpp to take advantage of the `using` declaration - works much better for left-to-right reading, alias name as  most important detail comes first.
- Add some of missing #include typedefs.hpp, sort some headers.

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed

### References (eg. other issues, pull requests)

This PR implements code modernisation suggested in the [GIL 3 Ideas](https://github.com/boostorg/gil/wiki/Boost.GIL-3-Ideas) wiki:
> ditch gil's simple data types, like bits32 or bits32f

