### PR TITLE
Fix for_each_pixel do not compile with lambdas

### DIFF
--- a/include/boost/gil/algorithm.hpp
+++ b/include/boost/gil/algorithm.hpp
@@ -746,7 +746,8 @@ F for_each_pixel(const V& img, F fun) {
         return std::for_each(img.begin().x(), img.end().x(), fun);
     } else {
         for (std::ptrdiff_t y=0; y<img.height(); ++y)
-            std::for_each(img.row_begin(y),img.row_end(y),fun);
+            for (auto begin = img.row_begin(y), end = img.row_end(y); begin != end; ++begin)
+                fun(*begin);
         return fun;
     }
 }


### PR DESCRIPTION
Fix #186 by replacing the inner for_each loop on lines with a simple range-based loop.

### Environment

Boost 1.68, tested with MSVC 2017.

### References

Fix #186