### PR TITLE
Add promote_integral metafunction

### DIFF
--- a/include/boost/gil/promote_integral.hpp
+++ b/include/boost/gil/promote_integral.hpp
@@ -1,0 +1,208 @@
+// Boost.GIL (Generic Image Library)
+//
+// Copyright (c) 2015, Oracle and/or its affiliates.
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+//
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+//
+// Source: Boost.Geometry (aka GGL, Generic Geometry Library)
+// Modifications: adapted for Boost.GIL
+//  - Rename namespace boost::geometry to boost::gil
+//  - Rename include guards
+//  - Remove support for boost::multiprecision types
+//  - Remove support for 128-bit integer types
+//
+#ifndef BOOST_GIL_PROMOTE_INTEGRAL_HPP
+#define BOOST_GIL_PROMOTE_INTEGRAL_HPP
+
+#include <climits>
+#include <cstddef>
+
+#include <boost/mpl/begin.hpp>
+#include <boost/mpl/deref.hpp>
+#include <boost/mpl/end.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/mpl/list.hpp>
+#include <boost/mpl/next.hpp>
+#include <boost/mpl/size_t.hpp>
+
+#include <boost/type_traits/integral_constant.hpp>
+#include <boost/type_traits/is_fundamental.hpp>
+#include <boost/type_traits/is_integral.hpp>
+#include <boost/type_traits/is_unsigned.hpp>
+
+namespace boost { namespace gil
+{
+
+namespace detail { namespace promote_integral
+{
+
+// meta-function that returns the bit size of a type
+template
+<
+    typename T,
+    bool IsFundamental = boost::is_fundamental<T>::type::value
+>
+struct bit_size {};
+
+// for fundamental types, just return CHAR_BIT * sizeof(T)
+template <typename T>
+struct bit_size<T, true> : boost::mpl::size_t<(CHAR_BIT * sizeof(T))> {};
+
+template
+<
+    typename T,
+    typename Iterator,
+    typename EndIterator,
+    std::size_t MinSize
+>
+struct promote_to_larger
+{
+    typedef typename boost::mpl::deref<Iterator>::type current_type;
+
+    typedef typename boost::mpl::if_c
+        <
+            (bit_size<current_type>::type::value >= MinSize),
+            current_type,
+            typename promote_to_larger
+                <
+                    T,
+                    typename boost::mpl::next<Iterator>::type,
+                    EndIterator,
+                    MinSize
+                >::type
+        >::type type;
+};
+
+// The following specialization is required to finish the loop over
+// all list elements
+template <typename T, typename EndIterator, std::size_t MinSize>
+struct promote_to_larger<T, EndIterator, EndIterator, MinSize>
+{
+    // if promotion fails, keep the number T
+    // (and cross fingers that overflow will not occur)
+    typedef T type;
+};
+
+}} // namespace detail::promote_integral
+
+/*!
+    \brief Meta-function to define an integral type with size
+    than is (roughly) twice the bit size of T
+    \ingroup utility
+    \details
+    This meta-function tries to promote the fundamental integral type T
+    to a another integral type with size (roughly) twice the bit size of T.
+
+    To do this, two times the bit size of T is tested against the bit sizes of:
+         short, int, long, boost::long_long_type, boost::int128_t
+    and the one that first matches is chosen.
+
+    For unsigned types the bit size of T is tested against the bit
+    sizes of the types above, if T is promoted to a signed type, or
+    the bit sizes of
+         unsigned short, unsigned int, unsigned long, std::size_t,
+         boost::ulong_long_type, boost::uint128_t
+    if T is promoted to an unsigned type.
+
+    By default an unsigned type is promoted to a signed type.
+    This behavior is controlled by the PromoteUnsignedToUnsigned
+    boolean template parameter, whose default value is "false".
+    To promote an unsigned type to an unsigned type set the value of
+    this template parameter to "true".
+
+    Finally, if the passed type is either a floating-point type or a
+    user-defined type it is returned as is.
+
+    \note boost::long_long_type and boost::ulong_long_type are
+    considered only if the macro BOOST_HAS_LONG_LONG is defined
+
+*/
+template
+<
+    typename T,
+    bool PromoteUnsignedToUnsigned = false,
+    bool UseCheckedInteger = false,
+    bool IsIntegral = boost::is_integral<T>::type::value
+>
+class promote_integral
+{
+private:
+    static bool const is_unsigned = boost::is_unsigned<T>::type::value;
+
+    typedef detail::promote_integral::bit_size<T> bit_size_type;
+
+    // Define the minimum size (in bits) needed for the promoted type
+    // If T is the input type and P the promoted type, then the
+    // minimum number of bits for P are (below b stands for the number
+    // of bits of T):
+    // * if T is unsigned and P is unsigned: 2 * b
+    // * if T is signed and P is signed: 2 * b - 1
+    // * if T is unsigned and P is signed: 2 * b + 1
+    typedef typename boost::mpl::if_c
+        <
+            (PromoteUnsignedToUnsigned && is_unsigned),
+            boost::mpl::size_t<(2 * bit_size_type::value)>,
+            typename boost::mpl::if_c
+                <
+                    is_unsigned,
+                    boost::mpl::size_t<(2 * bit_size_type::value + 1)>,
+                    boost::mpl::size_t<(2 * bit_size_type::value - 1)>
+                >::type
+        >::type min_bit_size_type;
+
+    // Define the list of signed integral types we are going to use
+    // for promotion
+    typedef boost::mpl::list
+        <
+            short, int, long
+#if defined(BOOST_HAS_LONG_LONG)
+            , boost::long_long_type
+#endif
+        > signed_integral_types;
+
+    // Define the list of unsigned integral types we are going to use
+    // for promotion
+    typedef boost::mpl::list
+        <
+            unsigned short, unsigned int, unsigned long, std::size_t
+#if defined(BOOST_HAS_LONG_LONG)
+            , boost::ulong_long_type
+#endif
+        > unsigned_integral_types;
+
+    // Define the list of integral types that will be used for
+    // promotion (depending in whether we was to promote unsigned to
+    // unsigned or not)
+    typedef typename boost::mpl::if_c
+        <
+            (is_unsigned && PromoteUnsignedToUnsigned),
+            unsigned_integral_types,
+            signed_integral_types
+        >::type integral_types;
+
+public:
+    typedef typename detail::promote_integral::promote_to_larger
+        <
+            T,
+            typename boost::mpl::begin<integral_types>::type,
+            typename boost::mpl::end<integral_types>::type,
+            min_bit_size_type::value
+        >::type type;
+};
+
+
+template <typename T, bool PromoteUnsignedToUnsigned, bool UseCheckedInteger>
+class promote_integral
+    <
+        T, PromoteUnsignedToUnsigned, UseCheckedInteger, false
+    >
+{
+public:
+    typedef T type;
+};
+
+}} // namespace boost::gil
+
+#endif // BOOST_GIL_ROMOTE_INTEGRAL_HPP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,7 +7,7 @@
 #
 message(STATUS "Configuring Boost.GIL core tests")
 
-foreach(name channel pixel pixel_iterator)
+foreach(name channel pixel pixel_iterator promote_integral)
   add_executable(gil_test_${name})
   target_sources(gil_test_${name}
     PRIVATE

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -17,6 +17,7 @@ project
     ;
 
 test-suite "boost-gil-test" :
+    [ run promote_integral.cpp ]
     [ run image.cpp sample_image.cpp error_if.cpp
         :
         : gil_reference_checksums.txt

--- a/test/promote_integral.cpp
+++ b/test/promote_integral.cpp
@@ -1,0 +1,376 @@
+// Boost.GIL (Generic Image Library)
+//
+// Copyright (c) 2015, Oracle and/or its affiliates.
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+//
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+//
+// Source: Boost.Geometry (aka GGL, Generic Geometry Library)
+// Modifications: adapted for Boost.GIL
+//  - Rename namespace boost::geometry to boost::gil
+//  - Rename define BOOST_GEOMETRY_TEST_DEBUG to BOOST_GIL_TEST_DEBUG
+//  - Remove use of macro BOOST_GEOMETRY_CONDITION
+//  - Remove support for boost::multiprecision types
+//  - Remove support for 128-bit integer types
+//  - Update and sort includes
+//
+#include <boost/gil/promote_integral.hpp>
+
+#include <boost/config.hpp>
+#include <boost/type_traits/is_same.hpp>
+#include <boost/type_traits/is_unsigned.hpp>
+
+#include <climits>
+#include <cstddef>
+#include <algorithm>
+#include <limits>
+#include <iostream>
+#include <string>
+#include <sstream>
+
+#ifndef BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE test_promote_integral
+#endif
+#include <gil_test_common.hpp>
+
+// Uncomment to enable debugging output
+//#define BOOST_GIL_TEST_DEBUG 1
+
+namespace bg = boost::gil;
+
+template
+<
+    typename T,
+    bool Signed = boost::is_fundamental<T>::type::value && ! boost::is_unsigned<T>::type::value
+>
+struct absolute_value
+{
+    static inline T apply(T const& t)
+    {
+        return t < 0 ? -t : t;
+    }
+};
+
+template <typename T>
+struct absolute_value<T, false>
+{
+    static inline T apply(T const& t)
+    {
+        return t;
+    }
+};
+
+template
+        <
+                typename Integral,
+                typename Promoted,
+                bool Signed = ! boost::is_unsigned<Promoted>::type::value
+        >
+struct test_max_values
+{
+    static inline void apply()
+    {
+        Promoted min_value = (std::numeric_limits<Integral>::min)();
+        min_value *= min_value;
+        BOOST_CHECK(absolute_value<Promoted>::apply(min_value) == min_value);
+        Promoted max_value = (std::numeric_limits<Integral>::max)();
+        max_value *= max_value;
+        BOOST_CHECK(absolute_value<Promoted>::apply(max_value) == max_value);
+
+#ifdef BOOST_GIL_TEST_DEBUG
+        std::cout << "integral min_value^2: " << min_value << std::endl;
+        std::cout << "promoted max_value:   "
+                  << (std::numeric_limits<Promoted>::max)() << std::endl;
+#endif
+    }
+};
+
+template <typename Integral, typename Promoted>
+struct test_max_values<Integral, Promoted, false>
+{
+    static inline void apply()
+    {
+        Promoted max_value = (std::numeric_limits<Integral>::max)();
+        Promoted max_value_sqr = max_value * max_value;
+        BOOST_CHECK(max_value_sqr < (std::numeric_limits<Promoted>::max)()
+                    &&
+                    max_value_sqr > max_value);
+
+#ifdef BOOST_GIL_TEST_DEBUG
+        std::cout << "integral max_value^2: " << max_value_sqr << std::endl;
+        std::cout << "promoted max_value:   "
+                  << (std::numeric_limits<Promoted>::max)() << std::endl;
+#endif
+    }
+};
+
+
+// helper function that returns the bit size of a type
+template
+        <
+                typename T,
+                bool IsFundamental = boost::is_fundamental<T>::type::value
+        >
+struct bit_size_impl : boost::mpl::size_t<0>
+{};
+
+template <typename T>
+struct bit_size_impl<T, true> : bg::detail::promote_integral::bit_size<T>::type
+{};
+
+template <typename T>
+std::size_t bit_size()
+{
+    return bit_size_impl<T>::type::value;
+}
+
+template <bool PromoteUnsignedToUnsigned>
+struct test_promote_integral
+{
+    template <typename Type, typename ExpectedPromotedType>
+    static inline void apply(std::string const& case_id)
+    {
+        typedef typename bg::promote_integral
+                <
+                        Type, PromoteUnsignedToUnsigned
+                >::type promoted_integral_type;
+
+        bool const same_types = boost::is_same
+                <
+                        promoted_integral_type, ExpectedPromotedType
+                >::type::value;
+
+        BOOST_CHECK_MESSAGE(same_types,
+                            "case ID: " << case_id
+                                        << "input type: " << typeid(Type).name()
+                                        << "; detected: "
+                                        << typeid(promoted_integral_type).name()
+                                        << "; expected: "
+                                        << typeid(ExpectedPromotedType).name());
+
+        if (!boost::is_same<Type, promoted_integral_type>::type::value)
+        {
+            test_max_values<Type, promoted_integral_type>::apply();
+        }
+
+#ifdef BOOST_GIL_TEST_DEBUG
+        std::cout << "case ID: " << case_id << std::endl
+                  << "type : " << typeid(Type).name()
+                  << ", sizeof (bits): " << bit_size<Type>()
+                  << ", min value: "
+                  << (std::numeric_limits<Type>::min)()
+                  << ", max value: "
+                  << (std::numeric_limits<Type>::max)()
+                  << std::endl;
+        std::cout << "detected promoted type : "
+                  << typeid(promoted_integral_type).name()
+                  << ", sizeof (bits): " << bit_size<promoted_integral_type>()
+                  << ", min value: "
+                  << (std::numeric_limits<promoted_integral_type>::min)()
+                  << ", max value: "
+                  << (std::numeric_limits<promoted_integral_type>::max)()
+                  << std::endl;
+        std::cout << "expected promoted type : "
+                  << typeid(ExpectedPromotedType).name()
+                  << ", sizeof (bits): " << bit_size<ExpectedPromotedType>()
+                  << ", min value: "
+                  << (std::numeric_limits<ExpectedPromotedType>::min)()
+                  << ", max value: "
+                  << (std::numeric_limits<ExpectedPromotedType>::max)()
+                  << std::endl;
+        std::cout << std::endl;
+#endif
+    }
+};
+
+template
+        <
+                typename T,
+                bool PromoteUnsignedToUnsigned = false,
+                bool IsSigned = ! boost::is_unsigned<T>::type::value
+        >
+struct test_promotion
+{
+    static inline void apply(std::string case_id)
+    {
+#ifdef BOOST_GIL_TEST_DEBUG
+        std::cout << "*** "
+                  << (IsSigned ? "signed" : "unsigned")
+                  << " -> signed ***" << std::endl;
+#endif
+
+        typedef test_promote_integral<PromoteUnsignedToUnsigned> tester;
+
+        case_id += (PromoteUnsignedToUnsigned ? "-t" : "-f");
+
+        std::size_t min_size = 2 * bit_size<T>() - 1;
+        if (!IsSigned)
+        {
+            min_size += 2;
+        }
+
+#ifdef BOOST_GIL_TEST_DEBUG
+        std::cout << "min size: " << min_size << std::endl;
+#endif
+
+        if (bit_size<short>() >= min_size)
+        {
+            tester::template apply<T, short>(case_id);
+        }
+        else if (bit_size<int>() >= min_size)
+        {
+            tester::template apply<T, int>(case_id);
+        }
+        else if (bit_size<long>() >= min_size)
+        {
+            tester::template apply<T, long>(case_id);
+        }
+#if defined(BOOST_HAS_LONG_LONG)
+        else if (bit_size<boost::long_long_type>() >= min_size)
+        {
+            tester::template apply<T, boost::long_long_type>(case_id);
+        }
+#endif
+#if defined(BOOST_HAS_INT128) && defined(BOOST_GEOMETRY_ENABLE_INT128)
+            else if (bit_size<boost::int128_type>() >= min_size)
+        {
+            tester::template apply<T, boost::int128_type>(case_id);
+        }
+#endif
+        else
+        {
+            tester::template apply<T, T>(case_id);
+        }
+    }
+};
+
+template <typename T>
+struct test_promotion<T, true, false>
+{
+    static inline void apply(std::string case_id)
+    {
+#ifdef BOOST_GIL_TEST_DEBUG
+        std::cout << "*** unsigned -> unsigned ***" << std::endl;
+#endif
+        case_id += "-t";
+
+        typedef test_promote_integral<true> tester;
+
+        std::size_t min_size = 2 * bit_size<T>();
+
+#ifdef BOOST_GIL_TEST_DEBUG
+        std::cout << "min size: " << min_size << std::endl;
+#endif
+
+        if (bit_size<unsigned short>() >= min_size)
+        {
+            tester::apply<T, unsigned short>(case_id);
+        }
+        else if (bit_size<unsigned int>() >= min_size)
+        {
+            tester::apply<T, unsigned int>(case_id);
+        }
+        else if (bit_size<unsigned long>() >= min_size)
+        {
+            tester::apply<T, unsigned long>(case_id);
+        }
+        else if (bit_size<std::size_t>() >= min_size)
+        {
+            tester::apply<T, std::size_t>(case_id);
+        }
+#if defined(BOOST_HAS_LONG_LONG)
+        else if (bit_size<boost::ulong_long_type>() >= min_size)
+        {
+            tester::template apply<T, boost::ulong_long_type>(case_id);
+        }
+#endif
+#if defined(BOOST_HAS_INT128) && defined(BOOST_GEOMETRY_ENABLE_INT128)
+            else if (bit_size<boost::uint128_type>() >= min_size)
+        {
+            tester::template apply<T, boost::uint128_type>(case_id);
+        }
+#endif
+        else
+        {
+            tester::apply<T, T>(case_id);
+        }
+    }
+};
+
+
+
+BOOST_AUTO_TEST_CASE( test_char )
+{
+    test_promotion<char>::apply("char");
+    test_promotion<char, true>::apply("char");
+    test_promotion<signed char>::apply("schar");
+    test_promotion<signed char, true>::apply("schar");
+    test_promotion<unsigned char>::apply("uchar");
+    test_promotion<unsigned char, true>::apply("uchar");
+}
+
+BOOST_AUTO_TEST_CASE( test_short )
+{
+    test_promotion<short>::apply("short");
+    test_promotion<short, true>::apply("short");
+    test_promotion<unsigned short>::apply("ushort");
+    test_promotion<unsigned short, true>::apply("ushort");
+}
+
+BOOST_AUTO_TEST_CASE( test_int )
+{
+    test_promotion<int>::apply("int");
+    test_promotion<int, true>::apply("int");
+    test_promotion<unsigned int>::apply("uint");
+    test_promotion<unsigned int, true>::apply("uint");
+}
+
+BOOST_AUTO_TEST_CASE( test_long )
+{
+    test_promotion<long>::apply("long");
+    test_promotion<long, true>::apply("long");
+    test_promotion<unsigned long>::apply("ulong");
+    test_promotion<unsigned long, true>::apply("ulong");
+}
+
+BOOST_AUTO_TEST_CASE( test_std_size_t )
+{
+    test_promotion<std::size_t>::apply("size_t");
+    test_promotion<std::size_t, true>::apply("size_t");
+}
+
+#ifdef BOOST_HAS_LONG_LONG
+BOOST_AUTO_TEST_CASE( test_long_long )
+{
+    test_promotion<boost::long_long_type>::apply("long long");
+    test_promotion<boost::long_long_type, true>::apply("long long");
+    test_promotion<boost::ulong_long_type>::apply("ulong long");
+    test_promotion<boost::ulong_long_type, true>::apply("ulong long");
+}
+#endif
+
+#if defined(BOOST_HAS_INT128) && defined(BOOST_GEOMETRY_ENABLE_INT128)
+BOOST_AUTO_TEST_CASE( test_int128 )
+{
+    test_promotion<boost::int128_type>::apply("int128_t");
+    test_promotion<boost::int128_type, true>::apply("int128_t");
+    test_promotion<boost::uint128_type>::apply("uint128_t");
+    test_promotion<boost::uint128_type, true>::apply("uint128_t");
+}
+#endif
+
+BOOST_AUTO_TEST_CASE( test_floating_point )
+{
+    typedef test_promote_integral<true> tester1;
+    typedef test_promote_integral<false> tester2;
+
+    // for floating-point types we do not do any promotion
+    tester1::apply<float, float>("fp-f");
+    tester1::apply<double, double>("fp-d");
+    tester1::apply<long double, long double>("fp-ld");
+
+    tester2::apply<float, float>("fp-f");
+    tester2::apply<double, double>("fp-d");
+    tester2::apply<long double, long double>("fp-ld");
+}


### PR DESCRIPTION
### Description

Copied from Boost.Geometry, including original tests, with some non-functional modifications explained in the comments.
The utility can be used where it is important to avoid integer overflow.

Files copied from Boost.Geometry include:

- [promote_integral.hpp](https://github.com/boostorg/geometry/blob/494045809e1ce639c8aa8d77b78e59564a4eeda3/include/boost/geometry/util/promote_integral.hpp)
- [test/util/promote_integral.cpp](https://github.com/boostorg/geometry/blob/ba9117b37ee7194dba547bade9c0f1f24c9dea98/test/util/promote_integral.cpp)

### Tasklist

- [x] Add test case(s)
- [ ] Review
- [ ] Adjust for comments
- [ ] All CI builds and checks have passed
