### PR TITLE
Trim trailing whitespaces in all source code files

### DIFF
--- a/include/boost/gil/bit_aligned_pixel_iterator.hpp
+++ b/include/boost/gil/bit_aligned_pixel_iterator.hpp
@@ -29,7 +29,7 @@ namespace boost { namespace gil {
 /// \brief An iterator over non-byte-aligned pixels. Models PixelIteratorConcept, PixelBasedConcept, MemoryBasedIteratorConcept, HasDynamicXStepTypeConcept
 ///
 /// An iterator over pixels that correspond to non-byte-aligned bit ranges. Examples of such pixels are single bit grayscale pixel, or a 6-bit RGB 222 pixel.
-/// 
+///
 /// \ingroup PixelIteratorNonAlignedPixelIterator PixelBasedModel
 
 template <typename NonAlignedPixelReference>
@@ -81,15 +81,15 @@ private:
     bool equal(const bit_aligned_pixel_iterator& it) const { return _bit_range==it._bit_range; }
 };
 
-template <typename NonAlignedPixelReference> 
-struct const_iterator_type<bit_aligned_pixel_iterator<NonAlignedPixelReference> > { 
-    typedef bit_aligned_pixel_iterator<typename NonAlignedPixelReference::const_reference> type; 
+template <typename NonAlignedPixelReference>
+struct const_iterator_type<bit_aligned_pixel_iterator<NonAlignedPixelReference> > {
+    typedef bit_aligned_pixel_iterator<typename NonAlignedPixelReference::const_reference> type;
 };
 
-template <typename NonAlignedPixelReference> 
+template <typename NonAlignedPixelReference>
 struct iterator_is_mutable<bit_aligned_pixel_iterator<NonAlignedPixelReference> > : public mpl::bool_<NonAlignedPixelReference::is_mutable> {};
 
-template <typename NonAlignedPixelReference> 
+template <typename NonAlignedPixelReference>
 struct is_iterator_adaptor<bit_aligned_pixel_iterator<NonAlignedPixelReference> > : public mpl::false_ {};
 
 /////////////////////////////
@@ -113,17 +113,17 @@ template <typename NonAlignedPixelReference>
 struct byte_to_memunit<bit_aligned_pixel_iterator<NonAlignedPixelReference> > : public mpl::int_<8> {};
 
 template <typename NonAlignedPixelReference>
-inline std::ptrdiff_t memunit_step(const bit_aligned_pixel_iterator<NonAlignedPixelReference>&) { 
-    return NonAlignedPixelReference::bit_size; 
+inline std::ptrdiff_t memunit_step(const bit_aligned_pixel_iterator<NonAlignedPixelReference>&) {
+    return NonAlignedPixelReference::bit_size;
 }
 
 template <typename NonAlignedPixelReference>
-inline std::ptrdiff_t memunit_distance(const bit_aligned_pixel_iterator<NonAlignedPixelReference>& p1, const bit_aligned_pixel_iterator<NonAlignedPixelReference>& p2) { 
-    return (p2.bit_range().current_byte() - p1.bit_range().current_byte())*8 + p2.bit_range().bit_offset() - p1.bit_range().bit_offset(); 
+inline std::ptrdiff_t memunit_distance(const bit_aligned_pixel_iterator<NonAlignedPixelReference>& p1, const bit_aligned_pixel_iterator<NonAlignedPixelReference>& p2) {
+    return (p2.bit_range().current_byte() - p1.bit_range().current_byte())*8 + p2.bit_range().bit_offset() - p1.bit_range().bit_offset();
 }
 
 template <typename NonAlignedPixelReference>
-inline void memunit_advance(bit_aligned_pixel_iterator<NonAlignedPixelReference>& p, std::ptrdiff_t diff) { 
+inline void memunit_advance(bit_aligned_pixel_iterator<NonAlignedPixelReference>& p, std::ptrdiff_t diff) {
     p.bit_range().bit_advance(diff);
 }
 
@@ -170,9 +170,9 @@ struct iterator_type_from_pixel<bit_aligned_pixel_reference<B,C,L,M>,IsPlanar,Is
 namespace std {
 
 // It is important to provide an overload of uninitialized_copy for bit_aligned_pixel_iterator. The default STL implementation calls placement new,
-// which is not defined for bit_aligned_pixel_iterator. 
+// which is not defined for bit_aligned_pixel_iterator.
 template <typename NonAlignedPixelReference>
-boost::gil::bit_aligned_pixel_iterator<NonAlignedPixelReference> uninitialized_copy(boost::gil::bit_aligned_pixel_iterator<NonAlignedPixelReference> first, 
+boost::gil::bit_aligned_pixel_iterator<NonAlignedPixelReference> uninitialized_copy(boost::gil::bit_aligned_pixel_iterator<NonAlignedPixelReference> first,
                                                                                    boost::gil::bit_aligned_pixel_iterator<NonAlignedPixelReference> last,
                                                                                    boost::gil::bit_aligned_pixel_iterator<NonAlignedPixelReference> dst) {
     return std::copy(first,last,dst);

--- a/include/boost/gil/cmyk.hpp
+++ b/include/boost/gil/cmyk.hpp
@@ -21,13 +21,13 @@ namespace boost { namespace gil {
 /// \{
 
 /// \brief Cyan
-struct cyan_t {};    
+struct cyan_t {};
 
 /// \brief Magenta
 struct magenta_t {};
 
 /// \brief Yellow
-struct yellow_t {}; 
+struct yellow_t {};
 
 /// \brief Black
 struct black_t {};

--- a/include/boost/gil/color_base.hpp
+++ b/include/boost/gil/color_base.hpp
@@ -44,19 +44,19 @@ template <typename ColorBase, int K> struct kth_element_const_reference_type<con
 namespace detail {
 
 template <typename DstLayout, typename SrcLayout, int K>
-struct mapping_transform 
-    : public mpl::at<typename SrcLayout::channel_mapping_t, 
+struct mapping_transform
+    : public mpl::at<typename SrcLayout::channel_mapping_t,
                      typename detail::type_to_index<typename DstLayout::channel_mapping_t,mpl::integral_c<int,K> >::type
                            >::type {};
 
-/// \defgroup ColorBaseModelHomogeneous detail::homogeneous_color_base 
+/// \defgroup ColorBaseModelHomogeneous detail::homogeneous_color_base
 /// \ingroup ColorBaseModel
 /// \brief A homogeneous color base holding one color element. Models HomogeneousColorBaseConcept or HomogeneousColorBaseValueConcept
 /// If the element type models Regular, this class models HomogeneousColorBaseValueConcept.
 
-#if BOOST_WORKAROUND(BOOST_MSVC, >= 1400) 
-#pragma warning(push) 
-#pragma warning(disable:4512) //assignment operator could not be generated 
+#if BOOST_WORKAROUND(BOOST_MSVC, >= 1400)
+#pragma warning(push)
+#pragma warning(disable:4512) //assignment operator could not be generated
 #endif
 
 /// \brief A homogeneous color base holding one color element. Models HomogeneousColorBaseConcept or HomogeneousColorBaseValueConcept
@@ -72,7 +72,7 @@ public:
 
     homogeneous_color_base() {}
     homogeneous_color_base(Element v) : _v0(v) {}
- 
+
     // grayscale pixel values are convertible to channel type
     operator Element () const { return _v0; }
 
@@ -97,25 +97,25 @@ public:
     explicit homogeneous_color_base(Element v) : _v0(v), _v1(v) {}
     homogeneous_color_base(Element v0, Element v1) : _v0(v0), _v1(v1) {}
 
-    template <typename E2, typename L2> homogeneous_color_base(const homogeneous_color_base<E2,L2,2>& c) : 
-        _v0(gil::at_c<mapping_transform<Layout,L2,0>::value>(c)), 
+    template <typename E2, typename L2> homogeneous_color_base(const homogeneous_color_base<E2,L2,2>& c) :
+        _v0(gil::at_c<mapping_transform<Layout,L2,0>::value>(c)),
         _v1(gil::at_c<mapping_transform<Layout,L2,1>::value>(c)) {}
 
     // Support for l-value reference proxy copy construction
-    template <typename E2, typename L2> homogeneous_color_base(      homogeneous_color_base<E2,L2,2>& c) : 
-        _v0(gil::at_c<mapping_transform<Layout,L2,0>::value>(c)), 
+    template <typename E2, typename L2> homogeneous_color_base(      homogeneous_color_base<E2,L2,2>& c) :
+        _v0(gil::at_c<mapping_transform<Layout,L2,0>::value>(c)),
         _v1(gil::at_c<mapping_transform<Layout,L2,1>::value>(c)) {}
 
     // Support for planar_pixel_iterator construction and dereferencing
-    template <typename P> homogeneous_color_base(P* p,bool) : 
-        _v0(&semantic_at_c<0>(*p)), 
+    template <typename P> homogeneous_color_base(P* p,bool) :
+        _v0(&semantic_at_c<0>(*p)),
         _v1(&semantic_at_c<1>(*p)) {}
-    template <typename Ref> Ref deref() const { 
-        return Ref(*semantic_at_c<0>(*this), 
+    template <typename Ref> Ref deref() const {
+        return Ref(*semantic_at_c<0>(*this),
                    *semantic_at_c<1>(*this)); }
 
     // Support for planar_pixel_reference offset constructor
-    template <typename Ptr> homogeneous_color_base(const Ptr& ptr, std::ptrdiff_t diff) 
+    template <typename Ptr> homogeneous_color_base(const Ptr& ptr, std::ptrdiff_t diff)
         : _v0(*memunit_advanced(semantic_at_c<0>(ptr),diff)),
           _v1(*memunit_advanced(semantic_at_c<1>(ptr),diff)) {}
 
@@ -145,29 +145,29 @@ public:
     explicit homogeneous_color_base(Element v) : _v0(v), _v1(v), _v2(v) {}
     homogeneous_color_base(Element v0, Element v1, Element v2) : _v0(v0), _v1(v1), _v2(v2) {}
 
-    template <typename E2, typename L2> homogeneous_color_base(const homogeneous_color_base<E2,L2,3>& c) : 
-        _v0(gil::at_c<mapping_transform<Layout,L2,0>::value>(c)), 
-        _v1(gil::at_c<mapping_transform<Layout,L2,1>::value>(c)), 
+    template <typename E2, typename L2> homogeneous_color_base(const homogeneous_color_base<E2,L2,3>& c) :
+        _v0(gil::at_c<mapping_transform<Layout,L2,0>::value>(c)),
+        _v1(gil::at_c<mapping_transform<Layout,L2,1>::value>(c)),
         _v2(gil::at_c<mapping_transform<Layout,L2,2>::value>(c)) {}
 
     // Support for l-value reference proxy copy construction
-    template <typename E2, typename L2> homogeneous_color_base(      homogeneous_color_base<E2,L2,3>& c) : 
-        _v0(gil::at_c<mapping_transform<Layout,L2,0>::value>(c)), 
-        _v1(gil::at_c<mapping_transform<Layout,L2,1>::value>(c)), 
+    template <typename E2, typename L2> homogeneous_color_base(      homogeneous_color_base<E2,L2,3>& c) :
+        _v0(gil::at_c<mapping_transform<Layout,L2,0>::value>(c)),
+        _v1(gil::at_c<mapping_transform<Layout,L2,1>::value>(c)),
         _v2(gil::at_c<mapping_transform<Layout,L2,2>::value>(c)) {}
 
     // Support for planar_pixel_iterator construction and dereferencing
-    template <typename P> homogeneous_color_base(P* p,bool) : 
-        _v0(&semantic_at_c<0>(*p)), 
-        _v1(&semantic_at_c<1>(*p)), 
+    template <typename P> homogeneous_color_base(P* p,bool) :
+        _v0(&semantic_at_c<0>(*p)),
+        _v1(&semantic_at_c<1>(*p)),
         _v2(&semantic_at_c<2>(*p)) {}
-    template <typename Ref> Ref deref() const { 
-        return Ref(*semantic_at_c<0>(*this), 
-                   *semantic_at_c<1>(*this), 
+    template <typename Ref> Ref deref() const {
+        return Ref(*semantic_at_c<0>(*this),
+                   *semantic_at_c<1>(*this),
                    *semantic_at_c<2>(*this)); }
 
     // Support for planar_pixel_reference offset constructor
-    template <typename Ptr> homogeneous_color_base(const Ptr& ptr, std::ptrdiff_t diff) 
+    template <typename Ptr> homogeneous_color_base(const Ptr& ptr, std::ptrdiff_t diff)
         : _v0(*memunit_advanced(semantic_at_c<0>(ptr),diff)),
           _v1(*memunit_advanced(semantic_at_c<1>(ptr),diff)),
           _v2(*memunit_advanced(semantic_at_c<2>(ptr),diff)) {}
@@ -203,33 +203,33 @@ public:
     homogeneous_color_base(Element v0, Element v1, Element v2, Element v3) : _v0(v0), _v1(v1), _v2(v2), _v3(v3) {}
 
     template <typename E2, typename L2> homogeneous_color_base(const homogeneous_color_base<E2,L2,4>& c) :
-        _v0(gil::at_c<mapping_transform<Layout,L2,0>::value>(c)), 
-        _v1(gil::at_c<mapping_transform<Layout,L2,1>::value>(c)), 
+        _v0(gil::at_c<mapping_transform<Layout,L2,0>::value>(c)),
+        _v1(gil::at_c<mapping_transform<Layout,L2,1>::value>(c)),
         _v2(gil::at_c<mapping_transform<Layout,L2,2>::value>(c)),
         _v3(gil::at_c<mapping_transform<Layout,L2,3>::value>(c)) {}
 
     // Support for l-value reference proxy copy construction
-    template <typename E2, typename L2> homogeneous_color_base(      homogeneous_color_base<E2,L2,4>& c) : 
-        _v0(gil::at_c<mapping_transform<Layout,L2,0>::value>(c)), 
-        _v1(gil::at_c<mapping_transform<Layout,L2,1>::value>(c)), 
+    template <typename E2, typename L2> homogeneous_color_base(      homogeneous_color_base<E2,L2,4>& c) :
+        _v0(gil::at_c<mapping_transform<Layout,L2,0>::value>(c)),
+        _v1(gil::at_c<mapping_transform<Layout,L2,1>::value>(c)),
         _v2(gil::at_c<mapping_transform<Layout,L2,2>::value>(c)),
         _v3(gil::at_c<mapping_transform<Layout,L2,3>::value>(c)) {}
 
     // Support for planar_pixel_iterator construction and dereferencing
-    template <typename P> homogeneous_color_base(P* p,bool) : 
-        _v0(&semantic_at_c<0>(*p)), 
-        _v1(&semantic_at_c<1>(*p)), 
-        _v2(&semantic_at_c<2>(*p)), 
+    template <typename P> homogeneous_color_base(P* p,bool) :
+        _v0(&semantic_at_c<0>(*p)),
+        _v1(&semantic_at_c<1>(*p)),
+        _v2(&semantic_at_c<2>(*p)),
         _v3(&semantic_at_c<3>(*p)) {}
 
-    template <typename Ref> Ref deref() const { 
-        return Ref(*semantic_at_c<0>(*this), 
-                   *semantic_at_c<1>(*this), 
-                   *semantic_at_c<2>(*this), 
+    template <typename Ref> Ref deref() const {
+        return Ref(*semantic_at_c<0>(*this),
+                   *semantic_at_c<1>(*this),
+                   *semantic_at_c<2>(*this),
                    *semantic_at_c<3>(*this)); }
 
     // Support for planar_pixel_reference offset constructor
-    template <typename Ptr> homogeneous_color_base(const Ptr& ptr, std::ptrdiff_t diff) 
+    template <typename Ptr> homogeneous_color_base(const Ptr& ptr, std::ptrdiff_t diff)
         : _v0(*memunit_advanced(semantic_at_c<0>(ptr),diff)),
           _v1(*memunit_advanced(semantic_at_c<1>(ptr),diff)),
           _v2(*memunit_advanced(semantic_at_c<2>(ptr),diff)),
@@ -269,37 +269,37 @@ public:
     homogeneous_color_base(Element v0, Element v1, Element v2, Element v3, Element v4) : _v0(v0), _v1(v1), _v2(v2), _v3(v3), _v4(v4) {}
 
     template <typename E2, typename L2> homogeneous_color_base(const homogeneous_color_base<E2,L2,5>& c) :
-        _v0(gil::at_c<mapping_transform<Layout,L2,0>::value>(c)), 
-        _v1(gil::at_c<mapping_transform<Layout,L2,1>::value>(c)), 
+        _v0(gil::at_c<mapping_transform<Layout,L2,0>::value>(c)),
+        _v1(gil::at_c<mapping_transform<Layout,L2,1>::value>(c)),
         _v2(gil::at_c<mapping_transform<Layout,L2,2>::value>(c)),
         _v3(gil::at_c<mapping_transform<Layout,L2,3>::value>(c)),
         _v4(gil::at_c<mapping_transform<Layout,L2,4>::value>(c)) {}
 
     // Support for l-value reference proxy copy construction
-    template <typename E2, typename L2> homogeneous_color_base(      homogeneous_color_base<E2,L2,5>& c) : 
-        _v0(gil::at_c<mapping_transform<Layout,L2,0>::value>(c)), 
-        _v1(gil::at_c<mapping_transform<Layout,L2,1>::value>(c)), 
+    template <typename E2, typename L2> homogeneous_color_base(      homogeneous_color_base<E2,L2,5>& c) :
+        _v0(gil::at_c<mapping_transform<Layout,L2,0>::value>(c)),
+        _v1(gil::at_c<mapping_transform<Layout,L2,1>::value>(c)),
         _v2(gil::at_c<mapping_transform<Layout,L2,2>::value>(c)),
         _v3(gil::at_c<mapping_transform<Layout,L2,3>::value>(c)),
         _v4(gil::at_c<mapping_transform<Layout,L2,4>::value>(c)) {}
 
     // Support for planar_pixel_iterator construction and dereferencing
-    template <typename P> homogeneous_color_base(P* p,bool) : 
-        _v0(&semantic_at_c<0>(*p)), 
-        _v1(&semantic_at_c<1>(*p)), 
-        _v2(&semantic_at_c<2>(*p)), 
+    template <typename P> homogeneous_color_base(P* p,bool) :
+        _v0(&semantic_at_c<0>(*p)),
+        _v1(&semantic_at_c<1>(*p)),
+        _v2(&semantic_at_c<2>(*p)),
         _v3(&semantic_at_c<3>(*p)),
         _v4(&semantic_at_c<4>(*p)) {}
 
-    template <typename Ref> Ref deref() const { 
-        return Ref(*semantic_at_c<0>(*this), 
-                   *semantic_at_c<1>(*this), 
-                   *semantic_at_c<2>(*this), 
+    template <typename Ref> Ref deref() const {
+        return Ref(*semantic_at_c<0>(*this),
+                   *semantic_at_c<1>(*this),
+                   *semantic_at_c<2>(*this),
                    *semantic_at_c<3>(*this),
                    *semantic_at_c<4>(*this)); }
 
     // Support for planar_pixel_reference offset constructor
-    template <typename Ptr> homogeneous_color_base(const Ptr& ptr, std::ptrdiff_t diff) 
+    template <typename Ptr> homogeneous_color_base(const Ptr& ptr, std::ptrdiff_t diff)
         : _v0(*memunit_advanced(semantic_at_c<0>(ptr),diff)),
           _v1(*memunit_advanced(semantic_at_c<1>(ptr),diff)),
           _v2(*memunit_advanced(semantic_at_c<2>(ptr),diff)),
@@ -318,9 +318,9 @@ public:
     }
 };
 
-#if BOOST_WORKAROUND(BOOST_MSVC, >= 1400) 
-#pragma warning(pop) 
-#endif 
+#if BOOST_WORKAROUND(BOOST_MSVC, >= 1400)
+#pragma warning(pop)
+#endif
 
 // The following way of casting adjacent channels (the contents of color_base) into an array appears to be unsafe
 // -- there is no guarantee that the compiler won't add any padding between adjacent channels.
@@ -333,28 +333,28 @@ public:
 // However, the client must nevertheless ensure that proper compiler settings are used for their compiler and their channel types.
 
 template <typename Element, typename Layout, int K>
-typename element_reference_type<homogeneous_color_base<Element,Layout,K> >::type       
+typename element_reference_type<homogeneous_color_base<Element,Layout,K> >::type
 dynamic_at_c(homogeneous_color_base<Element,Layout,K>& cb, std::size_t i) {
     assert(i<K);
     return (gil_reinterpret_cast<Element*>(&cb))[i];
 }
 
 template <typename Element, typename Layout, int K>
-typename element_const_reference_type<homogeneous_color_base<Element,Layout,K> >::type 
+typename element_const_reference_type<homogeneous_color_base<Element,Layout,K> >::type
 dynamic_at_c(const homogeneous_color_base<Element,Layout,K>& cb, std::size_t i) {
     assert(i<K);
     return (gil_reinterpret_cast_c<const Element*>(&cb))[i];
 }
 
 template <typename Element, typename Layout, int K>
-typename element_reference_type<homogeneous_color_base<Element&,Layout,K> >::type       
+typename element_reference_type<homogeneous_color_base<Element&,Layout,K> >::type
 dynamic_at_c(const homogeneous_color_base<Element&,Layout,K>& cb, std::size_t i) {
     assert(i<K);
     return cb.at_c_dynamic(i);
 }
 
 template <typename Element, typename Layout, int K>
-typename element_const_reference_type<homogeneous_color_base<const Element&,Layout,K> >::type 
+typename element_const_reference_type<homogeneous_color_base<const Element&,Layout,K> >::type
 dynamic_at_c(const homogeneous_color_base<const Element&,Layout,K>& cb, std::size_t i) {
     assert(i<K);
     return cb.at_c_dynamic(i);
@@ -363,15 +363,15 @@ dynamic_at_c(const homogeneous_color_base<const Element&,Layout,K>& cb, std::siz
 
 } // namespace detail
 
-template <typename Element, typename Layout, int K1, int K>  
+template <typename Element, typename Layout, int K1, int K>
 struct kth_element_type<detail::homogeneous_color_base<Element,Layout,K1>, K> {
     typedef Element type;
 };
 
-template <typename Element, typename Layout, int K1, int K> 
+template <typename Element, typename Layout, int K1, int K>
 struct kth_element_reference_type<detail::homogeneous_color_base<Element,Layout,K1>, K> : public add_reference<Element> {};
 
-template <typename Element, typename Layout, int K1, int K> 
+template <typename Element, typename Layout, int K1, int K>
 struct kth_element_const_reference_type<detail::homogeneous_color_base<Element,Layout,K1>, K> : public add_reference<typename add_const<Element>::type> {};
 
 /// \brief Provides mutable access to the K-th element, in physical order
@@ -395,7 +395,7 @@ namespace detail {
     };
 }
 template <typename E, typename L, int N> inline
-void swap(detail::homogeneous_color_base<E,L,N>& x, detail::homogeneous_color_base<E,L,N>& y) { 
+void swap(detail::homogeneous_color_base<E,L,N>& x, detail::homogeneous_color_base<E,L,N>& y) {
     static_for_each(x,y,detail::swap_fn());
 }
 

--- a/include/boost/gil/color_convert.hpp
+++ b/include/boost/gil/color_convert.hpp
@@ -30,12 +30,12 @@ namespace boost { namespace gil {
 template <typename P> struct channel_type;
 
 ////////////////////////////////////////////////////////////////////////////////////////
-///                 
+///
 ///                 COLOR SPACE CONVERSION
 ///
 ////////////////////////////////////////////////////////////////////////////////////////
 
-/// \ingroup ColorConvert 
+/// \ingroup ColorConvert
 /// \brief Color Convertion function object. To be specialized for every src/dst color space
 template <typename C1, typename C2>
 struct default_color_converter_impl {};
@@ -120,7 +120,7 @@ template <>
 struct default_color_converter_impl<rgb_t,gray_t> {
     template <typename P1, typename P2>
     void operator()(const P1& src, P2& dst) const {
-        get_color(dst,gray_color_t()) = 
+        get_color(dst,gray_color_t()) =
             detail::rgb_to_luminance<typename color_element_type<P2,gray_color_t>::type>(
                 get_color(src,red_t()), get_color(src,green_t()), get_color(src,blue_t())
             );
@@ -172,17 +172,17 @@ struct default_color_converter_impl<cmyk_t,rgb_t> {
         get_color(dst,red_t())  =
             channel_convert<typename color_element_type<P2,red_t>::type>(
                 channel_invert<T1>(
-                    (std::min)(channel_traits<T1>::max_value(), 
+                    (std::min)(channel_traits<T1>::max_value(),
                              T1(channel_multiply(get_color(src,cyan_t()),channel_invert(get_color(src,black_t())))+get_color(src,black_t())))));
         get_color(dst,green_t())=
             channel_convert<typename color_element_type<P2,green_t>::type>(
                 channel_invert<T1>(
-                    (std::min)(channel_traits<T1>::max_value(), 
+                    (std::min)(channel_traits<T1>::max_value(),
                              T1(channel_multiply(get_color(src,magenta_t()),channel_invert(get_color(src,black_t())))+get_color(src,black_t())))));
         get_color(dst,blue_t()) =
             channel_convert<typename color_element_type<P2,blue_t>::type>(
                 channel_invert<T1>(
-                    (std::min)(channel_traits<T1>::max_value(), 
+                    (std::min)(channel_traits<T1>::max_value(),
                              T1(channel_multiply(get_color(src,yellow_t()),channel_invert(get_color(src,black_t())))+get_color(src,black_t())))));
     }
 };
@@ -201,28 +201,28 @@ struct default_color_converter_impl<cmyk_t,gray_t> {
                 channel_multiply(
                     channel_invert(
                        detail::rgb_to_luminance<typename color_element_type<P1,black_t>::type>(
-                            get_color(src,cyan_t()), 
-                            get_color(src,magenta_t()), 
+                            get_color(src,cyan_t()),
+                            get_color(src,magenta_t()),
                             get_color(src,yellow_t())
                        )
-                    ), 
+                    ),
                     channel_invert(get_color(src,black_t()))));
     }
 };
 
 namespace detail {
-template <typename Pixel> 
+template <typename Pixel>
 typename channel_type<Pixel>::type alpha_or_max_impl(const Pixel& p, mpl::true_) {
     return get_color(p,alpha_t());
 }
-template <typename Pixel> 
+template <typename Pixel>
 typename channel_type<Pixel>::type alpha_or_max_impl(const Pixel&  , mpl::false_) {
     return channel_traits<typename channel_type<Pixel>::type>::max_value();
 }
 } // namespace detail
 
 // Returns max_value if the pixel has no alpha channel. Otherwise returns the alpha.
-template <typename Pixel> 
+template <typename Pixel>
 typename channel_type<Pixel>::type alpha_or_max(const Pixel& p) {
     return detail::alpha_or_max_impl(p, mpl::contains<typename color_space_type<Pixel>::type,alpha_t>());
 }
@@ -248,7 +248,7 @@ struct default_color_converter_impl<C1,rgba_t> {
 ///  \brief Converting RGBA to any pixel type. Note: Supports homogeneous pixels only.
 ///
 /// Done by multiplying the alpha to get to RGB, then converting the RGB to the target pixel type
-/// Note: This may be slower if the compiler doesn't optimize out constructing/destructing a temporary RGB pixel. 
+/// Note: This may be slower if the compiler doesn't optimize out constructing/destructing a temporary RGB pixel.
 ///       Consider rewriting if performance is an issue
 template <typename C2>
 struct default_color_converter_impl<rgba_t,C2> {
@@ -256,8 +256,8 @@ struct default_color_converter_impl<rgba_t,C2> {
     void operator()(const P1& src, P2& dst) const {
         typedef typename channel_type<P1>::type T1;
         default_color_converter_impl<rgb_t,C2>()(
-            pixel<T1,rgb_layout_t>(channel_multiply(get_color(src,red_t()),  get_color(src,alpha_t())), 
-                                   channel_multiply(get_color(src,green_t()),get_color(src,alpha_t())), 
+            pixel<T1,rgb_layout_t>(channel_multiply(get_color(src,red_t()),  get_color(src,alpha_t())),
+                                   channel_multiply(get_color(src,green_t()),get_color(src,alpha_t())),
                                    channel_multiply(get_color(src,blue_t()), get_color(src,alpha_t())))
             ,dst);
     }
@@ -281,7 +281,7 @@ struct default_color_converter_impl<rgba_t,rgba_t> {
 /// \brief class for color-converting one pixel to another
 struct default_color_converter {
     template <typename SrcP, typename DstP>
-    void operator()(const SrcP& src,DstP& dst) const { 
+    void operator()(const SrcP& src,DstP& dst) const {
         typedef typename color_space_type<SrcP>::type SrcColorSpace;
         typedef typename color_space_type<DstP>::type DstColorSpace;
         default_color_converter_impl<SrcColorSpace,DstColorSpace>()(src,dst);

--- a/include/boost/gil/extension/dynamic_image/algorithm.hpp
+++ b/include/boost/gil/extension/dynamic_image/algorithm.hpp
@@ -15,7 +15,7 @@
 #include <boost/bind.hpp>
 
 ////////////////////////////////////////////////////////////////////////////////////////
-/// \file               
+/// \file
 /// \brief Some basic STL-style algorithms when applied to runtime type specified image views
 /// \author Lubomir Bourdev and Hailin Jin \n
 ///         Adobe Systems Incorporated

--- a/include/boost/gil/extension/dynamic_image/apply_operation.hpp
+++ b/include/boost/gil/extension/dynamic_image/apply_operation.hpp
@@ -42,7 +42,7 @@ typename UnaryOp::result_type apply_operation(const variant<Types>& arg, UnaryOp
 /// \ingroup Variant
 /// \brief Invokes a generic constant operation (represented as a binary function object) on two variants
 template <typename Types1, typename Types2, typename BinaryOp> BOOST_FORCEINLINE
-typename BinaryOp::result_type apply_operation(const variant<Types1>& arg1, const variant<Types2>& arg2, BinaryOp op) {    
+typename BinaryOp::result_type apply_operation(const variant<Types1>& arg1, const variant<Types2>& arg2, BinaryOp op) {
     return apply_operation_base<Types1,Types2>(arg1._bits, arg1._index, arg2._bits, arg2._index, op);
 }
 

--- a/include/boost/gil/extension/dynamic_image/apply_operation_base.hpp
+++ b/include/boost/gil/extension/dynamic_image/apply_operation_base.hpp
@@ -15,7 +15,7 @@
 #include <boost/mpl/next.hpp>
 #include <boost/mpl/deref.hpp>
 #include <boost/mpl/size.hpp>
-#include <boost/preprocessor/repeat.hpp> 
+#include <boost/preprocessor/repeat.hpp>
 
 namespace boost { namespace gil {
 
@@ -55,7 +55,7 @@ GENERATE_APPLY_FWD_OPS generates for every N functions that look like this (for 
     };
 */
 
-#define GIL_FWD_TYPEDEFS(z, N, text)   T##N; typedef typename mpl::next<T##N>::type 
+#define GIL_FWD_TYPEDEFS(z, N, text)   T##N; typedef typename mpl::next<T##N>::type
 #define GIL_FWD_CASE(z, N, SUM)       case N: return op(*gil_reinterpret_cast<typename mpl::deref<T##N>::type*>(&bits));
 #define GIL_FWD_CONST_CASE(z, N, SUM) case N: return op(*gil_reinterpret_cast_c<const typename mpl::deref<T##N>::type*>(&bits));
 
@@ -116,13 +116,13 @@ GIL_GENERATE_APPLY_FWD_OPS(99)
 } // namespace detail
 
 // unary application
-template <typename Types, typename Bits, typename Op> 
+template <typename Types, typename Bits, typename Op>
 typename Op::result_type BOOST_FORCEINLINE apply_operation_basec(const Bits& bits, std::size_t index, Op op) {
     return detail::apply_operation_fwd_fn<mpl::size<Types>::value>().template applyc<Types>(bits,index,op);
 }
 
 // unary application
-template <typename Types, typename Bits, typename Op> 
+template <typename Types, typename Bits, typename Op>
 typename Op::result_type BOOST_FORCEINLINE apply_operation_base(      Bits& bits, std::size_t index, Op op) {
     return detail::apply_operation_fwd_fn<mpl::size<Types>::value>().template apply<Types>(bits,index,op);
 }
@@ -150,7 +150,7 @@ namespace detail {
 
         reduce_bind2(const Bits1& bits1, std::size_t index1, Op& op) : _bits1(bits1), _index1(index1), _op(op) {}
 
-        template <typename T2> BOOST_FORCEINLINE result_type operator()(const T2& t2) { 
+        template <typename T2> BOOST_FORCEINLINE result_type operator()(const T2& t2) {
             return apply_operation_basec<Types1>(_bits1, _index1, reduce_bind1<T2,Op>(t2, _op));
         }
     };

--- a/include/boost/gil/extension/toolbox/color_spaces/hsl.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/hsl.hpp
@@ -17,11 +17,11 @@ namespace boost{ namespace gil {
 namespace hsl_color_space
 {
 /// \brief Hue
-struct hue_t {};    
+struct hue_t {};
 /// \brief Saturation
 struct saturation_t {};
 /// \brief Lightness
-struct lightness_t {}; 
+struct lightness_t {};
 }
 /// \}
 
@@ -80,12 +80,12 @@ struct default_color_converter_impl< rgb_t, hsl_t >
 
          if( lightness < 0.5f )
          {
-            saturation = diff 
+            saturation = diff
                        / ( min_color + max_color );
          }
          else
          {
-            saturation = ( max_color - min_color ) 
+            saturation = ( max_color - min_color )
                        / ( 2.f - diff );
 
          }
@@ -94,7 +94,7 @@ struct default_color_converter_impl< rgb_t, hsl_t >
          if( std::abs( max_color - temp_red ) < 0.0001f )
          {
             // max_color is red
-            hue = ( temp_green - temp_blue ) 
+            hue = ( temp_green - temp_blue )
                 / diff;
 
          }
@@ -102,21 +102,21 @@ struct default_color_converter_impl< rgb_t, hsl_t >
          {
             // max_color is green
             // 2.0 + (b - r) / (maxColor - minColor);
-            hue = 2.f 
-                + ( temp_blue - temp_red ) 
+            hue = 2.f
+                + ( temp_blue - temp_red )
                 / diff;
 
          }
          else
          {
             // max_color is blue
-            hue = 4.f 
-                + ( temp_red - temp_blue ) 
+            hue = 4.f
+                + ( temp_red - temp_blue )
                 / diff;
          }
 
          hue /= 6.f;
-         
+
          if( hue < 0.f )
          {
             hue += 1.f;
@@ -154,29 +154,29 @@ struct default_color_converter_impl<hsl_t,rgb_t>
          float tempr, tempg, tempb;
 
          //Set the temporary values
-         if( get_color( src, lightness_t() ) < 0.5 ) 
+         if( get_color( src, lightness_t() ) < 0.5 )
          {
             temp2 = get_color( src, lightness_t() )
                   * ( 1.f + get_color( src, saturation_t() ) );
          }
          else
          {
-            temp2 = ( get_color( src, lightness_t() ) + get_color( src, saturation_t() )) 
+            temp2 = ( get_color( src, lightness_t() ) + get_color( src, saturation_t() ))
                   - ( get_color( src, lightness_t() ) * get_color( src, saturation_t() ));
          }
 
          temp1 = 2.f
-               * get_color( src, lightness_t() ) 
+               * get_color( src, lightness_t() )
                - temp2;
 
-         tempr = get_color( src, hue_t() ) + 1.f / 3.f;    
+         tempr = get_color( src, hue_t() ) + 1.f / 3.f;
 
          if( tempr > 1.f )
          {
             tempr--;
          }
 
-         tempg = get_color( src, hue_t() );     
+         tempg = get_color( src, hue_t() );
          tempb = get_color( src, hue_t() ) - 1.f / 3.f;
 
          if( tempb < 0.f )
@@ -184,7 +184,7 @@ struct default_color_converter_impl<hsl_t,rgb_t>
             tempb++;
          }
 
-         //Red     
+         //Red
          if( tempr < 1.f / 6.f )
          {
             red = temp1 + ( temp2 - temp1 ) * 6.f * tempr;
@@ -195,7 +195,7 @@ struct default_color_converter_impl<hsl_t,rgb_t>
          }
          else if( tempr < 2.f / 3.f )
          {
-            red = temp1 + (temp2 - temp1) 
+            red = temp1 + (temp2 - temp1)
                 * (( 2.f / 3.f ) - tempr) * 6.f;
          }
          else
@@ -203,7 +203,7 @@ struct default_color_converter_impl<hsl_t,rgb_t>
             red = temp1;
          }
 
-         //Green       
+         //Green
          if( tempg < 1.f / 6.f )
          {
             green = temp1 + ( temp2 - temp1 ) * 6.f * tempg;
@@ -222,7 +222,7 @@ struct default_color_converter_impl<hsl_t,rgb_t>
             green = temp1;
          }
 
-         //Blue    
+         //Blue
          if( tempb < 1.f / 6.f )
          {
             blue = temp1 + (temp2 - temp1) * 6.f * tempb;
@@ -233,7 +233,7 @@ struct default_color_converter_impl<hsl_t,rgb_t>
          }
          else if( tempb < 2.f / 3.f )
          {
-            blue = temp1 + (temp2 - temp1) 
+            blue = temp1 + (temp2 - temp1)
                  * (( 2.f / 3.f ) - tempb) * 6.f;
          }
          else

--- a/include/boost/gil/extension/toolbox/color_spaces/hsv.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/hsv.hpp
@@ -24,11 +24,11 @@ namespace boost{ namespace gil {
 namespace hsv_color_space
 {
 /// \brief Hue
-struct hue_t {};    
+struct hue_t {};
 /// \brief Saturation
 struct saturation_t{};
 /// \brief Value
-struct value_t {}; 
+struct value_t {};
 }
 /// \}
 
@@ -68,11 +68,11 @@ struct default_color_converter_impl< rgb_t, hsv_t >
       float32_t diff = max_color - min_color;
 
       if( max_color < 0.0001f )
-      {  
+      {
          saturation = 0.f;
       }
-      else  
-      {      
+      else
+      {
          saturation = diff / max_color;
       }
 
@@ -80,10 +80,10 @@ struct default_color_converter_impl< rgb_t, hsv_t >
       if( saturation < 0.0001f )
       {
          //it doesn't matter what value it has
-         hue = 0.f; 
-      }   
+         hue = 0.f;
+      }
       else
-      { 
+      {
          if( (std::abs)( boost::numeric_cast<float32_t>(temp_red - max_color) ) < 0.0001f )
          {
             hue = ( temp_green - temp_blue )
@@ -91,17 +91,17 @@ struct default_color_converter_impl< rgb_t, hsv_t >
          }
          else if( temp_green >= max_color ) // means == but >= avoids compiler warning; color is never greater than max
          {
-            hue = 2.f + ( temp_blue - temp_red ) 
+            hue = 2.f + ( temp_blue - temp_red )
                 / diff;
          }
          else
          {
-            hue = 4.f + ( temp_red - temp_green ) 
+            hue = 4.f + ( temp_red - temp_green )
                 / diff;
          }
 
          //to bring it to a number between 0 and 1
-         hue /= 6.f; 
+         hue /= 6.f;
 
          if( hue < 0.f )
          {
@@ -148,18 +148,18 @@ struct default_color_converter_impl<hsv_t,rgb_t>
 
          frac = h - i;
 
-         p = get_color( src, value_t() ) 
+         p = get_color( src, value_t() )
            * ( 1.f - get_color( src, saturation_t() ));
 
          q = get_color( src, value_t() )
            * ( 1.f - ( get_color( src, saturation_t() ) * frac ));
 
-         t = get_color( src, value_t() ) 
+         t = get_color( src, value_t() )
            * ( 1.f - ( get_color( src, saturation_t() ) * ( 1.f - frac )));
 
          switch( i )
-         {         
-            case 0: 
+         {
+            case 0:
             {
                red   = get_color( src, value_t() );
                green = t;
@@ -168,7 +168,7 @@ struct default_color_converter_impl<hsv_t,rgb_t>
                break;
             }
 
-            case 1: 
+            case 1:
             {
                red   = q;
                green = get_color( src, value_t() );
@@ -177,7 +177,7 @@ struct default_color_converter_impl<hsv_t,rgb_t>
                break;
             }
 
-            case 2: 
+            case 2:
             {
                red   = p;
                green = get_color( src, value_t() );
@@ -186,7 +186,7 @@ struct default_color_converter_impl<hsv_t,rgb_t>
                break;
             }
 
-            case 3: 
+            case 3:
             {
                red   = p;
                green = q;
@@ -195,7 +195,7 @@ struct default_color_converter_impl<hsv_t,rgb_t>
                break;
             }
 
-            case 4: 
+            case 4:
             {
                red   = t;
                green = p;
@@ -204,10 +204,10 @@ struct default_color_converter_impl<hsv_t,rgb_t>
                break;
             }
 
-            case 5: 
+            case 5:
             {
                red   = get_color( src, value_t() );
-               green = p; 
+               green = p;
                blue  = q;
 
                break;

--- a/include/boost/gil/extension/toolbox/color_spaces/lab.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/lab.hpp
@@ -21,11 +21,11 @@ namespace boost{ namespace gil {
 namespace lab_color_space
 {
 /// \brief Luminance
-struct luminance_t {};    
+struct luminance_t {};
 /// \brief a Color Component
 struct a_color_opponent_t {};
 /// \brief b Color Component
-struct b_color_opponent_t {}; 
+struct b_color_opponent_t {};
 }
 /// \}
 

--- a/include/boost/gil/extension/toolbox/color_spaces/xyz.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/xyz.hpp
@@ -19,11 +19,11 @@ namespace boost{ namespace gil {
 namespace xyz_color_space
 {
 /// \brief x Color Component
-struct x_t {};    
+struct x_t {};
 /// \brief y Color Component
 struct y_t {};
 /// \brief z Color Component
-struct z_t {}; 
+struct z_t {};
 }
 /// \}
 
@@ -40,7 +40,7 @@ GIL_DEFINE_ALL_TYPEDEFS(32f, float32_t, xyz)
 
 /// \ingroup ColorConvert
 /// \brief RGB to XYZ
-/// <a href="http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html">Link</a> 
+/// <a href="http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html">Link</a>
 /// \note rgb_t is assumed to be sRGB D65
 template <>
 struct default_color_converter_impl< rgb_t, xyz_t >

--- a/include/boost/gil/extension/toolbox/color_spaces/ycbcr.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/ycbcr.hpp
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright 2013 Juan V. Puertos G-Cluster, Christian Henning
 //
 // Distributed under the Boost Software License, Version 1.0
@@ -158,7 +158,7 @@ private:
 
 /*
  * Source: http://en.wikipedia.org/wiki/YCbCr#ITU-R_BT.601_conversion
- * digital Y′CbCr derived from digital R'dG'dB'd 8 bits per sample, each using the full range.
+ * digital Y'CbCr derived from digital R'dG'dB'd 8 bits per sample, each using the full range.
  * with NO footroom wither headroom.
  */
 /**

--- a/include/boost/gil/extension/toolbox/metafunctions/channel_view.hpp
+++ b/include/boost/gil/extension/toolbox/metafunctions/channel_view.hpp
@@ -35,7 +35,7 @@ struct channel_view_type : public kth_channel_view_type< channel_type_to_index< 
     static const int index = channel_type_to_index< Channel
                                                   , View
                                                   >::value;
-                                                  
+
     typedef kth_channel_view_type< index
                                  , View
                                  > parent_t;

--- a/include/boost/gil/image.hpp
+++ b/include/boost/gil/image.hpp
@@ -77,7 +77,7 @@ public:
     image(const point_t& dimensions,
           const Pixel& p_in,
           std::size_t alignment,
-          const Alloc alloc_in = Alloc())  : _memory(0), _align_in_bytes(alignment), _alloc(alloc_in) 
+          const Alloc alloc_in = Alloc())  : _memory(0), _align_in_bytes(alignment), _alloc(alloc_in)
                                            , _allocated_bytes( 0 ) {
         allocate_and_fill(dimensions, p_in);
     }
@@ -211,7 +211,7 @@ public:
     // with Allocator
     void recreate(const point_t& dims, std::size_t alignment, const Alloc alloc_in )
     {
-        if(  dims            == _view.dimensions() 
+        if(  dims            == _view.dimensions()
           && _align_in_bytes == alignment
           && alloc_in        == _alloc
           )
@@ -245,7 +245,7 @@ public:
 
     void recreate(const point_t& dims, const Pixel& p_in, std::size_t alignment, const Alloc alloc_in )
     {
-        if(  dims            == _view.dimensions() 
+        if(  dims            == _view.dimensions()
           && _align_in_bytes == alignment
           && alloc_in        == _alloc
           )
@@ -340,7 +340,7 @@ private:
         // when value_type is a non-pixel, like int or float, num_channels< ... > doesn't work.
         const std::size_t _channels_in_image = mpl::eval_if< is_pixel< value_type >
                                                            , num_channels< view_t >
-                                                           , mpl::int_< 1 > 
+                                                           , mpl::int_< 1 >
 														   >::type::value;
 
         std::size_t size_in_units = is_planar_impl( get_row_size_in_memunits( dimensions.x ) * dimensions.y
@@ -398,7 +398,7 @@ private:
 
         unsigned char* tmp = ( _align_in_bytes > 0 ) ? (unsigned char*) align( (std::size_t) _memory
                                                                              ,_align_in_bytes
-                                                                             ) 
+                                                                             )
                                                      : _memory;
         typename view_t::x_iterator first;
 

--- a/include/boost/gil/packed_pixel.hpp
+++ b/include/boost/gil/packed_pixel.hpp
@@ -22,12 +22,12 @@ namespace boost { namespace gil {
 /// A model of a heterogeneous pixel whose channels are bit ranges.
 /// For example 16-bit RGB in '565' format.
 
-/// \defgroup ColorBaseModelPackedPixel packed_pixel 
+/// \defgroup ColorBaseModelPackedPixel packed_pixel
 /// \ingroup ColorBaseModel
 /// \brief A heterogeneous color base whose elements are reference proxies to channels in a pixel. Models ColorBaseValueConcept. This class is used to model packed pixels, such as 16-bit packed RGB.
 
 /**
-\defgroup PixelModelPackedPixel packed_pixel 
+\defgroup PixelModelPackedPixel packed_pixel
 \ingroup PixelModel
 \brief A heterogeneous pixel used to represent packed pixels with non-byte-aligned channels. Models PixelValueConcept
 
@@ -40,7 +40,7 @@ rgb565_pixel_t r565;
 get_color(r565,red_t())   = 31;
 get_color(r565,green_t()) = 63;
 get_color(r565,blue_t())  = 31;
-assert(r565 == rgb565_pixel_t((uint16_t)0xFFFF));    
+assert(r565 == rgb565_pixel_t((uint16_t)0xFFFF));
 \endcode
 */
 
@@ -70,35 +70,35 @@ struct packed_pixel {
         boost::ignore_unused(d);
     }
     packed_pixel(int chan0, int chan1) : _bitfield(0) {
-        BOOST_STATIC_ASSERT((num_channels<packed_pixel>::value==2)); 
-        gil::at_c<0>(*this)=chan0; gil::at_c<1>(*this)=chan1; 
-    } 
-    packed_pixel(int chan0, int chan1, int chan2) : _bitfield(0) { 
-        BOOST_STATIC_ASSERT((num_channels<packed_pixel>::value==3)); 
+        BOOST_STATIC_ASSERT((num_channels<packed_pixel>::value==2));
+        gil::at_c<0>(*this)=chan0; gil::at_c<1>(*this)=chan1;
+    }
+    packed_pixel(int chan0, int chan1, int chan2) : _bitfield(0) {
+        BOOST_STATIC_ASSERT((num_channels<packed_pixel>::value==3));
         gil::at_c<0>(*this) = chan0;
         gil::at_c<1>(*this) = chan1;
         gil::at_c<2>(*this) = chan2;
-    } 
-    packed_pixel(int chan0, int chan1, int chan2, int chan3) : _bitfield(0) { 
-        BOOST_STATIC_ASSERT((num_channels<packed_pixel>::value==4)); 
-        gil::at_c<0>(*this)=chan0; gil::at_c<1>(*this)=chan1; gil::at_c<2>(*this)=chan2; gil::at_c<3>(*this)=chan3; 
-    } 
-    packed_pixel(int chan0, int chan1, int chan2, int chan3, int chan4) : _bitfield(0) { 
-        BOOST_STATIC_ASSERT((num_channels<packed_pixel>::value==5)); 
+    }
+    packed_pixel(int chan0, int chan1, int chan2, int chan3) : _bitfield(0) {
+        BOOST_STATIC_ASSERT((num_channels<packed_pixel>::value==4));
+        gil::at_c<0>(*this)=chan0; gil::at_c<1>(*this)=chan1; gil::at_c<2>(*this)=chan2; gil::at_c<3>(*this)=chan3;
+    }
+    packed_pixel(int chan0, int chan1, int chan2, int chan3, int chan4) : _bitfield(0) {
+        BOOST_STATIC_ASSERT((num_channels<packed_pixel>::value==5));
         gil::at_c<0>(*this)=chan0; gil::at_c<1>(*this)=chan1; gil::at_c<2>(*this)=chan2; gil::at_c<3>(*this)=chan3; gil::at_c<4>(*this)=chan4;
-    } 
+    }
 
     packed_pixel& operator=(const packed_pixel& p)     { _bitfield=p._bitfield; return *this; }
 
-    template <typename P> packed_pixel& operator=(const P& p)        { assign(p, mpl::bool_<is_pixel<P>::value>()); return *this; } 
-    template <typename P> bool          operator==(const P& p) const { return equal(p, mpl::bool_<is_pixel<P>::value>()); } 
+    template <typename P> packed_pixel& operator=(const P& p)        { assign(p, mpl::bool_<is_pixel<P>::value>()); return *this; }
+    template <typename P> bool          operator==(const P& p) const { return equal(p, mpl::bool_<is_pixel<P>::value>()); }
 
     template <typename P> bool operator!=(const P& p) const { return !(*this==p); }
 
 private:
     template <typename Pixel> static void check_compatible() { gil_function_requires<PixelsCompatibleConcept<Pixel,packed_pixel> >(); }
-    template <typename Pixel> void assign(const Pixel& p, mpl::true_)       { check_compatible<Pixel>(); static_copy(p,*this); } 
-    template <typename Pixel> bool  equal(const Pixel& p, mpl::true_) const { check_compatible<Pixel>(); return static_equal(*this,p); } 
+    template <typename Pixel> void assign(const Pixel& p, mpl::true_)       { check_compatible<Pixel>(); static_copy(p,*this); }
+    template <typename Pixel> bool  equal(const Pixel& p, mpl::true_) const { check_compatible<Pixel>(); return static_equal(*this,p); }
 
 // Support for assignment/equality comparison of a channel with a grayscale pixel
     static void check_gray() {  BOOST_STATIC_ASSERT((is_same<typename Layout::color_space_t, gray_t>::value)); }
@@ -113,26 +113,26 @@ public:
 //  ColorBasedConcept
 /////////////////////////////
 
-template <typename BitField, typename ChannelRefVec, typename Layout, int K>  
+template <typename BitField, typename ChannelRefVec, typename Layout, int K>
 struct kth_element_type<packed_pixel<BitField,ChannelRefVec,Layout>,K> : public mpl::at_c<ChannelRefVec,K> {};
 
-template <typename BitField, typename ChannelRefVec, typename Layout, int K>  
+template <typename BitField, typename ChannelRefVec, typename Layout, int K>
 struct kth_element_reference_type<packed_pixel<BitField,ChannelRefVec,Layout>,K> : public mpl::at_c<ChannelRefVec,K> {};
 
-template <typename BitField, typename ChannelRefVec, typename Layout, int K>  
+template <typename BitField, typename ChannelRefVec, typename Layout, int K>
 struct kth_element_const_reference_type<packed_pixel<BitField,ChannelRefVec,Layout>,K> {
     typedef typename channel_traits<typename mpl::at_c<ChannelRefVec,K>::type>::const_reference type;
 };
 
 template <int K, typename P, typename C, typename L> inline
-typename kth_element_reference_type<packed_pixel<P,C,L>, K>::type 
-at_c(packed_pixel<P,C,L>& p) { 
-    return typename kth_element_reference_type<packed_pixel<P,C,L>, K>::type(&p._bitfield); 
+typename kth_element_reference_type<packed_pixel<P,C,L>, K>::type
+at_c(packed_pixel<P,C,L>& p) {
+    return typename kth_element_reference_type<packed_pixel<P,C,L>, K>::type(&p._bitfield);
 }
 
 template <int K, typename P, typename C, typename L> inline
-typename kth_element_const_reference_type<packed_pixel<P,C,L>, K>::type 
-at_c(const packed_pixel<P,C,L>& p) { 
+typename kth_element_const_reference_type<packed_pixel<P,C,L>, K>::type
+at_c(const packed_pixel<P,C,L>& p) {
     return typename kth_element_const_reference_type<packed_pixel<P,C,L>, K>::type(&p._bitfield);
 }
 
@@ -141,7 +141,7 @@ at_c(const packed_pixel<P,C,L>& p) {
 /////////////////////////////
 
 // Metafunction predicate that flags packed_pixel as a model of PixelConcept. Required by PixelConcept
-template <typename BitField, typename ChannelRefVec, typename Layout>  
+template <typename BitField, typename ChannelRefVec, typename Layout>
 struct is_pixel<packed_pixel<BitField,ChannelRefVec,Layout> > : public mpl::true_{};
 
 /////////////////////////////
@@ -151,15 +151,15 @@ struct is_pixel<packed_pixel<BitField,ChannelRefVec,Layout> > : public mpl::true
 template <typename P, typename C, typename Layout>
 struct color_space_type<packed_pixel<P,C,Layout> > {
     typedef typename Layout::color_space_t type;
-}; 
+};
 
 template <typename P, typename C, typename Layout>
 struct channel_mapping_type<packed_pixel<P,C,Layout> > {
     typedef typename Layout::channel_mapping_t type;
-}; 
+};
 
 template <typename P, typename C, typename Layout>
-struct is_planar<packed_pixel<P,C,Layout> > : mpl::false_ {}; 
+struct is_planar<packed_pixel<P,C,Layout> > : mpl::false_ {};
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -173,9 +173,9 @@ struct is_planar<packed_pixel<P,C,Layout> > : mpl::false_ {};
 /// \brief Iterators over interleaved pixels.
 /// The pointer packed_pixel<P,CR,Layout>* is used as an iterator over interleaved pixels of packed format. Models PixelIteratorConcept, HasDynamicXStepTypeConcept, MemoryBasedIteratorConcept
 
-template <typename P, typename C, typename L>  
+template <typename P, typename C, typename L>
 struct iterator_is_mutable<packed_pixel<P,C,L>*> : public mpl::bool_<packed_pixel<P,C,L>::is_mutable> {};
-template <typename P, typename C, typename L>  
+template <typename P, typename C, typename L>
 struct iterator_is_mutable<const packed_pixel<P,C,L>*> : public mpl::false_ {};
 
 

--- a/include/boost/gil/pixel.hpp
+++ b/include/boost/gil/pixel.hpp
@@ -47,7 +47,7 @@ template <typename T> struct is_pixel<const T> : public is_pixel<T> {};
 /// \ingroup PixelBasedAlgorithm
 /// \brief Returns the number of channels of a pixel-based GIL construct
 template <typename PixelBased>
-struct num_channels : public mpl::size<typename color_space_type<PixelBased>::type> {}; 
+struct num_channels : public mpl::size<typename color_space_type<PixelBased>::type> {};
 
 /**
 \addtogroup PixelBasedAlgorithm
@@ -59,28 +59,28 @@ BOOST_STATIC_ASSERT((num_channels<cmyk16_planar_ptr_t>::value==4));
 
 BOOST_STATIC_ASSERT((is_planar<rgb16_planar_image_t>::value));
 BOOST_STATIC_ASSERT((is_same<color_space_type<rgb8_planar_ref_t>::type, rgb_t>::value));
-BOOST_STATIC_ASSERT((is_same<channel_mapping_type<cmyk8_pixel_t>::type, 
+BOOST_STATIC_ASSERT((is_same<channel_mapping_type<cmyk8_pixel_t>::type,
                              channel_mapping_type<rgba8_pixel_t>::type>::value));
 BOOST_STATIC_ASSERT((is_same<channel_type<bgr8_pixel_t>::type, uint8_t>::value));
 \endcode
 */
 
-/// \defgroup ColorBaseModelPixel pixel 
+/// \defgroup ColorBaseModelPixel pixel
 /// \ingroup ColorBaseModel
 /// \brief A homogeneous color base whose element is a channel value. Models HomogeneousColorBaseValueConcept
 
-/// \defgroup PixelModelPixel pixel 
+/// \defgroup PixelModelPixel pixel
 /// \ingroup PixelModel
 /// \brief A homogeneous pixel value. Models HomogeneousPixelValueConcept
 
 /// \ingroup PixelModelPixel ColorBaseModelPixel PixelBasedModel
 /// \brief Represents a pixel value (a container of channels). Models: HomogeneousColorBaseValueConcept, PixelValueConcept, HomogeneousPixelBasedConcept
-/// 
-/// A pixel is a set of channels defining the color at a given point in an image. Conceptually, a pixel is little more than a color base whose elements 
-/// model \p ChannelConcept. The class \p pixel defines a simple, homogeneous pixel value. It is used to store 
+///
+/// A pixel is a set of channels defining the color at a given point in an image. Conceptually, a pixel is little more than a color base whose elements
+/// model \p ChannelConcept. The class \p pixel defines a simple, homogeneous pixel value. It is used to store
 /// the value of a color. The built-in C++ references to \p pixel, \p pixel& and \p const \p pixel& are used to represent a reference to a pixel
 /// inside an interleaved image view (a view in which all channels are together in memory). Similarly, built-in pointer types \p pixel* and \p const \p pixel*
-/// are used as the standard iterator over a row of interleaved homogeneous pixels. 
+/// are used as the standard iterator over a row of interleaved homogeneous pixels.
 ///
 /// Since \p pixel inherits the properties of color base, assigning, equality comparison and copy-construcion are allowed between compatible pixels.
 /// This means that an 8-bit RGB pixel may be assigned to an 8-bit BGR pixel, or to an 8-bit planar reference. The channels are properly paired semantically.
@@ -117,8 +117,8 @@ public:
         boost::ignore_unused(dummy);
     }
 
-    template <typename P> pixel& operator=(const P& p)           { assign(p, mpl::bool_<is_pixel<P>::value>()); return *this; } 
-    template <typename P> bool   operator==(const P& p)    const { return equal(p, mpl::bool_<is_pixel<P>::value>()); } 
+    template <typename P> pixel& operator=(const P& p)           { assign(p, mpl::bool_<is_pixel<P>::value>()); return *this; }
+    template <typename P> bool   operator==(const P& p)    const { return equal(p, mpl::bool_<is_pixel<P>::value>()); }
 
     template <typename P> bool   operator!=(const P& p)    const { return !(*this==p); }
 
@@ -126,8 +126,8 @@ public:
     typename channel_traits<channel_t>::reference       operator[](std::size_t i)       { return dynamic_at_c(*this,i); }
     typename channel_traits<channel_t>::const_reference operator[](std::size_t i) const { return dynamic_at_c(*this,i); }
 private:
-    template <typename Pixel> void assign(const Pixel& p, mpl::true_)       { check_compatible<Pixel>(); static_copy(p,*this); } 
-    template <typename Pixel> bool  equal(const Pixel& p, mpl::true_) const { check_compatible<Pixel>(); return static_equal(*this,p); } 
+    template <typename Pixel> void assign(const Pixel& p, mpl::true_)       { check_compatible<Pixel>(); static_copy(p,*this); }
+    template <typename Pixel> bool  equal(const Pixel& p, mpl::true_) const { check_compatible<Pixel>(); return static_equal(*this,p); }
 
     template <typename Pixel> void check_compatible() const { gil_function_requires<PixelsCompatibleConcept<Pixel,pixel> >(); }
 
@@ -146,22 +146,22 @@ public:
 //  ColorBasedConcept
 /////////////////////////////
 
-template <typename ChannelValue, typename Layout, int K>  
+template <typename ChannelValue, typename Layout, int K>
 struct kth_element_type<pixel<ChannelValue,Layout>, K> {
     typedef ChannelValue type;
 };
 
-template <typename ChannelValue, typename Layout, int K>  
+template <typename ChannelValue, typename Layout, int K>
 struct kth_element_reference_type<pixel<ChannelValue,Layout>, K> {
     typedef typename channel_traits<ChannelValue>::reference type;
 };
 
-template <typename ChannelValue, typename Layout, int K>  
+template <typename ChannelValue, typename Layout, int K>
 struct kth_element_reference_type<const pixel<ChannelValue,Layout>, K> {
     typedef typename channel_traits<ChannelValue>::const_reference type;
 };
 
-template <typename ChannelValue, typename Layout, int K>  
+template <typename ChannelValue, typename Layout, int K>
 struct kth_element_const_reference_type<pixel<ChannelValue,Layout>, K> {
     typedef typename channel_traits<ChannelValue>::const_reference type;
 };
@@ -170,7 +170,7 @@ struct kth_element_const_reference_type<pixel<ChannelValue,Layout>, K> {
 //  PixelConcept
 /////////////////////////////
 
-template <typename ChannelValue, typename Layout> 
+template <typename ChannelValue, typename Layout>
 struct is_pixel<pixel<ChannelValue,Layout> > : public mpl::true_{};
 
 /////////////////////////////
@@ -180,12 +180,12 @@ struct is_pixel<pixel<ChannelValue,Layout> > : public mpl::true_{};
 template <typename ChannelValue, typename Layout>
 struct color_space_type<pixel<ChannelValue,Layout> > {
     typedef typename Layout::color_space_t type;
-}; 
+};
 
 template <typename ChannelValue, typename Layout>
 struct channel_mapping_type<pixel<ChannelValue,Layout> > {
     typedef typename Layout::channel_mapping_t type;
-}; 
+};
 
 template <typename ChannelValue, typename Layout>
 struct is_planar<pixel<ChannelValue,Layout> > : public mpl::false_ {};
@@ -193,12 +193,12 @@ struct is_planar<pixel<ChannelValue,Layout> > : public mpl::false_ {};
 template <typename ChannelValue, typename Layout>
 struct channel_type<pixel<ChannelValue,Layout> > {
     typedef ChannelValue type;
-}; 
+};
 
 }}  // namespace boost::gil
 
 namespace boost {
-    template <typename ChannelValue, typename Layout> 
+    template <typename ChannelValue, typename Layout>
     struct has_trivial_constructor<gil::pixel<ChannelValue,Layout> > : public has_trivial_constructor<ChannelValue> {};
 }
 

--- a/include/boost/gil/pixel_iterator.hpp
+++ b/include/boost/gil/pixel_iterator.hpp
@@ -64,13 +64,13 @@ template <typename T> struct iterator_is_mutable<const T*> : public mpl::false_{
 //  HasDynamicXStepTypeConcept
 /////////////////////////////
 
-/// \ingroup PixelIteratorModelInterleavedPtr 
+/// \ingroup PixelIteratorModelInterleavedPtr
 template <typename Pixel>
 struct dynamic_x_step_type<Pixel*> {
     typedef memory_based_step_iterator<Pixel*> type;
 };
 
-/// \ingroup PixelIteratorModelInterleavedPtr 
+/// \ingroup PixelIteratorModelInterleavedPtr
 template <typename Pixel>
 struct dynamic_x_step_type<const Pixel*> {
     typedef memory_based_step_iterator<const Pixel*> type;
@@ -115,12 +115,12 @@ template <typename P>
 inline std::ptrdiff_t memunit_step(const P*) { return sizeof(P); }
 
 template <typename P>
-inline std::ptrdiff_t memunit_distance(const P* p1, const P* p2) { 
-    return (gil_reinterpret_cast_c<const unsigned char*>(p2)-gil_reinterpret_cast_c<const unsigned char*>(p1)); 
+inline std::ptrdiff_t memunit_distance(const P* p1, const P* p2) {
+    return (gil_reinterpret_cast_c<const unsigned char*>(p2)-gil_reinterpret_cast_c<const unsigned char*>(p1));
 }
 
 template <typename P>
-inline void memunit_advance(P* &p, std::ptrdiff_t diff) { 
+inline void memunit_advance(P* &p, std::ptrdiff_t diff) {
     p=(P*)((unsigned char*)(p)+diff);
 }
 

--- a/include/boost/gil/pixel_iterator_adaptor.hpp
+++ b/include/boost/gil/pixel_iterator_adaptor.hpp
@@ -45,10 +45,10 @@ public:
     typedef DFn                                               dereference_fn;
 
     dereference_iterator_adaptor() {}
-    template <typename Iterator1> 
+    template <typename Iterator1>
     dereference_iterator_adaptor(const dereference_iterator_adaptor<Iterator1,DFn>& dit) : parent_t(dit.base()), _deref_fn(dit._deref_fn) {}
     dereference_iterator_adaptor(Iterator it, DFn deref_fn=DFn()) : parent_t(it), _deref_fn(deref_fn) {}
-    template <typename Iterator1, typename DFn1> 
+    template <typename Iterator1, typename DFn1>
     dereference_iterator_adaptor(const dereference_iterator_adaptor<Iterator1,DFn1>& it) : parent_t(it.base()), _deref_fn(it._deref_fn) {}
     /// For some reason operator[] provided by iterator_facade returns a custom class that is convertible to reference
     /// We require our own reference because it is registered in iterator_traits
@@ -67,19 +67,19 @@ public:
     const Iterator& base() const  { return this->base_reference(); }
     const DFn& deref_fn() const { return _deref_fn; }
 private:
-    template <typename Iterator1, typename DFn1> 
+    template <typename Iterator1, typename DFn1>
     friend class dereference_iterator_adaptor;
     friend class boost::iterator_core_access;
 
     reference dereference() const { return _deref_fn(*(this->base_reference())); }
 };
 
-template <typename I, typename DFn> 
-struct const_iterator_type<dereference_iterator_adaptor<I,DFn> > { 
-    typedef dereference_iterator_adaptor<typename const_iterator_type<I>::type,typename DFn::const_t> type; 
+template <typename I, typename DFn>
+struct const_iterator_type<dereference_iterator_adaptor<I,DFn> > {
+    typedef dereference_iterator_adaptor<typename const_iterator_type<I>::type,typename DFn::const_t> type;
 };
 
-template <typename I, typename DFn> 
+template <typename I, typename DFn>
 struct iterator_is_mutable<dereference_iterator_adaptor<I,DFn> > : public mpl::bool_<DFn::is_mutable> {};
 
 
@@ -121,37 +121,37 @@ template <typename Iterator, typename DFn>
 struct byte_to_memunit<dereference_iterator_adaptor<Iterator,DFn> > : public byte_to_memunit<Iterator> {};
 
 template <typename Iterator, typename DFn>
-inline typename std::iterator_traits<Iterator>::difference_type 
-memunit_step(const dereference_iterator_adaptor<Iterator,DFn>& p) { 
+inline typename std::iterator_traits<Iterator>::difference_type
+memunit_step(const dereference_iterator_adaptor<Iterator,DFn>& p) {
     return memunit_step(p.base());
 }
 
 template <typename Iterator, typename DFn>
-inline typename std::iterator_traits<Iterator>::difference_type 
-memunit_distance(const dereference_iterator_adaptor<Iterator,DFn>& p1, 
-              const dereference_iterator_adaptor<Iterator,DFn>& p2) { 
-    return memunit_distance(p1.base(),p2.base()); 
+inline typename std::iterator_traits<Iterator>::difference_type
+memunit_distance(const dereference_iterator_adaptor<Iterator,DFn>& p1,
+              const dereference_iterator_adaptor<Iterator,DFn>& p2) {
+    return memunit_distance(p1.base(),p2.base());
 }
 
 template <typename Iterator, typename DFn>
-inline void memunit_advance(dereference_iterator_adaptor<Iterator,DFn>& p, 
-                         typename std::iterator_traits<Iterator>::difference_type diff) { 
+inline void memunit_advance(dereference_iterator_adaptor<Iterator,DFn>& p,
+                         typename std::iterator_traits<Iterator>::difference_type diff) {
     memunit_advance(p.base(), diff);
 }
 
 template <typename Iterator, typename DFn>
-inline dereference_iterator_adaptor<Iterator,DFn> 
-memunit_advanced(const dereference_iterator_adaptor<Iterator,DFn>& p, 
-              typename std::iterator_traits<Iterator>::difference_type diff) { 
-    return dereference_iterator_adaptor<Iterator,DFn>(memunit_advanced(p.base(), diff), p.deref_fn()); 
+inline dereference_iterator_adaptor<Iterator,DFn>
+memunit_advanced(const dereference_iterator_adaptor<Iterator,DFn>& p,
+              typename std::iterator_traits<Iterator>::difference_type diff) {
+    return dereference_iterator_adaptor<Iterator,DFn>(memunit_advanced(p.base(), diff), p.deref_fn());
 }
 
 
 template <typename Iterator, typename DFn>
-inline 
-typename std::iterator_traits<dereference_iterator_adaptor<Iterator,DFn> >::reference 
-memunit_advanced_ref(const dereference_iterator_adaptor<Iterator,DFn>& p, 
-                  typename std::iterator_traits<Iterator>::difference_type diff) { 
+inline
+typename std::iterator_traits<dereference_iterator_adaptor<Iterator,DFn> >::reference
+memunit_advanced_ref(const dereference_iterator_adaptor<Iterator,DFn>& p,
+                  typename std::iterator_traits<Iterator>::difference_type diff) {
     return *memunit_advanced(p, diff);
 }
 
@@ -183,8 +183,8 @@ struct iterator_add_deref<dereference_iterator_adaptor<Iterator, PREV_DEREF>,Der
 
     typedef dereference_iterator_adaptor<Iterator, deref_compose<Deref,PREV_DEREF> > type;
 
-    static type make(const dereference_iterator_adaptor<Iterator, PREV_DEREF>& it, const Deref& d) { 
-        return type(it.base(),deref_compose<Deref,PREV_DEREF>(d,it.deref_fn())); 
+    static type make(const dereference_iterator_adaptor<Iterator, PREV_DEREF>& it, const Deref& d) {
+        return type(it.base(),deref_compose<Deref,PREV_DEREF>(d,it.deref_fn()));
     }
 };
 

--- a/include/boost/gil/planar_pixel_reference.hpp
+++ b/include/boost/gil/planar_pixel_reference.hpp
@@ -56,7 +56,7 @@ planar_pixel_reference(ChannelReference v0, ChannelReference v1, ChannelReferenc
     template <typename P>                         planar_pixel_reference(const P& p)        : parent_t(p) { check_compatible<P>();}
 
     // PERFORMANCE_CHECK: Is this constructor necessary?
-    template <typename ChannelV, typename Mapping>           
+    template <typename ChannelV, typename Mapping>
     planar_pixel_reference(pixel<ChannelV,layout<ColorSpace,Mapping> >& p)   : parent_t(p) { check_compatible<pixel<ChannelV,layout<ColorSpace,Mapping> > >();}
 
     // Construct at offset from a given location
@@ -91,19 +91,19 @@ private:
 //  ColorBasedConcept
 /////////////////////////////
 
-template <typename ChannelReference, typename ColorSpace, int K>  
+template <typename ChannelReference, typename ColorSpace, int K>
 struct kth_element_type<planar_pixel_reference<ChannelReference,ColorSpace>, K> {
     typedef ChannelReference type;
 };
 
-template <typename ChannelReference, typename ColorSpace, int K>  
+template <typename ChannelReference, typename ColorSpace, int K>
 struct kth_element_reference_type<planar_pixel_reference<ChannelReference,ColorSpace>, K> {
     typedef ChannelReference type;
 };
 
-template <typename ChannelReference, typename ColorSpace, int K>  
-struct kth_element_const_reference_type<planar_pixel_reference<ChannelReference,ColorSpace>, K> 
-    : public add_reference<typename add_const<ChannelReference>::type> 
+template <typename ChannelReference, typename ColorSpace, int K>
+struct kth_element_const_reference_type<planar_pixel_reference<ChannelReference,ColorSpace>, K>
+    : public add_reference<typename add_const<ChannelReference>::type>
 {
 //    typedef typename channel_traits<ChannelReference>::const_reference type;
 };
@@ -114,7 +114,7 @@ struct kth_element_const_reference_type<planar_pixel_reference<ChannelReference,
 
 /// \brief Metafunction predicate that flags planar_pixel_reference as a model of PixelConcept. Required by PixelConcept
 /// \ingroup PixelModelPlanarRef
-template <typename ChannelReference, typename ColorSpace>  
+template <typename ChannelReference, typename ColorSpace>
 struct is_pixel< planar_pixel_reference<ChannelReference,ColorSpace> > : public mpl::true_{};
 
 /////////////////////////////
@@ -123,35 +123,35 @@ struct is_pixel< planar_pixel_reference<ChannelReference,ColorSpace> > : public 
 
 /// \brief Specifies the color space type of a planar pixel reference. Required by PixelBasedConcept
 /// \ingroup PixelModelPlanarRef
-template <typename ChannelReference, typename ColorSpace>  
+template <typename ChannelReference, typename ColorSpace>
 struct color_space_type<planar_pixel_reference<ChannelReference,ColorSpace> > {
     typedef ColorSpace type;
-}; 
+};
 
 /// \brief Specifies the color space type of a planar pixel reference. Required by PixelBasedConcept
 /// \ingroup PixelModelPlanarRef
-template <typename ChannelReference, typename ColorSpace>  
+template <typename ChannelReference, typename ColorSpace>
 struct channel_mapping_type<planar_pixel_reference<ChannelReference,ColorSpace> > {
     typedef typename layout<ColorSpace>::channel_mapping_t type;
-}; 
+};
 
 /// \brief Specifies that planar_pixel_reference represents a planar construct. Required by PixelBasedConcept
 /// \ingroup PixelModelPlanarRef
-template <typename ChannelReference, typename ColorSpace>  
+template <typename ChannelReference, typename ColorSpace>
 struct is_planar<planar_pixel_reference<ChannelReference,ColorSpace> > : mpl::true_ {};
 
 /// \brief Specifies the color space type of a planar pixel reference. Required by HomogeneousPixelBasedConcept
 /// \ingroup PixelModelPlanarRef
-template <typename ChannelReference, typename ColorSpace>  
+template <typename ChannelReference, typename ColorSpace>
 struct channel_type<planar_pixel_reference<ChannelReference,ColorSpace> > {
     typedef typename channel_traits<ChannelReference>::value_type type;
-}; 
+};
 
 }}  // namespace boost::gil
 
 namespace std {
 // We are forced to define swap inside std namespace because on some platforms (Visual Studio 8) STL calls swap qualified.
-// swap with 'left bias': 
+// swap with 'left bias':
 // - swap between proxy and anything
 // - swap between value type and proxy
 // - swap between proxy and proxy
@@ -160,22 +160,22 @@ namespace std {
 /// \brief  swap for planar_pixel_reference
 /// \ingroup PixelModelPlanarRef
 template <typename CR, typename CS, typename R> inline
-void swap(const boost::gil::planar_pixel_reference<CR,CS> x, R& y) { 
-    boost::gil::swap_proxy<typename boost::gil::planar_pixel_reference<CR,CS>::value_type>(x,y); 
+void swap(const boost::gil::planar_pixel_reference<CR,CS> x, R& y) {
+    boost::gil::swap_proxy<typename boost::gil::planar_pixel_reference<CR,CS>::value_type>(x,y);
 }
 
 /// \brief  swap for planar_pixel_reference
 /// \ingroup PixelModelPlanarRef
 template <typename CR, typename CS> inline
-void swap(typename boost::gil::planar_pixel_reference<CR,CS>::value_type& x, const boost::gil::planar_pixel_reference<CR,CS> y) { 
-    boost::gil::swap_proxy<typename boost::gil::planar_pixel_reference<CR,CS>::value_type>(x,y); 
+void swap(typename boost::gil::planar_pixel_reference<CR,CS>::value_type& x, const boost::gil::planar_pixel_reference<CR,CS> y) {
+    boost::gil::swap_proxy<typename boost::gil::planar_pixel_reference<CR,CS>::value_type>(x,y);
 }
 
 /// \brief  swap for planar_pixel_reference
 /// \ingroup PixelModelPlanarRef
 template <typename CR, typename CS> inline
-void swap(const boost::gil::planar_pixel_reference<CR,CS> x, const boost::gil::planar_pixel_reference<CR,CS> y) { 
-    boost::gil::swap_proxy<typename boost::gil::planar_pixel_reference<CR,CS>::value_type>(x,y); 
+void swap(const boost::gil::planar_pixel_reference<CR,CS> x, const boost::gil::planar_pixel_reference<CR,CS> y) {
+    boost::gil::swap_proxy<typename boost::gil::planar_pixel_reference<CR,CS>::value_type>(x,y);
 }
 
 }   // namespace std

--- a/include/boost/gil/position_iterator.hpp
+++ b/include/boost/gil/position_iterator.hpp
@@ -16,7 +16,7 @@ namespace boost { namespace gil {
 
 /// \defgroup PixelIteratorModelVirtual position_iterator
 /// \ingroup PixelIteratorModel
-/// \brief An iterator that remembers its current X,Y position and invokes a function object with it upon dereferencing. Models PixelIteratorConcept, PixelBasedConcept, HasDynamicXStepTypeConcept. Used to create virtual image views. 
+/// \brief An iterator that remembers its current X,Y position and invokes a function object with it upon dereferencing. Models PixelIteratorConcept, PixelBasedConcept, HasDynamicXStepTypeConcept. Used to create virtual image views.
 
 
 /// \brief An iterator that remembers its current X,Y position and invokes a function object with it upon dereferencing. Models PixelIteratorConcept. Used to create virtual image views.
@@ -69,12 +69,12 @@ private:
     bool equal(const position_iterator& it) const { return _p==it._p; }
 };
 
-template <typename Deref,int Dim> 
+template <typename Deref,int Dim>
 struct const_iterator_type<position_iterator<Deref,Dim> > {
     typedef position_iterator<typename Deref::const_t,Dim> type;
 };
 
-template <typename Deref,int Dim> 
+template <typename Deref,int Dim>
 struct iterator_is_mutable<position_iterator<Deref,Dim> > : public mpl::bool_<Deref::is_mutable> {
 };
 
@@ -82,23 +82,23 @@ struct iterator_is_mutable<position_iterator<Deref,Dim> > : public mpl::bool_<De
 //  PixelBasedConcept
 /////////////////////////////
 
-template <typename Deref,int Dim> 
+template <typename Deref,int Dim>
 struct color_space_type<position_iterator<Deref,Dim> > : public color_space_type<typename Deref::value_type> {};
 
-template <typename Deref,int Dim> 
+template <typename Deref,int Dim>
 struct channel_mapping_type<position_iterator<Deref,Dim> > : public channel_mapping_type<typename Deref::value_type> {};
 
-template <typename Deref,int Dim> 
+template <typename Deref,int Dim>
 struct is_planar<position_iterator<Deref,Dim> > : public mpl::false_ {};
 
-template <typename Deref,int Dim> 
+template <typename Deref,int Dim>
 struct channel_type<position_iterator<Deref,Dim> > : public channel_type<typename Deref::value_type> {};
 
 /////////////////////////////
 //  HasDynamicXStepTypeConcept
 /////////////////////////////
 
-template <typename Deref,int Dim> 
+template <typename Deref,int Dim>
 struct dynamic_x_step_type<position_iterator<Deref,Dim> > {
     typedef position_iterator<Deref,Dim> type;
 };

--- a/include/boost/gil/rgb.hpp
+++ b/include/boost/gil/rgb.hpp
@@ -22,13 +22,13 @@ namespace boost { namespace gil {
 /// \{
 
 /// \brief Red
-struct red_t {};    
+struct red_t {};
 
 /// \brief Green
 struct green_t {};
 
 /// \brief Blue
-struct blue_t {}; 
+struct blue_t {};
 /// \}
 
 /// \ingroup ColorSpaceModel

--- a/include/boost/gil/rgba.hpp
+++ b/include/boost/gil/rgba.hpp
@@ -20,7 +20,7 @@ namespace boost { namespace gil {
 
 /// \ingroup ColorNameModel
 /// \brief Alpha
-struct alpha_t {};    
+struct alpha_t {};
 
 /// \ingroup ColorSpaceModel
 typedef mpl::vector4<red_t,green_t,blue_t,alpha_t> rgba_t;

--- a/include/boost/gil/step_iterator.hpp
+++ b/include/boost/gil/step_iterator.hpp
@@ -28,14 +28,14 @@ namespace detail {
 /// \ingroup PixelIteratorModelStepPtr
 /// \brief An adaptor over an existing iterator that changes the step unit
 ///
-/// (i.e. distance(it,it+1)) by a given predicate. Instead of calling base's 
+/// (i.e. distance(it,it+1)) by a given predicate. Instead of calling base's
 /// operators ++, --, +=, -=, etc. the adaptor is using the passed policy object SFn
 /// for advancing and for computing the distance between iterators.
 
 template <typename Derived,  // type of the derived class
           typename Iterator, // Models Iterator
           typename SFn>      // A policy object that can compute the distance between two iterators of type Iterator
-                             // and can advance an iterator of type Iterator a given number of Iterator's units  
+                             // and can advance an iterator of type Iterator a given number of Iterator's units
 class step_iterator_adaptor : public iterator_adaptor<Derived, Iterator, use_default, use_default, use_default, typename SFn::difference_type> {
 public:
     typedef iterator_adaptor<Derived, Iterator, use_default, use_default, use_default, typename SFn::difference_type> parent_t;
@@ -62,33 +62,33 @@ private:
 // although iterator_adaptor defines these, the default implementation computes distance and compares for zero.
 // it is often faster to just apply the relation operator to the base
 template <typename D,typename Iterator,typename SFn> inline
-bool operator>(const step_iterator_adaptor<D,Iterator,SFn>& p1, const step_iterator_adaptor<D,Iterator,SFn>& p2) { 
-    return p1.step()>0 ? p1.base()> p2.base() : p1.base()< p2.base(); 
+bool operator>(const step_iterator_adaptor<D,Iterator,SFn>& p1, const step_iterator_adaptor<D,Iterator,SFn>& p2) {
+    return p1.step()>0 ? p1.base()> p2.base() : p1.base()< p2.base();
 }
 
 template <typename D,typename Iterator,typename SFn> inline
-bool operator<(const step_iterator_adaptor<D,Iterator,SFn>& p1, const step_iterator_adaptor<D,Iterator,SFn>& p2) { 
-    return p1.step()>0 ? p1.base()< p2.base() : p1.base()> p2.base(); 
+bool operator<(const step_iterator_adaptor<D,Iterator,SFn>& p1, const step_iterator_adaptor<D,Iterator,SFn>& p2) {
+    return p1.step()>0 ? p1.base()< p2.base() : p1.base()> p2.base();
 }
 
 template <typename D,typename Iterator,typename SFn> inline
-bool operator>=(const step_iterator_adaptor<D,Iterator,SFn>& p1, const step_iterator_adaptor<D,Iterator,SFn>& p2) { 
-    return p1.step()>0 ? p1.base()>=p2.base() : p1.base()<=p2.base(); 
+bool operator>=(const step_iterator_adaptor<D,Iterator,SFn>& p1, const step_iterator_adaptor<D,Iterator,SFn>& p2) {
+    return p1.step()>0 ? p1.base()>=p2.base() : p1.base()<=p2.base();
 }
 
 template <typename D,typename Iterator,typename SFn> inline
-bool operator<=(const step_iterator_adaptor<D,Iterator,SFn>& p1, const step_iterator_adaptor<D,Iterator,SFn>& p2) { 
-    return p1.step()>0 ? p1.base()<=p2.base() : p1.base()>=p2.base(); 
+bool operator<=(const step_iterator_adaptor<D,Iterator,SFn>& p1, const step_iterator_adaptor<D,Iterator,SFn>& p2) {
+    return p1.step()>0 ? p1.base()<=p2.base() : p1.base()>=p2.base();
 }
 
 template <typename D,typename Iterator,typename SFn> inline
-bool operator==(const step_iterator_adaptor<D,Iterator,SFn>& p1, const step_iterator_adaptor<D,Iterator,SFn>& p2) { 
-    return p1.base()==p2.base(); 
+bool operator==(const step_iterator_adaptor<D,Iterator,SFn>& p1, const step_iterator_adaptor<D,Iterator,SFn>& p2) {
+    return p1.base()==p2.base();
 }
 
 template <typename D,typename Iterator,typename SFn> inline
-bool operator!=(const step_iterator_adaptor<D,Iterator,SFn>& p1, const step_iterator_adaptor<D,Iterator,SFn>& p2) { 
-    return p1.base()!=p2.base(); 
+bool operator!=(const step_iterator_adaptor<D,Iterator,SFn>& p1, const step_iterator_adaptor<D,Iterator,SFn>& p2) {
+    return p1.base()!=p2.base();
 }
 
 } // namespace detail
@@ -101,13 +101,13 @@ bool operator!=(const step_iterator_adaptor<D,Iterator,SFn>& p1, const step_iter
 /// \ingroup PixelIteratorModelStepPtr PixelBasedModel
 /// \brief Iterator with dynamically specified step in memory units (bytes or bits). Models StepIteratorConcept, IteratorAdaptorConcept, MemoryBasedIteratorConcept, PixelIteratorConcept, HasDynamicXStepTypeConcept
 ///
-/// A refinement of step_iterator_adaptor that uses a dynamic parameter for the step 
+/// A refinement of step_iterator_adaptor that uses a dynamic parameter for the step
 /// which is specified in memory units, such as bytes or bits
 ///
-/// Pixel step iterators are used to provide iteration over non-adjacent pixels. 
+/// Pixel step iterators are used to provide iteration over non-adjacent pixels.
 /// Common use is a vertical traversal, where the step is the row stride.
 ///
-/// Another application is as a sub-channel view. For example, a red intensity image over 
+/// Another application is as a sub-channel view. For example, a red intensity image over
 /// interleaved RGB data would use a step iterator adaptor with step sizeof(channel_t)*3
 /// In the latter example the step size could be fixed at compile time for efficiency.
 /// Compile-time fixed step can be implemented by providing a step function object that takes the step as a template
@@ -122,7 +122,7 @@ struct memunit_step_fn {
     memunit_step_fn(difference_type step=memunit_step(Iterator())) : _step(step) {}
 
     difference_type difference(const Iterator& it1, const Iterator& it2) const { return memunit_distance(it1,it2)/_step; }
-    void            advance(Iterator& it, difference_type d)             const { memunit_advance(it,d*_step); } 
+    void            advance(Iterator& it, difference_type d)             const { memunit_advance(it,d*_step); }
     difference_type step()                                               const { return _step; }
 
     void            set_step(std::ptrdiff_t step) { _step=step; }
@@ -132,13 +132,13 @@ private:
 };
 
 template <typename Iterator>
-class memory_based_step_iterator : public detail::step_iterator_adaptor<memory_based_step_iterator<Iterator>, 
-                                                                            Iterator, 
+class memory_based_step_iterator : public detail::step_iterator_adaptor<memory_based_step_iterator<Iterator>,
+                                                                            Iterator,
                                                                             memunit_step_fn<Iterator> > {
     GIL_CLASS_REQUIRE(Iterator, boost::gil, MemoryBasedIteratorConcept)
 public:
-    typedef detail::step_iterator_adaptor<memory_based_step_iterator<Iterator>, 
-                                          Iterator, 
+    typedef detail::step_iterator_adaptor<memory_based_step_iterator<Iterator>,
+                                          Iterator,
                                           memunit_step_fn<Iterator> > parent_t;
     typedef typename parent_t::reference                            reference;
     typedef typename parent_t::difference_type                      difference_type;
@@ -146,7 +146,7 @@ public:
 
     memory_based_step_iterator() : parent_t(Iterator()) {}
     memory_based_step_iterator(Iterator it, std::ptrdiff_t memunit_step) : parent_t(it, memunit_step_fn<Iterator>(memunit_step)) {}
-    template <typename I2> 
+    template <typename I2>
     memory_based_step_iterator(const memory_based_step_iterator<I2>& it)
         : parent_t(it.base(), memunit_step_fn<Iterator>(it.step())) {}
 
@@ -212,28 +212,28 @@ template <typename Iterator>
 inline std::ptrdiff_t memunit_step(const memory_based_step_iterator<Iterator>& p) { return p.step(); }
 
 template <typename Iterator>
-inline std::ptrdiff_t memunit_distance(const memory_based_step_iterator<Iterator>& p1, 
-                                    const memory_based_step_iterator<Iterator>& p2) { 
-    return memunit_distance(p1.base(),p2.base()); 
+inline std::ptrdiff_t memunit_distance(const memory_based_step_iterator<Iterator>& p1,
+                                    const memory_based_step_iterator<Iterator>& p2) {
+    return memunit_distance(p1.base(),p2.base());
 }
 
 template <typename Iterator>
-inline void memunit_advance(memory_based_step_iterator<Iterator>& p, 
-                         std::ptrdiff_t diff) { 
+inline void memunit_advance(memory_based_step_iterator<Iterator>& p,
+                         std::ptrdiff_t diff) {
     memunit_advance(p.base(), diff);
 }
 
 template <typename Iterator>
-inline memory_based_step_iterator<Iterator> 
-memunit_advanced(const memory_based_step_iterator<Iterator>& p, 
+inline memory_based_step_iterator<Iterator>
+memunit_advanced(const memory_based_step_iterator<Iterator>& p,
               std::ptrdiff_t diff) {
     return memory_based_step_iterator<Iterator>(memunit_advanced(p.base(), diff),p.step());
 }
 
 template <typename Iterator>
-inline typename std::iterator_traits<Iterator>::reference 
-memunit_advanced_ref(const memory_based_step_iterator<Iterator>& p, 
-                  std::ptrdiff_t diff) { 
+inline typename std::iterator_traits<Iterator>::reference
+memunit_advanced_ref(const memory_based_step_iterator<Iterator>& p,
+                  std::ptrdiff_t diff) {
     return memunit_advanced_ref(p.base(), diff);
 }
 
@@ -265,19 +265,19 @@ template <typename I> typename dynamic_x_step_type<I>::type make_step_iterator(c
 namespace detail {
 
 // if the iterator is a plain base iterator (non-adaptor), wraps it in memory_based_step_iterator
-template <typename I> 
+template <typename I>
 typename dynamic_x_step_type<I>::type make_step_iterator_impl(const I& it, std::ptrdiff_t step, mpl::false_) {
     return memory_based_step_iterator<I>(it, step);
 }
 
 // If the iterator is compound, put the step in its base
-template <typename I> 
+template <typename I>
 typename dynamic_x_step_type<I>::type make_step_iterator_impl(const I& it, std::ptrdiff_t step, mpl::true_) {
     return make_step_iterator(it.base(), step);
 }
 
 // If the iterator is memory_based_step_iterator, change the step
-template <typename BaseIt> 
+template <typename BaseIt>
 memory_based_step_iterator<BaseIt> make_step_iterator_impl(const memory_based_step_iterator<BaseIt>& it, std::ptrdiff_t step, mpl::true_) {
     return memory_based_step_iterator<BaseIt>(it.base(), step);
 }
@@ -286,7 +286,7 @@ memory_based_step_iterator<BaseIt> make_step_iterator_impl(const memory_based_st
 /// \brief Constructs a step iterator from a base iterator and a step.
 ///
 /// To construct a step iterator from a given iterator Iterator and a given step, if Iterator does not
-/// already have a dynamic step, we wrap it in a memory_based_step_iterator. Otherwise we 
+/// already have a dynamic step, we wrap it in a memory_based_step_iterator. Otherwise we
 /// do a compile-time traversal of the chain of iterator adaptors to locate the step iterator
 /// and then set it step to the new one.
 ///

--- a/include/boost/gil/virtual_locator.hpp
+++ b/include/boost/gil/virtual_locator.hpp
@@ -16,7 +16,7 @@ namespace boost { namespace gil {
 
 /// \brief A 2D locator over a virtual image. Upon dereferencing, invokes a given function object passing it its coordinates. Models: PixelLocatorConcept, HasDynamicXStepTypeConcept, HasDynamicYStepTypeConcept, HasTransposedTypeConcept
 /// \ingroup PixelLocatorModel PixelBasedModel
-/// 
+///
 template <typename Deref, bool IsTransposed>        // A function object that given a point returns a reference. Models PixelDereferenceAdaptorConcept
 class virtual_2d_locator : public pixel_2d_locator_base<virtual_2d_locator<Deref,IsTransposed>, position_iterator<Deref,IsTransposed>, position_iterator<Deref,1-IsTransposed> > {
     typedef virtual_2d_locator<Deref,IsTransposed>  this_t;
@@ -35,8 +35,8 @@ public:
 
     template <typename NewDeref> struct add_deref {
         typedef virtual_2d_locator<deref_compose<NewDeref,Deref>,IsTransposed > type;
-        static type make(const virtual_2d_locator<Deref,IsTransposed>& loc, const NewDeref& nderef) { 
-            return type(loc.pos(), loc.step(), deref_compose<NewDeref,Deref>(nderef,loc.deref_fn())); 
+        static type make(const virtual_2d_locator<Deref,IsTransposed>& loc, const NewDeref& nderef) {
+            return type(loc.pos(), loc.step(), deref_compose<NewDeref,Deref>(nderef,loc.deref_fn()));
         }
     };
 
@@ -44,8 +44,8 @@ public:
     template <typename D, bool TR> virtual_2d_locator(const virtual_2d_locator<D,TR>& loc, coord_t y_step)
         : _p(loc.pos(), point_t(loc.step().x,loc.step().y*y_step),     loc.deref_fn()) {}
     template <typename D, bool TR> virtual_2d_locator(const virtual_2d_locator<D,TR>& loc, coord_t x_step, coord_t y_step, bool transpose=false)
-        : _p(loc.pos(), transpose ? 
-                    point_t(loc.step().x*y_step,loc.step().y*x_step) : 
+        : _p(loc.pos(), transpose ?
+                    point_t(loc.step().x*y_step,loc.step().y*x_step) :
                     point_t(loc.step().x*x_step,loc.step().y*y_step), loc.deref_fn()) { assert(transpose==(IsTransposed!=TR));}
 
     template <typename D, bool TR> virtual_2d_locator(const virtual_2d_locator<D,TR>& pl) : _p(pl._p) {}


### PR DESCRIPTION
PowerShell script used to perform the trimming:

```powershell
Get-ChildItem -Recurse -Include @("*.cpp", "*.hpp") |
  ForEach-Object { (Get-Content $_.FullName)
      | Foreach {$_.TrimEnd()} | Set-Content $_.FullName }
```

### Tasklist

- [ ] Review
- [ ] Adjust for comments
- [ ] All CI builds and checks have passed
