### PR TITLE
[doc] Embed original video by Lubomir Bourdev in Tutorial

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -12,6 +12,17 @@ GIL consists of header files only and does not require any libraries to
 link against. It does not require Boost to be built and including
 ``boost/gil.hpp`` will be sufficient for most projects.
 
+Video Lecture by Lubomir Bourdev
+--------------------------------
+
+.. raw:: html
+
+    <div style="position: relative; overflow: hidden; max-width: 100%; height: auto;">
+        <iframe width="800" height="450" src="https://www.youtube.com/embed/sR8Wjg0pceE?rel=0" frameborder="0" allow="autoplay=false; encrypted-media" allowfullscreen></iframe>
+    </div>
+
+Source link: https://www.youtube.com/watch?v=sR8Wjg0pceE
+
 Example - Computing the Image Gradient
 --------------------------------------
 


### PR DESCRIPTION
This video lecture was originally published at
https://stlab.adobe.com/gil/presentation/index.htm

Boost.GIL maintainers received agreement from Lubomir Bourdev to copy and preseve the original video:
_Agreement to capture Lubomir's video lecture and PDFs_, https://lists.boost.org/boost-gil/2018/06/0032.php

The lecture has also been archived by Sean Parent (Adobe) at https://youtu.be/RjNz_sl-eXk
Thanks to Sean for sharing .MOV file he captured from the original server.
