### PR TITLE
Add casts to avoid warnings due to implicit integral promotions

### DIFF
--- a/test/promote_integral.cpp
+++ b/test/promote_integral.cpp
@@ -14,6 +14,7 @@
 //  - Remove support for boost::multiprecision types
 //  - Remove support for 128-bit integer types
 //  - Update and sort includes
+//  - Add explicit conversions to avoid warnings due to implicit integral promotions
 //
 #include <boost/gil/promote_integral.hpp>
 
@@ -46,7 +47,7 @@ struct absolute_value
 {
     static inline T apply(T const& t)
     {
-        return t < 0 ? -t : t;
+        return static_cast<T>(t < 0 ? -t : t);
     }
 };
 
@@ -73,11 +74,12 @@ struct test_max_values
         // but to avoid warning: comparing floating point with == is unsafe.
 
         Promoted min_value = (std::numeric_limits<Integral>::min)();
-        min_value *= min_value;
+        // Explicit casts to avoid warning: conversion to short int from int may alter its value
+        min_value = static_cast<Promoted>(min_value * min_value);
         BOOST_CHECK(absolute_value<Promoted>::apply(min_value) >= min_value);
         BOOST_CHECK(absolute_value<Promoted>::apply(min_value) <= min_value);
         Promoted max_value = (std::numeric_limits<Integral>::max)();
-        max_value *= max_value;
+        max_value = static_cast<Promoted>(max_value * max_value);
         BOOST_CHECK(absolute_value<Promoted>::apply(max_value) >= max_value);
         BOOST_CHECK(absolute_value<Promoted>::apply(max_value) <= max_value);
 
@@ -95,7 +97,7 @@ struct test_max_values<Integral, Promoted, false>
     static inline void apply()
     {
         Promoted max_value = (std::numeric_limits<Integral>::max)();
-        Promoted max_value_sqr = max_value * max_value;
+        Promoted max_value_sqr = static_cast<Promoted>(max_value * max_value);
         BOOST_CHECK(max_value_sqr < (std::numeric_limits<Promoted>::max)()
                     &&
                     max_value_sqr > max_value);


### PR DESCRIPTION
The explicit casts help to avoid warnings when integer types smaller than `int` are implicitly converted during arithmetic operations.

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed

-----

This should fix warnings during compilation of the test:

```
promote_integral.cpp: In instantiation of ‘static void test_max_values<Integral, Promoted, Signed>::apply() [with Integral = signed char; Promoted = short int; bool Signed = true]’:
promote_integral.cpp:157:65:   required from ‘static void test_promote_integral<PromoteUnsignedToUnsigned>::apply(const string&) [with Type = signed char; ExpectedPromotedType = short int; bool PromoteUnsignedToUnsigned = false; std::__cxx11::string = std::__cxx11::basic_string<char>]’
promote_integral.cpp:222:45:   required from ‘static void test_promotion<T, PromoteUnsignedToUnsigned, IsSigned>::apply(std::__cxx11::string) [with T = signed char; bool PromoteUnsignedToUnsigned = false; bool IsSigned = true; std::__cxx11::string = std::__cxx11::basic_string<char>]’
promote_integral.cpp:296:34:   required from here
promote_integral.cpp:76:19: warning: conversion to ‘short int’ from ‘int’ may alter its value [-Wconversion]
         min_value *= min_value;
                   ^
promote_integral.cpp:80:19: warning: conversion to ‘short int’ from ‘int’ may alter its value [-Wconversion]
         max_value *= max_value;
                   ^
promote_integral.cpp: In instantiation of ‘static void test_max_values<Integral, Promoted, false>::apply() [with Integral = unsigned char; Promoted = short unsigned int]’:
promote_integral.cpp:157:65:   required from ‘static void test_promote_integral<PromoteUnsignedToUnsigned>::apply(const string&) [with Type = unsigned char; ExpectedPromotedType = short unsigned int; bool PromoteUnsignedToUnsigned = true; std::__cxx11::string = std::__cxx11::basic_string<char>]’
promote_integral.cpp:265:45:   required from ‘static void test_promotion<T, true, false>::apply(std::__cxx11::string) [with T = unsigned char; std::__cxx11::string = std::__cxx11::basic_string<char>]’
promote_integral.cpp:299:42:   required from here
promote_integral.cpp:98:46: warning: conversion to ‘short unsigned int’ from ‘int’ may alter its value [-Wconversion]
         Promoted max_value_sqr = max_value * max_value;
                                              ^
promote_integral.cpp: In instantiation of ‘static T absolute_value<T, Signed>::apply(const T&) [with T = short int; bool Signed = true]’:
promote_integral.cpp:77:9:   required from ‘static void test_max_values<Integral, Promoted, Signed>::apply() [with Integral = char; Promoted = short int; bool Signed = true]’
promote_integral.cpp:157:65:   required from ‘static void test_promote_integral<PromoteUnsignedToUnsigned>::apply(const string&) [with Type = char; ExpectedPromotedType = short int; bool PromoteUnsignedToUnsigned = false; std::__cxx11::string = std::__cxx11::basic_string<char>]’
promote_integral.cpp:222:45:   required from ‘static void test_promotion<T, PromoteUnsignedToUnsigned, IsSigned>::apply(std::__cxx11::string) [with T = char; bool PromoteUnsignedToUnsigned = false; bool IsSigned = true; std::__cxx11::string = std::__cxx11::basic_string<char>]’
promote_integral.cpp:294:27:   required from here
promote_integral.cpp:49:29: warning: conversion to ‘short int’ from ‘int’ may alter its value [-Wconversion]
         return t < 0 ? -t : t;
                             ^
```