### PR TITLE
Apply clang-tidy modernize-use-nullptr

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,12 @@
+---
+Checks:                 '-*,modernize-use-nullptr*'
+WarningsAsErrors:       ''
+HeaderFilterRegex:      'boost\/gil\/.*'
+AnalyzeTemporaryDtors:  false
+FormatStyle:            mozilla
+User:                   gil-developers
+CheckOptions:
+  - key:                modernize-use-nullptr.NullMacros
+    value:              'NULL'
+...
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -390,6 +390,37 @@ Maintainer: [@stefanseefeld](https://github.com/stefanseefeld)
 
 *TODO:* _Describe_
 
+### Running clang-tidy
+
+[clang-tidy](http://clang.llvm.org/extra/clang-tidy/) can be run on demand to
+diagnose or diagnose and fix or refactor source code issues.
+Since the CMake configuration is provided, it is easier to run it
+using compile command database which can be easily generated.
+
+Currently, integration using the CMake 3.6+ target
+property `CXX_CLANG_TIDY` is not provided.
+
+First, generate `compile_commands.json` database for `clang-tidy`:
+
+```shell
+cmake -S . -B _build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+```
+
+Next, verify [what checks are aleady configured](http://clang.llvm.org/extra/clang-tidy/checks/list.html)
+in `.clang-tidy` file provided:
+
+```shell
+clang-tidy -dump-config
+clang-tidy -p _build -list-checks
+```
+
+Finally, run parallel `clang-tidy` runner script to apply any desired
+checks (and fixes) across the library source code:
+
+```shell
+run-clang-tidy.py -p=_build -header-filter='boost\/gil\/.*' -checks='-*,modernize-use-using' [-fix]
+```
+
 ## Guidelines
 
 Boost.GIL is a more than a decade old mature library maintained by several

--- a/include/boost/gil/algorithm.hpp
+++ b/include/boost/gil/algorithm.hpp
@@ -431,7 +431,7 @@ void destruct_range_impl( It
                         , typename enable_if< mpl::or_< mpl::not_< is_pointer< It > >
                                                       , boost::has_trivial_destructor< typename std::iterator_traits< It >::value_type >
                                                       >
-                                            >::type* /* ptr */ = 0)
+                                            >::type* /* ptr */ = nullptr)
 {}
 
 template <typename It> BOOST_FORCEINLINE
@@ -606,7 +606,7 @@ void default_construct_pixels_impl( const View& img_view
                                   , boost::enable_if< is_same< mpl::bool_< B >
                                                              , mpl::false_
                                                              >
-                                                    >* /* ptr */ = 0
+                                                    >* /* ptr */ = nullptr
                                   )
 {
     if( img_view.is_1d_traversable() )

--- a/include/boost/gil/bit_aligned_pixel_reference.hpp
+++ b/include/boost/gil/bit_aligned_pixel_reference.hpp
@@ -44,7 +44,7 @@ private:
     int     _bit_offset;     // offset from the beginning of the current byte. 0<=_bit_offset<=7
 
 public:
-    bit_range() : _current_byte(NULL), _bit_offset(0) {}
+    bit_range() : _current_byte(nullptr), _bit_offset(0) {}
     bit_range(byte_t* current_byte, int bit_offset) : _current_byte(current_byte), _bit_offset(bit_offset) { assert(bit_offset>=0 && bit_offset<8); }
 
     bit_range(const bit_range& br) : _current_byte(br._current_byte), _bit_offset(br._bit_offset) {}

--- a/include/boost/gil/extension/io/jpeg/detail/reader_backend.hpp
+++ b/include/boost/gil/extension/io/jpeg/detail/reader_backend.hpp
@@ -56,7 +56,7 @@ private:
             jpeg_destroy_decompress( jpeg_decompress_ptr );
 
             delete jpeg_decompress_ptr;
-            jpeg_decompress_ptr = NULL;
+            jpeg_decompress_ptr = nullptr;
         }
     }
 

--- a/include/boost/gil/extension/io/jpeg/detail/writer_backend.hpp
+++ b/include/boost/gil/extension/io/jpeg/detail/writer_backend.hpp
@@ -55,7 +55,7 @@ private:
             jpeg_destroy_compress( jpeg_compress_ptr );
 
             delete jpeg_compress_ptr;
-            jpeg_compress_ptr = NULL;
+            jpeg_compress_ptr = nullptr;
         }
     }
 

--- a/include/boost/gil/extension/io/png/detail/base.hpp
+++ b/include/boost/gil/extension/io/png/detail/base.hpp
@@ -17,8 +17,8 @@ namespace boost { namespace gil { namespace detail {
 struct png_ptr_wrapper
 {
     png_ptr_wrapper()
-    : _struct( NULL )
-    , _info  ( NULL )
+    : _struct( nullptr )
+    , _info  ( nullptr )
     {}
 
     png_structp _struct;
@@ -64,11 +64,11 @@ private:
 
             png_destroy_read_struct( &png_ptr->_struct
                                    , &png_ptr->_info
-                                   , NULL
+                                   , nullptr
                                    );
 
             delete png_ptr;
-            png_ptr = NULL;
+            png_ptr = nullptr;
         }
     }
 
@@ -83,7 +83,7 @@ private:
                                     );
 
             delete png_ptr;
-            png_ptr = NULL;
+            png_ptr = nullptr;
         }
     }
 

--- a/include/boost/gil/extension/io/png/detail/read.hpp
+++ b/include/boost/gil/extension/io/png/detail/read.hpp
@@ -220,7 +220,7 @@ public:
 
         // read rest of file, and get additional chunks in info_ptr
         png_read_end( this->get_struct()
-                    , NULL
+                    , nullptr
                     );
     }
 
@@ -265,7 +265,7 @@ private:
                     // Read the image using the "sparkle" effect.
                     png_read_rows( this->get_struct()
                                  , &row_ptr
-                                 , NULL
+                                 , nullptr
                                  , 1
                                  );
                 }
@@ -278,7 +278,7 @@ private:
                     // Read the image using the "sparkle" effect.
                     png_read_rows( this->get_struct()
                                  , &row_ptr
-                                 , NULL
+                                 , nullptr
                                  , 1
                                  );
 
@@ -302,7 +302,7 @@ private:
                     // Read the image using the "sparkle" effect.
                     png_read_rows( this->get_struct()
                                  , &row_ptr
-                                 , NULL
+                                 , nullptr
                                  , 1
                                  );
                 }
@@ -314,7 +314,7 @@ private:
                     // Read the image using the "sparkle" effect.
                     png_read_rows( this->get_struct()
                                  , &row_ptr
-                                 , NULL
+                                 , nullptr
                                  , 1
                                  );
                 }

--- a/include/boost/gil/extension/io/png/detail/reader_backend.hpp
+++ b/include/boost/gil/extension/io/png/detail/reader_backend.hpp
@@ -92,12 +92,12 @@ public:
         // the compiler header file version, so that we know if the application
         // was compiled with a compatible version of the library.  REQUIRED
         get()->_struct = png_create_read_struct( PNG_LIBPNG_VER_STRING
-                                             , NULL  // user_error_ptr
-                                             , NULL  // user_error_fn
-                                             , NULL  // user_warning_fn
+                                             , nullptr  // user_error_ptr
+                                             , nullptr  // user_error_fn
+                                             , nullptr  // user_warning_fn
                                              );
 
-        io_error_if( get()->_struct == NULL
+        io_error_if( get()->_struct == nullptr
                    , "png_reader: fail to call png_create_write_struct()"
                    );
 
@@ -114,11 +114,11 @@ public:
         // Allocate/initialize the memory for image information.  REQUIRED.
         get()->_info = png_create_info_struct( get_struct() );
 
-        if( get_info() == NULL )
+        if( get_info() == nullptr )
         {
             png_destroy_read_struct( &get()->_struct
-                                   , NULL
-                                   , NULL
+                                   , nullptr
+                                   , nullptr
                                    );
 
             io_error( "png_reader: fail to call png_create_info_struct()" );
@@ -132,7 +132,7 @@ public:
             //free all of the memory associated with the png_ptr and info_ptr
             png_destroy_read_struct( &get()->_struct
                                    , &get()->_info
-                                   , NULL
+                                   , nullptr
                                    );
 
             io_error( "png is invalid" );
@@ -153,12 +153,12 @@ public:
         // Set up a callback which implements user defined transformation.
         // @todo
         png_set_read_user_transform_fn( get_struct()
-                                      , png_user_transform_ptr( NULL )
+                                      , png_user_transform_ptr( nullptr )
                                       );
 
         png_set_keep_unknown_chunks( get_struct()
                                    , PNG_HANDLE_CHUNK_ALWAYS
-                                   , NULL
+                                   , nullptr
                                    , 0
                                    );
 
@@ -256,8 +256,8 @@ public:
         if( this->_settings._read_icc_profile )
         {
 #if PNG_LIBPNG_VER_MINOR >= 5
-            png_charp icc_name = png_charp( NULL );
-            png_bytep profile  = png_bytep( NULL );
+            png_charp icc_name = png_charp( nullptr );
+            png_bytep profile  = png_bytep( nullptr );
 
             this->_info._valid_icc_profile = png_get_iCCP( get_struct()
                                                          , get_info()
@@ -303,7 +303,7 @@ public:
         // get image palette information from png_info structure
         if( this->_settings._read_palette )
         {
-            png_colorp palette = png_colorp( NULL );
+            png_colorp palette = png_colorp( nullptr );
 
             this->_info._valid_palette = png_get_PLTE( get_struct()
                                                      , get_info()
@@ -324,7 +324,7 @@ public:
         // get background color
         if( this->_settings._read_background )
         {
-            png_color_16p background = png_color_16p( NULL );
+            png_color_16p background = png_color_16p( nullptr );
 
             this->_info._valid_background = png_get_bKGD( get_struct()
                                                         , get_info()
@@ -339,7 +339,7 @@ public:
         // get the histogram
         if( this->_settings._read_histogram )
         {
-            png_uint_16p histogram = png_uint_16p( NULL );
+            png_uint_16p histogram = png_uint_16p( nullptr );
 
             this->_info._valid_histogram = png_get_hIST( get_struct()
                                                        , get_info()
@@ -352,7 +352,7 @@ public:
                 // the palette.
                 if( this->_settings._read_palette == false )
                 {
-                    png_colorp palette = png_colorp( NULL );
+                    png_colorp palette = png_colorp( nullptr );
                     png_get_PLTE( get_struct()
                                 , get_info()
                                 , &palette
@@ -382,9 +382,9 @@ public:
         // get pixel calibration settings
         if( this->_settings._read_pixel_calibration )
         {
-            png_charp purpose = png_charp ( NULL );
-            png_charp units   = png_charp ( NULL );
-            png_charpp params = png_charpp( NULL );
+            png_charp purpose = png_charp ( nullptr );
+            png_charp units   = png_charp ( nullptr );
+            png_charpp params = png_charpp( nullptr );
 
             this->_info._valid_pixel_calibration = png_get_pCAL( get_struct()
                                                                , get_info()
@@ -449,7 +449,7 @@ public:
         // get number of significant bits for each color channel
         if( this->_settings._read_number_of_significant_bits )
         {
-            png_color_8p sig_bits = png_color_8p( NULL );
+            png_color_8p sig_bits = png_color_8p( nullptr );
 
             this->_info._valid_significant_bits = png_get_sBIT( get_struct()
                                                               , get_info()
@@ -491,8 +491,8 @@ public:
 #else
         if( this->_settings._read_scale_factors )
         {
-            png_charp scale_width  = NULL;
-            png_charp scale_height = NULL;
+            png_charp scale_width  = nullptr;
+            png_charp scale_height = nullptr;
 
             if( this->_info._valid_scale_factors = png_get_sCAL_s( get_struct()
                                                                  , get_info()
@@ -524,7 +524,7 @@ public:
         // get comments information from png_info structure
         if( this->_settings._read_comments )
         {
-            png_textp text = png_textp( NULL );
+            png_textp text = png_textp( nullptr );
 
             this->_info._valid_text = png_get_text( get_struct()
                                                   , get_info()
@@ -556,7 +556,7 @@ public:
         // get last modification time
         if( this->_settings._read_last_modification_time )
         {
-            png_timep mod_time = png_timep( NULL );
+            png_timep mod_time = png_timep( nullptr );
             this->_info._valid_modification_time = png_get_tIME( get_struct()
                                                                , get_info()
                                                                , &mod_time
@@ -570,8 +570,8 @@ public:
         // get transparency data
         if( this->_settings._read_transparency_data )
         {
-            png_bytep     trans        = png_bytep    ( NULL );
-            png_color_16p trans_values = png_color_16p( NULL );
+            png_bytep     trans        = png_bytep    ( nullptr );
+            png_color_16p trans_values = png_color_16p( nullptr );
 
             this->_info._valid_transparency_factors = png_get_tRNS( get_struct()
                                                                   , get_info()

--- a/include/boost/gil/extension/io/png/detail/write.hpp
+++ b/include/boost/gil/extension/io/png/detail/write.hpp
@@ -171,7 +171,7 @@ private:
     }
 
     template< typename Info >
-    void set_swap( typename enable_if< is_equal_to_sixteen< Info > >::type* /* ptr */ = 0 )
+    void set_swap( typename enable_if< is_equal_to_sixteen< Info > >::type* /* ptr */ = nullptr )
     {
         png_set_swap( this->get_struct() );
     }
@@ -180,7 +180,7 @@ private:
     void set_swap( typename enable_if< mpl::and_< mpl::not_< is_less_than_eight< Info > >
                                                 , mpl::not_< is_equal_to_sixteen< Info > >
                                                 >
-                                     >::type* /* ptr */ = 0
+                                     >::type* /* ptr */ = nullptr
                  )
     {}
 };

--- a/include/boost/gil/extension/io/png/detail/writer_backend.hpp
+++ b/include/boost/gil/extension/io/png/detail/writer_backend.hpp
@@ -61,22 +61,22 @@ public:
         // the library version is compatible with the one used at compile time,
         // in case we are using dynamically linked libraries.  REQUIRED.
         get()->_struct = png_create_write_struct( PNG_LIBPNG_VER_STRING
-                                                , NULL  // user_error_ptr
-                                                , NULL  // user_error_fn
-                                                , NULL  // user_warning_fn
+                                                , nullptr  // user_error_ptr
+                                                , nullptr  // user_error_fn
+                                                , nullptr  // user_warning_fn
                                                 );
 
-        io_error_if( get_struct() == NULL
+        io_error_if( get_struct() == nullptr
                    , "png_writer: fail to call png_create_write_struct()"
                    );
 
         // Allocate/initialize the image information data.  REQUIRED
         get()->_info = png_create_info_struct( get_struct() );
 
-        if( get_info() == NULL )
+        if( get_info() == nullptr )
         {
             png_destroy_write_struct( &get()->_struct
-                                    , NULL
+                                    , nullptr
                                     );
 
             io_error( "png_writer: fail to call png_create_info_struct()" );

--- a/include/boost/gil/extension/io/raw/detail/device.hpp
+++ b/include/boost/gil/extension/io/raw/detail/device.hpp
@@ -74,7 +74,7 @@ public:
 
     int unpack()                                                         { return _processor_ptr.get()->unpack(); }
     int dcraw_process()                                                  { return _processor_ptr.get()->dcraw_process(); }
-    libraw_processed_image_t* dcraw_make_mem_image(int* error_code=NULL) { return _processor_ptr.get()->dcraw_make_mem_image(error_code); }
+    libraw_processed_image_t* dcraw_make_mem_image(int* error_code=nullptr) { return _processor_ptr.get()->dcraw_make_mem_image(error_code); }
 
 protected:
 

--- a/include/boost/gil/extension/io/tiff/detail/device.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/device.hpp
@@ -347,7 +347,7 @@ public:
     {
         TIFF* tiff;
 
-        io_error_if( ( tiff = TIFFOpen( file_name.c_str(), "r" )) == NULL
+        io_error_if( ( tiff = TIFFOpen( file_name.c_str(), "r" )) == nullptr
                    , "file_stream_device: failed to open file" );
 
         _tiff_file = tiff_file_t( tiff, TIFFClose );
@@ -357,7 +357,7 @@ public:
     {
         TIFF* tiff;
 
-        io_error_if( ( tiff = TIFFOpen( file_name.c_str(), "w" )) == NULL
+        io_error_if( ( tiff = TIFFOpen( file_name.c_str(), "w" )) == nullptr
                    , "file_stream_device: failed to open file" );
 
         _tiff_file = tiff_file_t( tiff, TIFFClose );
@@ -384,7 +384,7 @@ public:
         io_error_if( ( tiff = TIFFStreamOpen( ""
                                             , &_out
                                             )
-                      ) == NULL
+                      ) == nullptr
                    , "ostream_device: failed to stream"
                    );
 
@@ -415,7 +415,7 @@ public:
         io_error_if( ( tiff = TIFFStreamOpen( ""
                                             , &_in
                                             )
-                     ) == NULL
+                     ) == nullptr
                    , "istream_device: failed to stream"
                    );
 

--- a/include/boost/gil/extension/io/tiff/detail/log.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/log.hpp
@@ -22,8 +22,8 @@ public:
 
     tiff_no_log()
     {
-        TIFFSetErrorHandler  ( NULL );
-        TIFFSetWarningHandler( NULL );
+        TIFFSetErrorHandler  ( nullptr );
+        TIFFSetWarningHandler( nullptr );
     }
 };
 

--- a/include/boost/gil/extension/io/tiff/detail/read.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/read.hpp
@@ -320,9 +320,9 @@ private:
                           , mpl::true_   // is View rgb16_view_t
                           )
    {
-      tiff_color_map::red_t   red   = NULL;
-      tiff_color_map::green_t green = NULL;
-      tiff_color_map::blue_t  blue  = NULL;
+      tiff_color_map::red_t   red   = nullptr;
+      tiff_color_map::green_t green = nullptr;
+      tiff_color_map::blue_t  blue  = nullptr;
 
       this->_io_dev.get_field_defaulted( red, green, blue );
 

--- a/include/boost/gil/extension/io/tiff/detail/reader_backend.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/reader_backend.hpp
@@ -40,9 +40,9 @@ public:
 
     , _scanline_length( 0 )
 
-    , _red  ( NULL )
-    , _green( NULL )
-    , _blue ( NULL )
+    , _red  ( nullptr )
+    , _green( nullptr )
+    , _blue ( nullptr )
     {
         init_multipage_read( settings );
 

--- a/include/boost/gil/image.hpp
+++ b/include/boost/gil/image.hpp
@@ -57,19 +57,19 @@ public:
 
     explicit image(std::size_t alignment=0,
                    const Alloc alloc_in = Alloc()) :
-        _memory(0), _align_in_bytes(alignment), _alloc(alloc_in), _allocated_bytes( 0 ) {}
+        _memory(nullptr), _align_in_bytes(alignment), _alloc(alloc_in), _allocated_bytes( 0 ) {}
 
     // Create with dimensions and optional initial value and alignment
     image(const point_t& dimensions,
           std::size_t alignment=0,
-          const Alloc alloc_in = Alloc()) : _memory(0), _align_in_bytes(alignment), _alloc(alloc_in)
+          const Alloc alloc_in = Alloc()) : _memory(nullptr), _align_in_bytes(alignment), _alloc(alloc_in)
                                           , _allocated_bytes( 0 ) {
         allocate_and_default_construct(dimensions);
     }
 
     image(x_coord_t width, y_coord_t height,
           std::size_t alignment=0,
-          const Alloc alloc_in = Alloc()) : _memory(0), _align_in_bytes(alignment), _alloc(alloc_in)
+          const Alloc alloc_in = Alloc()) : _memory(nullptr), _align_in_bytes(alignment), _alloc(alloc_in)
                                           , _allocated_bytes( 0 ) {
         allocate_and_default_construct(point_t(width,height));
     }
@@ -77,25 +77,25 @@ public:
     image(const point_t& dimensions,
           const Pixel& p_in,
           std::size_t alignment,
-          const Alloc alloc_in = Alloc())  : _memory(0), _align_in_bytes(alignment), _alloc(alloc_in)
+          const Alloc alloc_in = Alloc())  : _memory(nullptr), _align_in_bytes(alignment), _alloc(alloc_in)
                                            , _allocated_bytes( 0 ) {
         allocate_and_fill(dimensions, p_in);
     }
     image(x_coord_t width, y_coord_t height,
           const Pixel& p_in,
           std::size_t alignment = 0,
-          const Alloc alloc_in = Alloc())  : _memory(0), _align_in_bytes(alignment), _alloc(alloc_in)
+          const Alloc alloc_in = Alloc())  : _memory(nullptr), _align_in_bytes(alignment), _alloc(alloc_in)
                                            , _allocated_bytes ( 0 ) {
         allocate_and_fill(point_t(width,height),p_in);
     }
 
-    image(const image& img) : _memory(0), _align_in_bytes(img._align_in_bytes), _alloc(img._alloc)
+    image(const image& img) : _memory(nullptr), _align_in_bytes(img._align_in_bytes), _alloc(img._alloc)
                             , _allocated_bytes( img._allocated_bytes ) {
         allocate_and_copy(img.dimensions(),img._view);
     }
 
     template <typename P2, bool IP2, typename Alloc2>
-    image(const image<P2,IP2,Alloc2>& img) : _memory(0), _align_in_bytes(img._align_in_bytes), _alloc(img._alloc)
+    image(const image<P2,IP2,Alloc2>& img) : _memory(nullptr), _align_in_bytes(img._align_in_bytes), _alloc(img._alloc)
                                            , _allocated_bytes( img._allocated_bytes ) {
        allocate_and_copy(img.dimensions(),img._view);
     }

--- a/include/boost/gil/io/conversion_policies.hpp
+++ b/include/boost/gil/io/conversion_policies.hpp
@@ -30,7 +30,7 @@ public:
              , typename disable_if< typename pixels_are_compatible< typename std::iterator_traits<InIterator>::value_type
                                                                   , typename std::iterator_traits<OutIterator>::value_type
                                                                   >::type
-                                  >::type* /* ptr */ = 0
+                                  >::type* /* ptr */ = nullptr
              )
     {
         io_error( "Data cannot be copied because the pixels are incompatible." );
@@ -45,7 +45,7 @@ public:
              , typename enable_if< typename pixels_are_compatible< typename std::iterator_traits<InIterator>::value_type
                                                                  , typename std::iterator_traits<OutIterator>::value_type
                                                                  >::type
-                                 >::type* /* ptr */ = 0
+                                 >::type* /* ptr */ = nullptr
              )
     {
         std::copy( begin

--- a/include/boost/gil/io/device.hpp
+++ b/include/boost/gil/io/device.hpp
@@ -65,9 +65,9 @@ public:
                       , read_tag   = read_tag()
                       )
     {
-        FILE* file = NULL;
+        FILE* file = nullptr;
 
-        io_error_if( ( file = fopen( file_name.c_str(), "rb" )) == NULL
+        io_error_if( ( file = fopen( file_name.c_str(), "rb" )) == nullptr
                    , "file_stream_device: failed to open file"
                    );
 
@@ -83,9 +83,9 @@ public:
                       , read_tag   = read_tag()
                       )
     {
-        FILE* file = NULL;
+        FILE* file = nullptr;
 
-        io_error_if( ( file = fopen( file_name, "rb" )) == NULL
+        io_error_if( ( file = fopen( file_name, "rb" )) == nullptr
                    , "file_stream_device: failed to open file"
                    );
 
@@ -101,9 +101,9 @@ public:
                       , write_tag
                       )
     {
-        FILE* file = NULL;
+        FILE* file = nullptr;
 
-        io_error_if( ( file = fopen( file_name.c_str(), "wb" )) == NULL
+        io_error_if( ( file = fopen( file_name.c_str(), "wb" )) == nullptr
                    , "file_stream_device: failed to open file"
                    );
 
@@ -119,9 +119,9 @@ public:
                       , write_tag
                       )
     {
-        FILE* file = NULL;
+        FILE* file = nullptr;
 
-        io_error_if( ( file = fopen( file_name, "wb" )) == NULL
+        io_error_if( ( file = fopen( file_name, "wb" )) == nullptr
                    , "file_stream_device: failed to open file"
                    );
 

--- a/include/boost/gil/io/make_backend.hpp
+++ b/include/boost/gil/io/make_backend.hpp
@@ -27,7 +27,7 @@ make_reader_backend( const String&                           file_name
                    , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
                                                   , is_format_tag< FormatTag >
                                                            >
-                                       >::type* /* ptr */ = 0
+                                       >::type* /* ptr */ = nullptr
                    )
 {
     typedef typename get_read_device< String
@@ -95,7 +95,7 @@ make_reader_backend( Device&                                 io_dev
                                                                                      >
                                                   , is_format_tag< FormatTag >
                                                   >
-                                       >::type* /* ptr */ = 0
+                                       >::type* /* ptr */ = nullptr
                    )
 {
     typedef typename get_read_device< Device

--- a/include/boost/gil/io/make_dynamic_image_reader.hpp
+++ b/include/boost/gil/io/make_dynamic_image_reader.hpp
@@ -26,7 +26,7 @@ make_dynamic_image_reader( const String&    file_name
                          , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
                                                         , is_format_tag< FormatTag >
                                                                  >
-                                             >::type* /* ptr */ = 0
+                                             >::type* /* ptr */ = nullptr
                          )
 {
     typename get_read_device< String
@@ -126,7 +126,7 @@ make_dynamic_image_reader( const String&    file_name
                          , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
                                                         , is_format_tag< FormatTag >
                                                                  >
-                                             >::type* /* ptr */ = 0
+                                             >::type* /* ptr */ = nullptr
                          )
 {
     return make_dynamic_image_reader( file_name

--- a/include/boost/gil/io/make_dynamic_image_writer.hpp
+++ b/include/boost/gil/io/make_dynamic_image_writer.hpp
@@ -26,7 +26,7 @@ make_dynamic_image_writer( const String&                        file_name
                          , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
                                                         , is_format_tag< FormatTag >
                                                         >
-                                             >::type* /* ptr */ = 0
+                                             >::type* /* ptr */ = nullptr
                          )
 {
     typename get_write_device< String
@@ -126,7 +126,7 @@ make_dynamic_image_writer( const String&    file_name
                          , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
                                                         , is_format_tag< FormatTag >
                                                         >
-                                             >::type* /* ptr */ = 0
+                                             >::type* /* ptr */ = nullptr
                          )
 {
     return make_dynamic_image_writer( file_name

--- a/include/boost/gil/io/make_reader.hpp
+++ b/include/boost/gil/io/make_reader.hpp
@@ -29,7 +29,7 @@ make_reader( const String&    file_name
            , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
                                           , is_format_tag< FormatTag >
                                                    >
-                               >::type* /* ptr */ = 0
+                               >::type* /* ptr */ = nullptr
            )
 {
     typename get_read_device< String
@@ -115,7 +115,7 @@ make_reader( Device&                                 file
                                                                              >
                                           , is_format_tag< FormatTag >
                                           >
-                               >::type* /* ptr */ = 0
+                               >::type* /* ptr */ = nullptr
            )
 {
     typename get_read_device< Device
@@ -147,7 +147,7 @@ make_reader( const String&    file_name
            , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
                                           , is_format_tag< FormatTag >
                                                    >
-                               >::type* /* ptr */ = 0
+                               >::type* /* ptr */ = nullptr
            )
 {
     return make_reader( file_name
@@ -213,7 +213,7 @@ make_reader( Device&                 file
                                                                              >
                                           , is_format_tag< FormatTag >
                                           >
-                               >::type* /* ptr */ = 0
+                               >::type* /* ptr */ = nullptr
            )
 {
     return make_reader( file

--- a/include/boost/gil/io/make_scanline_reader.hpp
+++ b/include/boost/gil/io/make_scanline_reader.hpp
@@ -26,7 +26,7 @@ make_scanline_reader( const String&    file_name
                     , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
                                                    , is_format_tag< FormatTag >
                                                    >
-                                        >::type* /* ptr */ = 0
+                                        >::type* /* ptr */ = nullptr
            )
 {
     typename get_read_device< String

--- a/include/boost/gil/io/make_writer.hpp
+++ b/include/boost/gil/io/make_writer.hpp
@@ -26,7 +26,7 @@ make_writer( const String&                        file_name
            , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
                                           , is_format_tag< FormatTag >
                                           >
-                               >::type* /* ptr */ = 0
+                               >::type* /* ptr */ = nullptr
            )
 {
     typename get_write_device< String
@@ -97,7 +97,7 @@ make_writer( Device&                              file
            , typename enable_if< mpl::and_< typename detail::is_adaptable_output_device< FormatTag, Device >::type
                                           , is_format_tag< FormatTag >
                                           >
-                               >::type* /* ptr */ = 0
+                               >::type* /* ptr */ = nullptr
            )
 {
     typename get_write_device< Device
@@ -126,7 +126,7 @@ make_writer( const String&    file_name
            , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
                                           , is_format_tag< FormatTag >
                                           >
-                               >::type* /* ptr */ = 0
+                               >::type* /* ptr */ = nullptr
            )
 {
     return make_writer( file_name
@@ -177,7 +177,7 @@ make_writer( Device&          file
            , typename enable_if< mpl::and_< typename detail::is_adaptable_output_device< FormatTag, Device >::type
                                           , is_format_tag< FormatTag >
                                           >
-                               >::type* /* ptr */ = 0
+                               >::type* /* ptr */ = nullptr
            )
 {
     return make_writer( file

--- a/include/boost/gil/io/read_and_convert_image.hpp
+++ b/include/boost/gil/io/read_and_convert_image.hpp
@@ -37,7 +37,7 @@ void read_and_convert_image( Reader&                                 reader
                            , typename enable_if< mpl::and_< detail::is_reader< Reader >
                                                           , is_format_tag< typename Reader::format_tag_t >
                                                           >
-                           >::type* /* ptr */ = 0
+                           >::type* /* ptr */ = nullptr
                            )
 {
     reader.init_image( img
@@ -285,7 +285,7 @@ void read_and_convert_image( const String&    file_name
                            , typename enable_if< mpl::and_< is_format_tag< FormatTag >
                                                           , detail::is_supported_path_spec< String >
                                                           >
-                                               >::type* /* ptr */ = 0
+                                               >::type* /* ptr */ = nullptr
                            )
 {
     typedef typename get_reader< String
@@ -321,7 +321,7 @@ void read_and_convert_image( Device&          device
                                                                                   >
                                                           , is_format_tag< FormatTag >
                                                           >
-                                               >::type* /* ptr */ = 0
+                                               >::type* /* ptr */ = nullptr
                            )
 {
     typedef typename get_reader< Device

--- a/include/boost/gil/io/read_and_convert_view.hpp
+++ b/include/boost/gil/io/read_and_convert_view.hpp
@@ -37,7 +37,7 @@ void read_and_convert_view( Reader&     reader
                           , typename enable_if< mpl::and_< detail::is_reader< Reader >
                                                          , is_format_tag< typename Reader::format_tag_t >
                                                          >
-                          >::type* /* ptr */ = 0
+                          >::type* /* ptr */ = nullptr
                           )
 {
     reader.check_image_size( view.dimensions() );
@@ -289,7 +289,7 @@ void read_and_convert_view( const String&    file_name
                           , typename enable_if< mpl::and_< is_format_tag< FormatTag >
                                                          , detail::is_supported_path_spec< String >
                                                          >
-                                              >::type* /* ptr */ = 0
+                                              >::type* /* ptr */ = nullptr
                           )
 {
     typedef typename get_reader< String
@@ -325,7 +325,7 @@ void read_and_convert_view( Device&          device
                                                                                  >
                                                          , is_format_tag< FormatTag >
                                                          >
-                                               >::type* /* ptr */ = 0
+                                               >::type* /* ptr */ = nullptr
                           )
 {
     typedef typename get_reader< Device

--- a/include/boost/gil/io/read_image.hpp
+++ b/include/boost/gil/io/read_image.hpp
@@ -40,7 +40,7 @@ void read_image( Reader           reader
                                                                  , typename Reader::format_tag_t
                                                                  >
                                               >
-                                   >::type* /* ptr */ = 0
+                                   >::type* /* ptr */ = nullptr
                )
 {
     reader.init_image( img
@@ -110,7 +110,7 @@ void read_image( Device&          file
                                                                  , FormatTag
                                                                  >
                                               >
-                                   >::type* /* ptr */ = 0
+                                   >::type* /* ptr */ = nullptr
                )
 {
     typedef typename get_reader< Device
@@ -147,7 +147,7 @@ void read_image( const String&                           file_name
                                                                  , FormatTag
                                                                  >
                                               >
-                                   >::type* /* ptr */ = 0
+                                   >::type* /* ptr */ = nullptr
                )
 {
     typedef typename get_reader< String
@@ -184,7 +184,7 @@ void read_image( const String&    file_name
                                                                  , FormatTag
                                                                  >
                                               >
-                                   >::type* /* ptr */ = 0
+                                   >::type* /* ptr */ = nullptr
                )
 {
     typedef typename get_reader< String
@@ -213,7 +213,7 @@ void read_image( Reader&              reader
                , typename enable_if< mpl::and_< detail::is_dynamic_image_reader< Reader >
                                               , is_format_tag< typename Reader::format_tag_t >
                                               >
-                                   >::type* /* ptr */ = 0
+                                   >::type* /* ptr */ = nullptr
                )
 {
     reader.apply( images );
@@ -335,7 +335,7 @@ void read_image( const String&        file_name
                , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
                                               , is_format_tag< FormatTag >
                                               >
-                                   >::type* /* ptr */ = 0
+                                   >::type* /* ptr */ = nullptr
                )
 {
     typedef typename get_dynamic_image_reader< String

--- a/include/boost/gil/io/read_image_info.hpp
+++ b/include/boost/gil/io/read_image_info.hpp
@@ -40,7 +40,7 @@ read_image_info( Device&                                 file
                                                                                  >
                                               , is_format_tag< FormatTag >
                                               >
-                                   >::type* /* ptr */ = 0
+                                   >::type* /* ptr */ = nullptr
                )
 {
     return make_reader_backend( file, settings );
@@ -65,7 +65,7 @@ read_image_info( Device&          file
                                                                                  >
                                               , is_format_tag< FormatTag >
                                               >
-                                   >::type* /* ptr */ = 0
+                                   >::type* /* ptr */ = nullptr
                )
 {
     return read_image_info( file
@@ -90,7 +90,7 @@ read_image_info( const String&                           file_name
                , typename enable_if< mpl::and_< is_format_tag< FormatTag >
                                               , detail::is_supported_path_spec< String >
                                               >
-                                   >::type* /* ptr */ = 0
+                                   >::type* /* ptr */ = nullptr
                )
 {
     return make_reader_backend( file_name, settings );
@@ -113,7 +113,7 @@ read_image_info( const String&    file_name
                , typename enable_if< mpl::and_< is_format_tag< FormatTag >
                                               , detail::is_supported_path_spec< String >
                                               >
-                                   >::type* /* ptr */ = 0
+                                   >::type* /* ptr */ = nullptr
                )
 {
     return read_image_info( file_name

--- a/include/boost/gil/io/read_view.hpp
+++ b/include/boost/gil/io/read_view.hpp
@@ -39,7 +39,7 @@ void read_view( Reader                                  reader
                                                                                   , typename Reader::format_tag_t
                                                                                   >::type
                                                        >::type
-                                  >::type* /* ptr */ = 0
+                                  >::type* /* ptr */ = nullptr
               )
 {
     reader.check_image_size( view.dimensions() );
@@ -111,7 +111,7 @@ void read_view( Device&          file
                                                                                   , FormatTag
                                                                                   >::type
                                                       >::type
-                                  >::type* /* ptr */ = 0
+                                  >::type* /* ptr */ = nullptr
               )
 {
     typedef typename get_reader< Device
@@ -185,7 +185,7 @@ void read_view( const String&    file_name
                                                                                   , FormatTag
                                                                                   >::type
                                                       >::type
-                                  >::type* /* ptr */ = 0
+                                  >::type* /* ptr */ = nullptr
               )
 {
     typedef typename get_reader< String

--- a/include/boost/gil/io/write_view.hpp
+++ b/include/boost/gil/io/write_view.hpp
@@ -43,7 +43,7 @@ void write_view( Writer&     writer
                                                                                     , typename Writer::format_tag_t
                                                                                     >::type
                                                        >::type
-                                   >::type* /* ptr */ = 0
+                                   >::type* /* ptr */ = nullptr
                )
 {
     writer.apply( view );
@@ -65,7 +65,7 @@ void write_view( Device&          device
                                                                                     , FormatTag
                                                                                     >::type
                                                        >::type
-                                   >::type* /* ptr */ = 0
+                                   >::type* /* ptr */ = nullptr
                )
 {
     typedef typename get_writer< Device
@@ -95,7 +95,7 @@ void write_view( const String&    file_name
                                                                                     , FormatTag
                                                                                     >::type
                                                        >::type
-                                   >::type* /* ptr */ = 0
+                                   >::type* /* ptr */ = nullptr
                )
 {
     typedef typename get_writer< String
@@ -129,7 +129,7 @@ void write_view( Device&                                 device
                                                                                     , FormatTag
                                                                                     >::type
                                                        >::type
-                                   >::type* /* ptr */ = 0
+                                   >::type* /* ptr */ = nullptr
                )
 {
     typedef typename get_writer< Device
@@ -160,7 +160,7 @@ void write_view( const String&                             file_name
                                                                                     , FormatTag
                                                                                     >::type
                                                        >::type
-                                   >::type* /* ptr */ = 0
+                                   >::type* /* ptr */ = nullptr
                )
 {
     typedef typename get_writer< String
@@ -189,7 +189,7 @@ void write_view( Writer&                        writer
                , typename enable_if< typename mpl::and_< typename detail::is_dynamic_image_writer< Writer >::type
                                                        , typename is_format_tag< typename Writer::format_tag_t >::type
                                                        >::type
-                                   >::type* /* ptr */ = 0
+                                   >::type* /* ptr */ = nullptr
                )
 {
     writer.apply( view );
@@ -237,7 +237,7 @@ void write_view( const String&                  file_name
                , typename enable_if< typename mpl::and_< typename detail::is_supported_path_spec< String >::type
                                                        , typename is_format_tag< FormatTag >::type
                                                        >::type
-                                   >::type* /* ptr */ = 0
+                                   >::type* /* ptr */ = nullptr
                )
 {
     typedef typename get_dynamic_image_writer< String
@@ -301,7 +301,7 @@ void write_view( const String&                      file_name
                , typename enable_if< typename mpl::and_< typename detail::is_supported_path_spec< String >::type
                                                        , typename is_format_tag< FormatTag >::type
                                                        >::type
-                                   >::type* /* ptr */ = 0
+                                   >::type* /* ptr */ = nullptr
                )
 {
     typedef typename get_dynamic_image_writer< String

--- a/include/boost/gil/packed_pixel.hpp
+++ b/include/boost/gil/packed_pixel.hpp
@@ -65,7 +65,7 @@ struct packed_pixel {
 
     // Construct from another compatible pixel type
     packed_pixel(const packed_pixel& p) : _bitfield(p._bitfield) {}
-    template <typename P> packed_pixel(const P& p, typename enable_if_c<is_pixel<P>::value>::type* d=0) {
+    template <typename P> packed_pixel(const P& p, typename enable_if_c<is_pixel<P>::value>::type* d=nullptr) {
         check_compatible<P>(); static_copy(p,*this);
         boost::ignore_unused(d);
     }

--- a/include/boost/gil/pixel.hpp
+++ b/include/boost/gil/pixel.hpp
@@ -112,7 +112,7 @@ public:
     pixel&                       operator=(const pixel& p)       { static_copy(p,*this); return *this; }
 
     // Construct from another compatible pixel type
-    template <typename Pixel>    pixel(const Pixel& p, typename enable_if_c<is_pixel<Pixel>::value>::type* dummy = 0) : parent_t(p) {
+    template <typename Pixel>    pixel(const Pixel& p, typename enable_if_c<is_pixel<Pixel>::value>::type* dummy = nullptr) : parent_t(p) {
         check_compatible<Pixel>();
         boost::ignore_unused(dummy);
     }


### PR DESCRIPTION
(_IMPORTANT: This is a pilot PR with automatic code refactoring by clang-tidy. There are more PRs planned with basic/fundamental C++11 modernization, with every check added to the `.clang-tidy` configuration file as a record tracking checks already applied._)

Used clang-tidy 7.0 with the command:

```
  run-clang-tidy.py \
      -header-filter='boost\/gil\/.*' \
      -checks='-*,modernize-use-nullptr' -fix
```

Update `CONTRIBUTING.md` on how to generate compile command database and run clang-tidy.

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed
