### PR TITLE
Remove dependency on Boost.SmartPtr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -168,7 +168,6 @@ install:
   - git submodule --quiet update --init libs/mpl
   - git submodule --quiet update --init libs/numeric/conversion
   - git submodule --quiet update --init libs/preprocessor
-  - git submodule --quiet update --init libs/smart_ptr
   - git submodule --quiet update --init libs/static_assert
   - git submodule --quiet update --init libs/test
   - git submodule --quiet update --init libs/type_traits
@@ -194,6 +193,7 @@ install:
   - git submodule --quiet update --init libs/ratio
   - git submodule --quiet update --init libs/rational
   - git submodule --quiet update --init libs/regex
+  - git submodule --quiet update --init libs/smart_ptr
   - git submodule --quiet update --init libs/system
   - git submodule --quiet update --init libs/throw_exception
   - git submodule --quiet update --init libs/timer

--- a/include/boost/gil/extension/io/jpeg/detail/reader_backend.hpp
+++ b/include/boost/gil/extension/io/jpeg/detail/reader_backend.hpp
@@ -21,6 +21,8 @@
 
 #include <boost/gil/extension/io/jpeg/tags.hpp>
 
+#include <memory>
+
 namespace boost { namespace gil {
 
 #if BOOST_WORKAROUND(BOOST_MSVC, >= 1400) 
@@ -38,7 +40,7 @@ struct jpeg_decompress_wrapper
 {
 protected:
 
-    typedef boost::shared_ptr< jpeg_decompress_struct > jpeg_decompress_ptr_t;
+    using jpeg_decompress_ptr_t = std::shared_ptr<jpeg_decompress_struct> ;
 
 protected:
 

--- a/include/boost/gil/extension/io/jpeg/detail/writer_backend.hpp
+++ b/include/boost/gil/extension/io/jpeg/detail/writer_backend.hpp
@@ -20,8 +20,9 @@
 ////////////////////////////////////////////////////////////////////////////////////////
 
 #include <boost/gil/extension/io/jpeg/tags.hpp>
-
 #include <boost/gil/extension/io/jpeg/detail/base.hpp>
+
+#include <memory>
 
 namespace boost { namespace gil {
 
@@ -40,7 +41,7 @@ struct jpeg_compress_wrapper
 {
 protected:
 
-    typedef boost::shared_ptr< jpeg_compress_struct > jpeg_compress_ptr_t;
+    using jpeg_compress_ptr_t = std::shared_ptr<jpeg_compress_struct>;
 
 protected:
 

--- a/include/boost/gil/extension/io/png/detail/base.hpp
+++ b/include/boost/gil/extension/io/png/detail/base.hpp
@@ -19,6 +19,8 @@
 
 #include <boost/gil/extension/io/png/tags.hpp>
 
+#include <memory>
+
 namespace boost { namespace gil { namespace detail {
 
 struct png_ptr_wrapper
@@ -39,7 +41,7 @@ struct png_struct_info_wrapper
 {
 protected:
 
-    typedef boost::shared_ptr< png_ptr_wrapper > png_ptr_t;
+    using png_ptr_t = std::shared_ptr<png_ptr_wrapper>;
 
 protected:
 

--- a/include/boost/gil/extension/io/raw/detail/device.hpp
+++ b/include/boost/gil/extension/io/raw/detail/device.hpp
@@ -19,11 +19,12 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////////////
 
-#include <boost/shared_ptr.hpp>
 #include <boost/utility/enable_if.hpp>
 
 #include <boost/gil/io/base.hpp>
 #include <boost/gil/io/io_device.hpp>
+
+#include <memory>
 
 namespace boost { namespace gil { namespace detail {
 
@@ -84,7 +85,7 @@ public:
 
 protected:
 
-    typedef boost::shared_ptr< LibRaw > libraw_ptr_t;
+    using libraw_ptr_t = std::shared_ptr<LibRaw>;
     libraw_ptr_t _processor_ptr;
 };
 

--- a/include/boost/gil/extension/io/tiff/detail/device.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/device.hpp
@@ -36,32 +36,33 @@
 #include <tiffio.hxx>
 
 #include <boost/mpl/size.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/utility/enable_if.hpp>
 
 #include <boost/gil/io/base.hpp>
 #include <boost/gil/io/device.hpp>
 #include <boost/gil/extension/io/tiff/detail/log.hpp>
 
+#include <memory>
+
 namespace boost { namespace gil { namespace detail {
 
 template <int n_args>
 struct get_property_f {
 	template <typename Property>
-	bool call_me(typename Property:: type& value, shared_ptr <TIFF> & file);
+	bool call_me(typename Property:: type& value, std::shared_ptr<TIFF>& file);
 };
 
 template <int n_args>
 struct set_property_f {
 	template <typename Property>
-	bool call_me(const typename Property:: type& value, shared_ptr <TIFF> & file) const;
+	bool call_me(const typename Property:: type& value, std::shared_ptr<TIFF>& file) const;
 };
 
 template <> struct get_property_f <1> 
 {
 	// For single-valued properties
 	template <typename Property>
-	bool call_me(typename Property::type & value, shared_ptr <TIFF> & file) const
+	bool call_me(typename Property::type & value, std::shared_ptr<TIFF>& file) const
 	{
 		// @todo: defaulted, really?
 		return (1 == TIFFGetFieldDefaulted( file.get()
@@ -75,7 +76,7 @@ template <> struct get_property_f <2>
 	// Specialisation for multi-valued properties. @todo: add one of
 	// these for the three-parameter fields too.
 	template <typename Property>
-	bool call_me(typename Property:: type & vs, shared_ptr <TIFF> & file) const
+	bool call_me(typename Property:: type & vs, std::shared_ptr<TIFF>& file) const
 	{
 		typename mpl:: at <typename Property:: arg_types, mpl::int_<0> >:: type length;
 		typename mpl:: at <typename Property:: arg_types, mpl::int_<1> >:: type pointer;
@@ -95,7 +96,7 @@ template <> struct set_property_f <1>
 	// For single-valued properties
 	template <typename Property>
 	inline
-	bool call_me(typename Property:: type const & value, shared_ptr <TIFF> & file) const
+	bool call_me(typename Property:: type const & value, std::shared_ptr<TIFF>& file) const
 	{
 		return (1 == TIFFSetField( file.get()
 				, Property:: tag
@@ -113,7 +114,7 @@ template <> struct set_property_f <2>
 	// )
 	template <typename Property>
 	inline
-	bool call_me(typename Property:: type const & values, shared_ptr <TIFF> & file) const
+	bool call_me(typename Property:: type const & values, std::shared_ptr<TIFF>& file) const
 	{
 		typename mpl:: at <typename Property:: arg_types, mpl::int_<0> >:: type const length = values. size ();
 		typename mpl:: at <typename Property:: arg_types, mpl::int_<1> >:: type const pointer = & (values. front ()); 
@@ -128,7 +129,7 @@ template< typename Log >
 class tiff_device_base
 {
 public:
-   typedef shared_ptr<TIFF> tiff_file_t;
+    using tiff_file_t = std::shared_ptr<TIFF>;
 
     tiff_device_base()
     {}

--- a/include/boost/gil/extension/io/tiff/detail/write.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/write.hpp
@@ -28,7 +28,6 @@ extern "C" {
 #include <string>
 #include <vector>
 #include <boost/static_assert.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include <boost/gil/premultiply.hpp>
 

--- a/include/boost/gil/io/device.hpp
+++ b/include/boost/gil/io/device.hpp
@@ -21,10 +21,10 @@
 
 #include <cstdio>
 
-#include <boost/shared_ptr.hpp>
-
 #include <boost/utility/enable_if.hpp>
 #include <boost/gil/io/base.hpp>
+
+#include <memory>
 
 namespace boost { namespace gil {
 
@@ -342,7 +342,7 @@ private:
 
 private:
 
-    typedef boost::shared_ptr< FILE > file_ptr_t;
+    using file_ptr_t = std::shared_ptr<FILE> ;
     file_ptr_t _file;
 };
 

--- a/include/boost/gil/io/scanline_read_iterator.hpp
+++ b/include/boost/gil/io/scanline_read_iterator.hpp
@@ -19,11 +19,11 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////////////
 
-#include <boost/shared_ptr.hpp>
-#include <boost/make_shared.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 
 #include <boost/gil/io/error.hpp>
+
+#include <memory>
 
 namespace boost { namespace gil {
 
@@ -57,7 +57,7 @@ public:
     , _skip_scanline( true )
     , _reader( reader )
     {
-        _buffer = boost::make_shared<  buffer_t >( buffer_t( _reader._scanline_length ));
+        _buffer = std::make_shared<  buffer_t >( buffer_t( _reader._scanline_length ));
         _buffer_start = &_buffer->front();
     }
 
@@ -107,8 +107,8 @@ private:
     mutable bool _read_scanline;
     mutable bool _skip_scanline;
 
-    typedef std::vector< byte_t > buffer_t;
-    typedef boost::shared_ptr< buffer_t > buffer_ptr_t;
+    using buffer_t = std::vector<byte_t>;
+    using buffer_ptr_t = std::shared_ptr<buffer_t>;
 
     buffer_ptr_t _buffer;
     mutable byte_t* _buffer_start;


### PR DESCRIPTION
### Description: what does this pull request do?

Replace boost::shared_ptr with C++11 std::shared_ptr.

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed (except `ubsan_integer` still expected to fail)
