### PR TITLE
Remove deprecated unary/binary_function.

### DIFF
--- a/include/boost/gil/extension/numeric/channel_numeric_operations.hpp
+++ b/include/boost/gil/extension/numeric/channel_numeric_operations.hpp
@@ -10,8 +10,6 @@
 
 #include <boost/gil/channel.hpp>
 
-#include <functional>
-
 namespace boost { namespace gil {
 
 // Structures for channel-wise numeric operations
@@ -26,7 +24,7 @@ namespace boost { namespace gil {
 /// structure for adding one channel to another
 /// this is a generic implementation; user should specialize it for better performance
 template <typename Channel1,typename Channel2,typename ChannelR>
-struct channel_plus_t : public std::binary_function<Channel1,Channel2,ChannelR> {
+struct channel_plus_t {
     ChannelR operator()(typename channel_traits<Channel1>::const_reference ch1,
                         typename channel_traits<Channel2>::const_reference ch2) const {
         return ChannelR(ch1)+ChannelR(ch2);
@@ -37,7 +35,7 @@ struct channel_plus_t : public std::binary_function<Channel1,Channel2,ChannelR> 
 /// structure for subtracting one channel from another
 /// this is a generic implementation; user should specialize it for better performance
 template <typename Channel1,typename Channel2,typename ChannelR>
-struct channel_minus_t : public std::binary_function<Channel1,Channel2,ChannelR> {
+struct channel_minus_t {
     ChannelR operator()(typename channel_traits<Channel1>::const_reference ch1,
                         typename channel_traits<Channel2>::const_reference ch2) const {
         return ChannelR(ch1)-ChannelR(ch2);
@@ -48,7 +46,7 @@ struct channel_minus_t : public std::binary_function<Channel1,Channel2,ChannelR>
 /// structure for multiplying one channel to another
 /// this is a generic implementation; user should specialize it for better performance
 template <typename Channel1,typename Channel2,typename ChannelR>
-struct channel_multiplies_t : public std::binary_function<Channel1,Channel2,ChannelR> {
+struct channel_multiplies_t {
     ChannelR operator()(typename channel_traits<Channel1>::const_reference ch1,
                         typename channel_traits<Channel2>::const_reference ch2) const {
         return ChannelR(ch1)*ChannelR(ch2);
@@ -59,7 +57,7 @@ struct channel_multiplies_t : public std::binary_function<Channel1,Channel2,Chan
 /// structure for dividing channels
 /// this is a generic implementation; user should specialize it for better performance
 template <typename Channel1,typename Channel2,typename ChannelR>
-struct channel_divides_t : public std::binary_function<Channel1,Channel2,ChannelR> {
+struct channel_divides_t {
     ChannelR operator()(typename channel_traits<Channel1>::const_reference ch1,
                         typename channel_traits<Channel2>::const_reference ch2) const {
         return ChannelR(ch1)/ChannelR(ch2);
@@ -70,7 +68,7 @@ struct channel_divides_t : public std::binary_function<Channel1,Channel2,Channel
 /// structure for adding a scalar to a channel
 /// this is a generic implementation; user should specialize it for better performance
 template <typename Channel,typename Scalar,typename ChannelR>
-struct channel_plus_scalar_t : public std::binary_function<Channel,Scalar,ChannelR> {
+struct channel_plus_scalar_t {
     ChannelR operator()(typename channel_traits<Channel>::const_reference ch,
                         const Scalar& s) const {
         return ChannelR(ch)+ChannelR(s);
@@ -81,7 +79,7 @@ struct channel_plus_scalar_t : public std::binary_function<Channel,Scalar,Channe
 /// structure for subtracting a scalar from a channel
 /// this is a generic implementation; user should specialize it for better performance
 template <typename Channel,typename Scalar,typename ChannelR>
-struct channel_minus_scalar_t : public std::binary_function<Channel,Scalar,ChannelR> {
+struct channel_minus_scalar_t {
     ChannelR operator()(typename channel_traits<Channel>::const_reference ch,
                         const Scalar& s) const {
         return ChannelR(ch-s);
@@ -92,7 +90,7 @@ struct channel_minus_scalar_t : public std::binary_function<Channel,Scalar,Chann
 /// structure for multiplying a scalar to one channel
 /// this is a generic implementation; user should specialize it for better performance
 template <typename Channel,typename Scalar,typename ChannelR>
-struct channel_multiplies_scalar_t : public std::binary_function<Channel,Scalar,ChannelR> {
+struct channel_multiplies_scalar_t {
     ChannelR operator()(typename channel_traits<Channel>::const_reference ch,
                         const Scalar& s) const {
         return ChannelR(ch)*ChannelR(s);
@@ -103,7 +101,7 @@ struct channel_multiplies_scalar_t : public std::binary_function<Channel,Scalar,
 /// structure for dividing a channel by a scalar
 /// this is a generic implementation; user should specialize it for better performance
 template <typename Channel,typename Scalar,typename ChannelR>
-struct channel_divides_scalar_t : public std::binary_function<Channel,Scalar,ChannelR> {
+struct channel_divides_scalar_t {
     ChannelR operator()(typename channel_traits<Channel>::const_reference ch,
                         const Scalar& s) const {
         return ChannelR(ch)/ChannelR(s);
@@ -114,7 +112,7 @@ struct channel_divides_scalar_t : public std::binary_function<Channel,Scalar,Cha
 /// structure for halving a channel
 /// this is a generic implementation; user should specialize it for better performance
 template <typename Channel>
-struct channel_halves_t : public std::unary_function<Channel,Channel> {
+struct channel_halves_t {
     typename channel_traits<Channel>::reference
     operator()(typename channel_traits<Channel>::reference ch) const {
         return ch/=2.0;
@@ -125,7 +123,7 @@ struct channel_halves_t : public std::unary_function<Channel,Channel> {
 /// structure for setting a channel to zero
 /// this is a generic implementation; user should specialize it for better performance
 template <typename Channel>
-struct channel_zeros_t : public std::unary_function<Channel,Channel> {
+struct channel_zeros_t {
     typename channel_traits<Channel>::reference
     operator()(typename channel_traits<Channel>::reference ch) const {
         return ch=Channel(0);
@@ -136,7 +134,7 @@ struct channel_zeros_t : public std::unary_function<Channel,Channel> {
 /// structure for assigning one channel to another
 /// this is a generic implementation; user should specialize it for better performance
 template <typename Channel1,typename Channel2>
-struct channel_assigns_t : public std::binary_function<Channel1,Channel2,Channel2> {
+struct channel_assigns_t {
     typename channel_traits<Channel2>::reference
     operator()(typename channel_traits<Channel1>::const_reference ch1,
                typename channel_traits<Channel2>::reference ch2) const {

--- a/include/boost/gil/extension/numeric/pixel_numeric_operations.hpp
+++ b/include/boost/gil/extension/numeric/pixel_numeric_operations.hpp
@@ -13,8 +13,6 @@
 #include <boost/gil/color_base_algorithm.hpp>
 #include <boost/gil/pixel.hpp>
 
-#include <functional>
-
 namespace boost { namespace gil {
 
 // Structures for pixel-wise numeric operations


### PR DESCRIPTION
`std::unary_function` and `std::binary_function` are deprecated in C++11 and removed in C++17. I think they are safe to remove since C++11 is required anyway.