### PR TITLE
Remove dependency on boost::array

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -155,7 +155,6 @@ install:
   - git submodule --quiet update --init tools/boostdep
   ## Direct
   - git submodule --quiet update --init libs/algorithm
-  - git submodule --quiet update --init libs/array
   - git submodule --quiet update --init libs/bind
   - git submodule --quiet update --init libs/concept_check
   - git submodule --quiet update --init libs/config
@@ -176,6 +175,7 @@ install:
   - git submodule --quiet update --init libs/type_traits
   ## Transitive
   - git submodule --quiet update --init libs/assert
+  - git submodule --quiet update --init libs/array
   - git submodule --quiet update --init libs/atomic
   - git submodule --quiet update --init libs/chrono
   - git submodule --quiet update --init libs/container

--- a/include/boost/gil/extension/numeric/kernel.hpp
+++ b/include/boost/gil/extension/numeric/kernel.hpp
@@ -21,11 +21,11 @@
 
 #include <cstddef>
 #include <cassert>
+#include <array>
 #include <algorithm>
 #include <vector>
 #include <memory>
 
-#include <boost/array.hpp>
 #include <boost/gil/gil_config.hpp>
 #include <boost/gil/utilities.hpp>
 
@@ -76,8 +76,8 @@ public:
 
 /// \brief static-size kernel
 template <typename T,std::size_t Size>
-class kernel_1d_fixed : public detail::kernel_1d_adaptor<array<T,Size> > {
-    typedef detail::kernel_1d_adaptor<array<T,Size> > parent_t;
+class kernel_1d_fixed : public detail::kernel_1d_adaptor<std::array<T,Size> > {
+    typedef detail::kernel_1d_adaptor<std::array<T,Size> > parent_t;
 public:
     kernel_1d_fixed() {}
     explicit kernel_1d_fixed(std::size_t center_in) : parent_t(center_in) {}

--- a/include/boost/gil/io/base.hpp
+++ b/include/boost/gil/io/base.hpp
@@ -23,7 +23,6 @@
 #include <istream>
 #include <vector>
 
-#include <boost/array.hpp>
 #include <boost/bind.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 

--- a/include/boost/gil/io/bit_operations.hpp
+++ b/include/boost/gil/io/bit_operations.hpp
@@ -21,6 +21,8 @@
 
 #include <boost/bind.hpp>
 
+#include <array>
+
 namespace boost { namespace gil { namespace detail {
 
 // 1110 1100 -> 0011 0111
@@ -110,7 +112,7 @@ private:
 
     bool _apply_operation;
 
-    array< byte_t, 256 > _lookup;
+    std::array< byte_t, 256 > _lookup;
 };
 
 


### PR DESCRIPTION
### Description: what does this pull request do?

Replace `boost::array` with C++11 `std::array`.

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed (except [ubsan_integer](https://travis-ci.org/boostorg/gil/builds/396014158) still expected to fail)
