### PR TITLE
[travis] Allow failures for variant=ubsan_integer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,7 @@ matrix:
           - llvm-toolchain-trusty-5.0
 
     - os: linux
-      env: COMPILER=clang++-5.0 VARIANT=ubsan_undefined TOOLSET=clang CXXSTD=c++11 UBSAN_OPTIONS='print_stacktrace=1'
+      env: COMPILER=clang++-5.0 VARIANT=ubsan_nullability TOOLSET=clang CXXSTD=c++11 UBSAN_OPTIONS='print_stacktrace=1'
       addons:
         apt:
           packages:
@@ -121,7 +121,7 @@ matrix:
           - llvm-toolchain-trusty-5.0
 
     - os: linux
-      env: COMPILER=clang++-5.0 VARIANT=ubsan_nullability TOOLSET=clang CXXSTD=c++11 UBSAN_OPTIONS='print_stacktrace=1'
+      env: COMPILER=clang++-5.0 VARIANT=ubsan_undefined TOOLSET=clang CXXSTD=c++11 UBSAN_OPTIONS='print_stacktrace=1'
       addons:
         apt:
           packages:
@@ -141,6 +141,9 @@ matrix:
         apt:
           packages:
             - doxygen
+
+  allow_failures:
+    - env: COMPILER=clang++-5.0 VARIANT=ubsan_integer TOOLSET=clang CXXSTD=c++11 UBSAN_OPTIONS='print_stacktrace=1'
 
 install:
   - |-


### PR DESCRIPTION
### Description: what does this pull request do?

Currently, UBSan integer checks report several false positives due to unsigned integer overflows (well-defined):

Instead of hiding them completely, keep them displayed on the matrix until we decide how to handle.
For example, [build 375.9](https://travis-ci.org/boostorg/gil/jobs/396282494#L1181).

### Tasklist

- [x] All CI builds and checks have passed

### References

This has been discussed and agreed with @stefanseefeld, this should help us to keep the `master`-branch to be consistent with the one for `develop`. See #109 for further discussion.
