### PR TITLE
Replace some of Boost.MPL and Boost.TypeTraits with C++11 equivalents

### DIFF
--- a/test/promote_integral.cpp
+++ b/test/promote_integral.cpp
@@ -18,8 +18,6 @@
 #include <boost/gil/promote_integral.hpp>
 
 #include <boost/config.hpp>
-#include <boost/type_traits/is_same.hpp>
-#include <boost/type_traits/is_unsigned.hpp>
 
 #include <climits>
 #include <cstddef>
@@ -42,7 +40,7 @@ namespace bg = boost::gil;
 template
 <
     typename T,
-    bool Signed = boost::is_fundamental<T>::type::value && ! boost::is_unsigned<T>::type::value
+    bool Signed = std::is_fundamental<T>::type::value && !std::is_unsigned<T>::type::value
 >
 struct absolute_value
 {
@@ -62,11 +60,11 @@ struct absolute_value<T, false>
 };
 
 template
-        <
-                typename Integral,
-                typename Promoted,
-                bool Signed = ! boost::is_unsigned<Promoted>::type::value
-        >
+    <
+        typename Integral,
+        typename Promoted,
+        bool Signed = !std::is_unsigned<Promoted>::type::value
+    >
 struct test_max_values
 {
     static inline void apply()
@@ -108,11 +106,11 @@ struct test_max_values<Integral, Promoted, false>
 
 // helper function that returns the bit size of a type
 template
-        <
-                typename T,
-                bool IsFundamental = boost::is_fundamental<T>::type::value
-        >
-struct bit_size_impl : boost::mpl::size_t<0>
+    <
+        typename T,
+        bool IsFundamental = std::is_fundamental<T>::type::value
+    >
+struct bit_size_impl : std::integral_constant<std::size_t, 0>
 {};
 
 template <typename T>
@@ -132,14 +130,14 @@ struct test_promote_integral
     static inline void apply(std::string const& case_id)
     {
         typedef typename bg::promote_integral
-                <
-                        Type, PromoteUnsignedToUnsigned
-                >::type promoted_integral_type;
+            <
+                Type, PromoteUnsignedToUnsigned
+            >::type promoted_integral_type;
 
-        bool const same_types = boost::is_same
-                <
-                        promoted_integral_type, ExpectedPromotedType
-                >::type::value;
+        bool const same_types = std::is_same
+            <
+                promoted_integral_type, ExpectedPromotedType
+            >::type::value;
 
         BOOST_CHECK_MESSAGE(same_types,
                             "case ID: " << case_id
@@ -149,7 +147,7 @@ struct test_promote_integral
                                         << "; expected: "
                                         << typeid(ExpectedPromotedType).name());
 
-        if (!boost::is_same<Type, promoted_integral_type>::type::value)
+        if (!std::is_same<Type, promoted_integral_type>::type::value)
         {
             test_max_values<Type, promoted_integral_type>::apply();
         }
@@ -188,7 +186,7 @@ template
         <
                 typename T,
                 bool PromoteUnsignedToUnsigned = false,
-                bool IsSigned = ! boost::is_unsigned<T>::type::value
+                bool IsSigned = !std::is_unsigned<T>::type::value
         >
 struct test_promotion
 {
@@ -230,12 +228,6 @@ struct test_promotion
         else if (bit_size<boost::long_long_type>() >= min_size)
         {
             tester::template apply<T, boost::long_long_type>(case_id);
-        }
-#endif
-#if defined(BOOST_HAS_INT128) && defined(BOOST_GEOMETRY_ENABLE_INT128)
-            else if (bit_size<boost::int128_type>() >= min_size)
-        {
-            tester::template apply<T, boost::int128_type>(case_id);
         }
 #endif
         else
@@ -285,20 +277,12 @@ struct test_promotion<T, true, false>
             tester::template apply<T, boost::ulong_long_type>(case_id);
         }
 #endif
-#if defined(BOOST_HAS_INT128) && defined(BOOST_GEOMETRY_ENABLE_INT128)
-            else if (bit_size<boost::uint128_type>() >= min_size)
-        {
-            tester::template apply<T, boost::uint128_type>(case_id);
-        }
-#endif
         else
         {
             tester::apply<T, T>(case_id);
         }
     }
 };
-
-
 
 BOOST_AUTO_TEST_CASE( test_char )
 {
@@ -347,16 +331,6 @@ BOOST_AUTO_TEST_CASE( test_long_long )
     test_promotion<boost::long_long_type, true>::apply("long long");
     test_promotion<boost::ulong_long_type>::apply("ulong long");
     test_promotion<boost::ulong_long_type, true>::apply("ulong long");
-}
-#endif
-
-#if defined(BOOST_HAS_INT128) && defined(BOOST_GEOMETRY_ENABLE_INT128)
-BOOST_AUTO_TEST_CASE( test_int128 )
-{
-    test_promotion<boost::int128_type>::apply("int128_t");
-    test_promotion<boost::int128_type, true>::apply("int128_t");
-    test_promotion<boost::uint128_type>::apply("uint128_t");
-    test_promotion<boost::uint128_type, true>::apply("uint128_t");
 }
 #endif
 


### PR DESCRIPTION
### Description

Non-functional refactoring of `promote_integral` added in #91

### Tasklist

- [x] All CI builds and checks have passed

### References (eg. other issues, pull requests)

#91