### PR TITLE
Extract point2<T> from utilities.hpp to point.hpp

### DIFF
--- a/include/boost/gil.hpp
+++ b/include/boost/gil.hpp
@@ -23,6 +23,7 @@
 #include <boost/gil/pixel_iterator_adaptor.hpp>
 #include <boost/gil/planar_pixel_reference.hpp>
 #include <boost/gil/planar_pixel_iterator.hpp>
+#include <boost/gil/point.hpp>
 #include <boost/gil/step_iterator.hpp>
 #include <boost/gil/typedefs.hpp>
 #include <boost/gil/virtual_locator.hpp>

--- a/include/boost/gil/extension/dynamic_image/any_image_view.hpp
+++ b/include/boost/gil/extension/dynamic_image/any_image_view.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/gil/image.hpp>
 #include <boost/gil/image_view.hpp>
+#include <boost/gil/point.hpp>
 
 namespace boost { namespace gil {
 

--- a/include/boost/gil/extension/dynamic_image/image_view_factory.hpp
+++ b/include/boost/gil/extension/dynamic_image/image_view_factory.hpp
@@ -11,6 +11,7 @@
 #include <boost/gil/extension/dynamic_image/any_image_view.hpp>
 
 #include <boost/gil/image_view_factory.hpp>
+#include <boost/gil/point.hpp>
 
 namespace boost { namespace gil {
 

--- a/include/boost/gil/image_view_factory.hpp
+++ b/include/boost/gil/image_view_factory.hpp
@@ -11,6 +11,7 @@
 #include <boost/gil/color_convert.hpp>
 #include <boost/gil/gray.hpp>
 #include <boost/gil/metafunctions.hpp>
+#include <boost/gil/point.hpp>
 
 #include <cassert>
 #include <cstddef>
@@ -36,12 +37,12 @@ template <typename T> struct transposed_type;
 
 /// \brief Returns the type of a view that has a dynamic step along both X and Y
 /// \ingroup ImageViewTransformations
-template <typename View> 
+template <typename View>
 struct dynamic_xy_step_type : public dynamic_y_step_type<typename dynamic_x_step_type<View>::type> {};
 
 /// \brief Returns the type of a transposed view that has a dynamic step along both X and Y
 /// \ingroup ImageViewTransformations
-template <typename View> 
+template <typename View>
 struct dynamic_xy_step_transposed_type : public dynamic_xy_step_type<typename transposed_type<View>::type> {};
 
 
@@ -146,7 +147,7 @@ namespace detail {
 } // namespace detail
 
 
-/// \brief Returns the type of a view that does color conversion upon dereferencing its pixels 
+/// \brief Returns the type of a view that does color conversion upon dereferencing its pixels
 /// \ingroup ImageViewTransformationsColorConvert
 template <typename SrcView, typename DstP, typename CC=default_color_converter>
 struct color_converted_view_type : public detail::_color_converted_view_type<SrcView,
@@ -178,7 +179,7 @@ color_converted_view(const View& src) {
 
 /// \ingroup ImageViewTransformationsFlipUD
 template <typename View>
-inline typename dynamic_y_step_type<View>::type flipped_up_down_view(const View& src) { 
+inline typename dynamic_y_step_type<View>::type flipped_up_down_view(const View& src) {
     typedef typename dynamic_y_step_type<View>::type RView;
     return RView(src.dimensions(),typename RView::xy_locator(src.xy_at(0,src.height()-1),-1));
 }
@@ -188,7 +189,7 @@ inline typename dynamic_y_step_type<View>::type flipped_up_down_view(const View&
 /// \brief view of a view flipped left-to-right
 
 /// \ingroup ImageViewTransformationsFlipLR
-template <typename View> 
+template <typename View>
 inline typename dynamic_x_step_type<View>::type flipped_left_right_view(const View& src) {
     typedef typename dynamic_x_step_type<View>::type RView;
     return RView(src.dimensions(),typename RView::xy_locator(src.xy_at(src.width()-1,0),-1,1));
@@ -210,7 +211,7 @@ inline typename dynamic_xy_step_transposed_type<View>::type transposed_view(cons
 /// \brief view of a view rotated 90 degrees clockwise
 
 /// \ingroup ImageViewTransformations90CW
-template <typename View> 
+template <typename View>
 inline typename dynamic_xy_step_transposed_type<View>::type rotated90cw_view(const View& src) {
     typedef typename dynamic_xy_step_transposed_type<View>::type RView;
     return RView(src.height(),src.width(),typename RView::xy_locator(src.xy_at(0,src.height()-1),-1,1,true));
@@ -221,7 +222,7 @@ inline typename dynamic_xy_step_transposed_type<View>::type rotated90cw_view(con
 /// \brief view of a view rotated 90 degrees counter-clockwise
 
 /// \ingroup ImageViewTransformations90CCW
-template <typename View> 
+template <typename View>
 inline typename dynamic_xy_step_transposed_type<View>::type rotated90ccw_view(const View& src) {
     typedef typename dynamic_xy_step_transposed_type<View>::type RView;
     return RView(src.height(),src.width(),typename RView::xy_locator(src.xy_at(src.width()-1,0),1,-1,true));
@@ -232,7 +233,7 @@ inline typename dynamic_xy_step_transposed_type<View>::type rotated90ccw_view(co
 /// \brief view of a view rotated 180 degrees
 
 /// \ingroup ImageViewTransformations180
-template <typename View> 
+template <typename View>
 inline typename dynamic_xy_step_type<View>::type rotated180_view(const View& src) {
     typedef typename dynamic_xy_step_type<View>::type RView;
     return RView(src.dimensions(),typename RView::xy_locator(src.xy_at(src.width()-1,src.height()-1),-1,-1));
@@ -243,13 +244,13 @@ inline typename dynamic_xy_step_type<View>::type rotated180_view(const View& src
 /// \brief view of an axis-aligned rectangular area within an image_view
 
 /// \ingroup ImageViewTransformationsSubimage
-template <typename View> 
+template <typename View>
 inline View subimage_view(const View& src, const typename View::point_t& topleft, const typename View::point_t& dimensions) {
     return View(dimensions,src.xy_at(topleft));
 }
 
 /// \ingroup ImageViewTransformationsSubimage
-template <typename View> 
+template <typename View>
 inline View subimage_view(const View& src, int xMin, int yMin, int width, int height) {
     return View(width,height,src.xy_at(xMin,yMin));
 }
@@ -259,7 +260,7 @@ inline View subimage_view(const View& src, int xMin, int yMin, int width, int he
 /// \brief view of a subsampled version of an image_view, stepping over a number of channels in X and number of rows in Y
 
 /// \ingroup ImageViewTransformationsSubsampled
-template <typename View> 
+template <typename View>
 inline typename dynamic_xy_step_type<View>::type subsampled_view(const View& src, typename View::coord_t xStep, typename View::coord_t yStep) {
     assert(xStep>0 && yStep>0);
     typedef typename dynamic_xy_step_type<View>::type RView;
@@ -268,8 +269,8 @@ inline typename dynamic_xy_step_type<View>::type subsampled_view(const View& src
 }
 
 /// \ingroup ImageViewTransformationsSubsampled
-template <typename View> 
-inline typename dynamic_xy_step_type<View>::type subsampled_view(const View& src, const typename View::point_t& step) { 
+template <typename View>
+inline typename dynamic_xy_step_type<View>::type subsampled_view(const View& src, const typename View::point_t& step) {
     return subsampled_view(src,step.x,step.y);
 }
 
@@ -280,7 +281,7 @@ inline typename dynamic_xy_step_type<View>::type subsampled_view(const View& src
 namespace detail {
     template <typename View, bool AreChannelsTogether> struct __nth_channel_view_basic;
 
-    // nth_channel_view when the channels are not adjacent in memory. This can happen for multi-channel interleaved images 
+    // nth_channel_view when the channels are not adjacent in memory. This can happen for multi-channel interleaved images
     // or images with a step
     template <typename View>
     struct __nth_channel_view_basic<View,false> {
@@ -352,8 +353,8 @@ namespace detail {
 
         int _n;        // the channel to use
 
-        result_type operator()(argument_type srcP) const { 
-            return result_type(srcP[_n]); 
+        result_type operator()(argument_type srcP) const {
+            return result_type(srcP[_n]);
         }
     };
 
@@ -405,7 +406,7 @@ typename nth_channel_view_type<View>::type nth_channel_view(const View& src, int
 namespace detail {
     template <int K, typename View, bool AreChannelsTogether> struct __kth_channel_view_basic;
 
-    // kth_channel_view when the channels are not adjacent in memory. This can happen for multi-channel interleaved images 
+    // kth_channel_view when the channels are not adjacent in memory. This can happen for multi-channel interleaved images
     // or images with a step
     template <int K, typename View>
     struct __kth_channel_view_basic<K,View,false> {
@@ -481,7 +482,7 @@ namespace detail {
         kth_channel_deref_fn() {}
         template <typename P> kth_channel_deref_fn(const kth_channel_deref_fn<K,P>&) {}
 
-        result_type operator()(argument_type srcP) const { 
+        result_type operator()(argument_type srcP) const {
             return result_type(gil::at_c<K>(srcP));
         }
     };

--- a/include/boost/gil/io/typedefs.hpp
+++ b/include/boost/gil/io/typedefs.hpp
@@ -13,6 +13,7 @@
 #endif // BOOST_GIL_IO_ENABLE_GRAY_ALPHA
 
 #include <boost/gil/image.hpp>
+#include <boost/gil/point.hpp>
 #include <boost/gil/utilities.hpp>
 
 #include <boost/type_traits/is_base_of.hpp>

--- a/include/boost/gil/iterator_from_2d.hpp
+++ b/include/boost/gil/iterator_from_2d.hpp
@@ -9,8 +9,9 @@
 #define BOOST_GIL_ITERATOR_FROM_2D_HPP
 
 #include <boost/gil/concepts.hpp>
-#include <boost/gil/pixel_iterator.hpp>
 #include <boost/gil/locator.hpp>
+#include <boost/gil/pixel_iterator.hpp>
+#include <boost/gil/point.hpp>
 
 #include <boost/iterator/iterator_facade.hpp>
 
@@ -21,7 +22,7 @@ namespace boost { namespace gil {
 /// pixel step iterator, pixel image iterator and pixel dereference iterator
 
 ////////////////////////////////////////////////////////////////////////////////////////
-///                 
+///
 ///                 ITERATOR FROM 2D ADAPTOR
 ///
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -35,7 +36,7 @@ namespace boost { namespace gil {
 /// \ingroup PixelIteratorModelFromLocator PixelBasedModel
 /// \brief Provides 1D random-access navigation to the pixels of the image. Models: PixelIteratorConcept, PixelBasedConcept, HasDynamicXStepTypeConcept
 ///
-/// Pixels are traversed from the top to the bottom row and from the left to the right 
+/// Pixels are traversed from the top to the bottom row and from the left to the right
 /// within each row
 
 template <typename Loc2>    // Models PixelLocatorConcept
@@ -83,7 +84,7 @@ private:
             _coords.x=0;
             ++_coords.y;
             _p+=point_t(-_width,1);
-        }           
+        }
     }
     void decrement() {
         --_coords.x;
@@ -95,7 +96,7 @@ private:
         }
     }
 
-    BOOST_FORCEINLINE void advance(difference_type d) {  
+    BOOST_FORCEINLINE void advance(difference_type d) {
         if (_width==0) return;  // unfortunately we need to check for that. Default-constructed images have width of 0 and the code below will throw if executed.
         point_t delta;
         if (_coords.x+d>=0) {  // not going back to a previous row?
@@ -104,13 +105,13 @@ private:
         } else {
             delta.x=(_coords.x+(std::ptrdiff_t)d*(1-_width))%_width -_coords.x;
             delta.y=-(_width-_coords.x-(std::ptrdiff_t)d-1)/_width;
-        }   
+        }
         _p+=delta;
         _coords.x+=delta.x;
         _coords.y+=delta.y;
     }
 
-    difference_type distance_to(const iterator_from_2d& it) const { 
+    difference_type distance_to(const iterator_from_2d& it) const {
         if (_width==0) return 0;
         return (it.y_pos()-_coords.y)*_width + (it.x_pos()-_coords.x);
     }

--- a/include/boost/gil/locator.hpp
+++ b/include/boost/gil/locator.hpp
@@ -9,6 +9,7 @@
 #define BOOST_GIL_LOCATOR_HPP
 
 #include <boost/gil/pixel_iterator.hpp>
+#include <boost/gil/point.hpp>
 
 #include <cassert>
 #include <cstddef>

--- a/include/boost/gil/point.hpp
+++ b/include/boost/gil/point.hpp
@@ -46,7 +46,6 @@ public:
 
     point2() = default;
     point2(T px, T py) : x(px), y(py) {}
-    point2(point2 const& p) : x(p.x), y(p.y) {}
 
     point2& operator=(point2 const& p)
     {

--- a/include/boost/gil/point.hpp
+++ b/include/boost/gil/point.hpp
@@ -47,12 +47,6 @@ public:
     point2() = default;
     point2(T px, T py) : x(px), y(py) {}
 
-    {
-        x = p.x;
-        y = p.y;
-        return *this;
-    }
-
     point2 operator<<(std::ptrdiff_t shift) const
     {
         return point2(x << shift, y << shift);
@@ -228,6 +222,6 @@ inline point2<std::ptrdiff_t> iceil(const point2<double>& p)
     return point2<std::ptrdiff_t>(iceil(p.x), iceil(p.y));
 }
 
-}}  // namespace boost::gil
+}} // namespace boost::gil
 
 #endif

--- a/include/boost/gil/point.hpp
+++ b/include/boost/gil/point.hpp
@@ -47,7 +47,6 @@ public:
     point2() = default;
     point2(T px, T py) : x(px), y(py) {}
     point2(point2 const& p) : x(p.x), y(p.y) {}
-    ~point2() {}
 
     point2& operator=(point2 const& p)
     {

--- a/include/boost/gil/point.hpp
+++ b/include/boost/gil/point.hpp
@@ -1,0 +1,236 @@
+//
+// Copyright 2005-2007 Adobe Systems Incorporated
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#ifndef BOOST_GIL_POINT_HPP
+#define BOOST_GIL_POINT_HPP
+
+#include <boost/gil/utilities.hpp>
+
+#include <boost/config.hpp>
+#include <boost/config/no_tr1/cmath.hpp>
+
+#include <cstddef>
+
+namespace boost { namespace gil {
+
+/// \addtogroup PointModel
+///
+/// Example:
+/// \code
+/// point2<std::ptrdiff_t> p(3,2);
+/// assert((p[0] == p.x) && (p[1] == p.y));
+/// assert(axis_value<0>(p) == 3);
+/// assert(axis_value<1>(p) == 2);
+/// \endcode
+
+/// \brief 2D point both axes of which have the same dimension type
+/// \ingroup PointModel
+/// Models: Point2DConcept
+template <typename T>
+class point2
+{
+public:
+    using value_type = T;
+
+    template<std::size_t D>
+    struct axis
+    {
+        using coord_t = value_type;
+    };
+
+    static constexpr std::size_t num_dimensions = 2;
+
+    point2() = default;
+    point2(T px, T py) : x(px), y(py) {}
+    point2(point2 const& p) : x(p.x), y(p.y) {}
+    ~point2() {}
+
+    point2& operator=(point2 const& p)
+    {
+        x = p.x;
+        y = p.y;
+        return *this;
+    }
+
+    point2 operator<<(std::ptrdiff_t shift) const
+    {
+        return point2(x << shift, y << shift);
+    }
+
+    point2 operator>>(std::ptrdiff_t shift) const
+    {
+        return point2(x >> shift, y >> shift);
+    }
+
+    point2& operator+=(point2 const& p)
+    {
+        x += p.x;
+        y += p.y;
+        return *this;
+    }
+
+    point2& operator-=(point2 const& p)
+    {
+        x -= p.x;
+        y -= p.y;
+        return *this;
+    }
+
+    point2& operator/=(double t)
+    {
+        if (t < 0 || 0 < t) { x /= t; y /= t; }
+        return *this;
+    }
+
+    T const& operator[](std::size_t i) const
+    {
+        return this->*mem_array[i];
+    }
+
+    T& operator[](std::size_t i)
+    {
+        return this->*mem_array[i];
+    }
+
+    T x{0};
+    T y{0};
+
+private:
+    // this static array of pointers to member variables makes operator[] safe
+    // and doesn't seem to exhibit any performance penalty.
+    static T point2<T>::* const mem_array[num_dimensions];
+};
+
+template <typename T>
+T point2<T>::* const point2<T>::mem_array[point2<T>::num_dimensions] =
+{
+  & point2<T>::x,
+  & point2<T>::y
+};
+
+/// \ingroup PointModel
+template <typename T>
+BOOST_FORCEINLINE
+bool operator==(const point2<T>& p1, const point2<T>& p2)
+{
+    return (p1.x == p2.x && p1.y == p2.y);
+}
+
+/// \ingroup PointModel
+template <typename T>
+BOOST_FORCEINLINE
+bool operator!=(const point2<T>& p1, const point2<T>& p2)
+{
+    return p1.x != p2.x || p1.y != p2.y;
+}
+
+/// \ingroup PointModel
+template <typename T>
+BOOST_FORCEINLINE
+point2<T> operator+(const point2<T>& p1, const point2<T>& p2)
+{
+    return point2<T>(p1.x + p2.x, p1.y + p2.y);
+}
+
+/// \ingroup PointModel
+template <typename T>
+BOOST_FORCEINLINE
+point2<T> operator-(const point2<T>& p)
+{
+    return point2<T>(-p.x, -p.y);
+}
+
+/// \ingroup PointModel
+template <typename T>
+BOOST_FORCEINLINE
+point2<T> operator-(const point2<T>& p1, const point2<T>& p2)
+{
+    return point2<T>(p1.x - p2.x, p1.y - p2.y);
+}
+
+/// \ingroup PointModel
+template <typename T>
+BOOST_FORCEINLINE
+point2<double> operator/(const point2<T>& p, double t)
+{
+    return (t < 0 || 0 < t)
+        ? point2<double>(p.x / t, p.y / t)
+        : point2<double>(0, 0);
+}
+
+/// \ingroup PointModel
+template <typename T>
+BOOST_FORCEINLINE
+point2<T> operator*(const point2<T>& p, std::ptrdiff_t t)
+{
+    return point2<T>(p.x * t, p.y * t);
+}
+
+/// \ingroup PointModel
+template <typename T>
+BOOST_FORCEINLINE
+point2<T> operator*(std::ptrdiff_t t, const point2<T>& p)
+{
+    return point2<T>(p.x * t, p.y * t);
+}
+
+/// \ingroup PointModel
+template <std::size_t K, typename T>
+BOOST_FORCEINLINE
+T const& axis_value(const point2<T>& p) { return p[K]; }
+
+/// \ingroup PointModel
+template <std::size_t K, typename T>
+BOOST_FORCEINLINE
+T& axis_value(point2<T>& p) { return p[K]; }
+
+/// \addtogroup PointAlgorithm
+///
+/// Example:
+/// \code
+/// assert(iround(point2<double>(3.1, 3.9)) == point2<std::ptrdiff_t>(3,4));
+/// \endcode
+
+/// \ingroup PointAlgorithm
+inline point2<std::ptrdiff_t> iround(const point2<float>& p)
+{
+    return point2<std::ptrdiff_t>(iround(p.x), iround(p.y));
+}
+
+/// \ingroup PointAlgorithm
+inline point2<std::ptrdiff_t> iround(const point2<double>& p)
+{
+    return point2<std::ptrdiff_t>(iround(p.x), iround(p.y));
+}
+
+/// \ingroup PointAlgorithm
+inline point2<std::ptrdiff_t> ifloor(const point2<float>& p)
+{
+    return point2<std::ptrdiff_t>(ifloor(p.x), ifloor(p.y));
+}
+
+/// \ingroup PointAlgorithm
+inline point2<std::ptrdiff_t> ifloor(const point2<double>& p)
+{
+    return point2<std::ptrdiff_t>(ifloor(p.x), ifloor(p.y));
+}
+
+/// \ingroup PointAlgorithm
+inline point2<std::ptrdiff_t> iceil(const point2<float>& p)
+{
+    return point2<std::ptrdiff_t>(iceil(p.x), iceil(p.y));
+}
+
+/// \ingroup PointAlgorithm
+inline point2<std::ptrdiff_t> iceil(const point2<double>& p)
+{
+    return point2<std::ptrdiff_t>(iceil(p.x), iceil(p.y));
+}
+
+}}  // namespace boost::gil
+
+#endif

--- a/include/boost/gil/point.hpp
+++ b/include/boost/gil/point.hpp
@@ -47,7 +47,6 @@ public:
     point2() = default;
     point2(T px, T py) : x(px), y(py) {}
 
-    point2& operator=(point2 const& p)
     {
         x = p.x;
         y = p.y;

--- a/include/boost/gil/typedefs.hpp
+++ b/include/boost/gil/typedefs.hpp
@@ -12,6 +12,7 @@
 #include <boost/gil/cmyk.hpp>
 #include <boost/gil/device_n.hpp>
 #include <boost/gil/gray.hpp>
+#include <boost/gil/point.hpp>
 #include <boost/gil/rgb.hpp>
 #include <boost/gil/rgba.hpp>
 

--- a/include/boost/gil/utilities.hpp
+++ b/include/boost/gil/utilities.hpp
@@ -30,144 +30,65 @@ namespace boost { namespace gil {
 /// Various utilities not specific to the image library.
 /// Some are non-standard STL extensions or generic iterator adaptors
 
-/**
-\addtogroup PointModel
-
-Example:
-\code
-point2<std::ptrdiff_t> p(3,2);
-assert((p[0] == p.x) && (p[1] == p.y));
-assert(axis_value<0>(p) == 3);
-assert(axis_value<1>(p) == 2);
-\endcode
-*/
-
-////////////////////////////////////////////////////////////////////////////////////////
-//                           CLASS point2
-///
-/// \brief 2D point both axes of which have the same dimension type
-/// \ingroup PointModel
-/// Models: Point2DConcept
-///
-////////////////////////////////////////////////////////////////////////////////////////
-
-template <typename T>
-class point2 {
-public:
-    typedef T value_type;
-    template <std::size_t D> struct axis { typedef value_type coord_t; };
-    static const std::size_t num_dimensions=2;
-
-    point2()                : x(0),     y(0)    {}
-    point2(T newX, T newY)  : x(newX),  y(newY) {}
-    point2(const point2& p) : x(p.x), y(p.y) {}
-    ~point2() {}
-
-    point2& operator=(const point2& p)            { x=p.x; y=p.y; return *this; }
-
-    point2        operator<<(std::ptrdiff_t shift)         const   { return point2(x<<shift,y<<shift); }
-    point2        operator>>(std::ptrdiff_t shift)         const   { return point2(x>>shift,y>>shift); }
-    point2& operator+=(const point2& p)           { x+=p.x; y+=p.y; return *this; }
-    point2& operator-=(const point2& p)           { x-=p.x; y-=p.y; return *this; }
-    point2& operator/=(double t)                  { if (t<0 || 0<t) { x/=t; y/=t; } return *this; }
-
-    const T& operator[](std::size_t i)          const   { return this->*mem_array[i]; }
-          T& operator[](std::size_t i)                  { return this->*mem_array[i]; }
-
-    T x,y;
-private:
-    // this static array of pointers to member variables makes operator[] safe and doesn't seem to exhibit any performance penalty
-    static T point2<T>::* const mem_array[num_dimensions];
-};
-
-template <typename T>
-T point2<T>::* const point2<T>::mem_array[point2<T>::num_dimensions] = { &point2<T>::x, &point2<T>::y };
-
-/// \ingroup PointModel
-template <typename T> BOOST_FORCEINLINE
-bool operator==(const point2<T>& p1, const point2<T>& p2) { return (p1.x==p2.x && p1.y==p2.y); }
-/// \ingroup PointModel
-template <typename T> BOOST_FORCEINLINE
-bool operator!=(const point2<T>& p1, const point2<T>& p2) { return  p1.x!=p2.x || p1.y!=p2.y; }
-/// \ingroup PointModel
-template <typename T> BOOST_FORCEINLINE
-point2<T> operator+(const point2<T>& p1, const point2<T>& p2) { return point2<T>(p1.x+p2.x,p1.y+p2.y); }
-/// \ingroup PointModel
-template <typename T> BOOST_FORCEINLINE
-point2<T> operator-(const point2<T>& p) { return point2<T>(-p.x,-p.y); }
-/// \ingroup PointModel
-template <typename T> BOOST_FORCEINLINE
-point2<T> operator-(const point2<T>& p1, const point2<T>& p2) { return point2<T>(p1.x-p2.x,p1.y-p2.y); }
-/// \ingroup PointModel
-template <typename T> BOOST_FORCEINLINE
-point2<double> operator/(const point2<T>& p, double t)      { return (t<0 || 0<t) ? point2<double>(p.x/t,p.y/t) : point2<double>(0,0); }
-/// \ingroup PointModel
-template <typename T> BOOST_FORCEINLINE
-point2<T> operator*(const point2<T>& p, std::ptrdiff_t t)      { return point2<T>(p.x*t,p.y*t); }
-/// \ingroup PointModel
-template <typename T> BOOST_FORCEINLINE
-point2<T> operator*(std::ptrdiff_t t, const point2<T>& p)      { return point2<T>(p.x*t,p.y*t); }
-
-/// \ingroup PointModel
-template <std::size_t K, typename T> BOOST_FORCEINLINE
-const T& axis_value(const point2<T>& p) { return p[K]; }
-
-/// \ingroup PointModel
-template <std::size_t K, typename T> BOOST_FORCEINLINE
-      T& axis_value(      point2<T>& p) { return p[K]; }
-
-////////////////////////////////////////////////////////////////////////////////////////
-///
+////////////////////////////////////////////////////////////////////////////////
 ///  Rounding of real numbers / points to integers / integer points
-///
-////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
 
-inline std::ptrdiff_t iround(float x ) { return static_cast<std::ptrdiff_t>(x + (x < 0.0f ? -0.5f : 0.5f)); }
-inline std::ptrdiff_t iround(double x) { return static_cast<std::ptrdiff_t>(x + (x < 0.0 ? -0.5 : 0.5)); }
-inline std::ptrdiff_t ifloor(float x ) { return static_cast<std::ptrdiff_t>(std::floor(x)); }
-inline std::ptrdiff_t ifloor(double x) { return static_cast<std::ptrdiff_t>(std::floor(x)); }
-inline std::ptrdiff_t iceil(float x )  { return static_cast<std::ptrdiff_t>(std::ceil(x)); }
-inline std::ptrdiff_t iceil(double x)  { return static_cast<std::ptrdiff_t>(std::ceil(x)); }
+inline std::ptrdiff_t iround(float x)
+{
+    return static_cast<std::ptrdiff_t>(x + (x < 0.0f ? -0.5f : 0.5f));
+}
 
-/**
-\addtogroup PointAlgorithm
+inline std::ptrdiff_t iround(double x)
+{
+    return static_cast<std::ptrdiff_t>(x + (x < 0.0 ? -0.5 : 0.5));
+}
 
-Example:
-\code
-assert(iround(point2<double>(3.1, 3.9)) == point2<std::ptrdiff_t>(3,4));
-\endcode
-*/
+inline std::ptrdiff_t ifloor(float x)
+{
+    return static_cast<std::ptrdiff_t>(std::floor(x));
+}
 
-/// \ingroup PointAlgorithm
-inline point2<std::ptrdiff_t> iround(const point2<float >& p)  { return point2<std::ptrdiff_t>(iround(p.x),iround(p.y)); }
-/// \ingroup PointAlgorithm
-inline point2<std::ptrdiff_t> iround(const point2<double>& p)  { return point2<std::ptrdiff_t>(iround(p.x),iround(p.y)); }
-/// \ingroup PointAlgorithm
-inline point2<std::ptrdiff_t> ifloor(const point2<float >& p)  { return point2<std::ptrdiff_t>(ifloor(p.x),ifloor(p.y)); }
-/// \ingroup PointAlgorithm
-inline point2<std::ptrdiff_t> ifloor(const point2<double>& p)  { return point2<std::ptrdiff_t>(ifloor(p.x),ifloor(p.y)); }
-/// \ingroup PointAlgorithm
-inline point2<std::ptrdiff_t> iceil (const point2<float >& p)  { return point2<std::ptrdiff_t>(iceil(p.x), iceil(p.y)); }
-/// \ingroup PointAlgorithm
-inline point2<std::ptrdiff_t> iceil (const point2<double>& p)  { return point2<std::ptrdiff_t>(iceil(p.x), iceil(p.y)); }
+inline std::ptrdiff_t ifloor(double x)
+{
+    return static_cast<std::ptrdiff_t>(std::floor(x));
+}
 
-////////////////////////////////////////////////////////////////////////////////////////
-///
+inline std::ptrdiff_t iceil(float x)
+{
+    return static_cast<std::ptrdiff_t>(std::ceil(x));
+}
+
+inline std::ptrdiff_t iceil(double x)
+{
+    return static_cast<std::ptrdiff_t>(std::ceil(x));
+}
+
+////////////////////////////////////////////////////////////////////////////////
 ///  computing size with alignment
-///
-////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
 
 template <typename T>
-inline T align(T val, std::size_t alignment) {
+inline T align(T val, std::size_t alignment)
+{
     return val+(alignment - val%alignment)%alignment;
 }
 
 /// \brief Helper base class for pixel dereference adaptors.
 /// \ingroup PixelDereferenceAdaptorModel
 ///
-template <typename ConstT, typename Value, typename Reference, typename ConstReference,
-          typename ArgType, typename ResultType, bool IsMutable>
-struct deref_base {
+template
+<
+    typename ConstT,
+    typename Value,
+    typename Reference,
+    typename ConstReference,
+    typename ArgType,
+    typename ResultType,
+    bool IsMutable
+>
+struct deref_base
+{
     typedef ArgType        argument_type;
     typedef ResultType     result_type;
     typedef ConstT         const_t;
@@ -181,10 +102,16 @@ struct deref_base {
 /// \ingroup PixelDereferenceAdaptorModel
 ///
 template <typename D1, typename D2>
-class deref_compose : public deref_base<
+class deref_compose : public deref_base
+<
       deref_compose<typename D1::const_t, typename D2::const_t>,
-      typename D1::value_type, typename D1::reference, typename D1::const_reference,
-      typename D2::argument_type, typename D1::result_type, D1::is_mutable && D2::is_mutable>
+      typename D1::value_type,
+      typename D1::reference,
+      typename D1::const_reference,
+      typename D2::argument_type,
+      typename D1::result_type,
+      D1::is_mutable && D2::is_mutable
+>
 {
 public:
     D1 _fn1;
@@ -193,35 +120,45 @@ public:
     typedef typename D2::argument_type   argument_type;
     typedef typename D1::result_type     result_type;
 
-    deref_compose() {}
+    deref_compose() = default;
     deref_compose(const D1& x, const D2& y) : _fn1(x), _fn2(y) {}
     deref_compose(const deref_compose& dc)  : _fn1(dc._fn1), _fn2(dc._fn2) {}
-    template <typename _D1, typename _D2> deref_compose(const deref_compose<_D1,_D2>& dc) : _fn1(dc._fn1), _fn2(dc._fn2) {}
+
+    template <typename _D1, typename _D2>
+    deref_compose(const deref_compose<_D1,_D2>& dc)
+        : _fn1(dc._fn1), _fn2(dc._fn2)
+    {}
 
     result_type operator()(argument_type x) const { return _fn1(_fn2(x)); }
     result_type operator()(argument_type x)       { return _fn1(_fn2(x)); }
 };
 
 // reinterpret_cast is implementation-defined. Static cast is not.
-template <typename OutPtr, typename In> BOOST_FORCEINLINE
-      OutPtr gil_reinterpret_cast(      In* p) { return static_cast<OutPtr>(static_cast<void*>(p)); }
+template <typename OutPtr, typename In>
+BOOST_FORCEINLINE
+OutPtr gil_reinterpret_cast(In* p)
+{
+    return static_cast<OutPtr>(static_cast<void*>(p));
+}
 
 template <typename OutPtr, typename In> BOOST_FORCEINLINE
-const OutPtr gil_reinterpret_cast_c(const In* p) { return static_cast<const OutPtr>(static_cast<const void*>(p)); }
+const OutPtr gil_reinterpret_cast_c(const In* p)
+{
+    return static_cast<const OutPtr>(static_cast<const void*>(p));
+}
 
 namespace detail {
 
-////////////////////////////////////////////////////////////////////////////////////////
-///
+////////////////////////////////////////////////////////////////////////////////
 ///  \brief copy_n taken from SGI STL.
-///
-////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
 
 template <class InputIter, class Size, class OutputIter>
 std::pair<InputIter, OutputIter> _copy_n(InputIter first, Size count,
-                                         OutputIter result,
-                                         std::input_iterator_tag) {
-   for ( ; count > 0; --count) {
+    OutputIter result, std::input_iterator_tag)
+{
+   for ( ; count > 0; --count)
+   {
       *result = *first;
       ++first;
       ++result;
@@ -231,26 +168,30 @@ std::pair<InputIter, OutputIter> _copy_n(InputIter first, Size count,
 
 template <class RAIter, class Size, class OutputIter>
 inline std::pair<RAIter, OutputIter>
-_copy_n(RAIter first, Size count, OutputIter result, std::random_access_iterator_tag) {
+_copy_n(RAIter first, Size count, OutputIter result, std::random_access_iterator_tag)
+{
    RAIter last = first + count;
    return std::pair<RAIter, OutputIter>(last, std::copy(first, last, result));
 }
 
 template <class InputIter, class Size, class OutputIter>
 inline std::pair<InputIter, OutputIter>
-_copy_n(InputIter first, Size count, OutputIter result) {
+_copy_n(InputIter first, Size count, OutputIter result)
+{
    return _copy_n(first, count, result, typename std::iterator_traits<InputIter>::iterator_category());
 }
 
 template <class InputIter, class Size, class OutputIter>
 inline std::pair<InputIter, OutputIter>
-copy_n(InputIter first, Size count, OutputIter result) {
+copy_n(InputIter first, Size count, OutputIter result)
+{
     return detail::_copy_n(first, count, result);
 }
 
 /// \brief identity taken from SGI STL.
 template <typename T>
-struct identity {
+struct identity
+{
     typedef T argument_type;
     typedef T result_type;
     const T& operator()(const T& val) const { return val; }
@@ -262,14 +203,16 @@ struct plus_asymmetric {
     typedef T1 first_argument_type;
     typedef T2 second_argument_type;
     typedef T1 result_type;
-    T1 operator()(T1 f1, T2 f2) const {
+    T1 operator()(T1 f1, T2 f2) const
+    {
         return f1+f2;
     }
 };
 
 /// \brief operator++ wrapped in a function object
 template <typename T>
-struct inc {
+struct inc
+{
     typedef T argument_type;
     typedef T result_type;
     T operator()(T x) const { return ++x; }
@@ -277,7 +220,8 @@ struct inc {
 
 /// \brief operator-- wrapped in a function object
 template <typename T>
-struct dec {
+struct dec
+{
     typedef T argument_type;
     typedef T result_type;
     T operator()(T x) const { return --x; }
@@ -287,33 +231,42 @@ struct dec {
 //         a given MPL RandomAccessSequence (or size if the type is not present)
 template <typename Types, typename T>
 struct type_to_index
-    : public mpl::distance<typename mpl::begin<Types>::type,
-                                  typename mpl::find<Types,T>::type>::type {};
+    : public mpl::distance
+        <
+            typename mpl::begin<Types>::type,
+            typename mpl::find<Types,T>::type
+        >::type
+    {
+    };
 } // namespace detail
 
 /// \ingroup ColorSpaceAndLayoutModel
 /// \brief Represents a color space and ordering of channels in memory
-template <typename ColorSpace, typename ChannelMapping = mpl::range_c<int,0,mpl::size<ColorSpace>::value> >
-struct layout {
+template <typename ColorSpace, typename ChannelMapping = mpl::range_c<int,0,mpl::size<ColorSpace>::value>>
+struct layout
+{
     typedef ColorSpace      color_space_t;
     typedef ChannelMapping  channel_mapping_t;
 };
 
 /// \brief A version of swap that also works with reference proxy objects
 template <typename Value, typename T1, typename T2> // where value_type<T1>  == value_type<T2> == Value
-void swap_proxy(T1& left, T2& right) {
+void swap_proxy(T1& left, T2& right)
+{
     Value tmp = left;
     left = right;
     right = tmp;
 }
 
 /// \brief Run-time detection of whether the underlying architecture is little endian
-inline bool little_endian() {
+BOOST_FORCEINLINE bool little_endian()
+{
     short tester = 0x0001;
     return  *(char*)&tester!=0;
 }
 /// \brief Run-time detection of whether the underlying architecture is big endian
-inline bool big_endian() {
+BOOST_FORCEINLINE bool big_endian()
+{
     return !little_endian();
 }
 


### PR DESCRIPTION
The point belongs to core basic concepts in GIL, not an optional utility. The tutorial starts with description of point.

Such core concepts are defined in dedicated headers which is quite a useful convention that also makes the code structure clearer.

Clean up point.hpp formatting (eg. respect line length limit).
### Tasklist

- [ ] ~Rename `point2` to `point` and add `using point2 = point;` for backward compatibility (see @stefanseefeld suggestion below)~ - moved to separate PR, see https://github.com/boostorg/gil/pull/154#issuecomment-431106310
- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed

------

@stefanseefeld suggested on Gitter:
> why don't we use point<> rather than point2<> ?
> Given that this is not a generic "Point" class, but one specific to (2D) image processing, the '2' is implicit.
> I'd thus suggest we rename it to point, and then add a using point2 = point; for backward compatibility.