### PR TITLE
Add #include directives with missing headers

### DIFF
--- a/include/boost/gil/io/bit_operations.hpp
+++ b/include/boost/gil/io/bit_operations.hpp
@@ -8,8 +8,12 @@
 #ifndef BOOST_GIL_IO_BIT_OPERATIONS_HPP
 #define BOOST_GIL_IO_BIT_OPERATIONS_HPP
 
-#include <boost/bind.hpp>
+#include <boost/gil/io/typedefs.hpp>
 
+#include <boost/bind.hpp>
+#include <boost/mpl/bool.hpp>
+
+#include <cstddef>
 #include <array>
 
 namespace boost { namespace gil { namespace detail {

--- a/include/boost/gil/io/conversion_policies.hpp
+++ b/include/boost/gil/io/conversion_policies.hpp
@@ -9,6 +9,7 @@
 #define BOOST_GIL_IO_CONVERSION_POLICIES_HPP
 
 #include <boost/gil/image_view_factory.hpp>
+#include <boost/gil/io/error.hpp>
 
 #include <algorithm>
 #include <iterator>

--- a/include/boost/gil/io/error.hpp
+++ b/include/boost/gil/io/error.hpp
@@ -8,19 +8,19 @@
 #ifndef BOOST_GIL_IO_ERROR_HPP
 #define BOOST_GIL_IO_ERROR_HPP
 
+#include <ios>
+
 namespace boost { namespace gil {
 
-inline
-void io_error( const char* descr )
+inline void io_error(const char* descr)
 {
-   throw std::ios_base::failure( descr );
+   throw std::ios_base::failure(descr);
 }
 
-inline
-void io_error_if( bool expr, const char* descr )
+inline void io_error_if(bool expr, const char* descr)
 {
-   if( expr )
-      io_error( descr );
+   if (expr)
+      io_error(descr);
 }
 
 } // namespace gil

--- a/include/boost/gil/io/path_spec.hpp
+++ b/include/boost/gil/io/path_spec.hpp
@@ -13,7 +13,7 @@
 #include <boost/filesystem/path.hpp>
 #endif // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 
-#include <boost/mpl/bool_fwd.hpp>
+#include <boost/mpl/bool.hpp> // for complete types of true_ and false_
 
 #include <cstdlib>
 #include <string>

--- a/include/boost/gil/io/read_and_convert_image.hpp
+++ b/include/boost/gil/io/read_and_convert_image.hpp
@@ -11,6 +11,7 @@
 #include <boost/gil/io/base.hpp>
 #include <boost/gil/io/conversion_policies.hpp>
 #include <boost/gil/io/device.hpp>
+#include <boost/gil/io/get_reader.hpp>
 #include <boost/gil/io/path_spec.hpp>
 
 #include <boost/mpl/and.hpp>

--- a/include/boost/gil/io/read_and_convert_view.hpp
+++ b/include/boost/gil/io/read_and_convert_view.hpp
@@ -11,6 +11,7 @@
 #include <boost/gil/io/base.hpp>
 #include <boost/gil/io/conversion_policies.hpp>
 #include <boost/gil/io/device.hpp>
+#include <boost/gil/io/get_reader.hpp>
 #include <boost/gil/io/path_spec.hpp>
 
 #include <boost/mpl/and.hpp>

--- a/include/boost/gil/io/read_image.hpp
+++ b/include/boost/gil/io/read_image.hpp
@@ -13,6 +13,7 @@
 #include <boost/gil/io/base.hpp>
 #include <boost/gil/io/conversion_policies.hpp>
 #include <boost/gil/io/device.hpp>
+#include <boost/gil/io/get_reader.hpp>
 #include <boost/gil/io/path_spec.hpp>
 
 #include <boost/algorithm/string.hpp>

--- a/include/boost/gil/io/read_image_info.hpp
+++ b/include/boost/gil/io/read_image_info.hpp
@@ -10,6 +10,7 @@
 
 #include <boost/gil/io/base.hpp>
 #include <boost/gil/io/device.hpp>
+#include <boost/gil/io/get_reader.hpp>
 #include <boost/gil/io/path_spec.hpp>
 
 #include <boost/mpl/and.hpp>

--- a/include/boost/gil/io/read_view.hpp
+++ b/include/boost/gil/io/read_view.hpp
@@ -9,7 +9,9 @@
 #define BOOST_GIL_IO_READ_VIEW_HPP
 
 #include <boost/gil/io/base.hpp>
+#include <boost/gil/io/conversion_policies.hpp>
 #include <boost/gil/io/device.hpp>
+#include <boost/gil/io/get_reader.hpp>
 #include <boost/gil/io/path_spec.hpp>
 
 #include <boost/type_traits/is_base_and_derived.hpp>

--- a/include/boost/gil/io/row_buffer_helper.hpp
+++ b/include/boost/gil/io/row_buffer_helper.hpp
@@ -8,9 +8,18 @@
 #ifndef BOOST_GIL_IO_ROW_BUFFER_HELPER_HPP
 #define BOOST_GIL_IO_ROW_BUFFER_HELPER_HPP
 
+// TODO: Shall we move toolbox to core?
 #include <boost/gil/extension/toolbox/metafunctions/is_bit_aligned.hpp>
+#include <boost/gil/extension/toolbox/metafunctions/is_homogeneous.hpp>
+#include <boost/gil/extension/toolbox/metafunctions/pixel_bit_size.hpp>
 
 #include <boost/gil/io/typedefs.hpp>
+
+#include <boost/mpl/and.hpp>
+#include <boost/utility/enable_if.hpp>
+
+#include <cstddef>
+#include <vector>
 
 namespace boost { namespace gil { namespace detail {
 
@@ -98,13 +107,19 @@ private:
     buffer_t _row_buffer;
 };
 
-template<typename Pixel >
-struct row_buffer_helper< Pixel
-                        , typename boost::enable_if< typename mpl::and_< typename is_bit_aligned< Pixel >::type
-                                                                , typename is_homogeneous< Pixel >::type
-                                                                >::type
-                                            >
-                        >
+template<typename Pixel>
+struct row_buffer_helper
+<
+    Pixel,
+    typename boost::enable_if
+    <
+        typename mpl::and_
+        <
+            typename is_bit_aligned<Pixel>::type,
+            typename is_homogeneous<Pixel>::type
+        >::type
+    >
+>
 {
     typedef byte_t element_t;
     typedef std::vector< element_t > buffer_t;

--- a/include/boost/gil/io/scanline_read_iterator.hpp
+++ b/include/boost/gil/io/scanline_read_iterator.hpp
@@ -9,10 +9,13 @@
 #define BOOST_GIL_IO_SCANLINE_READ_ITERATOR_HPP
 
 #include <boost/gil/io/error.hpp>
+#include <boost/gil/io/typedefs.hpp>
 
 #include <boost/iterator/iterator_facade.hpp>
 
+#include <iterator>
 #include <memory>
+#include <vector>
 
 namespace boost { namespace gil {
 

--- a/include/boost/gil/io/write_view.hpp
+++ b/include/boost/gil/io/write_view.hpp
@@ -11,6 +11,7 @@
 #include <boost/gil/io/base.hpp>
 #include <boost/gil/io/conversion_policies.hpp>
 #include <boost/gil/io/device.hpp>
+#include <boost/gil/io/get_writer.hpp>
 #include <boost/gil/io/path_spec.hpp>
 
 #include <boost/mpl/and.hpp>


### PR DESCRIPTION
Make core and io headers self-contained.
Required by test to verify headers are self-contained in #147.

-----

The missing headers revealed using the test from #147 using GCC 5.5 locally.

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed
