### PR TITLE
Disable unaligned pointer access

### DIFF
--- a/include/boost/gil/channel.hpp
+++ b/include/boost/gil/channel.hpp
@@ -344,7 +344,7 @@ protected:
     static const num_value_t num_values = static_cast< num_value_t >( 1 ) << NumBits ;
     static const max_value_t max_val    = static_cast< max_value_t >( num_values - 1 );
     
-#ifdef GIL_NONWORD_POINTER_ALIGNMENT_SUPPORTED
+#if defined(BOOST_GIL_CONFIG_HAS_UNALIGNED_ACCESS)
     const bitfield_t& get_data()                      const { return *static_cast<const bitfield_t*>(_data_ptr); }
     void              set_data(const bitfield_t& val) const {        *static_cast<      bitfield_t*>(_data_ptr) = val; }
 #else

--- a/include/boost/gil/gil_config.hpp
+++ b/include/boost/gil/gil_config.hpp
@@ -1,6 +1,7 @@
 /*
     Copyright 2005-2007 Adobe Systems Incorporated
-   
+    Copyright 2018 Mateusz Loskot <mateusz at loskot dot net>
+
     Use, modification and distribution are subject to the Boost Software License,
     Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
     http://www.boost.org/LICENSE_1_0.txt).
@@ -14,7 +15,7 @@
 #define GIL_CONFIG_HPP
 
 ////////////////////////////////////////////////////////////////////////////////////////
-/// \file               
+/// \file
 /// \brief GIL configuration file
 /// \author Lubomir Bourdev and Hailin Jin \n
 ///         Adobe Systems Incorporated
@@ -22,13 +23,40 @@
 ////////////////////////////////////////////////////////////////////////////////////////
 
 #include <boost/config.hpp>
+#include <boost/config/pragma_message.hpp>
 
 #define GIL_VERSION "2.1.2"
 
-// Enable GIL_NONWORD_POINTER_ALIGNMENT_SUPPORTED if your platform supports dereferencing on non-word memory boundary.
-// Enabling the flag results in performance improvement
-#if !defined(__hpux) && !defined(sun) && !defined(__sun) && !defined(__osf__)
-    #define GIL_NONWORD_POINTER_ALIGNMENT_SUPPORTED
+#if defined(BOOST_GIL_DOXYGEN_ONLY)
+/// \def BOOST_GIL_CONFIG_HAS_UNALIGNED_ACCESS
+/// \brief Define to allow unaligned memory access
+/// Theoretically (or historically?) on platforms which support dereferencing on
+/// non-word memory boundary, unaligned access may result in performance improvement.
+/// \warning Unfortunately, this optimization may be a C/C++ strict aliasing rules
+/// violation, if accessed data buffer has effective type that cannot be aliased
+/// without leading to undefined behaviour.
+#define BOOST_GIL_CONFIG_HAS_UNALIGNED_ACCESS
 #endif
+
+#if defined(BOOST_GIL_CONFIG_HAS_UNALIGNED_ACCESS)
+#if defined(sun) || defined(__sun) || \             // SunOS
+    defined(__osf__) || defined(__osf) || \         // Tru64
+    defined(_hpux) || defined(hpux) || \            // HP-UX
+    defined(__arm__) || defined(__ARM_ARCH) || \    // ARM
+    defined(_AIX)                                   // AIX
+#error Unaligned access strictly disabled for some UNIX platforms or ARM architecture
+#elif defined(__i386__) || defined(__x86_64__) || defined(__vax__)
+    // The check for little-endian architectures that tolerate unaligned memory
+    // accesses is just an optimization. Nothing will break if it fails to detect
+    // a suitable architecture.
+    //
+    // Unfortunately, this optimization may be a C/C++ strict aliasing rules violation
+    // if accessed data buffer has effective type that cannot be aliased
+    // without leading to undefined behaviour.
+BOOST_PRAGMA_MESSAGE("CAUTION: Unaligned access tolerated on little-endian may cause undefined behaviour")
+#else
+#error Unaligned access disabled for unknown platforms and architectures
+#endif
+#endif // defined(BOOST_GIL_CONFIG_HAS_UNALIGNED_ACCESS)
 
 #endif


### PR DESCRIPTION
(NOTE: _Assigned to self - if accepted, I'd like to merge myself. Thanks._)

### Description: what does this pull request do?

Rename `GIL_NONWORD_POINTER_ALIGNMENT_SUPPORTED`   to `BOOST_GIL_CONFIG_HAS_UNALIGNED_ACCESS`.
Undefine `BOOST_GIL_CONFIG_HAS_UNALIGNED_ACCESS` by default and document it.
If defined, issue warning or error, depending on target platform.

This changes how `packed_channel_reference_base`-based channels perform access - aligned memory access by default.

This also fixes undefined behavior detected by UBSan in some test cases.

-----

Accessing a misaligned pointer results in undefined behavior and causes numerous [UBSan sanitizer run-time errors](https://travis-ci.org/boostorg/gil/jobs/395130083) on Travis CI (and locally too).

For example:

```
channel.hpp:348:70: runtime error: reference binding to misaligned address 0x0000029c2cf1 for type
  'const boost::gil::detail::packed_channel_reference_base<boost::gil::packed_dynamic_channel_reference<unsigned short, 1, true>, unsigned short, 1, true>::bitfield_t' (aka 'const unsigned short'),
  which requires 2 byte alignment 0x0000029c2cf1
```

### Tasklist

- [x] Disable `GIL_NONWORD_POINTER_ALIGNMENT_SUPPORTED`  by default.
- [x] Rename `GIL_NONWORD_POINTER_ALIGNMENT_SUPPORTED` to clearer `BOOST_GIL_CONFIG_HAS_UNALIGNED_ACCESS`
- [x] Adjust for comments
- [x] All CI builds and checks have passed (minus `ubsan_integer` still expected to fail)

### Questions

Apparently, the 10+ years old rationale to enable misaligned access is improved performance:

https://github.com/boostorg/gil/blob/d882b844944001f5f94e55aed3faaf651aae3032/include/boost/gil/gil_config.hpp#L28-L32

But, is it?

The unaligned access is not cheap either, but it is troublesome due to the _undefined behaviour_ in C and C++. Unfortunately, I don't have time to prepare GIL-specific benchmark to compare performance with and without `GIL_NONWORD_POINTER_ALIGNMENT_SUPPORTED` defined.

However, shall we review it and perhaps agree to disable `GIL_NONWORD_POINTER_ALIGNMENT_SUPPORTED` by default?

-----

BTW, I have added `-Wcast-align` to `<cxxflags>` in the Jamfile, see https://github.com/boostorg/gil/commit/e385653a239405af207ab0bc86a1fe5e80ae217d, but so far I haven't noticed any related warnings reported.