### PR TITLE
Correct description of image_is_basic metafunction (Trac 2979)

### DIFF
--- a/include/boost/gil/metafunctions.hpp
+++ b/include/boost/gil/metafunctions.hpp
@@ -115,7 +115,7 @@ template <typename View> struct view_is_basic : public mpl::false_ {};
 template <typename Loc> struct view_is_basic<image_view<Loc> > : public locator_is_basic<Loc> {};
 
 /// \ingroup GILIsBasic
-/// \brief Basic images must use basic views and std::allocator of char
+/// \brief Basic images must use basic views and std::allocator
 template <typename Img> struct image_is_basic : public mpl::false_ {};
 template <typename Pixel, bool IsPlanar, typename Alloc> struct image_is_basic<image<Pixel,IsPlanar,Alloc> > : public mpl::true_ {};
 


### PR DESCRIPTION
https://svn.boost.org/trac10/ticket/2979 description:

> The description of the metafunction boost::gil::image_is_basic says that
> it will return mpl::true_ if the image uses a basic view and
> std::allocator<unsigned char>, however the implementation returns true
> for any kind images that use any kind of allocator.

### Tasklist

- [ ] Review (@chhenning & @stefanseefeld could you review the change, please?)
- [ ] Adjust for comments