### PR TITLE
Apply minor fixes to CMake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,11 +97,13 @@ if (GIL_ENABLE_IO)
     find_package(JPEG)
     find_package(PNG)
     find_package(TIFF)
-  endif()
 
-  # C++ stream interface for TIFF
-  find_path(_tiffxx_include_dir NAMES tiffio.hxx)
-  find_library(_tiffxx_library NAMES tiffxx)
+    if (NOT MSVC)
+      # Typically, Linux packages provide C++ stream interface for TIFF
+      find_path(_tiffxx_include_dir NAMES tiffio.hxx)
+      find_library(_tiffxx_library NAMES tiffxx)
+    endif()
+  endif()
 endif()
 
 #-----------------------------------------------------------------------------

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -8,7 +8,14 @@
 #
 message(STATUS "Configuring Boost.GIL examples tests")
 
-foreach(name affine convolution dynamic_image histogram interleaved_ptr mandelbrot packed_pixel resize x_gradient)
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.12.0)
+  file(GLOB_RECURSE _examples ${CMAKE_CURRENT_LIST_DIR}/*.cpp CONFIGURE_DEPEND)
+else()
+  file(GLOB_RECURSE _examples ${CMAKE_CURRENT_LIST_DIR}/*.cpp)
+endif()
+
+foreach(example ${_examples})
+  get_filename_component(name ${example} NAME_WE)
   add_executable(gil_example_${name} ${name}.cpp)
   target_compile_definitions(gil_example_${name} PRIVATE BOOST_GIL_USE_CONCEPT_CHECK=1)
   # Unfortunately, ALIAS of imported target is not supported
@@ -29,6 +36,10 @@ foreach(name affine convolution dynamic_image histogram interleaved_ptr mandelbr
       PNG::PNG
       TIFF::TIFF
       ${JPEG_LIBRARIES})
-    target_include_directories(gil_example_${name} ${JPEG_INCLUDE_DIR})
+    if (JPEG_LIBRARIES AND JPEG_INCLUDE_DIR)
+      target_include_directories(gil_example_${name} PRIVATE ${JPEG_INCLUDE_DIR})
+    endif()
   endif()
 endforeach()
+
+unset(_examples)

--- a/io/test/CMakeLists.txt
+++ b/io/test/CMakeLists.txt
@@ -29,13 +29,17 @@ list(APPEND _headers ${_boost_gil_headers})
 
 add_definitions(-DBOOST_GIL_IO_TEST_ALLOW_READING_IMAGES=1)
 add_definitions(-DBOOST_GIL_IO_TEST_ALLOW_WRITING_IMAGES=1)
-add_definitions(-DBOOST_TEST_DYN_LINK)
+if(NOT MSVC)
+  add_definitions(-DBOOST_TEST_DYN_LINK)
+endif()
 
 add_executable(gil_test_ext_io_simple "")
 target_sources(gil_test_ext_io_simple PRIVATE ${_headers} all_formats_test.cpp)
 target_link_libraries(gil_test_ext_io_simple PRIVATE
   ${_boost_deps} ${_jpeg_deps} ${_png_deps} ${_tiff_deps})
-target_include_directories(gil_test_ext_io_simple PRIVATE ${JPEG_INCLUDE_DIR})
+if (JPEG_LIBRARIES AND JPEG_INCLUDE_DIR)
+  target_include_directories(gil_test_ext_io_simple PRIVATE ${JPEG_INCLUDE_DIR})
+endif()
 add_test(tests.ext.io.simple gil_test_ext_io_simple)
 
 add_executable(gil_test_ext_io_bmp "")
@@ -48,7 +52,9 @@ add_executable(gil_test_ext_io_jpeg "")
 target_sources(gil_test_ext_io_jpeg PRIVATE ${_headers}
   jpeg_test.cpp jpeg_old_test.cpp jpeg_read_test.cpp jpeg_write_test.cpp)
 target_link_libraries(gil_test_ext_io_jpeg PRIVATE ${_boost_deps} ${_jpeg_deps})
-target_include_directories(gil_test_ext_io_jpeg PRIVATE ${JPEG_INCLUDE_DIR})
+if (JPEG_LIBRARIES AND JPEG_INCLUDE_DIR)
+  target_include_directories(gil_test_ext_io_jpeg PRIVATE ${JPEG_INCLUDE_DIR})
+endif()
 add_test(tests.ext.io.jpeg gil_test_ext_io_jpeg)
 
 add_executable(gil_test_ext_io_png "")


### PR DESCRIPTION
### Description

Several minor fixes for CMake setup of GIL examples and IO tests.

### References

This does NOT address #40 - examples still may not compile
