### PR TITLE
Add test to verify headers are self-contained

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,6 +20,7 @@ environment:
     - TOOLSET: msvc-14.1
       ARCH: x86_64
       VARIANT: debug
+      TEST_HEADERS: 1
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     - TOOLSET: msvc-14.1
       ARCH: x86_64

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ indent_style = space
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[{CMakeLists.txt,CMakeSettings.json,*.cmake}]
+[{Jamfile*,CMakeLists.txt,CMakeSettings.json,*.cmake}]
 indent_size = 2
 indent_style = space
 trim_trailing_whitespace = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
     - env: BOGUS_JOB=true
   include:
     - os: linux
-      env: COMPILER=g++-5 VARIANT=debug TOOLSET=gcc CXXSTD=c++11
+      env: COMPILER=g++-5 VARIANT=debug TOOLSET=gcc CXXSTD=c++11 TEST_HEADERS=1
       addons:
         apt:
           packages:

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -1,30 +1,78 @@
 # Boost.GIL (Generic Image Library) - tests
 #
+# Copyright (c) 2007-2015 Andrey Semashev
 # Copyright (c) 2008 Lubomir Bourdev, Hailin Jin
 # Copyright (c) 2018 Mateusz Loskot <mateusz@loskot.net>
+# Copyright (c) 2018 Dmitry Arkhipov
 #
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or
 # copy at http://www.boost.org/LICENSE_1_0.txt)
 
+import os ;
+import path ;
+import regex ;
 import testing ;
 
 project
-    : requirements
+  : requirements
     <include>$(BOOST_ROOT)
     <include>.
-    ;
+  ;
+
+# This rule is based on script copied from similar rule in Boost.Log
+# and improved by Dmitry Arkhipov via #boost at cpplang.slack.com.
+rule generate_self_contained_headers
+{
+  local targets ;
+
+  # NOTE: All '/' in test names are replaced with '-' because apparently
+  #       test scripts have a problem with test names containing slashes.
+
+  local top_headers_path = [ path.make $(BOOST_ROOT)/libs/gil/include/boost/gil ] ;
+
+  # boost/gil core headers
+  for local file in [ path.glob-tree $(top_headers_path) : *.hpp : extension io ]
+  {
+    local rel_file = [ path.relative-to $(top_headers_path) $(file) ] ;
+    local target_name = [ regex.replace self-contained/$(rel_file) "/" "-" ] ;
+    targets += [
+      compile self_contained_header.cpp
+        : <define>"BOOST_GIL_TEST_HEADER=$(rel_file)" <dependency>$(file)
+        : $(target_name)
+    ] ;
+  }
+
+  # boost/gil/io headers
+  local headers_path = [ path.make $(BOOST_ROOT)/libs/gil/include/boost/gil/io ] ;
+  for local file in [ path.glob-tree $(headers_path) : *.hpp : extension io ]
+  {
+    local rel_file = [ path.relative-to $(top_headers_path) $(file) ] ;
+    local target_name = [ regex.replace self-contained/$(rel_file) "/" "-" ] ;
+    targets += [
+      compile self_contained_header.cpp
+        : <define>"BOOST_GIL_TEST_HEADER=$(rel_file)" <dependency>$(file)
+        : $(target_name)
+    ] ;
+  }
+
+  return $(targets) ;
+}
+
+# On CI services, test the self-contained headers on-demand only to avoid build timeouts
+# CI environment is common for Travis CI, AppVeyor, CircleCI, etc.
+if ! [ os.environ CI ] || [ os.environ TEST_HEADERS ]
+{
+  alias self_contained_headers : [ generate_self_contained_headers ] ;
+}
 
 run promote_integral.cpp ;
 run image.cpp sample_image.cpp error_if.cpp : : gil_reference_checksums.txt ;
 run channel.cpp error_if.cpp ;
 run pixel.cpp error_if.cpp ;
 run pixel_iterator.cpp error_if.cpp ;
-
-alias perf :
-    [ run performance.cpp ]
-    ;
-explicit perf ;
-
 build-project channel ;
 build-project image_view ;
+
+alias perf : [ run performance.cpp ] ;
+explicit perf ;

--- a/test/self_contained_header.cpp
+++ b/test/self_contained_header.cpp
@@ -1,0 +1,18 @@
+//
+// Copyright (c) 2007-2015 Andrey Semashev
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+// This file contains a test boilerplate for checking that every public header
+// is self-contained and does not have any missing #include-s.
+
+#define BOOST_GIL_TEST_INCLUDE_HEADER() <boost/gil/BOOST_GIL_TEST_HEADER>
+
+#include BOOST_GIL_TEST_INCLUDE_HEADER()
+
+int main()
+{
+    return 0;
+}


### PR DESCRIPTION
For each header, a translation unit is generated along with corresponding compile target.
Currently, only `boost/gil/*.hpp` and `boost/gil/io/* headres` are included.

On CI services, compile self_contained_headers targets only if `TEST_HEADERS` environment variable is set. This is to avoid build timeouts due to CI services limits.
When running b2 locally, the tests are compiled by default.

-----

NOTE: The self-contained headers tests are built by default. There will be compilation errors due to actual 'broken' headers! Obviously, those need to be fixed via dedicated PRs/commits.

### References

* #148 

### Tasklist

- [x] Review
- [x] Adjust for comments
- [ ] All CI builds and checks have passed
