### PR TITLE
Fix -Wconversion about float from unsigned int

### DIFF
--- a/include/boost/gil/channel_algorithm.hpp
+++ b/include/boost/gil/channel_algorithm.hpp
@@ -315,8 +315,12 @@ template <> struct channel_converter_unsigned<float32_t,uint32_t> {
     typedef uint32_t result_type;
     uint32_t operator()(float32_t x) const {
         // unfortunately without an explicit check it is possible to get a round-off error. We must ensure that max_value of uint32_t matches max_value of float32_t
-        if (x>=channel_traits<float32_t>::max_value()) return channel_traits<uint32_t>::max_value();
-        return uint32_t(x * channel_traits<uint32_t>::max_value() + 0.5f);
+        if (x>=channel_traits<float32_t>::max_value())
+            return channel_traits<uint32_t>::max_value();
+
+        auto const max_value = channel_traits<uint32_t>::max_value();
+        auto const result = x * static_cast<float32_t::base_channel_t>(max_value) + 0.5f;
+        return static_cast<uint32_t>(result);
     }
 };
 


### PR DESCRIPTION
### Description

Use of `gil::float32_t` type members typedefs with variables for half-results.
Observing intermediate values might be useful during debugging.

-----

It also aligns with the recent agreement to stick to 80-90 line length.
The `return` statements in separate line might also be preferred or even blessed [in particular time, for breakpoints](https://www.youtube.com/watch?v=QTLn3goa3A8&t=10m20s).

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed

### Environment

All relevant information like:

- Compiler version: GCC 7.3
