### PR TITLE
Update example/dynamic_image.cpp after IO reimplentation

### DIFF
--- a/example/dynamic_image.cpp
+++ b/example/dynamic_image.cpp
@@ -15,20 +15,19 @@
 /// \author Lubomir Bourdev and Hailin Jin
 /// \date February 27, 2007
 
-#include <boost/mpl/vector.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/dynamic_image/any_image.hpp>
-#include <boost/gil/extension/io/jpeg_dynamic_io.hpp>
+#include <boost/gil/extension/io/jpeg.hpp>
+#include <boost/mpl/vector.hpp>
 
-int main() {
-    using namespace boost::gil;
+int main()
+{
+    namespace bg = boost::gil;
 
-    typedef boost::mpl::vector<gray8_image_t, rgb8_image_t, gray16_image_t, rgb16_image_t> my_images_t;
-
-    any_image<my_images_t> dynamic_img;
-    jpeg_read_image("test.jpg",dynamic_img);
-
+    using my_images_t = boost::mpl::vector<bg::gray8_image_t, bg::rgb8_image_t, bg::gray16_image_t, bg::rgb16_image_t>;
+    bg::any_image<my_images_t> dynamic_image;
+    bg::read_image("test.jpg", dynamic_image, bg::jpeg_tag());
     // Save the image upside down, preserving its native color space and channel depth
-    jpeg_write_view("out-dynamic_image.jpg",flipped_up_down_view(const_view(dynamic_img)));
-
-    return 0;
+    auto view = bg::flipped_up_down_view(bg::const_view(dynamic_image));
+    bg::write_view("out-dynamic_image.jpg", view, bg::jpeg_tag());
 }


### PR DESCRIPTION
Reminder: Boost.GIL 2.2 released in Boost 1.67 has completely reimplemented I/O extensions.
There still may be examples that no longer compiler.

### Environment

All relevant information like:

- Compiler version: GCC 8.x

### Tasklist

- [x] All CI builds and checks have passed
