### PR TITLE
Remove dependency on boost/algorithm/clamp.hpp

### DIFF
--- a/include/boost/gil/extension/toolbox/image_types/subchroma_image.hpp
+++ b/include/boost/gil/extension/toolbox/image_types/subchroma_image.hpp
@@ -59,7 +59,7 @@ struct subchroma_image_deref_fn
     {}
 
     /// operator()
-    typename result_type operator()( const point_t& p ) const
+    result_type operator()( const point_t& p ) const
     {
         typedef Scaling_Factors< mpl::at_c< Factors, 0 >::type::value
                                , mpl::at_c< Factors, 1 >::type::value


### PR DESCRIPTION
Copy `boost::algorithm::clamp` to where it was solely used in Toolbox.
Add `subchroma_image.cpp` missing from build target of Toolbox test.

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed
