### PR TITLE
Add first batch of examples to Jamfile

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -55,7 +55,6 @@ variant ubsan_undefined
     <define>BOOST_USE_ASAN=1
     ;
 
-build-project example ;
 build-project test ;
 build-project numeric/test ;
 build-project toolbox/test ;

--- a/example/Jamfile
+++ b/example/Jamfile
@@ -6,8 +6,33 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+import ac ;
+import regex ;
+import testing ;
+
+using libjpeg : : : : true ; # work around bug on master
+
 project boost-gil-example
     : # requirements
     ;
 
-# TODO: Add targets for examples
+# TODO: Add missing examples
+
+local sources =
+    affine.cpp
+    dynamic_image.cpp
+    histogram.cpp
+    ;
+
+local targets ;
+
+for local s in $(sources)
+{
+    targets +=
+        [ compile $(s) :
+            [ ac.check-library /libjpeg//libjpeg : <library>/libjpeg//libjpeg : <build>no ]
+        ]
+        ;
+}
+
+alias examples : $(targets) ;

--- a/example/affine.cpp
+++ b/example/affine.cpp
@@ -1,6 +1,6 @@
 /*
     Copyright 2005-2007 Adobe Systems Incorporated
-   
+
     Use, modification and distribution are subject to the Boost Software License,
     Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
     http://www.boost.org/LICENSE_1_0.txt).
@@ -12,7 +12,7 @@
 
 ///////////////////////
 ////  NOTE: This sample file uses the numeric extension, which does not come with the Boost distribution.
-////  You may download it from http://opensource.adobe.com/gil 
+////  You may download it from http://opensource.adobe.com/gil
 ///////////////////////
 
 /// \file
@@ -20,27 +20,28 @@
 /// \author Lubomir Bourdev and Hailin Jin
 /// \date February 27, 2007
 
-#include <boost/gil/image.hpp>
-#include <boost/gil/typedefs.hpp>
-#include <boost/gil/extension/io/jpeg_io.hpp>
+#include <boost/gil.hpp>
+#include <boost/gil/extension/io/jpeg.hpp>
 #include <boost/gil/extension/numeric/sampler.hpp>
 #include <boost/gil/extension/numeric/resample.hpp>
 
-int main() {
-    using namespace boost::gil;
+int main()
+{
+    namespace gil = boost::gil;
 
-    rgb8_image_t img;
-    jpeg_read_image("test.jpg",img);
+    gil::rgb8_image_t img;
+    gil::read_image("test.jpg", img, gil::jpeg_tag());
 
     // test resample_pixels
     // Transform the image by an arbitrary affine transformation using nearest-neighbor resampling
-    rgb8_image_t transf(rgb8_image_t::point_t(view(img).dimensions()*2));
-    fill_pixels(view(transf),rgb8_pixel_t(255,0,0));    // the background is red
+    gil::rgb8_image_t transf(gil::rgb8_image_t::point_t(gil::view(img).dimensions() * 2));
+    gil::fill_pixels(gil::view(transf), gil::rgb8_pixel_t(255, 0, 0)); // the background is red
 
-    matrix3x2<double> mat = matrix3x2<double>::get_translate(-point2<double>(200,250)) *
-                            matrix3x2<double>::get_rotate(-15*3.14/180.0);
-    resample_pixels(const_view(img), view(transf), mat, nearest_neighbor_sampler());
-    jpeg_write_view("out-affine.jpg", view(transf));
+    gil::matrix3x2<double> mat =
+        gil::matrix3x2<double>::get_translate(-gil::point2<double>(200,250)) *
+        gil::matrix3x2<double>::get_rotate(-15*3.14/180.0);
+    gil::resample_pixels(const_view(img), gil::view(transf), mat, gil::nearest_neighbor_sampler());
+    gil::write_view("out-affine.jpg", gil::view(transf), gil::jpeg_tag());
 
     return 0;
 }

--- a/example/dynamic_image.cpp
+++ b/example/dynamic_image.cpp
@@ -1,6 +1,6 @@
 /*
     Copyright 2005-2007 Adobe Systems Incorporated
-   
+
     Use, modification and distribution are subject to the Boost Software License,
     Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
     http://www.boost.org/LICENSE_1_0.txt).
@@ -22,12 +22,12 @@
 
 int main()
 {
-    namespace bg = boost::gil;
+    namespace gil = boost::gil;
 
-    using my_images_t = boost::mpl::vector<bg::gray8_image_t, bg::rgb8_image_t, bg::gray16_image_t, bg::rgb16_image_t>;
-    bg::any_image<my_images_t> dynamic_image;
-    bg::read_image("test.jpg", dynamic_image, bg::jpeg_tag());
+    using my_images_t = boost::mpl::vector<gil::gray8_image_t, gil::rgb8_image_t, gil::gray16_image_t, gil::rgb16_image_t>;
+    gil::any_image<my_images_t> dynamic_image;
+    gil::read_image("test.jpg", dynamic_image, gil::jpeg_tag());
     // Save the image upside down, preserving its native color space and channel depth
-    auto view = bg::flipped_up_down_view(bg::const_view(dynamic_image));
-    bg::write_view("out-dynamic_image.jpg", view, bg::jpeg_tag());
+    auto view = gil::flipped_up_down_view(gil::const_view(dynamic_image));
+    gil::write_view("out-dynamic_image.jpg", view, gil::jpeg_tag());
 }

--- a/example/histogram.cpp
+++ b/example/histogram.cpp
@@ -1,6 +1,6 @@
 /*
     Copyright 2005-2007 Adobe Systems Incorporated
-   
+
     Use, modification and distribution are subject to the Boost Software License,
     Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
     http://www.boost.org/LICENSE_1_0.txt).
@@ -15,12 +15,10 @@
 /// \author Lubomir Bourdev and Hailin Jin
 /// \date February 27, 2007
 
+#include <boost/gil.hpp>
+#include <boost/gil/extension/io/jpeg.hpp>
 #include <algorithm>
 #include <fstream>
-#include <boost/gil/image.hpp>
-#include <boost/gil/typedefs.hpp>
-#include <boost/gil/color_convert.hpp>
-#include <boost/gil/extension/io/jpeg_io.hpp>
 
 using namespace boost::gil;
 
@@ -38,14 +36,14 @@ void get_hist(const V& img_view, R& hist) {
 
 int main() {
     rgb8_image_t img;
-    jpeg_read_image("test.jpg",img);
+    read_image("test.jpg", img, jpeg_tag());
 
     int histogram[256];
-    std::fill(histogram,histogram+256,0);
-    get_hist(const_view(img),histogram);
+    std::fill(histogram,histogram + 256, 0);
+    get_hist(const_view(img), histogram);
 
-    std::fstream histo_file("out-histogram.txt",std::ios::out);
-    for(std::size_t ii=0;ii<256;++ii)
+    std::fstream histo_file("out-histogram.txt", std::ios::out);
+    for(std::size_t ii = 0; ii < 256; ++ii)
         histo_file << histogram[ii] << std::endl;
     histo_file.close();
 


### PR DESCRIPTION
Update examples to catch up with recent changes and ensure they both
compile without errors (using GCC 5).

### References

* #40

### Tasklist

- [x ] All CI builds and checks have passed

-----

ATM, examples are not compiled by default on CI-s but I've verified these compile locally with GCC 5.