### PR TITLE
Simplify and clean up Jamfiles

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -9,6 +9,25 @@
 
 # TODO: Remove -Wno-unused below once tests have been cleaned up, and no longer use of assert() macro, etc.
 
+project boost-gil
+    :
+    requirements
+        # MSVC: Since VS2017, default is -std:c++14, so no explicit switch is required.
+        <toolset>msvc:<asynch-exceptions>on
+        <toolset>msvc:<cxxflags>/W4
+        <toolset>msvc:<cxxflags>/bigobj
+        <toolset>msvc:<define>_SCL_SECURE_NO_DEPRECATE <define>_CRT_SECURE_NO_WARNINGS <define>_CRT_NONSTDC_NO_DEPRECATE <define>NOMINMAX
+        <toolset>intel:<debug-symbols>off
+        # GCC default flags with warnings sugested by https://svn.boost.org/trac10/wiki/Guidelines/WarningsGuidelines
+        <toolset>gcc:<cxxflags>"-std=c++11 -pedantic -fstrict-aliasing -Wcast-align -Wconversion -Wextra -Wfloat-equal -Wshadow -Wsign-promo -Wstrict-aliasing -Wunused-parameter"
+        # GCC default flags extended with warnings suggested by https://svn.boost.org/trac10/ticket/4014
+        #<toolset>gcc:<cxxflags>"-std=c++11 -pedantic -fstrict-aliasing -Wall -Wcast-align -Wconversion -Wctor-dtor-privacy -Wdisabled-optimization -Werror=non-virtual-dtor -Werror=return-type -Wextra -Wfloat-equal -Winit-self -Winvalid-pch -Wmissing-format-attribute -Wmissing-include-dirs -Wmissing-noreturn -Wno-multichar -Woverloaded-virtual -Wpacked -Wredundant-decls -Wshadow -Wsign-promo -Wstrict-aliasing -Wswitch-default -Wundef -Wunused-parameter -Wwrite-strings"
+        # variant filter for clang is necessary to allow ubsan_* variants declare distinct set of <cxxflags>
+        <toolset>clang,<variant>debug:<cxxflags>"-std=c++11 -pedantic -fstrict-aliasing -Wcast-align -Wconversion -Wextra -Wfloat-equal -Wshadow -Wsign-promo -Wstrict-aliasing -Wunused-parameter -Wsign-conversion"
+        <toolset>clang,<variant>release:<cxxflags>"-std=c++11 -pedantic -fstrict-aliasing -Wcast-align -Wconversion -Wextra -Wfloat-equal -Wshadow -Wsign-promo -Wstrict-aliasing -Wunused-parameter -Wsign-conversion"
+        <toolset>darwin:<cxxflags>"-std=c++11 -pedantic -fstrict-aliasing -Wcast-align -Wconversion -Wextra -Wfloat-equal -Wshadow -Wsign-promo -Wstrict-aliasing -Wunused-parameter "
+    ;
+
 variant ubsan_integer
     : release
     :
@@ -34,25 +53,6 @@ variant ubsan_undefined
     <linkflags>"-fsanitize=undefined"
     <debug-symbols>on
     <define>BOOST_USE_ASAN=1
-    ;
-
-project boost-gil
-    :
-    requirements
-        # MSVC: Since VS2017, default is -std:c++14, so no explicit switch is required.
-        <toolset>msvc:<asynch-exceptions>on
-        <toolset>msvc:<cxxflags>/W4
-        <toolset>msvc:<cxxflags>/bigobj
-        <toolset>msvc:<define>_SCL_SECURE_NO_DEPRECATE <define>_CRT_SECURE_NO_WARNINGS <define>_CRT_NONSTDC_NO_DEPRECATE <define>NOMINMAX
-        <toolset>intel:<debug-symbols>off
-        # GCC default flags with warnings sugested by https://svn.boost.org/trac10/wiki/Guidelines/WarningsGuidelines
-        <toolset>gcc:<cxxflags>"-std=c++11 -pedantic -fstrict-aliasing -Wcast-align -Wconversion -Wextra -Wfloat-equal -Wshadow -Wsign-promo -Wstrict-aliasing -Wunused-parameter"
-        # GCC default flags extended with warnings suggested by https://svn.boost.org/trac10/ticket/4014
-        #<toolset>gcc:<cxxflags>"-std=c++11 -pedantic -fstrict-aliasing -Wall -Wcast-align -Wconversion -Wctor-dtor-privacy -Wdisabled-optimization -Werror=non-virtual-dtor -Werror=return-type -Wextra -Wfloat-equal -Winit-self -Winvalid-pch -Wmissing-format-attribute -Wmissing-include-dirs -Wmissing-noreturn -Wno-multichar -Woverloaded-virtual -Wpacked -Wredundant-decls -Wshadow -Wsign-promo -Wstrict-aliasing -Wswitch-default -Wundef -Wunused-parameter -Wwrite-strings"
-        # variant filter for clang is necessary to allow ubsan_* variants declare distinct set of <cxxflags>
-        <toolset>clang,<variant>debug:<cxxflags>"-std=c++11 -pedantic -fstrict-aliasing -Wcast-align -Wconversion -Wextra -Wfloat-equal -Wshadow -Wsign-promo -Wstrict-aliasing -Wunused-parameter -Wsign-conversion"
-        <toolset>clang,<variant>release:<cxxflags>"-std=c++11 -pedantic -fstrict-aliasing -Wcast-align -Wconversion -Wextra -Wfloat-equal -Wshadow -Wsign-promo -Wstrict-aliasing -Wunused-parameter -Wsign-conversion"
-        <toolset>darwin:<cxxflags>"-std=c++11 -pedantic -fstrict-aliasing -Wcast-align -Wconversion -Wextra -Wfloat-equal -Wshadow -Wsign-promo -Wstrict-aliasing -Wunused-parameter "
     ;
 
 build-project example ;

--- a/doc/Jamfile
+++ b/doc/Jamfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 Stefan Seefeld
+# Boost.GIL (Generic Image Library) - documentation
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/example/Jamfile
+++ b/example/Jamfile
@@ -1,6 +1,5 @@
-# Boost.GIL (Generic Image Library)
-# Controls building of Boost.GIL examples
-# 
+# Boost.GIL (Generic Image Library) - examples
+#
 # Copyright (c) 2018 Mateusz Loskot <mateusz@loskot.net>
 #
 # Use, modification and distribution is subject to the Boost Software License,

--- a/io/doc/Jamfile
+++ b/io/doc/Jamfile
@@ -1,14 +1,10 @@
-# Boost.GIL.IO
+# Boost.GIL (Generic Image Library) - IO documentation
 #
 # Copyright (c) 2012 Christian Henning
 #
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
-
-
-# Quickbook
-# -----------------------------------------------------------------------------
 
 import quickbook ;
 using boostbook ;
@@ -23,7 +19,7 @@ path-constant images_location : html ;
 boostbook standalone
     :
         io
-	:
+    :
         <xsl:param>boost.root=../../../../..
         <xsl:param>boost.max.id.length=1024
         <xsl:param>toc.max.depth=4

--- a/io/test/Jamfile
+++ b/io/test/Jamfile
@@ -1,13 +1,13 @@
-# Boost.GIL.IO
+# Boost.GIL (Generic Image Library) - IO tests
 #
-# (C) Copyright 2012: Mateusz Loskot and Christian Henning
-# (C) Copyright 2017: Stefan Seefeld
+# Copyright (c) 2012 Christian Henning
+# Copyright (c) 2017 Stefan Seefeld
+# Copyright (c) 2012-2018 Mateusz Loskot <mateusz@loskot.net>
+#
 # Distributed under the Boost Software License, Version 1.0.
-# (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+# (See accompanying file LICENSE_1_0.txt or
+# copy at http://www.boost.org/LICENSE_1_0.txt)
 
-# Please make sure to read readme.txt!
-
-# bring in rules for testing
 import testing ;
 import ac ;
 
@@ -26,7 +26,7 @@ project
     <library>/boost/filesystem//boost_filesystem
     ;
 
-test-suite simple
+alias simple
   : [ run all_formats_test.cpp
       : # args
       : # input files
@@ -40,7 +40,7 @@ test-suite simple
     ]
 ;
 
-test-suite full :
+alias full :
     [ run bmp_test.cpp bmp_old_test.cpp bmp_read_test.cpp bmp_write_test.cpp ]
     [ run jpeg_test.cpp jpeg_old_test.cpp jpeg_read_test.cpp jpeg_write_test.cpp
       :

--- a/numeric/doc/Jamfile
+++ b/numeric/doc/Jamfile
@@ -1,14 +1,10 @@
-# Boost.GIL.Numeric
+# Boost.GIL (Generic Image Library) - Numeric documentation
 #
 # Copyright (c) 2013 Christian Henning
 #
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
-
-
-# Quickbook
-# -----------------------------------------------------------------------------
 
 use-project boost : c:/boost ;
 
@@ -18,36 +14,36 @@ using boostbook ;
 
 # taken from http://boost.2283326.n4.nabble.com/Doxygen-Running-Doxygen-from-BB-td3657608.html
 doxygen reference.html
-    : 
-        [ glob 
-            ../../../../boost/gil/extension/numeric/*.hpp 
+    :
+        [ glob
+            ../../../../boost/gil/extension/numeric/*.hpp
         ]
-    : 
+    :
        <doxygen:param>"PROJECT_NAME=\"Boost GIL Numeric\""
        <doxygen:param>"PROJECT_LOGO=\"$(BOOST_ROOT)/boost.png\""
        #messages
        <doxygen:param>QUIET=YES
        <doxygen:param>WARN_IF_UNDOCUMENTED=YES
        <doxygen:param>WARN_IF_DOC_ERROR=YES
-        # input 
-        <doxygen:param>JAVADOC_AUTOBRIEF=YES 
-        <doxygen:param>EXTRACT_PRIVATE=NO 
-        <doxygen:param>EXTRACT_STATIC=YES 
-        <doxygen:param>HIDE_UNDOC_MEMBERS=YES 
-        <doxygen:param>HIDE_UNDOC_CLASSES=YES 
-        # output 
-        <doxygen:param>HIDE_SCOPE_NAMES=YES 
-        <doxygen:param>INLINE_INFO=NO 
-        <doxygen:param>SORT_MEMBER_DOCS=NO 
-        <doxygen:param>SHOW_DIRECTORIES=YES 
-        <doxygen:param>SOURCE_BROWSER=YES 
-        <doxygen:param>REFERENCED_BY_RELATION=NO 
-        <doxygen:param>REFERENCES_RELATION=NO 
-        <doxygen:param>REFERENCES_LINK_SOURCE=NO 
-        <doxygen:param>VERBATIM_HEADERS=NO 
+        # input
+        <doxygen:param>JAVADOC_AUTOBRIEF=YES
+        <doxygen:param>EXTRACT_PRIVATE=NO
+        <doxygen:param>EXTRACT_STATIC=YES
+        <doxygen:param>HIDE_UNDOC_MEMBERS=YES
+        <doxygen:param>HIDE_UNDOC_CLASSES=YES
+        # output
+        <doxygen:param>HIDE_SCOPE_NAMES=YES
+        <doxygen:param>INLINE_INFO=NO
+        <doxygen:param>SORT_MEMBER_DOCS=NO
+        <doxygen:param>SHOW_DIRECTORIES=YES
+        <doxygen:param>SOURCE_BROWSER=YES
+        <doxygen:param>REFERENCED_BY_RELATION=NO
+        <doxygen:param>REFERENCES_RELATION=NO
+        <doxygen:param>REFERENCES_LINK_SOURCE=NO
+        <doxygen:param>VERBATIM_HEADERS=NO
         <doxygen:param>HIDE_UNDOC_RELATIONS=NO
         <doxygen:param>"EXCLUDE_SYMBOLS = \"detail::*\""
-    ; 
+    ;
 
 xml toolbox : numeric.qbk ;
 

--- a/numeric/test/Jamfile
+++ b/numeric/test/Jamfile
@@ -1,11 +1,11 @@
-# Boost.GIL.Numeric
+# Boost.GIL (Generic Image Library) - Numeric tests
 #
-# (C) Copyright 2013: Christian Henning
+# Copyright (c) 2013 Christian Henning
 #
 # Distributed under the Boost Software License, Version 1.0.
-# (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+# (See accompanying file LICENSE_1_0.txt or
+# copy at http://www.boost.org/LICENSE_1_0.txt)
 
-# bring in rules for testing
 import testing ;
 
 project
@@ -14,11 +14,4 @@ project
     <library>/boost/test//boost_unit_test_framework
     ;
 
-test-suite "gil::numeric"
-    :
-    [ run
-        # sources
-        test.cpp
-        numeric.cpp
-    ]
-    ;
+run numeric.cpp ;

--- a/numeric/test/numeric.cpp
+++ b/numeric/test/numeric.cpp
@@ -13,6 +13,7 @@
 #include <boost/gil/extension/numeric/resample.hpp>
 #include <boost/gil/extension/numeric/sampler.hpp>
 
+#define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
 
 using namespace boost;

--- a/numeric/test/test.cpp
+++ b/numeric/test/test.cpp
@@ -1,2 +1,0 @@
-#define BOOST_TEST_MAIN
-#include <boost/test/unit_test.hpp>

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -1,32 +1,30 @@
-# Boost.GIL
+# Boost.GIL (Generic Image Library) - tests
 #
-# (C) Copyright 2008: Lubomir Bourdev and Hailin Jin
+# Copyright (c) 2008 Lubomir Bourdev, Hailin Jin
+# Copyright (c) 2018 Mateusz Loskot <mateusz@loskot.net>
 #
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or
 # copy at http://www.boost.org/LICENSE_1_0.txt)
 
-# bring in rules for testing
 import testing ;
 
 project
     : requirements
     <include>$(BOOST_ROOT)
     <include>.
-    <library>/boost/filesystem//boost_filesystem
     ;
 
-test-suite "boost-gil-test" :
-    [ run promote_integral.cpp ]
-    [ run image.cpp sample_image.cpp error_if.cpp
-        :
-        : gil_reference_checksums.txt
-        :
-    ]
-    [ run channel.cpp error_if.cpp ]
-    [ run pixel.cpp error_if.cpp ]
-    [ run pixel_iterator.cpp error_if.cpp ]
+run promote_integral.cpp ;
+run image.cpp sample_image.cpp error_if.cpp : : gil_reference_checksums.txt ;
+run channel.cpp error_if.cpp ;
+run pixel.cpp error_if.cpp ;
+run pixel_iterator.cpp error_if.cpp ;
+
+alias perf :
+    [ run performance.cpp ]
     ;
+explicit perf ;
 
 build-project channel ;
 build-project image_view ;

--- a/test/channel/Jamfile
+++ b/test/channel/Jamfile
@@ -1,6 +1,6 @@
-# Boost.GIL
+# Boost.GIL (Generic Image Library) - tests
 #
-# Copyright (c) 2018 Mateusz Loskot <mateusz at loskot dot net>
+# Copyright (c) 2018 Mateusz Loskot <mateusz@loskot.net>
 #
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or
@@ -14,15 +14,12 @@ project
     <include>..
     ;
 
-test-suite "boost-gil-test-channel"
-    :
-    [ compile channel_concepts.cpp ]
-    [ run channel_test_fixture.cpp ]
-    [ run channel_traits.cpp ]
-    [ run scoped_channel_value.cpp ]
-    [ run algorithm_channel_arithmetic.cpp ]
-    [ run algorithm_channel_convert.cpp ]
-    [ run algorithm_channel_invert.cpp ]
-    [ run algorithm_channel_multiply.cpp ]
-    [ run algorithm_channel_relation.cpp ]
-    ;
+compile channel_concepts.cpp ;
+run channel_test_fixture.cpp ;
+run channel_traits.cpp ;
+run scoped_channel_value.cpp ;
+run algorithm_channel_arithmetic.cpp ;
+run algorithm_channel_convert.cpp ;
+run algorithm_channel_invert.cpp ;
+run algorithm_channel_multiply.cpp ;
+run algorithm_channel_relation.cpp ;

--- a/test/image_view/Jamfile
+++ b/test/image_view/Jamfile
@@ -1,6 +1,6 @@
-# Boost.GIL
+# Boost.GIL (Generic Image Library) - tests
 #
-# Copyright (c) 2018 Mateusz Loskot <mateusz at loskot dot net>
+# Copyright (c) 2018 Mateusz Loskot <mateusz@loskot.net>
 #
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or
@@ -14,8 +14,5 @@ project
     <include>..
     ;
 
-test-suite "boost-gil-test-image-view"
-    :
-    [ compile image_view_concepts.cpp ]
-    [ run collection.cpp ]
-    ;
+compile image_view_concepts.cpp ;
+run collection.cpp ;

--- a/toolbox/doc/Jamfile
+++ b/toolbox/doc/Jamfile
@@ -1,14 +1,10 @@
-# Boost.GIL.ToolBox
+# Boost.GIL (Generic Image Library) - Toolbox documentation
 #
 # Copyright (c) 2012 Christian Henning
 #
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
-
-
-# Quickbook
-# -----------------------------------------------------------------------------
 
 use-project boost : c:/boost ;
 
@@ -18,40 +14,40 @@ using boostbook ;
 
 # taken from http://boost.2283326.n4.nabble.com/Doxygen-Running-Doxygen-from-BB-td3657608.html
 doxygen reference.html
-    : 
-        [ glob 
-            ../../../../boost/gil/extension/toolbox/*.hpp 
-            ../../../../boost/gil/extension/toolbox/color_converters/*.hpp 
-            ../../../../boost/gil/extension/toolbox/color_spaces/*.hpp 
+    :
+        [ glob
+            ../../../../boost/gil/extension/toolbox/*.hpp
+            ../../../../boost/gil/extension/toolbox/color_converters/*.hpp
+            ../../../../boost/gil/extension/toolbox/color_spaces/*.hpp
             ../../../../boost/gil/extension/toolbox/image_types/*.hpp
             ../../../../boost/gil/extension/toolbox/metafunctions/*.hpp
         ]
-    : 
+    :
        <doxygen:param>"PROJECT_NAME=\"Boost GIL Toolbox\""
        <doxygen:param>"PROJECT_LOGO=\"$(BOOST_ROOT)/boost.png\""
        #messages
        <doxygen:param>QUIET=YES
        <doxygen:param>WARN_IF_UNDOCUMENTED=YES
        <doxygen:param>WARN_IF_DOC_ERROR=YES
-        # input 
-        <doxygen:param>JAVADOC_AUTOBRIEF=YES 
-        <doxygen:param>EXTRACT_PRIVATE=NO 
-        <doxygen:param>EXTRACT_STATIC=YES 
-        <doxygen:param>HIDE_UNDOC_MEMBERS=YES 
-        <doxygen:param>HIDE_UNDOC_CLASSES=YES 
-        # output 
-        <doxygen:param>HIDE_SCOPE_NAMES=YES 
-        <doxygen:param>INLINE_INFO=NO 
-        <doxygen:param>SORT_MEMBER_DOCS=NO 
-        <doxygen:param>SHOW_DIRECTORIES=YES 
-        <doxygen:param>SOURCE_BROWSER=YES 
-        <doxygen:param>REFERENCED_BY_RELATION=NO 
-        <doxygen:param>REFERENCES_RELATION=NO 
-        <doxygen:param>REFERENCES_LINK_SOURCE=NO 
-        <doxygen:param>VERBATIM_HEADERS=NO 
+        # input
+        <doxygen:param>JAVADOC_AUTOBRIEF=YES
+        <doxygen:param>EXTRACT_PRIVATE=NO
+        <doxygen:param>EXTRACT_STATIC=YES
+        <doxygen:param>HIDE_UNDOC_MEMBERS=YES
+        <doxygen:param>HIDE_UNDOC_CLASSES=YES
+        # output
+        <doxygen:param>HIDE_SCOPE_NAMES=YES
+        <doxygen:param>INLINE_INFO=NO
+        <doxygen:param>SORT_MEMBER_DOCS=NO
+        <doxygen:param>SHOW_DIRECTORIES=YES
+        <doxygen:param>SOURCE_BROWSER=YES
+        <doxygen:param>REFERENCED_BY_RELATION=NO
+        <doxygen:param>REFERENCES_RELATION=NO
+        <doxygen:param>REFERENCES_LINK_SOURCE=NO
+        <doxygen:param>VERBATIM_HEADERS=NO
         <doxygen:param>HIDE_UNDOC_RELATIONS=NO
         <doxygen:param>"EXCLUDE_SYMBOLS = \"detail::*\""
-    ; 
+    ;
 
 xml toolbox : toolbox.qbk ;
 

--- a/toolbox/test/Jamfile
+++ b/toolbox/test/Jamfile
@@ -1,11 +1,11 @@
-# Boost.GIL.ToolBox
+# Boost.GIL (Generic Image Library) - Toolbox tests
 #
-# (C) Copyright 2012: Mateusz Loskot and Christian Henning
+# Copyright (c) 2012 Christian Henning
+# Copyright (c) 2012 Mateusz Loskot <mateusz@loskot.net>
 #
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-# bring in rules for testing
 import testing ;
 
 project
@@ -14,31 +14,22 @@ project
     <library>/boost/test//boost_unit_test_framework
     ;
 
-test-suite "gil::toolbox" :
-    [ run
-        # sources
-        test.cpp
-        channel_type.cpp
-        channel_view.cpp
-        cmyka.cpp
-        get_num_bits.cpp
-        get_pixel_type.cpp
-        gray_alpha.cpp
-        gray_to_rgba.cpp
-        hsl_hsv_test.cpp
-        indexed_image_test.cpp
-        is_bit_aligned.cpp
-        is_homogeneous.cpp
-        is_similar.cpp
-        lab_test.cpp
-        pixel_bit_size.cpp
-        rgb_to_luminance.cpp
-        xyz_test.cpp
-        : # args
-        : # input-files
-        :	# requirements
-        : # target-name
-        gil_io_new_tests
-        : # default-build
-    ]
+run
+    test.cpp
+    channel_type.cpp
+    channel_view.cpp
+    cmyka.cpp
+    get_num_bits.cpp
+    get_pixel_type.cpp
+    gray_alpha.cpp
+    gray_to_rgba.cpp
+    hsl_hsv_test.cpp
+    indexed_image_test.cpp
+    is_bit_aligned.cpp
+    is_homogeneous.cpp
+    is_similar.cpp
+    lab_test.cpp
+    pixel_bit_size.cpp
+    rgb_to_luminance.cpp
+    xyz_test.cpp
     ;


### PR DESCRIPTION
Rename `Jamfile.v2` to `Jamfile` - BBv1 is dead.
Remove `numeric/test/test.cpp` as redundant.

### Tasklist

- [x] All CI builds and checks have passed
