### PR TITLE
Fix undefined behaviour due to unsequenced side effects of same scalar

### DIFF
--- a/toolbox/test/indexed_image_test.cpp
+++ b/toolbox/test/indexed_image_test.cpp
@@ -37,7 +37,7 @@ BOOST_AUTO_TEST_CASE( index_image_test )
                        , [] () -> uint8_t
                         {
                             static uint8_t i = 0;
-                            i = ( i == 256 ) ? 0 : ++i;
+                            i = (i == 256) ? 0 : (i + 1);
 
                             return gray8_pixel_t( i );
                         }
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE( index_image_test )
                        , [] () ->rgb8_pixel_t
                         {
                             static uint8_t i = 0;
-                            i = ( i == 256 ) ? 0 : ++i;
+                            i = (i == 256) ? 0 : (i + 1);
 
                             return rgb8_pixel_t( i, i, i );
                         }
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE( index_image_test )
         for( image_t::indices_view_t::iterator it = indices.begin(); it != indices.end(); ++it )
         {
             static uint8_t i = 0;
-            i = ( i == 256 ) ? 0 : ++i;
+            i = (i == 256) ? 0 : (i + 1);
 
             *it = gray8_pixel_t( i );
         }
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE( index_image_test )
         for( image_t::palette_view_t::iterator it = colors.begin(); it != colors.end(); ++it )
         {
             static uint8_t i = 0;
-            i = ( i == 256 ) ? 0 : ++i;
+            i = (i == 256) ? 0 : (i + 1);
 
             *it = rgb8_pixel_t( i, i, i );
         }
@@ -90,8 +90,7 @@ BOOST_AUTO_TEST_CASE( index_image_test )
                        , [] () -> uint8_t
                        {
                             static uint8_t i = 0;
-                            i = ( i == 256 ) ? 0 : ++i;
-
+                            i = (i == 256) ? 0 : (i + 1);
                             return i;
                        }
                        );
@@ -101,7 +100,7 @@ BOOST_AUTO_TEST_CASE( index_image_test )
                        , [] () ->rgb8_pixel_t
                        {
                           static uint8_t i = 0;
-                          i = ( i == 256 ) ? 0 : ++i;
+                           i = (i == 256) ? 0 : (i + 1);
 
                           return rgb8_pixel_t( i, i, i );
                        }
@@ -111,7 +110,7 @@ BOOST_AUTO_TEST_CASE( index_image_test )
         for( image_t::indices_view_t::iterator it = indices.begin(); it != indices.end(); ++it )
         {
             static uint8_t i = 0;
-            i = ( i == 256 ) ? 0 : ++i;
+            i = (i == 256) ? 0 : (i + 1);
 
             *it = gray8_pixel_t( i );
         }
@@ -120,7 +119,7 @@ BOOST_AUTO_TEST_CASE( index_image_test )
         for( image_t::palette_view_t::iterator it = colors.begin(); it != colors.end(); ++it )
         {
             static uint8_t i = 0;
-            i = ( i == 256 ) ? 0 : ++i;
+            i = (i == 256) ? 0 : (i + 1);
 
             *it = rgb8_pixel_t( i, i, i );
         }


### PR DESCRIPTION
Let's give toolbox some love.

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed

----

By the way, apart from the expression nonsense, there is also testing `uint8_t` for values of `256` 

```
toolbox/test/indexed_image_test.cpp: In lambda function:
toolbox/test/indexed_image_test.cpp:40:36: warning: comparison is always false due to limited range of data type [-Wtype-limits]
                             i = (i == 256) ? 0 : (i + 1);
                                    ^
toolbox/test/indexed_image_test.cpp: In lambda function:
toolbox/test/indexed_image_test.cpp:51:36: warning: comparison is always false due to limited range of data type [-Wtype-limits]
                             i = (i == 256) ? 0 : (i + 1);
                                    ^
```

Now, is the `uint8_t` supposed to be larger or `256` decreased to `255`?
 