### PR TITLE
Add missing #include-s to ensure self-contained headers

### DIFF
--- a/include/boost/gil/extension/numeric/algorithm.hpp
+++ b/include/boost/gil/extension/numeric/algorithm.hpp
@@ -8,6 +8,8 @@
 #ifndef BOOST_GIL_EXTENSION_NUMERIC_ALGORITHM_HPP
 #define BOOST_GIL_EXTENSION_NUMERIC_ALGORITHM_HPP
 
+#include <boost/gil/extension/numeric/pixel_numeric_operations.hpp>
+
 #include <boost/gil/metafunctions.hpp>
 #include <boost/gil/pixel_iterator.hpp>
 

--- a/include/boost/gil/extension/numeric/channel_numeric_operations.hpp
+++ b/include/boost/gil/extension/numeric/channel_numeric_operations.hpp
@@ -8,6 +8,8 @@
 #ifndef BOOST_GIL_EXTENSION_NUMERIC_CHANNEL_NUMERIC_OPERATIONS_HPP
 #define BOOST_GIL_EXTENSION_NUMERIC_CHANNEL_NUMERIC_OPERATIONS_HPP
 
+#include <boost/gil/channel.hpp>
+
 #include <functional>
 
 namespace boost { namespace gil {

--- a/include/boost/gil/extension/toolbox/color_spaces/hsl.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/hsl.hpp
@@ -8,6 +8,7 @@
 #ifndef BOOST_GIL_EXTENSION_TOOLBOX_COLOR_SPACES_HSL_HPP
 #define BOOST_GIL_EXTENSION_TOOLBOX_COLOR_SPACES_HSL_HPP
 
+#include <boost/gil/color_convert.hpp>
 #include <boost/gil/typedefs.hpp>
 
 namespace boost{ namespace gil {

--- a/include/boost/gil/extension/toolbox/color_spaces/hsv.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/hsv.hpp
@@ -10,6 +10,7 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 
+#include <boost/gil/color_convert.hpp>
 #include <boost/gil/typedefs.hpp>
 
 #include <boost/mpl/vector.hpp>

--- a/include/boost/gil/extension/toolbox/color_spaces/lab.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/lab.hpp
@@ -10,6 +10,7 @@
 
 #include <boost/gil/extension/toolbox/color_spaces/xyz.hpp>
 
+#include <boost/gil/color_convert.hpp>
 #include <boost/gil.hpp> // FIXME: Include what you use, not everything, even in extensions!
 
 #include <boost/mpl/vector.hpp>

--- a/include/boost/gil/extension/toolbox/color_spaces/xyz.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/xyz.hpp
@@ -8,6 +8,7 @@
 #ifndef BOOST_GIL_EXTENSION_TOOLBOX_COLOR_SPACES_XYZ_HPP
 #define BOOST_GIL_EXTENSION_TOOLBOX_COLOR_SPACES_XYZ_HPP
 
+#include <boost/gil/color_convert.hpp>
 #include <boost/gil/typedefs.hpp>
 
 #include <boost/mpl/vector.hpp>

--- a/include/boost/gil/extension/toolbox/color_spaces/ycbcr.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/ycbcr.hpp
@@ -10,6 +10,7 @@
 
 #include <boost/gil/extension/toolbox/metafunctions/get_num_bits.hpp>
 
+#include <boost/gil/color_convert.hpp>
 #include <boost/gil.hpp> // FIXME: Include what you use!
 
 #include <boost/mpl/identity.hpp>

--- a/include/boost/gil/extension/toolbox/image_types/indexed_image.hpp
+++ b/include/boost/gil/extension/toolbox/image_types/indexed_image.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/gil/image.hpp>
 #include <boost/gil/point.hpp>
+#include <boost/gil/virtual_locator.hpp>
 
 #include <boost/mpl/if.hpp>
 #include <boost/type_traits/is_integral.hpp>


### PR DESCRIPTION
Follows up the improvements in the self-contained headers test in https://github.com/boostorg/gil/commit/1075967712afd85b52dae49fb996a664632a98c5, that revealed issues in the extensions.

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed
