### PR TITLE
Remove dependency on boost::lexical_cast

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -166,7 +166,6 @@ install:
   - git submodule --quiet update --init libs/integer
   - git submodule --quiet update --init libs/iterator
   - git submodule --quiet update --init libs/lambda
-  - git submodule --quiet update --init libs/lexical_cast
   - git submodule --quiet update --init libs/mpl
   - git submodule --quiet update --init libs/numeric/conversion
   - git submodule --quiet update --init libs/preprocessor

--- a/include/boost/gil/extension/io/pnm/detail/write.hpp
+++ b/include/boost/gil/extension/io/pnm/detail/write.hpp
@@ -19,9 +19,8 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////////////
 
-#include <stdlib.h>
-
-#include <boost/lexical_cast.hpp>
+#include <cstdlib>
+#include <string>
 
 #include <boost/gil/extension/io/pnm/tags.hpp>
 
@@ -93,15 +92,15 @@ public:
         // Add a white space at each string so read_int() can decide when a numbers ends.
 
         std::string str( "P" );
-        str += lexical_cast< std::string >( type ) + std::string( " " );
+        str += std::to_string( type ) + std::string( " " );
         this->_io_dev.print_line( str );
 
         str.clear();
-        str += lexical_cast< std::string >( width ) + std::string( " " );
+        str += std::to_string( width ) + std::string( " " );
         this->_io_dev.print_line( str );
 
         str.clear();
-        str += lexical_cast< std::string >( height ) + std::string( " " );
+        str += std::to_string( height ) + std::string( " " );
         this->_io_dev.print_line( str );
 
         if( type != pnm_image_type::mono_bin_t::value )


### PR DESCRIPTION
### Description: what does this pull request do?

Replace `lexical_cast` with C++11 `std::to_string` function.

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed (except [ubsan_integer](https://travis-ci.org/boostorg/gil/builds/396014158) still expected to fail)
