### PR TITLE
Fix const on return type not applied to pointee type of typedef

### DIFF
--- a/include/boost/gil/extension/io/png/detail/base.hpp
+++ b/include/boost/gil/extension/io/png/detail/base.hpp
@@ -46,13 +46,13 @@ protected:
     {}
 
     png_ptr_wrapper*       get()       { return _png_ptr.get(); }
-    const png_ptr_wrapper* get() const { return _png_ptr.get(); }
+    png_ptr_wrapper const* get() const { return _png_ptr.get(); }
 
-    png_structp       get_struct()       { return get()->_struct; }
-    const png_structp get_struct() const { return get()->_struct; }
+    png_struct*       get_struct()       { return get()->_struct; }
+    png_struct const* get_struct() const { return get()->_struct; }
 
-    png_infop       get_info()       { return get()->_info; }
-    const png_infop get_info() const { return get()->_info; }
+    png_info*       get_info()       { return get()->_info; }
+    png_info const* get_info() const { return get()->_info; }
 
 private:
 


### PR DESCRIPTION
Replace `png_structp` and `png_infop` aliases with regular pointers to to prevent type qualifiers ignored on function return type.

### Tasklist

- [ ] Review
- [ ] Adjust for comments
- [ ] All CI builds and checks have passed

-----

By the way, the alias is defined as `typedef png_struct FAR * png_structp;` and I think we are safe to ignore the `FAR` qualifier :)