### PR TITLE
Fix warning: comparing floating point with == is unsafe

### DIFF
--- a/include/boost/gil/extension/toolbox/color_spaces/hsv.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/hsv.hpp
@@ -95,7 +95,7 @@ struct default_color_converter_impl< rgb_t, hsv_t >
             hue = ( temp_green - temp_blue )
                 / diff;
          }
-         else if( temp_green == max_color )
+         else if( temp_green >= max_color ) // means == but >= avoids compiler warning; color is never greater than max
          {
             hue = 2.f + ( temp_blue - temp_red ) 
                 / diff;


### PR DESCRIPTION
Trick compiler by using `>=` instead of `==`, where LHS color is guaranteed to never be greater than RHS color value.

### Environment

All relevant information like:

- Compiler version: GCC 8.x

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed
