### PR TITLE
Fix compile-time bugs subchroma_image.hpp definions

### DIFF
--- a/include/boost/gil/extension/toolbox/color_spaces/ycbcr.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/ycbcr.hpp
@@ -13,6 +13,7 @@
 #include <boost/gil/color_convert.hpp>
 #include <boost/gil.hpp> // FIXME: Include what you use!
 
+#include <boost/config.hpp>
 #include <boost/mpl/identity.hpp>
 #include <boost/mpl/range_c.hpp>
 #include <boost/mpl/vector_c.hpp>
@@ -60,7 +61,7 @@ namespace detail {
 
 // Source:boost/algorithm/clamp.hpp
 template<typename T>
-constexpr T const& clamp(T const& val,
+BOOST_CXX14_CONSTEXPR T const& clamp(T const& val,
     typename boost::mpl::identity<T>::type const & lo,
     typename boost::mpl::identity<T>::type const & hi)
 {

--- a/include/boost/gil/extension/toolbox/image_types/subchroma_image.hpp
+++ b/include/boost/gil/extension/toolbox/image_types/subchroma_image.hpp
@@ -54,14 +54,13 @@ struct scaling_factors
                                                      >::type::value )
                          );
 
-    BOOST_STATIC_CONSTANT( int, ss_Y = ( mpl::if_< mpl::equal_to< mpl::int_<B>, mpl::int_< 0 > >
+    BOOST_STATIC_CONSTANT( int, ss_Y = (mpl::if_< mpl::equal_to< mpl::int_<B>, mpl::int_< 0 > >
                                                  , mpl::int_< 2 >
-                                                 , mpl::if_< mpl::equal_to< mpl::int_<A>, mpl::int_<B> >
+                                                 , typename mpl::if_< mpl::equal_to< mpl::int_<A>, mpl::int_<B> >
                                                            , mpl::int_< 1 >
                                                            , mpl::int_< 4 >
-                                                           >
-                                                 >::type::value )
-                         );
+                                                           >::type
+                                                 >::type::value));
 };
 
 } // namespace detail

--- a/toolbox/test/CMakeLists.txt
+++ b/toolbox/test/CMakeLists.txt
@@ -32,6 +32,9 @@ target_sources(gil_test_ext_toolbox
   lab_test.cpp
   pixel_bit_size.cpp
   rgb_to_luminance.cpp
+  # TODO: Add subchroma_image.cpp after fixing run-time failure,
+  #       for details see https://github.com/boostorg/gil/pull/164
+  #subchroma_image.cpp
   xyz_test.cpp)
 target_link_libraries(gil_test_ext_toolbox
   PRIVATE

--- a/toolbox/test/Jamfile
+++ b/toolbox/test/Jamfile
@@ -31,5 +31,8 @@ run
     lab_test.cpp
     pixel_bit_size.cpp
     rgb_to_luminance.cpp
+    # TODO: Add subchroma_image.cpp after fixing run-time failure,
+    #       for details see https://github.com/boostorg/gil/pull/164
+    #subchroma_image.cpp
     xyz_test.cpp
     ;

--- a/toolbox/test/fabscript
+++ b/toolbox/test/fabscript
@@ -30,6 +30,8 @@ def gil_test(name, sources, features, condition=True):
     return test(name, binary(name, sources, features=features, condition=condition))
 
 
+# TODO: Add `subchroma_image.cpp` after fixing run-time failure,
+#       for details see https://github.com/boostorg/gil/pull/164
 tests = [gil_test('toolbox',
                   ['test.cpp', 'channel_type.cpp', 'channel_view.cpp', 'cmyka.cpp',
                    'get_num_bits.cpp', 'get_pixel_type.cpp', 'gray_alpha.cpp', 'gray_to_rgba.cpp',

--- a/toolbox/test/subchroma_image.cpp
+++ b/toolbox/test/subchroma_image.cpp
@@ -8,7 +8,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/gil.hpp>
-
 #include <boost/gil/extension/toolbox/color_spaces/ycbcr.hpp>
 #include <boost/gil/extension/toolbox/image_types/subchroma_image.hpp>
 
@@ -92,7 +91,8 @@ BOOST_AUTO_TEST_CASE( subchroma_image_test )
                                                                 , y_height
                                                                 , &data.front()
                                                                 );
-        rgb8_pixel_t p = *v.xy_at( 0, 0 );
+        rgb8_pixel_t p;
+        p = *v.xy_at( 0, 0 );
     }
 }
 


### PR DESCRIPTION
Add missing typenamei in mpl::if_ condition result

Restore BOOST_CXX14_CONSTEXPR in boost::algorithm::clamp function
    - apparently, GCC 5.5.0 does not compile it with C++11 constexpr.

Still not adding subchroma_image.cpp to toolbox test target input sources due to run-time failure.

Depends on #176

### Tasklist

- [x] Review
- [x] Adjust for comments
- [ ] All CI builds and checks have passed
