### PR TITLE
Apply clang-tidy modernize-use-override

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:                 '-*,modernize-use-nullptr*'
+Checks:                 '-*,modernize-use-nullptr,modernize-use-override'
 WarningsAsErrors:       ''
 HeaderFilterRegex:      'boost\/gil\/.*'
 AnalyzeTemporaryDtors:  false

--- a/test/image.cpp
+++ b/test/image.cpp
@@ -389,8 +389,8 @@ public:
     checksum_image_test(const char* filename) : _filename(filename) {}
 private:
     const char* _filename;
-    virtual void initialize();
-    virtual void check_view_impl(const rgb8c_view_t& v, const string& name);
+    void initialize() override;
+    void check_view_impl(const rgb8c_view_t& v, const string& name) override;
 };
 
 // Load the checksums from the reference file and create the start image
@@ -444,8 +444,8 @@ public:
     checksum_image_generate(const char* filename) : _filename(filename) {}
 private:
     const char* _filename;
-    virtual void check_view_impl(const rgb8c_view_t& img_view, const string& name);
-    virtual void finalize();
+    void check_view_impl(const rgb8c_view_t& img_view, const string& name) override;
+    void finalize() override;
 };
 
 // Add the checksum of the given view to the map of checksums


### PR DESCRIPTION
Used clang-tidy 7.0 with the command:

```
run-clang-tidy.py \
    -header-filter='boost\/gil\/.*'
    -checks='-*,modernize-use-override' -fix
```

### References

- #180

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed
