### PR TITLE
Require PRs to be based on develop, and never on master

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,8 @@
-### Description: what does this pull request do?
+*(IMPORTANT: Pull Requests must come from topic branch based on `develop`, and **never** on `master`.)*
+
+### Description
+
+*What does this pull request do?*
 
 ### Environment
 
@@ -8,11 +12,13 @@ All relevant information like:
 - Compiler version:
 - Build settings:
 
-### References (eg. other issues, pull requests)
+### References
+
+*Link related issues, pull requests here*
 
 ### Tasklist
 
-- [ ] YOUR TASK(S)
+- [ ] *YOUR TASK(S)*
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,8 @@ git remote add username https://github.com/username/gil.git
 All Boost.GIL contributions should be developed inside a topic branch created by
 branching off the `develop` branch of [boostorg/gil](https://github.com/boostorg/gil).
 
+**IMPORTANT:** Pull Requests must come from a branch based on `develop`, and **never** on `master`.
+
 **NOTE:** The branching workflow model
 [Boost recommends](https://svn.boost.org/trac10/wiki/StartModWorkflow)
 is called Git Flow.


### PR DESCRIPTION
This documents a simple PR protocol with requirement that all new PRs should be submitted from a topic branch based on `develop`, and never on `master`.