### PR TITLE
[appveyor] List required Boost libraries explicitly

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -84,11 +84,61 @@ install:
 before_build:
   - git clone --quiet -b develop --depth 1 https://github.com/boostorg/boost.git c:\projects\boost
   - cd c:\projects\boost
+  # List all (recursive) dependencies explicitly to control any new additions
   - git submodule --quiet update --init tools/build
-  - git submodule --quiet update --init libs/config
   - git submodule --quiet update --init tools/boostdep
+  ## Direct
+  - git submodule --quiet update --init libs/algorithm
+  - git submodule --quiet update --init libs/array
+  - git submodule --quiet update --init libs/bind
+  - git submodule --quiet update --init libs/concept_check
+  - git submodule --quiet update --init libs/config
+  - git submodule --quiet update --init libs/core
+  - git submodule --quiet update --init libs/crc
+  - git submodule --quiet update --init libs/filesystem
+  - git submodule --quiet update --init libs/function
+  - git submodule --quiet update --init libs/integer
+  - git submodule --quiet update --init libs/iterator
+  - git submodule --quiet update --init libs/lambda
+  - git submodule --quiet update --init libs/lexical_cast
+  - git submodule --quiet update --init libs/mpl
+  - git submodule --quiet update --init libs/numeric/conversion
+  - git submodule --quiet update --init libs/preprocessor
+  - git submodule --quiet update --init libs/smart_ptr
+  - git submodule --quiet update --init libs/static_assert
+  - git submodule --quiet update --init libs/test
+  - git submodule --quiet update --init libs/type_traits
+  ## Transitive
+  - git submodule --quiet update --init libs/assert
+  - git submodule --quiet update --init libs/atomic
+  - git submodule --quiet update --init libs/chrono
+  - git submodule --quiet update --init libs/container
+  - git submodule --quiet update --init libs/container_hash
+  - git submodule --quiet update --init libs/conversion
+  - git submodule --quiet update --init libs/detail
+  - git submodule --quiet update --init libs/exception
+  - git submodule --quiet update --init libs/function_types
+  - git submodule --quiet update --init libs/fusion
+  - git submodule --quiet update --init libs/intrusive
+  - git submodule --quiet update --init libs/io
+  - git submodule --quiet update --init libs/math
+  - git submodule --quiet update --init libs/move
+  - git submodule --quiet update --init libs/optional
+  - git submodule --quiet update --init libs/predef
+  - git submodule --quiet update --init libs/range
+  - git submodule --quiet update --init libs/ratio
+  - git submodule --quiet update --init libs/rational
+  - git submodule --quiet update --init libs/regex
+  - git submodule --quiet update --init libs/system
+  - git submodule --quiet update --init libs/throw_exception
+  - git submodule --quiet update --init libs/timer
+  - git submodule --quiet update --init libs/tuple
+  - git submodule --quiet update --init libs/type_index
+  - git submodule --quiet update --init libs/typeof
+  - git submodule --quiet update --init libs/unordered
+  - git submodule --quiet update --init libs/utility
+  - git submodule --quiet update --init libs/winapi
   - xcopy /s /e /q %APPVEYOR_BUILD_FOLDER% libs\gil
-  - python tools/boostdep/depinst/depinst.py gil
   - cmd /c bootstrap
   - .\b2 headers
   - if DEFINED GENERATOR .\b2 address-model=%AM% toolset=%TOOLSET% variant=%VARIANT% --with-filesystem --with-test stage

--- a/.travis.yml
+++ b/.travis.yml
@@ -151,59 +151,59 @@ install:
   - git clone -b master --depth 1 https://github.com/boostorg/boost.git boost-root
   - cd boost-root
   # List all (recursive) dependencies explicitly to control any new additions
-  - git submodule update --init tools/build
-  - git submodule update --init tools/boostdep
+  - git submodule --quiet update --init tools/build
+  - git submodule --quiet update --init tools/boostdep
   ## Direct
-  - git submodule update --init libs/algorithm
-  - git submodule update --init libs/array
-  - git submodule update --init libs/bind
-  - git submodule update --init libs/concept_check
-  - git submodule update --init libs/config
-  - git submodule update --init libs/core
-  - git submodule update --init libs/crc
-  - git submodule update --init libs/filesystem
-  - git submodule update --init libs/function
-  - git submodule update --init libs/integer
-  - git submodule update --init libs/iterator
-  - git submodule update --init libs/lambda
-  - git submodule update --init libs/lexical_cast
-  - git submodule update --init libs/mpl
-  - git submodule update --init libs/numeric/conversion
-  - git submodule update --init libs/preprocessor
-  - git submodule update --init libs/smart_ptr
-  - git submodule update --init libs/static_assert
-  - git submodule update --init libs/test
-  - git submodule update --init libs/type_traits
+  - git submodule --quiet update --init libs/algorithm
+  - git submodule --quiet update --init libs/array
+  - git submodule --quiet update --init libs/bind
+  - git submodule --quiet update --init libs/concept_check
+  - git submodule --quiet update --init libs/config
+  - git submodule --quiet update --init libs/core
+  - git submodule --quiet update --init libs/crc
+  - git submodule --quiet update --init libs/filesystem
+  - git submodule --quiet update --init libs/function
+  - git submodule --quiet update --init libs/integer
+  - git submodule --quiet update --init libs/iterator
+  - git submodule --quiet update --init libs/lambda
+  - git submodule --quiet update --init libs/lexical_cast
+  - git submodule --quiet update --init libs/mpl
+  - git submodule --quiet update --init libs/numeric/conversion
+  - git submodule --quiet update --init libs/preprocessor
+  - git submodule --quiet update --init libs/smart_ptr
+  - git submodule --quiet update --init libs/static_assert
+  - git submodule --quiet update --init libs/test
+  - git submodule --quiet update --init libs/type_traits
   ## Transitive
-  - git submodule update --init libs/assert
-  - git submodule update --init libs/atomic
-  - git submodule update --init libs/chrono
-  - git submodule update --init libs/container
-  - git submodule update --init libs/container_hash
-  - git submodule update --init libs/conversion
-  - git submodule update --init libs/detail
-  - git submodule update --init libs/exception
-  - git submodule update --init libs/function_types
-  - git submodule update --init libs/fusion
-  - git submodule update --init libs/intrusive
-  - git submodule update --init libs/io
-  - git submodule update --init libs/math
-  - git submodule update --init libs/move
-  - git submodule update --init libs/optional
-  - git submodule update --init libs/predef
-  - git submodule update --init libs/range
-  - git submodule update --init libs/ratio
-  - git submodule update --init libs/rational
-  - git submodule update --init libs/regex
-  - git submodule update --init libs/system
-  - git submodule update --init libs/throw_exception
-  - git submodule update --init libs/timer
-  - git submodule update --init libs/tuple
-  - git submodule update --init libs/type_index
-  - git submodule update --init libs/typeof
-  - git submodule update --init libs/unordered
-  - git submodule update --init libs/utility
-  - git submodule update --init libs/winapi
+  - git submodule --quiet update --init libs/assert
+  - git submodule --quiet update --init libs/atomic
+  - git submodule --quiet update --init libs/chrono
+  - git submodule --quiet update --init libs/container
+  - git submodule --quiet update --init libs/container_hash
+  - git submodule --quiet update --init libs/conversion
+  - git submodule --quiet update --init libs/detail
+  - git submodule --quiet update --init libs/exception
+  - git submodule --quiet update --init libs/function_types
+  - git submodule --quiet update --init libs/fusion
+  - git submodule --quiet update --init libs/intrusive
+  - git submodule --quiet update --init libs/io
+  - git submodule --quiet update --init libs/math
+  - git submodule --quiet update --init libs/move
+  - git submodule --quiet update --init libs/optional
+  - git submodule --quiet update --init libs/predef
+  - git submodule --quiet update --init libs/range
+  - git submodule --quiet update --init libs/ratio
+  - git submodule --quiet update --init libs/rational
+  - git submodule --quiet update --init libs/regex
+  - git submodule --quiet update --init libs/system
+  - git submodule --quiet update --init libs/throw_exception
+  - git submodule --quiet update --init libs/timer
+  - git submodule --quiet update --init libs/tuple
+  - git submodule --quiet update --init libs/type_index
+  - git submodule --quiet update --init libs/typeof
+  - git submodule --quiet update --init libs/unordered
+  - git submodule --quiet update --init libs/utility
+  - git submodule --quiet update --init libs/winapi
   - rm -rf libs/gil
   - mkdir libs/gil
   - cp -r $TRAVIS_BUILD_DIR/* libs/gil


### PR DESCRIPTION
(This change has already been reviewed as part of #101)

### Description: what does this pull request do?

Group list of deps for easy identification of direct ones.
Add --quiet option to git submodule commands on Travis CI.

### References (eg. other issues, pull requests)

#101 

### Tasklist

- [x] All CI builds and checks have passed (except [ubsan_integer](https://travis-ci.org/boostorg/gil/builds/396014158?utm_source=github_status&utm_medium=notification) still expected to fail)
