### PR TITLE
Add missing template keyword prior to dependent name axis_iterator (Trac 8896)

### DIFF
--- a/include/boost/gil/image_view.hpp
+++ b/include/boost/gil/image_view.hpp
@@ -1,6 +1,6 @@
 /*
     Copyright 2005-2007 Adobe Systems Incorporated
-   
+
     Use, modification and distribution are subject to the Boost Software License,
     Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
     http://www.boost.org/LICENSE_1_0.txt).
@@ -13,7 +13,7 @@
 #define GIL_IMAGE_VIEW_H
 
 ////////////////////////////////////////////////////////////////////////////////////////
-/// \file               
+/// \file
 /// \brief image view class
 /// \author Lubomir Bourdev and Hailin Jin \n
 ///         Adobe Systems Incorporated
@@ -45,8 +45,8 @@ namespace boost { namespace gil {
 /// that don't own the pixels. It is the user's responsibility that the underlying data remains
 /// valid for the lifetime of the image view.
 ///
-/// Similar to iterators and ranges, constness of views does not extend to constness of pixels. 
-/// A const \p image_view does not allow changing its location in memory (resizing, moving) but does 
+/// Similar to iterators and ranges, constness of views does not extend to constness of pixels.
+/// A const \p image_view does not allow changing its location in memory (resizing, moving) but does
 /// not prevent one from changing the pixels. The latter requires an image view whose value_type
 /// is const.
 ///
@@ -120,7 +120,7 @@ public:
 
     //\{@
     /// \name 1D navigation
-    size_type           size()               const { return width()*height(); }  
+    size_type           size()               const { return width()*height(); }
     iterator            begin()              const { return iterator(_pixels,_dimensions.x); }
     iterator            end()                const { return begin()+(difference_type)size(); }    // potential performance problem!
     reverse_iterator    rbegin()             const { return reverse_iterator(end()); }
@@ -136,7 +136,7 @@ public:
     /// \name 2-D navigation
     reference operator()(const point_t& p)        const { return _pixels(p.x,p.y); }
     reference operator()(x_coord_t x, y_coord_t y)const { return _pixels(x,y); }
-    template <std::size_t D> typename axis<D>::iterator axis_iterator(const point_t& p) const { return _pixels.axis_iterator<D>(p); }
+    template <std::size_t D> typename axis<D>::iterator axis_iterator(const point_t& p) const { return _pixels.template axis_iterator<D>(p); }
     xy_locator xy_at(x_coord_t x, y_coord_t y)    const { return _pixels+point_t(x_coord_t(x),y_coord_t(y)); }
     locator    xy_at(const point_t& p)            const { return _pixels+p; }
     //\}@
@@ -164,10 +164,10 @@ private:
     xy_locator _pixels;
 };
 
-template <typename L2> 
-inline void swap(image_view<L2>& x, image_view<L2>& y) { 
+template <typename L2>
+inline void swap(image_view<L2>& x, image_view<L2>& y) {
     using std::swap;
-    swap(x._dimensions,y._dimensions); 
+    swap(x._dimensions,y._dimensions);
     swap(x._pixels, y._pixels);            // TODO: Extend further
 }
 
@@ -176,16 +176,16 @@ inline void swap(image_view<L2>& x, image_view<L2>& y) {
 /////////////////////////////
 
 template <typename L>
-struct channel_type<image_view<L> > : public channel_type<L> {}; 
+struct channel_type<image_view<L> > : public channel_type<L> {};
 
 template <typename L>
-struct color_space_type<image_view<L> > : public color_space_type<L> {}; 
+struct color_space_type<image_view<L> > : public color_space_type<L> {};
 
 template <typename L>
-struct channel_mapping_type<image_view<L> > : public channel_mapping_type<L> {}; 
+struct channel_mapping_type<image_view<L> > : public channel_mapping_type<L> {};
 
 template <typename L>
-struct is_planar<image_view<L> > : public is_planar<L> {}; 
+struct is_planar<image_view<L> > : public is_planar<L> {};
 
 /////////////////////////////
 //  HasDynamicXStepTypeConcept

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -29,3 +29,4 @@ test-suite "boost-gil-test" :
     ;
 
 build-project channel ;
+build-project image_view ;

--- a/test/image_view/CMakeLists.txt
+++ b/test/image_view/CMakeLists.txt
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2018 Mateusz Loskot <mateusz at loskot dot net>
+#
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+#
+foreach(name
+  image_view_concepts)
+
+  add_executable(gil_test_${name} "")
+  target_sources(gil_test_${name}
+    PRIVATE
+    ${_boost_gil_headers}
+    ${name}.cpp)
+  target_link_libraries(gil_test_${name}
+    PRIVATE
+    Boost::disable_autolinking
+    Boost::unit_test_framework)
+  add_test(gil.tests.core.${name} gil_test_${name})
+endforeach()

--- a/test/image_view/Jamfile
+++ b/test/image_view/Jamfile
@@ -1,0 +1,20 @@
+# Boost.GIL
+#
+# Copyright (c) 2018 Mateusz Loskot <mateusz at loskot dot net>
+#
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or
+# copy at http://www.boost.org/LICENSE_1_0.txt)
+
+import testing ;
+
+project
+    : requirements
+    <include>$(BOOST_ROOT)
+    <include>..
+    ;
+
+test-suite "boost-gil-test-image-view"
+    :
+    [ compile image_view_concepts.cpp ]
+    ;

--- a/test/image_view/image_view_concepts.cpp
+++ b/test/image_view/image_view_concepts.cpp
@@ -1,0 +1,20 @@
+//
+// Copyright 2018 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/gil/gil_concept.hpp>
+#include <boost/gil/image_view.hpp>
+#include <boost/gil/typedefs.hpp>
+
+#define BOOST_TEST_MODULE test_image_view_concepts
+#include <gil_test_common.hpp>
+
+namespace gil = boost::gil;
+
+BOOST_AUTO_TEST_CASE(RandomAccessND)
+{
+    boost::function_requires<gil::RandomAccessNDImageViewConcept<gil::gray8_view_t>>();
+}


### PR DESCRIPTION
### Description

* Apply patch from https://svn.boost.org/trac10/ticket/8896
* Add compile-time test of `RandomAccessNDImageViewConcept`
  * Confirms the reported failure (tested with GCC 7.3 and clang 5.0)
  * Verifies correctness of the patch

### Environment

All relevant information like:

- Boost version (see `<boost/version.hpp>`): 1.68
- Compiler version: GCC 4.2 or later, clang 3.8 or later
- Build settings:

### References

https://svn.boost.org/trac10/ticket/8896

### Tasklist

- [x] Review (@chhenning & @stefanseefeld could you review the change, please?)
- [x] Adjust for comments
- [x] All CI builds and checks have passed

-----

The MWE to reproduce the problem originally posted in the Trac ticket:

```
mloskot@xenial:~/tmp$ cat gil_ticket_8896.cpp
#include <iostream>
#include <boost/gil/gil_all.hpp>
using namespace boost;
namespace bg = boost::gil;
int main(int argc, char **argv)
{
    bg::gray8_image_t img(2,2);
    bg::gray8_view_t vw(bg::view(img));
    bg::gray8_view_t::point_t p(0,0);
    bg::gray8_view_t::axis<0>::iterator iter = vw.template axis_iterator<0>(p);

    std::cout << (*iter)[0] << std::endl;
    return 0;
}
```

* Compiled with GCC 7.3.0

```
mloskot@xenial:~/tmp$ g++ -std=c++11 -I/mnt/d/boost.wsl  gil_ticket_8896.cpp
In file included from /mnt/d/boost.wsl/boost/gil/algorithm.hpp:32:0,
                 from /mnt/d/boost.wsl/boost/gil/gil_all.hpp:27,
                 from gil_ticket_8896.cpp:2:
/mnt/d/boost.wsl/boost/gil/image_view.hpp: In instantiation of ‘typename boost::gil::image_view<L>::axis<D>::iterator boost::gil::image_view<L>::axis_iterator(const point_t&) const [with long unsigned int D = 0; Loc = boost::gil::memory_based_2d_locator<boost::gil::memory_based_step_iterator<boost::gil::pixel<unsigned char, boost::gil::layout<boost::mpl::vector1<boost::gil::gray_color_t> > >*> >; typename boost::gil::image_view<L>::axis<D>::iterator = boost::gil::pixel<unsigned char, boost::gil::layout<boost::mpl::vector1<boost::gil::gray_color_t> > >*; boost::gil::image_view<L>::point_t = boost::gil::point2<long int>]’:
gil_ticket_8896.cpp:10:69:   required from here
/mnt/d/boost.wsl/boost/gil/image_view.hpp:139:125: error: invalid operands of types ‘<unresolved overloaded function type>’ and ‘long unsigned int’ to binary ‘operator<’
     template <std::size_t D> typename axis<D>::iterator axis_iterator(const point_t& p) const { return _pixels.axis_iterator<D>(p); }
                                                                                                        ~~~~~~~~~~~~~~~~~~~~~^~
```

* Compiled with clang 5.0.0

```
mloskot@xenial:~/tmp$ clang++ -std=c++11 -I/mnt/d/boost.wsl  gil_ticket_8896.cpp
In file included from gil_ticket_8896.cpp:2:
In file included from /mnt/d/boost.wsl/boost/gil/gil_all.hpp:27:
In file included from /mnt/d/boost.wsl/boost/gil/algorithm.hpp:32:
/mnt/d/boost.wsl/boost/gil/image_view.hpp:139:112: error: missing 'template' keyword prior to dependent template name 'axis_iterator'
    template <std::size_t D> typename axis<D>::iterator axis_iterator(const point_t& p) const { return _pixels.axis_iterator<D>(p); }
                                                                                                               ^
gil_ticket_8896.cpp:10:51: note: in instantiation of function template specialization 'boost::gil::image_view<boost::gil::memory_based_2d_locator<boost::gil::memory_based_step_iterator<boost::gil::pixel<unsigned char,
      boost::gil::layout<boost::mpl::vector1<boost::gil::gray_color_t>, boost::mpl::range_c<int, 0, 1> > > *> > >::axis_iterator<0>' requested here
    bg::gray8_view_t::axis<0>::iterator iter = vw.axis_iterator<0>(p);
                                                  ^
1 error generated.
```

The patch fixes the both compilations.