### PR TITLE
[travis] List required Boost libraries explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -150,12 +150,62 @@ install:
   - cd ..
   - git clone -b master --depth 1 https://github.com/boostorg/boost.git boost-root
   - cd boost-root
+  # List all (recursive) dependencies explicitly to control any new additions
   - git submodule update --init tools/build
-  - git submodule update --init libs/config
   - git submodule update --init tools/boostdep
+  - git submodule update --init libs/algorithm
+  - git submodule update --init libs/array
+  - git submodule update --init libs/assert
+  - git submodule update --init libs/atomic
+  - git submodule update --init libs/bind
+  - git submodule update --init libs/chrono
+  - git submodule update --init libs/concept_check
+  - git submodule update --init libs/config
+  - git submodule update --init libs/container
+  - git submodule update --init libs/container_hash
+  - git submodule update --init libs/conversion
+  - git submodule update --init libs/core
+  - git submodule update --init libs/crc
+  - git submodule update --init libs/detail
+  - git submodule update --init libs/exception
+  - git submodule update --init libs/filesystem
+  - git submodule update --init libs/function
+  - git submodule update --init libs/function_types
+  - git submodule update --init libs/fusion
+  - git submodule update --init libs/integer
+  - git submodule update --init libs/intrusive
+  - git submodule update --init libs/io
+  - git submodule update --init libs/iterator
+  - git submodule update --init libs/lambda
+  - git submodule update --init libs/lexical_cast
+  - git submodule update --init libs/math
+  - git submodule update --init libs/move
+  - git submodule update --init libs/mpl
+  - git submodule update --init libs/numeric/conversion
+  - git submodule update --init libs/optional
+  - git submodule update --init libs/predef
+  - git submodule update --init libs/preprocessor
+  - git submodule update --init libs/range
+  - git submodule update --init libs/ratio
+  - git submodule update --init libs/rational
+  - git submodule update --init libs/regex
+  - git submodule update --init libs/smart_ptr
+  - git submodule update --init libs/static_assert
+  - git submodule update --init libs/system
+  - git submodule update --init libs/test
+  - git submodule update --init libs/throw_exception
+  - git submodule update --init libs/timer
+  - git submodule update --init libs/tuple
+  - git submodule update --init libs/type_index
+  - git submodule update --init libs/type_traits
+  - git submodule update --init libs/typeof
+  - git submodule update --init libs/unordered
+  - git submodule update --init libs/utility
+  - git submodule update --init libs/winapi
+  - rm -rf libs/gil
+  - mkdir libs/gil
   - cp -r $TRAVIS_BUILD_DIR/* libs/gil
   - cp -r $TRAVIS_BUILD_DIR/.ci libs/gil
-  - python tools/boostdep/depinst/depinst.py gil
   - ./bootstrap.sh
   - ./b2 headers
 


### PR DESCRIPTION
(NOTE: _Assigned to self - if accepted, I'd like to merge myself. Thanks._)

### Description: what does this pull request do?

`tools/boostdep/depinst/depinst.py` helper automatically calculates maximum set of required Boost libraries, based on `#include`-s.

Manual listing should help to control any new additions and prevent introduction of unwanted dependencies.

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed
