### PR TITLE
[travis] Switch Boost super-project to develop branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,7 +126,7 @@ matrix:
             - llvm-toolchain-precise-3.9
 
     - os: linux
-      env: COMPILER=clang++-5.0 VARIANT=ubsan_integer TOOLSET=clang CXXSTD=c++11 UBSAN_OPTIONS='print_stacktrace=1'
+      env: COMPILER=clang++-5.0 VARIANT=ubsan_integer TOOLSET=clang CXXSTD=c++11 B2_OPTIONS="visibility=global" UBSAN_OPTIONS='print_stacktrace=1'
       addons:
         apt:
           packages:
@@ -140,7 +140,7 @@ matrix:
             - llvm-toolchain-trusty-5.0
 
     - os: linux
-      env: COMPILER=clang++-5.0 VARIANT=ubsan_nullability TOOLSET=clang CXXSTD=c++11 UBSAN_OPTIONS='print_stacktrace=1'
+      env: COMPILER=clang++-5.0 VARIANT=ubsan_nullability TOOLSET=clang CXXSTD=c++11 B2_OPTIONS="visibility=global" UBSAN_OPTIONS='print_stacktrace=1'
       addons:
         apt:
           packages:
@@ -154,7 +154,7 @@ matrix:
             - llvm-toolchain-trusty-5.0
 
     - os: linux
-      env: COMPILER=clang++-5.0 VARIANT=ubsan_undefined TOOLSET=clang CXXSTD=c++11 UBSAN_OPTIONS='print_stacktrace=1'
+      env: COMPILER=clang++-5.0 VARIANT=ubsan_undefined TOOLSET=clang CXXSTD=c++11 B2_OPTIONS="visibility=global" UBSAN_OPTIONS='print_stacktrace=1'
       addons:
         apt:
           packages:
@@ -180,7 +180,7 @@ matrix:
             - doxygen
 
   allow_failures:
-    - env: COMPILER=clang++-5.0 VARIANT=ubsan_integer TOOLSET=clang CXXSTD=c++11 UBSAN_OPTIONS='print_stacktrace=1'
+    - env: COMPILER=clang++-5.0 VARIANT=ubsan_integer TOOLSET=clang CXXSTD=c++11 B2_OPTIONS="visibility=global" UBSAN_OPTIONS='print_stacktrace=1'
 
 install:
   - |-
@@ -188,7 +188,9 @@ install:
       pip install --user sphinx==1.7.9
     fi
   - cd ..
-  - git clone -b master --depth 1 https://github.com/boostorg/boost.git boost-root
+  # NOTE: Here switch between master or develop depending on against which branch of Boost
+  #       super-project we want to test GIL
+  - git clone -b develop --depth 1 https://github.com/boostorg/boost.git boost-root
   - cd boost-root
   # List all (recursive) dependencies explicitly to control any new additions
   - git submodule --quiet update --init tools/build


### PR DESCRIPTION
Currently, we are experiencing UBSan builds failures due to issues in Boost.Function version attached to Boost super-project.
Build UBSan with b2 `visibility=global` instead of default `hidden`.

Detailed discussions at:
- https://github.com/boostorg/function/pull/29
- https://lists.boost.org/boost-gil/2018/10/0100.php

Note, we are switching temporarily and we should switch back to testing against Boost super-project master branch - a stable Boost version closest to the next release state.

### Tasklist

- [x] All CI builds and checks have passed

-----

I've got Travis CI for my fork at https://travis-ci.org/mloskot/gil which starts and completes the builds much quicker than for the org at https://travis-ci.org/boostorg/gil/