### PR TITLE
Add <implicit-dependency>/boost//headers to root Jamfile

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -9,6 +9,7 @@
 project boost-gil
     :
     requirements
+        <implicit-dependency>/boost//headers
         # MSVC: Since VS2017, default is -std:c++14, so no explicit switch is required.
         <toolset>msvc:<asynch-exceptions>on
         <toolset>msvc:<cxxflags>/W4


### PR DESCRIPTION
### Description: what does this pull request do?

For in-tree builds, this should ensure any changes of headers if dependency Boost libraries are considered and trigger compilation of dependant sources of tests and examples.

### Tasklist

- [ ] Review
- [ ] Adjust for comments
- [ ] All CI builds and checks have passed
