### PR TITLE
Base get_num_bits metafunction for T on mpl::size_t instead of mpl::int_

### DIFF
--- a/include/boost/gil/extension/toolbox/metafunctions/get_num_bits.hpp
+++ b/include/boost/gil/extension/toolbox/metafunctions/get_num_bits.hpp
@@ -22,6 +22,7 @@
 #include <boost/gil/channel.hpp>
 
 #include <boost/mpl/int.hpp>
+#include <boost/mpl/size_t.hpp>
 #include <boost/type_traits/is_integral.hpp>
 #include <boost/type_traits/is_class.hpp>
 #include <boost/utility/enable_if.hpp>
@@ -64,7 +65,7 @@ struct get_num_bits< T
                                                   , mpl::not_< is_class< T > >
                                                   >
                                        >::type
-                   > : mpl::int_< sizeof(T) * 8 >
+                   > : mpl::size_t< sizeof(T) * 8 >
 {};
 
 } // namespace gil


### PR DESCRIPTION
Previously used `mpl::int_` assumes signed integer, while `sizeof(T)` is unsigned and compiler issues warning.

### Environment

All relevant information like:

- Compiler version: GCC 8.x

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed
