### PR TITLE
Fix warning about assigned but unused variable num_elements

### DIFF
--- a/include/boost/gil/io/device.hpp
+++ b/include/boost/gil/io/device.hpp
@@ -21,6 +21,7 @@
 
 #include <cstdio>
 
+#include <boost/core/ignore_unused.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/gil/io/base.hpp>
 
@@ -323,6 +324,7 @@ public:
                                          );
 
         assert( num_elements == line.size() );
+        boost::ignore_unused(num_elements);
     }
 
     int error()


### PR DESCRIPTION
The `num_elements` is used only in `assert`, so it is unused in optimised builds.