### PR TITLE
Add template of Minimal Working Example program [ci skip]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ stdcerr
 /*build*
 /cmake-build-debug/
 /cmake-build-release/
+/example/minimal_working_example.cpp
 
 # JetBrains
 /.idea

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,11 +97,13 @@ if (GIL_ENABLE_IO)
     find_package(JPEG)
     find_package(PNG)
     find_package(TIFF)
-  endif()
 
-  # C++ stream interface for TIFF
-  find_path(_tiffxx_include_dir NAMES tiffio.hxx)
-  find_library(_tiffxx_library NAMES tiffxx)
+    if (NOT MSVC)
+      # Typically, Linux packages provide C++ stream interface for TIFF
+      find_path(_tiffxx_include_dir NAMES tiffio.hxx)
+      find_library(_tiffxx_library NAMES tiffxx)
+    endif()
+  endif()
 endif()
 
 #-----------------------------------------------------------------------------

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -8,7 +8,18 @@
 #
 message(STATUS "Configuring Boost.GIL examples tests")
 
-foreach(name affine convolution dynamic_image histogram interleaved_ptr mandelbrot packed_pixel resize x_gradient)
+# MWE is dedicated for GIL users and contributors, compiled source file is ignored by git
+if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/minimal_working_example.cpp)
+  configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/minimal_working_example.cpp.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/minimal_working_example.cpp
+    COPYONLY)
+endif()
+
+file(GLOB _examples ${CMAKE_CURRENT_LIST_DIR}/*.cpp CONFIGURE_DEPEND)
+
+foreach(example ${_examples})
+  get_filename_component(name ${example} NAME_WE)
   add_executable(gil_example_${name} ${name}.cpp)
   target_compile_definitions(gil_example_${name} PRIVATE BOOST_GIL_USE_CONCEPT_CHECK=1)
   # Unfortunately, ALIAS of imported target is not supported
@@ -29,6 +40,9 @@ foreach(name affine convolution dynamic_image histogram interleaved_ptr mandelbr
       PNG::PNG
       TIFF::TIFF
       ${JPEG_LIBRARIES})
-    target_include_directories(gil_example_${name} ${JPEG_INCLUDE_DIR})
+    if (JPEG_LIBRARIES AND JPEG_INCLUDE_DIR)
+      target_include_directories(gil_example_${name} PRIVATE ${JPEG_INCLUDE_DIR})
+    endif()
   endif()
 endforeach()
+

--- a/example/minimal_working_example.cpp.in
+++ b/example/minimal_working_example.cpp.in
@@ -1,0 +1,23 @@
+#include <boost/gil.hpp>
+#include <boost/gil/io/io.hpp>
+#include <iostream>
+// TODO: include any headers you may require
+namespace gil = boost::gil;
+
+int main(int argc, char* argv[])
+{
+    try
+    {
+        // TODO: Write your example below
+        gil::rgb8_pixel_t white{255, 255, 255};
+        gil::rgb8_image_t image(256, 256);
+        gil::fill_pixels(gil::view(image), white);
+
+        return EXIT_SUCCESS;
+    }
+    catch (std::exception const& e)
+    {
+        std::cerr << e.what() << std::endl;
+    }
+    return EXIT_FAILURE;
+}

--- a/io/test/CMakeLists.txt
+++ b/io/test/CMakeLists.txt
@@ -29,13 +29,17 @@ list(APPEND _headers ${_boost_gil_headers})
 
 add_definitions(-DBOOST_GIL_IO_TEST_ALLOW_READING_IMAGES=1)
 add_definitions(-DBOOST_GIL_IO_TEST_ALLOW_WRITING_IMAGES=1)
-add_definitions(-DBOOST_TEST_DYN_LINK)
+if(NOT MSVC)
+  add_definitions(-DBOOST_TEST_DYN_LINK)
+endif()
 
 add_executable(gil_test_ext_io_simple "")
 target_sources(gil_test_ext_io_simple PRIVATE ${_headers} all_formats_test.cpp)
 target_link_libraries(gil_test_ext_io_simple PRIVATE
   ${_boost_deps} ${_jpeg_deps} ${_png_deps} ${_tiff_deps})
-target_include_directories(gil_test_ext_io_simple PRIVATE ${JPEG_INCLUDE_DIR})
+if (JPEG_LIBRARIES AND JPEG_INCLUDE_DIR)
+  target_include_directories(gil_test_ext_io_simple PRIVATE ${JPEG_INCLUDE_DIR})
+endif()
 add_test(tests.ext.io.simple gil_test_ext_io_simple)
 
 add_executable(gil_test_ext_io_bmp "")
@@ -48,7 +52,9 @@ add_executable(gil_test_ext_io_jpeg "")
 target_sources(gil_test_ext_io_jpeg PRIVATE ${_headers}
   jpeg_test.cpp jpeg_old_test.cpp jpeg_read_test.cpp jpeg_write_test.cpp)
 target_link_libraries(gil_test_ext_io_jpeg PRIVATE ${_boost_deps} ${_jpeg_deps})
-target_include_directories(gil_test_ext_io_jpeg PRIVATE ${JPEG_INCLUDE_DIR})
+if (JPEG_LIBRARIES AND JPEG_INCLUDE_DIR)
+  target_include_directories(gil_test_ext_io_jpeg PRIVATE ${JPEG_INCLUDE_DIR})
+endif()
 add_test(tests.ext.io.jpeg gil_test_ext_io_jpeg)
 
 add_executable(gil_test_ext_io_png "")


### PR DESCRIPTION
### Description

For users and contributors convenience, CMake configuration
generates basic example, ready to compile.

Apply minor fixes to some CMakeLists.txt files.

### Tasklist

- [ ] Review
- [ ] Adjust for comments

-----

@stefanseefeld This is not a high priority but I think it would be good to let it released with Boost 1.68