### PR TITLE
Reformat boost/gil/concepts/*.hpp to limit line length to 90 characters

### DIFF
--- a/include/boost/gil/concepts/channel.hpp
+++ b/include/boost/gil/concepts/channel.hpp
@@ -28,8 +28,8 @@ template <typename T>
 struct channel_traits;
 
 template <typename DstT, typename SrcT>
-typename channel_traits<DstT>::value_type channel_convert(SrcT const& val);
-
+auto channel_convert(SrcT const& val)
+    -> typename channel_traits<DstT>::value_type;
 
 /// \ingroup ChannelConcept
 /// \brief A channel is the building block of a color.
@@ -145,7 +145,7 @@ struct ChannelValueConcept
 /// \ingroup ChannelAlgorithm
 template <typename T1, typename T2>  // Models GIL Pixel
 struct channels_are_compatible
-    : public is_same
+    : is_same
         <
             typename channel_traits<T1>::value_type,
             typename channel_traits<T2>::value_type
@@ -189,7 +189,7 @@ struct ChannelConvertibleConcept
     {
         gil_function_requires<ChannelConcept<SrcChannel>>();
         gil_function_requires<MutableChannelConcept<DstChannel>>();
-        dst = channel_convert<DstChannel,SrcChannel>(src);
+        dst = channel_convert<DstChannel, SrcChannel>(src);
         ignore_unused_variable_warning(dst);
     }
     SrcChannel src;

--- a/include/boost/gil/concepts/color.hpp
+++ b/include/boost/gil/concepts/color.hpp
@@ -39,8 +39,8 @@ struct ColorSpaceConcept
 };
 
 // Models ColorSpaceConcept
-template <typename ColorSpace1, typename ColorSpace2>
-struct color_spaces_are_compatible : public is_same<ColorSpace1,ColorSpace2>
+template <typename CS1, typename CS2>
+struct color_spaces_are_compatible : is_same<CS1, CS2>
 {
 };
 

--- a/include/boost/gil/concepts/detail/type_traits.hpp
+++ b/include/boost/gil/concepts/detail/type_traits.hpp
@@ -14,7 +14,7 @@ namespace boost { namespace gil { namespace detail {
 
 template <typename T>
 struct remove_const_and_reference
-    : public ::boost::remove_const<typename ::boost::remove_reference<T>::type>
+    : ::boost::remove_const<typename ::boost::remove_reference<T>::type>
 {
 };
 

--- a/include/boost/gil/concepts/image.hpp
+++ b/include/boost/gil/concepts/image.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace gil {
 /// \brief N-dimensional container of values
 ///
 /// \code
-/// concept RandomAccessNDImageConcept<typename Img> : Regular<Img>
+/// concept RandomAccessNDImageConcept<typename Image> : Regular<Image>
 /// {
 ///     typename view_t; where MutableRandomAccessNDImageViewConcept<view_t>;
 ///     typename const_view_t = view_t::const_t;
@@ -35,48 +35,47 @@ namespace boost { namespace gil {
 ///     typename value_type   = view_t::value_type;
 ///     typename allocator_type;
 ///
-///     Img::Img(point_t dims, std::size_t alignment=1);
-///     Img::Img(point_t dims, value_type fill_value, std::size_t alignment);
+///     Image::Image(point_t dims, std::size_t alignment=1);
+///     Image::Image(point_t dims, value_type fill_value, std::size_t alignment);
 ///
-///     void Img::recreate(point_t new_dims, std::size_t alignment=1);
-///     void Img::recreate(point_t new_dims, value_type fill_value, std::size_t alignment);
+///     void Image::recreate(point_t new_dims, std::size_t alignment=1);
+///     void Image::recreate(point_t new_dims, value_type fill_value, std::size_t alignment);
 ///
-///     const point_t&        Img::dimensions() const;
-///     const const_view_t&   const_view(const Img&);
-///     const view_t&         view(Img&);
+///     const point_t&        Image::dimensions() const;
+///     const const_view_t&   const_view(const Image&);
+///     const view_t&         view(Image&);
 /// };
 /// \endcode
-template <typename Img>
+template <typename Image>
 struct RandomAccessNDImageConcept
 {
     void constraints()
     {
-        gil_function_requires<Regular<Img>>();
+        gil_function_requires<Regular<Image>>();
 
-        typedef typename Img::view_t       view_t;
-        gil_function_requires<MutableRandomAccessNDImageViewConcept<view_t> >();
+        using view_t = typename Image::view_t;
+        gil_function_requires<MutableRandomAccessNDImageViewConcept<view_t>>();
 
-        typedef typename Img::const_view_t const_view_t;
-        typedef typename Img::value_type   pixel_t;
+        using const_view_t = typename Image::const_view_t;
+        using pixel_t = typename Image::value_type;
+        using point_t = typename Image::point_t;
+        gil_function_requires<PointNDConcept<point_t>>();
 
-        typedef typename Img::point_t        point_t;
-        gil_function_requires<PointNDConcept<point_t> >();
-
-        const_view_t cv = const_view(img);
+        const_view_t cv = const_view(image);
         ignore_unused_variable_warning(cv);
-        view_t v  = view(img);
+        view_t v = view(image);
         ignore_unused_variable_warning(v);
 
         pixel_t fill_value;
-        point_t pt=img.dimensions();
-        Img im1(pt);
-        Img im2(pt,1);
-        Img im3(pt,fill_value,1);
-        img.recreate(pt);
-        img.recreate(pt,1);
-        img.recreate(pt,fill_value,1);
+        point_t pt = image.dimensions();
+        Image image1(pt);
+        Image image2(pt, 1);
+        Image image3(pt, fill_value, 1);
+        image.recreate(pt);
+        image.recreate(pt, 1);
+        image.recreate(pt, fill_value, 1);
     }
-    Img img;
+    Image image;
 };
 
 
@@ -84,70 +83,70 @@ struct RandomAccessNDImageConcept
 /// \brief 2-dimensional container of values
 ///
 /// \code
-/// concept RandomAccess2DImageConcept<RandomAccessNDImageConcept Img>
+/// concept RandomAccess2DImageConcept<RandomAccessNDImageConcept Image>
 /// {
 ///     typename x_coord_t = const_view_t::x_coord_t;
 ///     typename y_coord_t = const_view_t::y_coord_t;
 ///
-///     Img::Img(x_coord_t width, y_coord_t height, std::size_t alignment=1);
-///     Img::Img(x_coord_t width, y_coord_t height, value_type fill_value, std::size_t alignment);
+///     Image::Image(x_coord_t width, y_coord_t height, std::size_t alignment=1);
+///     Image::Image(x_coord_t width, y_coord_t height, value_type fill_value, std::size_t alignment);
 ///
-///     x_coord_t Img::width() const;
-///     y_coord_t Img::height() const;
+///     x_coord_t Image::width() const;
+///     y_coord_t Image::height() const;
 ///
-///     void Img::recreate(x_coord_t width, y_coord_t height, std::size_t alignment=1);
-///     void Img::recreate(x_coord_t width, y_coord_t height, value_type fill_value, std::size_t alignment);
+///     void Image::recreate(x_coord_t width, y_coord_t height, std::size_t alignment=1);
+///     void Image::recreate(x_coord_t width, y_coord_t height, value_type fill_value, std::size_t alignment);
 /// };
 /// \endcode
-template <typename Img>
+template <typename Image>
 struct RandomAccess2DImageConcept
 {
     void constraints()
     {
-        gil_function_requires<RandomAccessNDImageConcept<Img> >();
-        typedef typename Img::x_coord_t  x_coord_t;
-        typedef typename Img::y_coord_t  y_coord_t;
-        typedef typename Img::value_type value_t;
+        gil_function_requires<RandomAccessNDImageConcept<Image>>();
+        using x_coord_t = typename Image::x_coord_t;
+        using y_coord_t = typename Image::y_coord_t;
+        using value_t = typename Image::value_type;
 
-        gil_function_requires<MutableRandomAccess2DImageViewConcept<typename Img::view_t> >();
+        gil_function_requires<MutableRandomAccess2DImageViewConcept<typename Image::view_t>>();
 
-        x_coord_t w=img.width();
-        y_coord_t h=img.height();
+        x_coord_t w=image.width();
+        y_coord_t h=image.height();
         value_t fill_value;
-        Img im1(w,h);
-        Img im2(w,h,1);
-        Img im3(w,h,fill_value,1);
-        img.recreate(w,h);
-        img.recreate(w,h,1);
-        img.recreate(w,h,fill_value,1);
+        Image im1(w,h);
+        Image im2(w,h,1);
+        Image im3(w,h,fill_value,1);
+        image.recreate(w,h);
+        image.recreate(w,h,1);
+        image.recreate(w,h,fill_value,1);
     }
-    Img img;
+    Image image;
 };
 
 /// \ingroup ImageConcept
 /// \brief 2-dimensional image whose value type models PixelValueConcept
 ///
 /// \code
-/// concept ImageConcept<RandomAccess2DImageConcept Img>
+/// concept ImageConcept<RandomAccess2DImageConcept Image>
 /// {
 ///     where MutableImageViewConcept<view_t>;
 ///     typename coord_t  = view_t::coord_t;
 /// };
 /// \endcode
-template <typename Img>
+template <typename Image>
 struct ImageConcept
 {
     void constraints()
     {
-        gil_function_requires<RandomAccess2DImageConcept<Img> >();
-        gil_function_requires<MutableImageViewConcept<typename Img::view_t> >();
-        typedef typename Img::coord_t        coord_t;
-        BOOST_STATIC_ASSERT(num_channels<Img>::value == mpl::size<typename color_space_type<Img>::type>::value);
+        gil_function_requires<RandomAccess2DImageConcept<Image>>();
+        gil_function_requires<MutableImageViewConcept<typename Image::view_t>>();
+        using coord_t = typename Image::coord_t;
+        BOOST_STATIC_ASSERT(num_channels<Image>::value == mpl::size<typename color_space_type<Image>::type>::value);
 
-        BOOST_STATIC_ASSERT((is_same<coord_t, typename Img::x_coord_t>::value));
-        BOOST_STATIC_ASSERT((is_same<coord_t, typename Img::y_coord_t>::value));
+        BOOST_STATIC_ASSERT((is_same<coord_t, typename Image::x_coord_t>::value));
+        BOOST_STATIC_ASSERT((is_same<coord_t, typename Image::y_coord_t>::value));
     }
-    Img img;
+    Image image;
 };
 
 }} // namespace boost::gil

--- a/include/boost/gil/concepts/image_view.hpp
+++ b/include/boost/gil/concepts/image_view.hpp
@@ -98,25 +98,25 @@ struct RandomAccessNDImageViewConcept
     {
         gil_function_requires<Regular<View>>();
 
-        typedef typename View::value_type       value_type;
-        typedef typename View::reference        reference;       // result of dereferencing
-        typedef typename View::pointer          pointer;
-        typedef typename View::difference_type  difference_type; // result of operator-(1d_iterator,1d_iterator)
-        typedef typename View::const_t          const_t;         // same as this type, but over const values
-        typedef typename View::point_t          point_t;         // N-dimensional point
-        typedef typename View::locator          locator;         // N-dimensional locator
-        typedef typename View::iterator         iterator;
-        typedef typename View::const_iterator   const_iterator;
-        typedef typename View::reverse_iterator reverse_iterator;
-        typedef typename View::size_type        size_type;
+        using value_type = typename View::value_type;
+        using reference = typename View::reference; // result of dereferencing
+        using pointer = typename View::pointer;
+        using difference_type = typename View::difference_type; // result of operator-(1d_iterator,1d_iterator)
+        using const_t = typename View::const_t; // same as this type, but over const values
+        using point_t = typename View::point_t; // N-dimensional point
+        using locator = typename View::locator; // N-dimensional locator
+        using iterator = typename View::iterator;
+        using const_iterator = typename View::const_iterator;
+        using reverse_iterator = typename View::reverse_iterator;
+        using size_type = typename View::size_type;
         static const std::size_t N=View::num_dimensions;
 
         gil_function_requires<RandomAccessNDLocatorConcept<locator>>();
         gil_function_requires<boost_concepts::RandomAccessTraversalConcept<iterator>>();
         gil_function_requires<boost_concepts::RandomAccessTraversalConcept<reverse_iterator>>();
 
-        typedef typename View::template axis<0>::iterator   first_it_type;
-        typedef typename View::template axis<N-1>::iterator last_it_type;
+        using first_it_type = typename View::template axis<0>::iterator;
+        using last_it_type = typename View::template axis<N-1>::iterator;
         gil_function_requires<boost_concepts::RandomAccessTraversalConcept<first_it_type>>();
         gil_function_requires<boost_concepts::RandomAccessTraversalConcept<last_it_type>>();
 
@@ -126,8 +126,16 @@ struct RandomAccessNDImageViewConcept
         // point_t must be an N-dimensional point, each dimension of which must have the same type as difference_type of the corresponding iterator
         gil_function_requires<PointNDConcept<point_t>>();
         BOOST_STATIC_ASSERT(point_t::num_dimensions==N);
-        BOOST_STATIC_ASSERT((is_same<typename std::iterator_traits<first_it_type>::difference_type, typename point_t::template axis<0>::coord_t>::value));
-        BOOST_STATIC_ASSERT((is_same<typename std::iterator_traits<last_it_type>::difference_type, typename point_t::template axis<N-1>::coord_t>::value));
+        BOOST_STATIC_ASSERT((is_same
+            <
+                typename std::iterator_traits<first_it_type>::difference_type,
+                typename point_t::template axis<0>::coord_t
+            >::value));
+        BOOST_STATIC_ASSERT((is_same
+            <
+                typename std::iterator_traits<last_it_type>::difference_type,
+                typename point_t::template axis<N-1>::coord_t
+            >::value));
 
         point_t p;
         locator lc;
@@ -148,8 +156,8 @@ struct RandomAccessNDImageViewConcept
         rit = view.rbegin();
         rit = view.rend();
 
-        reference r1 = view[d]; ignore_unused_variable_warning(r1);    // 1D access
-        reference r2 = view(p); ignore_unused_variable_warning(r2);    // 2D access
+        reference r1 = view[d]; ignore_unused_variable_warning(r1); // 1D access
+        reference r2 = view(p); ignore_unused_variable_warning(r2); // 2D access
 
         // get 1-D iterator of any dimension at a given pixel location
         first_it_type fi = view.template axis_iterator<0>(p);
@@ -157,8 +165,8 @@ struct RandomAccessNDImageViewConcept
         last_it_type li = view.template axis_iterator<N-1>(p);
         ignore_unused_variable_warning(li);
 
-        typedef PixelDereferenceAdaptorArchetype<typename View::value_type> deref_t;
-        typedef typename View::template add_deref<deref_t>::type dtype;
+        using deref_t = PixelDereferenceAdaptorArchetype<typename View::value_type>;
+        using dtype = typename View::template add_deref<deref_t>::type;
     }
     View view;
 };
@@ -212,15 +220,14 @@ struct RandomAccess2DImageViewConcept
         // TODO: This executes the requirements for RandomAccessNDLocatorConcept again. Fix it to improve compile time
         gil_function_requires<RandomAccess2DLocatorConcept<typename View::locator>>();
 
-        typedef typename dynamic_x_step_type<View>::type  dynamic_x_step_t;
-        typedef typename dynamic_y_step_type<View>::type  dynamic_y_step_t;
-        typedef typename transposed_type<View>::type      transposed_t;
-
-        typedef typename View::x_iterator x_iterator;
-        typedef typename View::y_iterator y_iterator;
-        typedef typename View::x_coord_t  x_coord_t;
-        typedef typename View::y_coord_t  y_coord_t;
-        typedef typename View::xy_locator xy_locator;
+        using dynamic_x_step_t = typename dynamic_x_step_type<View>::type;
+        using dynamic_y_step_t = typename dynamic_y_step_type<View>::type;
+        using transposed_t = typename transposed_type<View>::type;
+        using x_iterator = typename View::x_iterator;
+        using y_iterator = typename View::y_iterator;
+        using x_coord_t = typename View::x_coord_t;
+        using y_coord_t = typename View::y_coord_t;
+        using xy_locator = typename View::xy_locator;
 
         x_coord_t xd = 0; ignore_unused_variable_warning(xd);
         y_coord_t yd = 0; ignore_unused_variable_warning(yd);
@@ -228,12 +235,12 @@ struct RandomAccess2DImageViewConcept
         y_iterator yit;
         typename View::point_t d;
 
-        View(xd, yd, xy_locator());       // constructible with width, height, 2d_locator
+        View(xd, yd, xy_locator()); // constructible with width, height, 2d_locator
 
         xy_locator lc = view.xy_at(xd, yd);
         lc = view.xy_at(d);
 
-        typename View::reference r=view(xd, yd);
+        typename View::reference r = view(xd, yd);
         ignore_unused_variable_warning(r);
         xd = view.width();
         yd = view.height();
@@ -368,7 +375,7 @@ struct ImageViewConcept
 
         BOOST_STATIC_ASSERT((is_same<typename View::x_coord_t, typename View::y_coord_t>::value));
 
-        typedef typename View::coord_t           coord_t;      // 1D difference type (same for all dimensions)
+        using coord_t = typename View::coord_t; // 1D difference type (same for all dimensions)
         std::size_t num_chan = view.num_channels(); ignore_unused_variable_warning(num_chan);
     }
     View view;
@@ -385,16 +392,32 @@ struct RandomAccessNDImageViewIsMutableConcept
         gil_function_requires<detail::RandomAccessNDLocatorIsMutableConcept<typename View::locator>>();
 
         gil_function_requires<detail::RandomAccessIteratorIsMutableConcept<typename View::iterator>>();
-        gil_function_requires<detail::RandomAccessIteratorIsMutableConcept<typename View::reverse_iterator>>();
-        gil_function_requires<detail::RandomAccessIteratorIsMutableConcept<typename View::template axis<0>::iterator>>();
-        gil_function_requires<detail::RandomAccessIteratorIsMutableConcept<typename View::template axis<View::num_dimensions-1>::iterator>>();
 
-        typename View::difference_type diff; initialize_it(diff); ignore_unused_variable_warning(diff);
+        gil_function_requires<detail::RandomAccessIteratorIsMutableConcept
+            <
+                typename View::reverse_iterator
+            >>();
+
+        gil_function_requires<detail::RandomAccessIteratorIsMutableConcept
+            <
+                typename View::template axis<0>::iterator
+            >>();
+
+        gil_function_requires<detail::RandomAccessIteratorIsMutableConcept
+            <
+                typename View::template axis<View::num_dimensions - 1>::iterator
+            >>();
+
+        typename View::difference_type diff;
+        initialize_it(diff);
+        ignore_unused_variable_warning(diff);
+
         typename View::point_t pt;
-        typename View::value_type v; initialize_it(v);
+        typename View::value_type v;
+        initialize_it(v);
 
-        view[diff]=v;
-        view(pt)=v;
+        view[diff] = v;
+        view(pt) = v;
     }
     View view;
 };
@@ -406,10 +429,10 @@ struct RandomAccess2DImageViewIsMutableConcept
     void constraints()
     {
         gil_function_requires<detail::RandomAccessNDImageViewIsMutableConcept<View>>();
-        typename View::x_coord_t xd=0; ignore_unused_variable_warning(xd);
-        typename View::y_coord_t yd=0; ignore_unused_variable_warning(yd);
+        typename View::x_coord_t xd = 0; ignore_unused_variable_warning(xd);
+        typename View::y_coord_t yd = 0; ignore_unused_variable_warning(yd);
         typename View::value_type v; initialize_it(v);
-        view(xd,yd)=v;
+        view(xd, yd) = v;
     }
     View view;
 };
@@ -489,12 +512,14 @@ struct MutableImageViewConcept
 ///
 template <typename V1, typename V2>
 struct views_are_compatible
-    : public pixels_are_compatible<typename V1::value_type, typename V2::value_type>
+    : pixels_are_compatible<typename V1::value_type, typename V2::value_type>
 {
 };
 
 /// \ingroup ImageViewConcept
-/// \brief Views are compatible if they have the same color spaces and compatible channel values. Constness and layout are not important for compatibility
+/// \brief Views are compatible if they have the same color spaces and compatible channel values.
+///
+/// Constness and layout are not important for compatibility.
 ///
 /// \code
 /// concept ViewsCompatibleConcept<ImageViewConcept V1, ImageViewConcept V2>
@@ -507,7 +532,7 @@ struct ViewsCompatibleConcept
 {
     void constraints()
     {
-        BOOST_STATIC_ASSERT((views_are_compatible<V1,V2>::value));
+        BOOST_STATIC_ASSERT((views_are_compatible<V1, V2>::value));
     }
 };
 

--- a/include/boost/gil/concepts/pixel.hpp
+++ b/include/boost/gil/concepts/pixel.hpp
@@ -67,14 +67,20 @@ struct PixelConcept
         static const bool is_mutable = P::is_mutable;
         ignore_unused_variable_warning(is_mutable);
 
-        typedef typename P::value_type value_type;
+        using value_type = typename P::value_type;
 //      gil_function_requires<PixelValueConcept<value_type>>();
 
-        typedef typename P::reference reference;
-        gil_function_requires<PixelConcept<typename detail::remove_const_and_reference<reference>::type>>();
+        using reference = typename P::reference;
+        gil_function_requires<PixelConcept
+            <
+                typename detail::remove_const_and_reference<reference>::type
+            >>();
 
-        typedef typename P::const_reference const_reference;
-        gil_function_requires<PixelConcept<typename detail::remove_const_and_reference<const_reference>::type>>();
+        using const_reference = typename P::const_reference;
+        gil_function_requires<PixelConcept
+            <
+                typename detail::remove_const_and_reference<const_reference>::type
+            >>();
     }
 };
 

--- a/include/boost/gil/concepts/pixel_based.hpp
+++ b/include/boost/gil/concepts/pixel_based.hpp
@@ -24,7 +24,11 @@
 namespace boost { namespace gil {
 
 /// \ingroup PixelBasedConcept
-/// \brief Concept for all pixel-based GIL constructs, such as pixels, iterators, locators, views and images whose value type is a pixel.
+/// \brief Concept for all pixel-based GIL constructs.
+///
+/// Pixel-based constructs include pixels, iterators, locators, views and
+/// images whose value type is a pixel.
+///
 /// \code
 /// concept PixelBasedConcept<typename T>
 /// {
@@ -44,9 +48,10 @@ struct PixelBasedConcept
 {
     void constraints()
     {
-        typedef typename color_space_type<P>::type color_space_t;
+        using color_space_t = typename color_space_type<P>::type;
         gil_function_requires<ColorSpaceConcept<color_space_t>>();
-        typedef typename channel_mapping_type<P>::type channel_mapping_t;
+
+        using channel_mapping_t = typename channel_mapping_type<P>::type ;
         gil_function_requires<ChannelMappingConcept<channel_mapping_t>>();
 
         static const bool planar = is_planar<P>::type::value;
@@ -74,7 +79,8 @@ struct HomogeneousPixelBasedConcept
     void constraints()
     {
         gil_function_requires<PixelBasedConcept<P>>();
-        typedef typename channel_type<P>::type channel_t;
+
+        using channel_t = typename channel_type<P>::type;
         gil_function_requires<ChannelConcept<channel_t>>();
     }
 };

--- a/include/boost/gil/concepts/pixel_dereference.hpp
+++ b/include/boost/gil/concepts/pixel_dereference.hpp
@@ -61,16 +61,21 @@ struct PixelDereferenceAdaptorConcept
         gil_function_requires<boost::CopyConstructibleConcept<D>>();
         gil_function_requires<boost::AssignableConcept<D>>();
 
-        gil_function_requires<PixelConcept<typename detail::remove_const_and_reference<typename D::result_type>::type>>();
+        gil_function_requires<PixelConcept
+            <
+                typename detail::remove_const_and_reference<typename D::result_type>::type
+            >>();
 
-        typedef typename D::const_t const_t;
+        using const_t = typename D::const_t;
         gil_function_requires<PixelDereferenceAdaptorConcept<const_t>>();
-        typedef typename D::value_type value_type;
-        gil_function_requires<PixelValueConcept<value_type>>();
-        typedef typename D::reference reference;                // == PixelConcept (if you remove const and reference)
-        typedef typename D::const_reference const_reference;    // == PixelConcept (if you remove const and reference)
 
-        const bool is_mutable = D::is_mutable;
+        using value_type = typename D::value_type;
+        gil_function_requires<PixelValueConcept<value_type>>();
+
+        using reference = typename D::reference; // == PixelConcept (if you remove const and reference)
+        using const_reference = typename D::const_reference; // == PixelConcept (if you remove const and reference)
+
+        bool const is_mutable = D::is_mutable;
         ignore_unused_variable_warning(is_mutable);
     }
     D d;
@@ -79,12 +84,13 @@ struct PixelDereferenceAdaptorConcept
 template <typename P>
 struct PixelDereferenceAdaptorArchetype
 {
-    typedef P argument_type;
-    typedef P result_type;
-    typedef PixelDereferenceAdaptorArchetype const_t;
-    typedef typename remove_reference<P>::type value_type;
-    typedef typename add_reference<P>::type reference;
-    typedef reference const_reference;
+    using argument_type = P;
+    using result_type = P;
+    using const_t = PixelDereferenceAdaptorArchetype;
+    using value_type = typename remove_reference<P>::type;
+    using reference = typename add_reference<P>::type;
+    using const_reference = reference;
+
     static const bool is_mutable = false;
     P operator()(P) const { throw; }
 };

--- a/include/boost/gil/concepts/pixel_iterator.hpp
+++ b/include/boost/gil/concepts/pixel_iterator.hpp
@@ -69,7 +69,8 @@ struct RandomAccessIteratorIsMutableConcept
     void constraints()
     {
         gil_function_requires<BidirectionalIteratorIsMutableConcept<TT>>();
-        typename std::iterator_traits<TT>::difference_type n=0;
+
+        typename std::iterator_traits<TT>::difference_type n = 0;
         ignore_unused_variable_warning(n);
         i[n] = *i; // require element access and assignment
     }
@@ -103,8 +104,12 @@ struct PixelIteratorIsMutableConcept
     void constraints()
     {
         gil_function_requires<detail::RandomAccessIteratorIsMutableConcept<Iterator>>();
-        typedef typename remove_reference<typename std::iterator_traits<Iterator>::reference>::type ref;
-        typedef typename element_type<ref>::type channel_t;
+
+        using ref_t = typename remove_reference
+            <
+                typename std::iterator_traits<Iterator>::reference
+            >::type;
+        using channel_t = typename element_type<ref_t>::type;
         gil_function_requires<detail::ChannelIsMutableConcept<channel_t>>();
     }
 };
@@ -126,7 +131,7 @@ struct HasDynamicXStepTypeConcept
 {
     void constraints()
     {
-        typedef typename dynamic_x_step_type<T>::type type;
+        using type = typename dynamic_x_step_type<T>::type;
     }
 };
 
@@ -144,7 +149,7 @@ struct HasDynamicYStepTypeConcept
 {
     void constraints()
     {
-        typedef typename dynamic_y_step_type<T>::type type;
+        using type = typename dynamic_y_step_type<T>::type;
     }
 };
 
@@ -162,7 +167,7 @@ struct HasTransposedTypeConcept
 {
     void constraints()
     {
-        typedef typename transposed_type<T>::type type;
+        using type = typename transposed_type<T>::type;
     }
 };
 
@@ -197,12 +202,12 @@ struct PixelIteratorConcept
         gil_function_requires<boost_concepts::RandomAccessTraversalConcept<Iterator>>();
         gil_function_requires<PixelBasedConcept<Iterator>>();
 
-        typedef typename std::iterator_traits<Iterator>::value_type value_type;
+        using value_type = typename std::iterator_traits<Iterator>::value_type;
         gil_function_requires<PixelValueConcept<value_type>>();
 
-        typedef typename const_iterator_type<Iterator>::type const_t;
-        static const bool is_mut = iterator_is_mutable<Iterator>::type::value;
-        ignore_unused_variable_warning(is_mut);
+        using const_t = typename const_iterator_type<Iterator>::type;
+        static bool const is_mutable = iterator_is_mutable<Iterator>::type::value;
+        ignore_unused_variable_warning(is_mutable);
 
         // immutable iterator must be constructible from (possibly mutable) iterator
         const_t const_it(it);
@@ -215,7 +220,7 @@ struct PixelIteratorConcept
 
     void check_base(mpl::true_)
     {
-        typedef typename iterator_adaptor_get_base<Iterator>::type base_t;
+        using base_t = typename iterator_adaptor_get_base<Iterator>::type;
         gil_function_requires<PixelIteratorConcept<base_t>>();
     }
 
@@ -343,13 +348,13 @@ struct IteratorAdaptorConcept
     {
         gil_function_requires<boost_concepts::ForwardTraversalConcept<Iterator>>();
 
-        typedef typename iterator_adaptor_get_base<Iterator>::type base_t;
+        using base_t = typename iterator_adaptor_get_base<Iterator>::type;
         gil_function_requires<boost_concepts::ForwardTraversalConcept<base_t>>();
 
         BOOST_STATIC_ASSERT(is_iterator_adaptor<Iterator>::value);
-        typedef typename iterator_adaptor_rebind<Iterator, void*>::type rebind_t;
+        using rebind_t = typename iterator_adaptor_rebind<Iterator, void*>::type;
 
-        base_t base=it.base();
+        base_t base = it.base();
         ignore_unused_variable_warning(base);
     }
     Iterator it;

--- a/include/boost/gil/concepts/pixel_locator.hpp
+++ b/include/boost/gil/concepts/pixel_locator.hpp
@@ -98,43 +98,54 @@ struct RandomAccessNDLocatorConcept
     {
         gil_function_requires<Regular<Loc>>();
 
-        typedef typename Loc::value_type        value_type;
-        typedef typename Loc::reference         reference;          // result of dereferencing
-        typedef typename Loc::difference_type   difference_type;    // result of operator-(pixel_locator, pixel_locator)
-        typedef typename Loc::cached_location_t cached_location_t;  // type used to store relative location (to allow for more efficient repeated access)
-        typedef typename Loc::const_t           const_t;         // same as this type, but over const values
-        typedef typename Loc::point_t           point_t;         // same as difference_type
-        static const std::size_t N=Loc::num_dimensions; ignore_unused_variable_warning(N);
+        using value_type = typename Loc::value_type;
+        using reference = typename Loc::reference; // result of dereferencing
+        using difference_type = typename Loc::difference_type; // result of operator-(pixel_locator, pixel_locator)
+        using cached_location_t = typename Loc::cached_location_t; // type used to store relative location (to allow for more efficient repeated access)
+        using const_t = typename Loc::const_t; // same as this type, but over const values
+        using point_t = typename Loc::point_t; // same as difference_type
 
-        typedef typename Loc::template axis<0>::iterator    first_it_type;
-        typedef typename Loc::template axis<N-1>::iterator  last_it_type;
+        static std::size_t const N = Loc::num_dimensions; ignore_unused_variable_warning(N);
+
+        using first_it_type = typename Loc::template axis<0>::iterator;
+        using last_it_type = typename Loc::template axis<N-1>::iterator;
         gil_function_requires<boost_concepts::RandomAccessTraversalConcept<first_it_type>>();
         gil_function_requires<boost_concepts::RandomAccessTraversalConcept<last_it_type>>();
 
-        // point_t must be an N-dimensional point, each dimension of which must have the same type as difference_type of the corresponding iterator
+        // point_t must be an N-dimensional point, each dimension of which must
+        // have the same type as difference_type of the corresponding iterator
         gil_function_requires<PointNDConcept<point_t>>();
         BOOST_STATIC_ASSERT(point_t::num_dimensions==N);
-        BOOST_STATIC_ASSERT((is_same<typename std::iterator_traits<first_it_type>::difference_type, typename point_t::template axis<0>::coord_t>::value));
-        BOOST_STATIC_ASSERT((is_same<typename std::iterator_traits<last_it_type>::difference_type, typename point_t::template axis<N-1>::coord_t>::value));
+        BOOST_STATIC_ASSERT((is_same
+            <
+                typename std::iterator_traits<first_it_type>::difference_type,
+                typename point_t::template axis<0>::coord_t
+            >::value));
+        BOOST_STATIC_ASSERT((is_same
+            <
+                typename std::iterator_traits<last_it_type>::difference_type,
+                typename point_t::template axis<N-1>::coord_t
+            >::value));
 
         difference_type d;
-        loc+=d;
-        loc-=d;
-        loc=loc+d;
-        loc=loc-d;
-        reference r1=loc[d];  ignore_unused_variable_warning(r1);
-        reference r2=*loc;  ignore_unused_variable_warning(r2);
-        cached_location_t cl=loc.cache_location(d);  ignore_unused_variable_warning(cl);
-        reference r3=loc[d];  ignore_unused_variable_warning(r3);
+        loc += d;
+        loc -= d;
+        loc = loc + d;
+        loc = loc - d;
+        reference r1 = loc[d];  ignore_unused_variable_warning(r1);
+        reference r2 = *loc;  ignore_unused_variable_warning(r2);
+        cached_location_t cl = loc.cache_location(d);  ignore_unused_variable_warning(cl);
+        reference r3 = loc[d];  ignore_unused_variable_warning(r3);
 
-        first_it_type fi=loc.template axis_iterator<0>();
-        fi=loc.template axis_iterator<0>(d);
-        last_it_type li=loc.template axis_iterator<N-1>();
-        li=loc.template axis_iterator<N-1>(d);
+        first_it_type fi = loc.template axis_iterator<0>();
+        fi = loc.template axis_iterator<0>(d);
+        last_it_type li = loc.template axis_iterator<N-1>();
+        li = loc.template axis_iterator<N-1>(d);
 
-        typedef PixelDereferenceAdaptorArchetype<typename Loc::value_type> deref_t;
-        typedef typename Loc::template add_deref<deref_t>::type dtype;
-        //gil_function_requires<RandomAccessNDLocatorConcept<dtype>>();    // infinite recursion
+        using deref_t = PixelDereferenceAdaptorArchetype<typename Loc::value_type>;
+        using dtype = typename Loc::template add_deref<deref_t>::type;
+        // TODO: infinite recursion - FIXME?
+        //gil_function_requires<RandomAccessNDLocatorConcept<dtype>>();
     }
     Loc loc;
 };
@@ -187,20 +198,20 @@ struct RandomAccess2DLocatorConcept
         gil_function_requires<RandomAccessNDLocatorConcept<Loc>>();
         BOOST_STATIC_ASSERT(Loc::num_dimensions==2);
 
-        typedef typename dynamic_x_step_type<Loc>::type dynamic_x_step_t;
-        typedef typename dynamic_y_step_type<Loc>::type dynamic_y_step_t;
-        typedef typename transposed_type<Loc>::type     transposed_t;
+        using dynamic_x_step_t = typename dynamic_x_step_type<Loc>::type;
+        using dynamic_y_step_t = typename dynamic_y_step_type<Loc>::type;
+        using transposed_t = typename transposed_type<Loc>::type;
 
-        typedef typename Loc::cached_location_t   cached_location_t;
+        using cached_location_t = typename Loc::cached_location_t;
         gil_function_requires<Point2DConcept<typename Loc::point_t>>();
 
-        typedef typename Loc::x_iterator x_iterator;
-        typedef typename Loc::y_iterator y_iterator;
-        typedef typename Loc::x_coord_t  x_coord_t;
-        typedef typename Loc::y_coord_t  y_coord_t;
+        using x_iterator = typename Loc::x_iterator;
+        using y_iterator = typename Loc::y_iterator;
+        using x_coord_t = typename Loc::x_coord_t;
+        using y_coord_t = typename Loc::y_coord_t;
 
-        x_coord_t xd=0; ignore_unused_variable_warning(xd);
-        y_coord_t yd=0; ignore_unused_variable_warning(yd);
+        x_coord_t xd = 0; ignore_unused_variable_warning(xd);
+        y_coord_t yd = 0; ignore_unused_variable_warning(yd);
 
         typename Loc::difference_type d;
         typename Loc::reference r=loc(xd,yd);  ignore_unused_variable_warning(r);
@@ -208,24 +219,30 @@ struct RandomAccess2DLocatorConcept
         dynamic_x_step_t loc2(dynamic_x_step_t(), yd);
         dynamic_x_step_t loc3(dynamic_x_step_t(), xd, yd);
 
-        typedef typename dynamic_y_step_type<typename dynamic_x_step_type<transposed_t>::type>::type dynamic_xy_step_transposed_t;
+        using dynamic_xy_step_transposed_t = typename dynamic_y_step_type
+            <
+                typename dynamic_x_step_type<transposed_t>::type
+            >::type;
         dynamic_xy_step_transposed_t loc4(loc, xd,yd,true);
 
-        bool is_contiguous=loc.is_1d_traversable(xd); ignore_unused_variable_warning(is_contiguous);
+        bool is_contiguous = loc.is_1d_traversable(xd);
+        ignore_unused_variable_warning(is_contiguous);
+
         loc.y_distance_to(loc, xd);
 
-        loc=loc.xy_at(d);
-        loc=loc.xy_at(xd,yd);
+        loc = loc.xy_at(d);
+        loc = loc.xy_at(xd, yd);
 
-        x_iterator xit=loc.x_at(d);
-        xit=loc.x_at(xd,yd);
-        xit=loc.x();
+        x_iterator xit = loc.x_at(d);
+        xit = loc.x_at(xd, yd);
+        xit = loc.x();
 
-        y_iterator yit=loc.y_at(d);
-        yit=loc.y_at(xd,yd);
-        yit=loc.y();
+        y_iterator yit = loc.y_at(d);
+        yit = loc.y_at(xd, yd);
+        yit = loc.y();
 
-        cached_location_t cl=loc.cache_location(xd,yd);  ignore_unused_variable_warning(cl);
+        cached_location_t cl = loc.cache_location(xd, yd);
+        ignore_unused_variable_warning(cl);
     }
     Loc loc;
 };
@@ -251,7 +268,7 @@ struct PixelLocatorConcept
         gil_function_requires<RandomAccess2DLocatorConcept<Loc>>();
         gil_function_requires<PixelIteratorConcept<typename Loc::x_iterator>>();
         gil_function_requires<PixelIteratorConcept<typename Loc::y_iterator>>();
-        typedef typename Loc::coord_t                      coord_t;
+        using coord_t = typename Loc::coord_t;
         BOOST_STATIC_ASSERT((is_same<typename Loc::x_coord_t, typename Loc::y_coord_t>::value));
     }
     Loc loc;
@@ -265,15 +282,21 @@ struct RandomAccessNDLocatorIsMutableConcept
 {
     void constraints()
     {
-        gil_function_requires<detail::RandomAccessIteratorIsMutableConcept<typename Loc::template axis<0>::iterator>>();
-        gil_function_requires<detail::RandomAccessIteratorIsMutableConcept<typename Loc::template axis<Loc::num_dimensions-1>::iterator>>();
+        gil_function_requires<detail::RandomAccessIteratorIsMutableConcept
+            <
+                typename Loc::template axis<0>::iterator
+            >>();
+        gil_function_requires<detail::RandomAccessIteratorIsMutableConcept
+            <
+                typename Loc::template axis<Loc::num_dimensions-1>::iterator
+            >>();
 
         typename Loc::difference_type d; initialize_it(d);
-        typename Loc::value_type v;initialize_it(v);
-        typename Loc::cached_location_t cl=loc.cache_location(d);
-        *loc=v;
-        loc[d]=v;
-        loc[cl]=v;
+        typename Loc::value_type v; initialize_it(v);
+        typename Loc::cached_location_t cl = loc.cache_location(d);
+        *loc = v;
+        loc[d] = v;
+        loc[cl] = v;
     }
     Loc loc;
 };
@@ -285,10 +308,10 @@ struct RandomAccess2DLocatorIsMutableConcept
     void constraints()
     {
         gil_function_requires<detail::RandomAccessNDLocatorIsMutableConcept<Loc>>();
-        typename Loc::x_coord_t xd=0; ignore_unused_variable_warning(xd);
-        typename Loc::y_coord_t yd=0; ignore_unused_variable_warning(yd);
+        typename Loc::x_coord_t xd = 0; ignore_unused_variable_warning(xd);
+        typename Loc::y_coord_t yd = 0; ignore_unused_variable_warning(yd);
         typename Loc::value_type v; initialize_it(v);
-        loc(xd,yd)=v;
+        loc(xd, yd) = v;
     }
     Loc loc;
 };

--- a/include/boost/gil/concepts/point.hpp
+++ b/include/boost/gil/concepts/point.hpp
@@ -58,15 +58,15 @@ struct PointNDConcept
     {
         gil_function_requires<Regular<P>>();
 
-        typedef typename P::value_type value_type;
+        using value_type = typename P::value_type;
         static const std::size_t N = P::num_dimensions;
         ignore_unused_variable_warning(N);
-        typedef typename P::template axis<0>::coord_t FT;
-        typedef typename P::template axis<N-1>::coord_t LT;
+        using FT = typename P::template axis<0>::coord_t;
+        using LT = typename P::template axis<N - 1>::coord_t;
         FT ft = gil::axis_value<0>(point);
         axis_value<0>(point) = ft;
-        LT lt = axis_value<N-1>(point);
-        axis_value<N-1>(point) = lt;
+        LT lt = axis_value<N - 1>(point);
+        axis_value<N - 1>(point) = lt;
 
         //value_type v=point[0];
         //ignore_unused_variable_warning(v);


### PR DESCRIPTION
Replace `typedef` with using declaration.
Replace complex return type declared for functions with trailing return type and `auto`.
Format complex metaprogramming constructs in clear and readable way.
Remove superfluous `public` access specifier from `struct` inheritance.
Rename ambiguous type aliases.
Make template parameters
- upper-case (if initials e.g. CS)
- camel-case if multi-word (e.g. ColorSpace).

### References

Part of ongoing extensive modernisation, reformatting and clean-up prior being applied, also as preparation for overhaul removing/replacing with C++11 Boost.MPL, Boost.TypeTraits and other tightly coupled Boost libraries as dependencies.

### Tasklist

- [ ] Review
- [ ] Adjust for comments
- [ ] All CI builds and checks have passed
