### PR TITLE
Apply clang-tidy modernize-use-using to core headers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:                 '-*,modernize-use-nullptr,modernize-use-override'
+Checks:                 '-*,modernize-use-nullptr,modernize-use-override,modernize-use-using'
 WarningsAsErrors:       ''
 HeaderFilterRegex:      'boost\/gil\/.*'
 AnalyzeTemporaryDtors:  false

--- a/include/boost/gil/algorithm.hpp
+++ b/include/boost/gil/algorithm.hpp
@@ -79,7 +79,7 @@ struct error_t {};
 /// is not required and the default throws std::bad_cast.
 template <typename Derived, typename Result=void>
 struct binary_operation_obj {
-    typedef Result result_type;
+    using result_type = Result;
 
     template <typename V1, typename V2> BOOST_FORCEINLINE
     result_type operator()(const std::pair<const V1*,const V2*>& p) const {
@@ -175,7 +175,7 @@ struct copier_n {
 /// Source range is delimited by image iterators
 template <typename IL, typename O>  // IL Models ConstPixelLocatorConcept, O Models PixelIteratorConcept
 struct copier_n<iterator_from_2d<IL>,O> {
-    typedef typename std::iterator_traits<iterator_from_2d<IL> >::difference_type diff_t;
+    using diff_t = typename std::iterator_traits<iterator_from_2d<IL> >::difference_type;
     BOOST_FORCEINLINE void operator()(iterator_from_2d<IL> src, diff_t n, O dst) const {
         gil_function_requires<PixelLocatorConcept<IL> >();
         gil_function_requires<MutablePixelIteratorConcept<O> >();
@@ -193,7 +193,7 @@ struct copier_n<iterator_from_2d<IL>,O> {
 /// Destination range is delimited by image iterators
 template <typename I, typename OL> // I Models ConstPixelIteratorConcept, OL Models PixelLocatorConcept
 struct copier_n<I,iterator_from_2d<OL> > {
-    typedef typename std::iterator_traits<I>::difference_type diff_t;
+    using diff_t = typename std::iterator_traits<I>::difference_type;
     BOOST_FORCEINLINE void operator()(I src, diff_t n, iterator_from_2d<OL> dst) const {
         gil_function_requires<PixelIteratorConcept<I> >();
         gil_function_requires<MutablePixelLocatorConcept<OL> >();
@@ -211,7 +211,7 @@ struct copier_n<I,iterator_from_2d<OL> > {
 /// Both source and destination ranges are delimited by image iterators
 template <typename IL, typename OL>
 struct copier_n<iterator_from_2d<IL>,iterator_from_2d<OL> > {
-   typedef typename iterator_from_2d<IL>::difference_type diff_t;
+   using diff_t = typename iterator_from_2d<IL>::difference_type;
    BOOST_FORCEINLINE void operator()(iterator_from_2d<IL> src, diff_t n, iterator_from_2d<OL> dst) const {
         gil_function_requires<PixelLocatorConcept<IL> >();
         gil_function_requires<MutablePixelLocatorConcept<OL> >();
@@ -233,8 +233,8 @@ struct copier_n<iterator_from_2d<IL>,iterator_from_2d<OL> > {
 
 template <typename SrcIterator, typename DstIterator>
 BOOST_FORCEINLINE DstIterator copy_with_2d_iterators(SrcIterator first, SrcIterator last, DstIterator dst) {
-    typedef typename SrcIterator::x_iterator src_x_iterator;
-    typedef typename DstIterator::x_iterator dst_x_iterator;
+    using src_x_iterator = typename SrcIterator::x_iterator;
+    using dst_x_iterator = typename DstIterator::x_iterator;
 
     typename SrcIterator::difference_type n = last - first;
 
@@ -290,7 +290,7 @@ class copy_and_convert_pixels_fn : public binary_operation_obj<copy_and_convert_
 private:
     CC _cc;
 public:
-    typedef typename binary_operation_obj<copy_and_convert_pixels_fn<CC> >::result_type result_type;
+    using result_type = typename binary_operation_obj<copy_and_convert_pixels_fn<default_color_converter> >::result_type;
     copy_and_convert_pixels_fn() {}
     copy_and_convert_pixels_fn(CC cc_in) : _cc(cc_in) {}
    // when the two color spaces are incompatible, a color conversion is performed
@@ -491,7 +491,7 @@ void uninitialized_fill_aux(It first, It last,
                             const P& p, mpl::true_) {
     int channel=0;
     try {
-        typedef typename std::iterator_traits<It>::value_type pixel_t;
+        using pixel_t = typename std::iterator_traits<It>::value_type;
         while (channel < num_channels<pixel_t>::value) {
             std::uninitialized_fill(dynamic_at_c(first,channel), dynamic_at_c(last,channel),
                                     dynamic_at_c(p,channel));
@@ -550,7 +550,7 @@ void uninitialized_fill_pixels(const View& img_view, const Value& val) {
 namespace detail {
 template <typename It> BOOST_FORCEINLINE
 void default_construct_range_impl(It first, It last, mpl::true_) {
-    typedef typename std::iterator_traits<It>::value_type value_t;
+    using value_t = typename std::iterator_traits<It>::value_type;
     It first1=first;
     try {
         while (first!=last) {
@@ -575,7 +575,7 @@ BOOST_FORCEINLINE
 void default_construct_aux(It first, It last, mpl::true_) {
     int channel=0;
     try {
-        typedef typename std::iterator_traits<It>::value_type pixel_t;
+        using pixel_t = typename std::iterator_traits<It>::value_type;
         while (channel < num_channels<pixel_t>::value) {
             default_construct_range(dynamic_at_c(first,channel), dynamic_at_c(last,channel));
             ++channel;
@@ -675,7 +675,7 @@ void uninitialized_copy_aux(It1 first1, It1 last1,
                             It2 first2, mpl::true_) {
     int channel=0;
     try {
-        typedef typename std::iterator_traits<It1>::value_type pixel_t;
+        using pixel_t = typename std::iterator_traits<It1>::value_type;
         while (channel < num_channels<pixel_t>::value) {
             std::uninitialized_copy(dynamic_at_c(first1,channel), dynamic_at_c(last1,channel), dynamic_at_c(first2,channel));
             ++channel;
@@ -703,7 +703,7 @@ void uninitialized_copy_aux(It1 first1, It1 last1,
 /// If an exception is thrown destructs any in-place copy-constructed objects
 template <typename View1, typename View2>
 void uninitialized_copy_pixels(const View1& view1, const View2& view2) {
-    typedef mpl::bool_<is_planar<View1>::value && is_planar<View2>::value> is_planar;
+    using is_planar = mpl::bool_<is_planar<View1>::value && is_planar<View2>::value>;
     assert(view1.dimensions()==view2.dimensions());
     if (view1.is_1d_traversable() && view2.is_1d_traversable())
         detail::uninitialized_copy_aux(view1.begin().x(), view1.end().x(),

--- a/include/boost/gil/bit_aligned_pixel_iterator.hpp
+++ b/include/boost/gil/bit_aligned_pixel_iterator.hpp
@@ -46,10 +46,10 @@ private:
                             typename NonAlignedPixelReference::bit_range_t::difference_type> parent_t;
     template <typename Ref> friend struct bit_aligned_pixel_iterator;
 
-    typedef typename NonAlignedPixelReference::bit_range_t bit_range_t;
+    using bit_range_t = typename NonAlignedPixelReference::bit_range_t;
 public:
-    typedef typename parent_t::difference_type             difference_type;
-    typedef typename parent_t::reference                   reference;
+    using difference_type = typename parent_t::difference_type;
+    using reference = typename parent_t::reference;
 
     bit_aligned_pixel_iterator() {}
     bit_aligned_pixel_iterator(const bit_aligned_pixel_iterator& p) : _bit_range(p._bit_range) {}
@@ -83,7 +83,7 @@ private:
 
 template <typename NonAlignedPixelReference>
 struct const_iterator_type<bit_aligned_pixel_iterator<NonAlignedPixelReference> > {
-    typedef bit_aligned_pixel_iterator<typename NonAlignedPixelReference::const_reference> type;
+    using type = bit_aligned_pixel_iterator<typename NonAlignedPixelReference::const_reference>;
 };
 
 template <typename NonAlignedPixelReference>
@@ -144,7 +144,7 @@ NonAlignedPixelReference memunit_advanced_ref(bit_aligned_pixel_iterator<NonAlig
 
 template <typename NonAlignedPixelReference>
 struct dynamic_x_step_type<bit_aligned_pixel_iterator<NonAlignedPixelReference> > {
-    typedef memory_based_step_iterator<bit_aligned_pixel_iterator<NonAlignedPixelReference> > type;
+    using type = memory_based_step_iterator<bit_aligned_pixel_iterator<NonAlignedPixelReference> >;
 };
 
 /////////////////////////////

--- a/include/boost/gil/bit_aligned_pixel_iterator.hpp
+++ b/include/boost/gil/bit_aligned_pixel_iterator.hpp
@@ -39,11 +39,11 @@ struct bit_aligned_pixel_iterator : public iterator_facade<bit_aligned_pixel_ite
                                                   const NonAlignedPixelReference,
                                                   typename NonAlignedPixelReference::bit_range_t::difference_type> {
 private:
-    typedef iterator_facade<bit_aligned_pixel_iterator<NonAlignedPixelReference>,
+    using parent_t = iterator_facade<bit_aligned_pixel_iterator<NonAlignedPixelReference>,
                             typename NonAlignedPixelReference::value_type,
                             std::random_access_iterator_tag,
                             const NonAlignedPixelReference,
-                            typename NonAlignedPixelReference::bit_range_t::difference_type> parent_t;
+                            typename NonAlignedPixelReference::bit_range_t::difference_type>;
     template <typename Ref> friend struct bit_aligned_pixel_iterator;
 
     using bit_range_t = typename NonAlignedPixelReference::bit_range_t;
@@ -152,13 +152,15 @@ struct dynamic_x_step_type<bit_aligned_pixel_iterator<NonAlignedPixelReference> 
 /////////////////////////////
 
 template <typename B, typename C, typename L, bool M>
-struct iterator_type_from_pixel<const bit_aligned_pixel_reference<B,C,L,M>,false,false,false> {
-    typedef bit_aligned_pixel_iterator<bit_aligned_pixel_reference<B,C,L,false> > type;
+struct iterator_type_from_pixel<const bit_aligned_pixel_reference<B,C,L,M>,false,false,false>
+{
+    using type = bit_aligned_pixel_iterator<bit_aligned_pixel_reference<B,C,L,false>> ;
 };
 
 template <typename B, typename C, typename L, bool M>
-struct iterator_type_from_pixel<const bit_aligned_pixel_reference<B,C,L,M>,false,false,true> {
-    typedef bit_aligned_pixel_iterator<bit_aligned_pixel_reference<B,C,L,true> > type;
+struct iterator_type_from_pixel<const bit_aligned_pixel_reference<B,C,L,M>,false,false,true>
+{
+    using type = bit_aligned_pixel_iterator<bit_aligned_pixel_reference<B,C,L,true>>;
 };
 
 template <typename B, typename C, typename L, bool M, bool IsPlanar, bool IsStep, bool IsMutable>

--- a/include/boost/gil/bit_aligned_pixel_reference.hpp
+++ b/include/boost/gil/bit_aligned_pixel_reference.hpp
@@ -37,7 +37,7 @@ template <int RangeSize, bool Mutable>
 class bit_range {
 public:
     typedef typename mpl::if_c<Mutable,unsigned char,const unsigned char>::type byte_t;
-    typedef std::ptrdiff_t difference_type;
+    using difference_type = std::ptrdiff_t;
     template <int RS, bool M> friend class bit_range;
 private:
     byte_t* _current_byte;   // the starting byte of the bit range
@@ -113,13 +113,13 @@ template <typename BitField,
 struct bit_aligned_pixel_reference {
     BOOST_STATIC_CONSTANT(int, bit_size = (mpl::accumulate<ChannelBitSizes, mpl::int_<0>, mpl::plus<mpl::_1, mpl::_2> >::type::value));
     typedef boost::gil::bit_range<bit_size,IsMutable>                                           bit_range_t;
-    typedef BitField                                                                bitfield_t;
+    using bitfield_t = BitField;
     typedef typename mpl::if_c<IsMutable,unsigned char*,const unsigned char*>::type data_ptr_t;
 
-    typedef Layout layout_t;
+    using layout_t = Layout;
 
     typedef typename packed_pixel_type<bitfield_t,ChannelBitSizes,Layout>::type       value_type;
-    typedef const bit_aligned_pixel_reference                                         reference;
+    using reference = const bit_aligned_pixel_reference<BitField, ChannelBitSizes, Layout, IsMutable>;
     typedef const bit_aligned_pixel_reference<BitField,ChannelBitSizes,Layout,false>  const_reference;
 
     BOOST_STATIC_CONSTANT(bool, is_mutable = IsMutable);
@@ -197,7 +197,7 @@ typename kth_element_reference_type<bit_aligned_pixel_reference<BitField,Channel
 at_c(const bit_aligned_pixel_reference<BitField,ChannelBitSizes,L,Mutable>& p) {
     typedef bit_aligned_pixel_reference<BitField,ChannelBitSizes,L,Mutable> pixel_t;
     typedef typename kth_element_reference_type<pixel_t,K>::type channel_t;
-    typedef typename pixel_t::bit_range_t bit_range_t;
+    using bit_range_t = typename pixel_t::bit_range_t;
 
     bit_range_t bit_range(p.bit_range());
     bit_range.bit_advance(detail::sum_k<ChannelBitSizes,K>::value);
@@ -219,12 +219,12 @@ struct is_pixel<bit_aligned_pixel_reference<B,C,L,M> > : public mpl::true_{};
 
 template <typename B, typename C, typename L, bool M>
 struct color_space_type<bit_aligned_pixel_reference<B,C,L,M> > {
-    typedef typename L::color_space_t type;
+    using type = typename L::color_space_t;
 };
 
 template <typename B, typename C, typename L, bool M>
 struct channel_mapping_type<bit_aligned_pixel_reference<B,C,L,M> > {
-    typedef typename L::channel_mapping_t type;
+    using type = typename L::channel_mapping_t;
 };
 
 template <typename B, typename C, typename L, bool M>
@@ -238,7 +238,7 @@ namespace detail {
     // returns a vector containing K copies of the type T
     template <unsigned K, typename T> struct k_copies;
     template <typename T> struct k_copies<0,T> {
-        typedef mpl::vector0<> type;
+        using type = mpl::vector0<>;
     };
     template <unsigned K, typename T> struct k_copies : public mpl::push_back<typename k_copies<K-1,T>::type, T> {};
 }
@@ -247,7 +247,7 @@ namespace detail {
 template <typename BitField, int NumBits, typename Layout>
 struct pixel_reference_type<const packed_dynamic_channel_reference<BitField,NumBits,false>, Layout, false, false> {
 private:
-    typedef typename mpl::size<typename Layout::color_space_t>::type size_t;
+    using size_t = typename mpl::size<typename Layout::color_space_t>::type;
     typedef typename detail::k_copies<size_t::value,mpl::integral_c<unsigned,NumBits> >::type channel_bit_sizes_t;
 public:
     typedef bit_aligned_pixel_reference<BitField, channel_bit_sizes_t, Layout, false> type;
@@ -257,7 +257,7 @@ public:
 template <typename BitField, int NumBits, typename Layout>
 struct pixel_reference_type<const packed_dynamic_channel_reference<BitField,NumBits,true>, Layout, false, true> {
 private:
-    typedef typename mpl::size<typename Layout::color_space_t>::type size_t;
+    using size_t = typename mpl::size<typename Layout::color_space_t>::type;
     typedef typename detail::k_copies<size_t::value,mpl::integral_c<unsigned,NumBits> >::type channel_bit_sizes_t;
 public:
     typedef bit_aligned_pixel_reference<BitField, channel_bit_sizes_t, Layout, true> type;

--- a/include/boost/gil/bit_aligned_pixel_reference.hpp
+++ b/include/boost/gil/bit_aligned_pixel_reference.hpp
@@ -91,7 +91,7 @@ Example:
 unsigned char data=0;
 
 // A mutable reference to a 6-bit BGR pixel in "123" format (1 bit for red, 2 bits for green, 3 bits for blue)
-typedef const bit_aligned_pixel_reference<unsigned char, mpl::vector3_c<int,1,2,3>, rgb_layout_t, true>  rgb123_ref_t;
+using rgb123_ref_t = bit_aligned_pixel_reference<unsigned char, mpl::vector3_c<int,1,2,3>, rgb_layout_t, true> const;
 
 // create the pixel reference at bit offset 2
 // (i.e. red = [2], green = [3,4], blue = [5,6,7] bits)

--- a/include/boost/gil/bit_aligned_pixel_reference.hpp
+++ b/include/boost/gil/bit_aligned_pixel_reference.hpp
@@ -36,7 +36,7 @@ namespace boost { namespace gil {
 template <int RangeSize, bool Mutable>
 class bit_range {
 public:
-    typedef typename mpl::if_c<Mutable,unsigned char,const unsigned char>::type byte_t;
+    using byte_t = typename mpl::if_c<Mutable,unsigned char,const unsigned char>::type;
     using difference_type = std::ptrdiff_t;
     template <int RS, bool M> friend class bit_range;
 private:
@@ -112,15 +112,15 @@ template <typename BitField,
           bool IsMutable>
 struct bit_aligned_pixel_reference {
     BOOST_STATIC_CONSTANT(int, bit_size = (mpl::accumulate<ChannelBitSizes, mpl::int_<0>, mpl::plus<mpl::_1, mpl::_2> >::type::value));
-    typedef boost::gil::bit_range<bit_size,IsMutable>                                           bit_range_t;
+    using bit_range_t = boost::gil::bit_range<bit_size,IsMutable>;
     using bitfield_t = BitField;
-    typedef typename mpl::if_c<IsMutable,unsigned char*,const unsigned char*>::type data_ptr_t;
+    using data_ptr_t =typename mpl::if_c<IsMutable,unsigned char*,const unsigned char*>::type;
 
     using layout_t = Layout;
 
-    typedef typename packed_pixel_type<bitfield_t,ChannelBitSizes,Layout>::type       value_type;
+    using value_type = typename packed_pixel_type<bitfield_t,ChannelBitSizes,Layout>::type;
     using reference = const bit_aligned_pixel_reference<BitField, ChannelBitSizes, Layout, IsMutable>;
-    typedef const bit_aligned_pixel_reference<BitField,ChannelBitSizes,Layout,false>  const_reference;
+    using const_reference = bit_aligned_pixel_reference<BitField,ChannelBitSizes,Layout,false> const;
 
     BOOST_STATIC_CONSTANT(bool, is_mutable = IsMutable);
 
@@ -169,9 +169,9 @@ private:
 /////////////////////////////
 
 template <typename BitField, typename ChannelBitSizes, typename L, bool IsMutable, int K>
-struct kth_element_type<bit_aligned_pixel_reference<BitField,ChannelBitSizes,L,IsMutable>, K> {
-public:
-    typedef const packed_dynamic_channel_reference<BitField, mpl::at_c<ChannelBitSizes,K>::type::value, IsMutable> type;
+struct kth_element_type<bit_aligned_pixel_reference<BitField,ChannelBitSizes,L,IsMutable>, K>
+{
+    using type = packed_dynamic_channel_reference<BitField, mpl::at_c<ChannelBitSizes,K>::type::value, IsMutable> const;
 };
 
 template <typename B, typename C, typename L, bool M, int K>
@@ -194,9 +194,10 @@ namespace detail {
 // at_c required by MutableColorBaseConcept
 template <int K, typename BitField, typename ChannelBitSizes, typename L, bool Mutable> inline
 typename kth_element_reference_type<bit_aligned_pixel_reference<BitField,ChannelBitSizes,L,Mutable>,K>::type
-at_c(const bit_aligned_pixel_reference<BitField,ChannelBitSizes,L,Mutable>& p) {
-    typedef bit_aligned_pixel_reference<BitField,ChannelBitSizes,L,Mutable> pixel_t;
-    typedef typename kth_element_reference_type<pixel_t,K>::type channel_t;
+at_c(const bit_aligned_pixel_reference<BitField,ChannelBitSizes,L,Mutable>& p)
+{
+    using pixel_t = bit_aligned_pixel_reference<BitField,ChannelBitSizes,L,Mutable>;
+    using channel_t = typename kth_element_reference_type<pixel_t,K>::type;
     using bit_range_t = typename pixel_t::bit_range_t;
 
     bit_range_t bit_range(p.bit_range());
@@ -245,22 +246,24 @@ namespace detail {
 
 // Constructs a homogeneous bit_aligned_pixel_reference given a channel reference
 template <typename BitField, int NumBits, typename Layout>
-struct pixel_reference_type<const packed_dynamic_channel_reference<BitField,NumBits,false>, Layout, false, false> {
+struct pixel_reference_type<const packed_dynamic_channel_reference<BitField,NumBits,false>, Layout, false, false>
+{
 private:
     using size_t = typename mpl::size<typename Layout::color_space_t>::type;
-    typedef typename detail::k_copies<size_t::value,mpl::integral_c<unsigned,NumBits> >::type channel_bit_sizes_t;
+    using channel_bit_sizes_t = typename detail::k_copies<size_t::value,mpl::integral_c<unsigned,NumBits> >::type;
 public:
-    typedef bit_aligned_pixel_reference<BitField, channel_bit_sizes_t, Layout, false> type;
+    using type = bit_aligned_pixel_reference<BitField, channel_bit_sizes_t, Layout, false>;
 };
 
 // Same but for the mutable case. We cannot combine the mutable and read-only cases because this triggers ambiguity
 template <typename BitField, int NumBits, typename Layout>
-struct pixel_reference_type<const packed_dynamic_channel_reference<BitField,NumBits,true>, Layout, false, true> {
+struct pixel_reference_type<const packed_dynamic_channel_reference<BitField,NumBits,true>, Layout, false, true>
+{
 private:
     using size_t = typename mpl::size<typename Layout::color_space_t>::type;
-    typedef typename detail::k_copies<size_t::value,mpl::integral_c<unsigned,NumBits> >::type channel_bit_sizes_t;
+    using channel_bit_sizes_t = typename detail::k_copies<size_t::value,mpl::integral_c<unsigned,NumBits>>::type;
 public:
-    typedef bit_aligned_pixel_reference<BitField, channel_bit_sizes_t, Layout, true> type;
+    using type = bit_aligned_pixel_reference<BitField, channel_bit_sizes_t, Layout, true>;
 };
 
 } }  // namespace boost::gil

--- a/include/boost/gil/channel.hpp
+++ b/include/boost/gil/channel.hpp
@@ -112,11 +112,11 @@ namespace detail {
 \code
 template <typename Channel>
 struct channel_traits {
-    typedef ... value_type;
-    typedef ... reference;
-    typedef ... pointer;
-    typedef ... const_reference;
-    typedef ... const_pointer;
+    using value_type = ...;
+    using reference = ...;
+    using pointer = ...;
+    using const_reference = ...;
+    using const_pointer = ...;
 
     static const bool is_mutable;
     static value_type min_value();
@@ -153,7 +153,7 @@ Example:
 // Create a double channel with range [-0.5 .. 0.5]
 struct double_minus_half  { static double apply() { return -0.5; } };
 struct double_plus_half   { static double apply() { return  0.5; } };
-typedef scoped_channel_value<double, double_minus_half, double_plus_half> bits64custom_t;
+using bits64custom_t = scoped_channel_value<double, double_minus_half, double_plus_half>;
 
 // channel_convert its maximum should map to the maximum
 bits64custom_t x = channel_traits<bits64custom_t>::max_value();
@@ -257,7 +257,7 @@ namespace detail {
 Example:
 \code
 // A 4-bit unsigned integral channel.
-typedef packed_channel_value<4> bits4;
+using bits4 = packed_channel_value<4>;
 
 assert(channel_traits<bits4>::min_value()==0);
 assert(channel_traits<bits4>::max_value()==15);
@@ -387,7 +387,7 @@ private:
 Example:
 \code
 // Reference to a 2-bit channel starting at bit 1 (i.e. the second bit)
-typedef const packed_channel_reference<uint16_t,1,2,true> bits2_1_ref_t;
+using bits2_1_ref_t = packed_channel_reference<uint16_t,1,2,true> const;
 
 uint16_t data=0;
 bits2_1_ref_t channel_ref(&data);
@@ -508,7 +508,7 @@ namespace boost { namespace gil {
 Example:
 \code
 // Reference to a 2-bit channel whose offset is specified at construction time
-typedef const packed_dynamic_channel_reference<uint8_t,2,true> bits2_dynamic_ref_t;
+using bits2_dynamic_ref_t = packed_dynamic_channel_reference<uint8_t,2,true> const;
 
 uint16_t data=0;
 bits2_dynamic_ref_t channel_ref(&data,1);

--- a/include/boost/gil/channel.hpp
+++ b/include/boost/gil/channel.hpp
@@ -74,11 +74,11 @@ namespace detail {
     // channel traits for custom class
     template <typename T>
     struct channel_traits_impl<T, true> {
-        typedef typename T::value_type      value_type;
-        typedef typename T::reference       reference;
-        typedef typename T::pointer         pointer;
-        typedef typename T::const_reference const_reference;
-        typedef typename T::const_pointer   const_pointer;
+        using value_type = typename T::value_type;
+        using reference = typename T::reference;
+        using pointer = typename T::pointer;
+        using const_reference = typename T::const_reference;
+        using const_pointer = typename T::const_pointer;
         BOOST_STATIC_CONSTANT(bool, is_mutable=T::is_mutable);
         static value_type min_value() { return T::min_value(); }
         static value_type max_value() { return T::max_value(); }
@@ -87,11 +87,11 @@ namespace detail {
     // channel traits implementation for built-in integral or floating point channel type
     template <typename T>
     struct channel_traits_impl<T, false> {
-        typedef T           value_type;
-        typedef T&          reference;
-        typedef T*          pointer;
-        typedef const T&    const_reference;
-        typedef T const*    const_pointer;
+        using value_type = T;
+        using reference = T&;
+        using pointer = T*;
+        using const_reference = T const&;
+        using const_pointer = T const*;
         BOOST_STATIC_CONSTANT(bool, is_mutable=true);
         static value_type min_value() { return (std::numeric_limits<T>::min)(); }
         static value_type max_value() { return (std::numeric_limits<T>::max)(); }
@@ -100,8 +100,8 @@ namespace detail {
     // channel traits implementation for constant built-in scalar or floating point type
     template <typename T>
     struct channel_traits_impl<const T, false> : public channel_traits_impl<T, false> {
-        typedef const T&    reference;
-        typedef const T*    pointer;
+        using reference = const T &;
+        using pointer = const T *;
         BOOST_STATIC_CONSTANT(bool, is_mutable=false);
     };
 }
@@ -128,12 +128,12 @@ template <typename T>
 struct channel_traits : public detail::channel_traits_impl<T, is_class<T>::value> {};
 
 // Channel traits for C++ reference type - remove the reference
-template <typename T> struct channel_traits<      T&> : public channel_traits<T> {};
+template <typename T> struct channel_traits<T&> : public channel_traits<T> {};
 
 // Channel traits for constant C++ reference type
-template <typename T> struct channel_traits<const T&> : public channel_traits<T> {
-    typedef typename channel_traits<T>::const_reference reference;
-    typedef typename channel_traits<T>::const_pointer   pointer;
+template <typename T> struct channel_traits<T const&> : public channel_traits<T> {
+    using reference = typename channel_traits<T>::const_reference;
+    using pointer = typename channel_traits<T>::const_pointer;
     BOOST_STATIC_CONSTANT(bool, is_mutable=false);
 };
 
@@ -168,14 +168,14 @@ assert(y == 65535);
 template <typename BaseChannelValue,        // base channel (models ChannelValueConcept)
           typename MinVal, typename MaxVal> // classes with a static apply() function returning the minimum/maximum channel values
 struct scoped_channel_value {
-    typedef scoped_channel_value    value_type;
-    typedef value_type&             reference;
-    typedef value_type*             pointer;
-    typedef const value_type&       const_reference;
-    typedef const value_type*       const_pointer;
+    using value_type = scoped_channel_value<BaseChannelValue, MinVal, MaxVal>;
+    using reference = value_type&;
+    using pointer = value_type*;
+    using const_reference = value_type const&;
+    using const_pointer = value_type const*;
     BOOST_STATIC_CONSTANT(bool, is_mutable=channel_traits<BaseChannelValue>::is_mutable);
 
-    typedef BaseChannelValue base_channel_t;
+    using base_channel_t = BaseChannelValue;
 
     static value_type min_value() { return MinVal::apply(); }
     static value_type max_value() { return MaxVal::apply(); }
@@ -272,14 +272,13 @@ template <int NumBits>
 class packed_channel_value {
 
 public:
-    typedef typename detail::min_fast_uint<NumBits>::type integer_t;
+    using integer_t = typename detail::min_fast_uint<NumBits>::type;
 
-
-    typedef packed_channel_value   value_type;
-    typedef value_type&            reference;
-    typedef const value_type&      const_reference;
-    typedef value_type*            pointer;
-    typedef const value_type*      const_pointer;
+    using value_type = packed_channel_value<NumBits>;
+    using reference = value_type&;
+    using const_reference = value_type const&;
+    using pointer = value_type*;
+    using const_pointer = value_type const*;
 
     static value_type min_value() { return 0; }
     static value_type max_value() { return low_bits_mask_t< NumBits >::sig_bits; }
@@ -316,22 +315,22 @@ struct static_copy_bytes<0> {
 template <typename Derived, typename BitField, int NumBits, bool Mutable>
 class packed_channel_reference_base {
 protected:
-    typedef typename mpl::if_c<Mutable,void*,const void*>::type data_ptr_t;
+    using data_ptr_t = typename mpl::if_c<Mutable,void*,const void*>::type;
 public:
     data_ptr_t _data_ptr;   // void* pointer to the first byte of the bit range
 
-    typedef packed_channel_value<NumBits>   value_type;
-    typedef const Derived                   reference;
-    typedef value_type*                     pointer;
-    typedef const value_type*               const_pointer;
+    using value_type = packed_channel_value<NumBits>;
+    using reference = const Derived;
+    using pointer = value_type *;
+    using const_pointer = const value_type *;
     BOOST_STATIC_CONSTANT(int,  num_bits=NumBits);
     BOOST_STATIC_CONSTANT(bool, is_mutable=Mutable);
 
     static value_type min_value()       { return channel_traits<value_type>::min_value(); }
     static value_type max_value()       { return channel_traits<value_type>::max_value(); }
 
-    typedef BitField                       bitfield_t;
-    typedef typename value_type::integer_t integer_t;
+    using bitfield_t = BitField;
+    using integer_t = typename value_type::integer_t;
 
     packed_channel_reference_base(data_ptr_t data_ptr) : _data_ptr(data_ptr) {}
     packed_channel_reference_base(const packed_channel_reference_base& ref) : _data_ptr(ref._data_ptr) {}
@@ -352,8 +351,8 @@ public:
     data_ptr_t operator &() const {return _data_ptr;}
 protected:
 
-    typedef  typename detail::num_value_fn< NumBits >::type num_value_t;
-    typedef  typename detail::max_value_fn< NumBits >::type max_value_t;
+    using num_value_t = typename detail::num_value_fn<NumBits>::type;
+    using max_value_t = typename detail::max_value_fn<NumBits>::type;
 
     static const num_value_t num_values = static_cast< num_value_t >( 1 ) << NumBits ;
     static const max_value_t max_val    = static_cast< max_value_t >( num_values - 1 );
@@ -411,17 +410,18 @@ class packed_dynamic_channel_reference;
 /// \brief A constant subbyte channel reference whose bit offset is fixed at compile time. Models ChannelConcept
 template <typename BitField, int FirstBit, int NumBits>
 class packed_channel_reference<BitField,FirstBit,NumBits,false>
-   : public detail::packed_channel_reference_base<packed_channel_reference<BitField,FirstBit,NumBits,false>,BitField,NumBits,false> {
-    typedef detail::packed_channel_reference_base<packed_channel_reference<BitField,FirstBit,NumBits,false>,BitField,NumBits,false> parent_t;
+   : public detail::packed_channel_reference_base<packed_channel_reference<BitField,FirstBit,NumBits,false>,BitField,NumBits,false>
+{
+    using parent_t = detail::packed_channel_reference_base<packed_channel_reference<BitField,FirstBit,NumBits,false>,BitField,NumBits,false>;
     friend class packed_channel_reference<BitField,FirstBit,NumBits,true>;
 
     static const BitField channel_mask = static_cast< BitField >( parent_t::max_val ) << FirstBit;
 
     void operator=(const packed_channel_reference&);
 public:
-    typedef const packed_channel_reference<BitField,FirstBit,NumBits,false> const_reference;
-    typedef const packed_channel_reference<BitField,FirstBit,NumBits,true>  mutable_reference;
-    typedef typename parent_t::integer_t                           integer_t;
+    using const_reference = packed_channel_reference<BitField,FirstBit,NumBits,false> const;
+    using mutable_reference = packed_channel_reference<BitField,FirstBit,NumBits,true> const;
+    using integer_t = typename parent_t::integer_t;
 
     explicit packed_channel_reference(const void* data_ptr) : parent_t(data_ptr) {}
     packed_channel_reference(const packed_channel_reference& ref) : parent_t(ref._data_ptr) {}
@@ -436,16 +436,17 @@ public:
 /// \brief A mutable subbyte channel reference whose bit offset is fixed at compile time. Models ChannelConcept
 template <typename BitField, int FirstBit, int NumBits>
 class packed_channel_reference<BitField,FirstBit,NumBits,true>
-   : public detail::packed_channel_reference_base<packed_channel_reference<BitField,FirstBit,NumBits,true>,BitField,NumBits,true> {
-    typedef detail::packed_channel_reference_base<packed_channel_reference<BitField,FirstBit,NumBits,true>,BitField,NumBits,true> parent_t;
+   : public detail::packed_channel_reference_base<packed_channel_reference<BitField,FirstBit,NumBits,true>,BitField,NumBits,true>
+{
+    using parent_t = detail::packed_channel_reference_base<packed_channel_reference<BitField,FirstBit,NumBits,true>,BitField,NumBits,true>;
     friend class packed_channel_reference<BitField,FirstBit,NumBits,false>;
 
     static const BitField channel_mask = static_cast< BitField >( parent_t::max_val ) << FirstBit;
 
 public:
-    typedef const packed_channel_reference<BitField,FirstBit,NumBits,false> const_reference;
-    typedef const packed_channel_reference<BitField,FirstBit,NumBits,true>  mutable_reference;
-    typedef typename parent_t::integer_t                           integer_t;
+    using const_reference = packed_channel_reference<BitField,FirstBit,NumBits,false> const;
+    using mutable_reference = packed_channel_reference<BitField,FirstBit,NumBits,true> const;
+    using integer_t = typename parent_t::integer_t;
 
     explicit packed_channel_reference(void* data_ptr) : parent_t(data_ptr) {}
     packed_channel_reference(const packed_channel_reference& ref) : parent_t(ref._data_ptr) {}
@@ -521,17 +522,18 @@ assert(data == 6);                                                  // == (3<<1)
 /// \ingroup PackedChannelDynamicReferenceModel
 template <typename BitField, int NumBits>
 class packed_dynamic_channel_reference<BitField,NumBits,false>
-   : public detail::packed_channel_reference_base<packed_dynamic_channel_reference<BitField,NumBits,false>,BitField,NumBits,false> {
-    typedef detail::packed_channel_reference_base<packed_dynamic_channel_reference<BitField,NumBits,false>,BitField,NumBits,false> parent_t;
+   : public detail::packed_channel_reference_base<packed_dynamic_channel_reference<BitField,NumBits,false>,BitField,NumBits,false>
+{
+    using parent_t = detail::packed_channel_reference_base<packed_dynamic_channel_reference<BitField,NumBits,false>,BitField,NumBits,false>;
     friend class packed_dynamic_channel_reference<BitField,NumBits,true>;
 
     unsigned _first_bit;     // 0..7
 
     void operator=(const packed_dynamic_channel_reference&);
 public:
-    typedef const packed_dynamic_channel_reference<BitField,NumBits,false> const_reference;
-    typedef const packed_dynamic_channel_reference<BitField,NumBits,true>  mutable_reference;
-    typedef typename parent_t::integer_t                          integer_t;
+    using const_reference = packed_dynamic_channel_reference<BitField,NumBits,false> const;
+    using mutable_reference = packed_dynamic_channel_reference<BitField,NumBits,true> const;
+    using integer_t = typename parent_t::integer_t;
 
     packed_dynamic_channel_reference(const void* data_ptr, unsigned first_bit) : parent_t(data_ptr), _first_bit(first_bit) {}
     packed_dynamic_channel_reference(const const_reference&   ref) : parent_t(ref._data_ptr), _first_bit(ref._first_bit) {}
@@ -550,16 +552,17 @@ public:
 /// \ingroup PackedChannelDynamicReferenceModel
 template <typename BitField, int NumBits>
 class packed_dynamic_channel_reference<BitField,NumBits,true>
-   : public detail::packed_channel_reference_base<packed_dynamic_channel_reference<BitField,NumBits,true>,BitField,NumBits,true> {
-    typedef detail::packed_channel_reference_base<packed_dynamic_channel_reference<BitField,NumBits,true>,BitField,NumBits,true> parent_t;
+   : public detail::packed_channel_reference_base<packed_dynamic_channel_reference<BitField,NumBits,true>,BitField,NumBits,true>
+{
+    using parent_t = detail::packed_channel_reference_base<packed_dynamic_channel_reference<BitField,NumBits,true>,BitField,NumBits,true>;
     friend class packed_dynamic_channel_reference<BitField,NumBits,false>;
 
     unsigned _first_bit;
 
 public:
-    typedef const packed_dynamic_channel_reference<BitField,NumBits,false> const_reference;
-    typedef const packed_dynamic_channel_reference<BitField,NumBits,true>  mutable_reference;
-    typedef typename parent_t::integer_t                          integer_t;
+    using const_reference = packed_dynamic_channel_reference<BitField,NumBits,false> const;
+    using mutable_reference = packed_dynamic_channel_reference<BitField,NumBits,true> const;
+    using integer_t = typename parent_t::integer_t;
 
     packed_dynamic_channel_reference(void* data_ptr, unsigned first_bit) : parent_t(data_ptr), _first_bit(first_bit) {}
     packed_dynamic_channel_reference(const packed_dynamic_channel_reference& ref) : parent_t(ref._data_ptr), _first_bit(ref._first_bit) {}
@@ -636,23 +639,27 @@ struct is_integral<gil::scoped_channel_value<BaseChannelValue,MinVal,MaxVal> > :
 // \brief Determines the fundamental type which may be used, e.g., to cast from larger to smaller channel types.
 namespace boost { namespace gil {
 template <typename T>
-struct base_channel_type_impl { typedef T type; };
+struct base_channel_type_impl { using type = T; };
 
 template <int N>
 struct base_channel_type_impl<packed_channel_value<N> >
-{ typedef typename packed_channel_value<N>::integer_t type; };
+{ using type = typename packed_channel_value<N>::integer_t; };
 
 template <typename B, int F, int N, bool M>
 struct base_channel_type_impl<packed_channel_reference<B, F, N, M> >
-{ typedef typename packed_channel_reference<B,F,N,M>::integer_t type; };
+{
+    using type = typename packed_channel_reference<B,F,N,M>::integer_t;
+};
 
 template <typename B, int N, bool M>
 struct base_channel_type_impl<packed_dynamic_channel_reference<B, N, M> >
-{ typedef typename packed_dynamic_channel_reference<B,N,M>::integer_t type; };
+{
+    using type = typename packed_dynamic_channel_reference<B,N,M>::integer_t;
+};
 
 template <typename ChannelValue, typename MinV, typename MaxV>
 struct base_channel_type_impl<scoped_channel_value<ChannelValue, MinV, MaxV> >
-{ typedef ChannelValue type; };
+{ using type = ChannelValue; };
 
 template <typename T>
 struct base_channel_type : base_channel_type_impl<typename remove_cv<T>::type > {};

--- a/include/boost/gil/channel_algorithm.hpp
+++ b/include/boost/gil/channel_algorithm.hpp
@@ -84,7 +84,7 @@ Example:
 float32_t src_channel = channel_traits<float32_t>::max_value();
 assert(src_channel == 1);
 
-// uint8_t is 8-bit unsigned integral channel (typedef-ed from unsigned char)
+// uint8_t is 8-bit unsigned integral channel (aliased from unsigned char)
 uint8_t dst_channel = channel_convert<uint8_t>(src_channel);
 assert(dst_channel == 255);     // max value goes to max value
 \endcode
@@ -308,7 +308,7 @@ template <> struct channel_converter_unsigned<float32_t,uint32_t> {
 
 namespace detail {
 // Converting from signed to unsigned integral channel.
-// It is both a unary function, and a metafunction (thus requires the 'type' nested typedef, which equals result_type)
+// It is both a unary function, and a metafunction (thus requires the 'type' nested alias, which equals result_type)
 template <typename ChannelValue>     // Model ChannelValueConcept
 struct channel_convert_to_unsigned : public detail::identity<ChannelValue> {
     using type = ChannelValue;
@@ -343,7 +343,7 @@ template <> struct channel_convert_to_unsigned<int32_t> {
 
 
 // Converting from unsigned to signed integral channel
-// It is both a unary function, and a metafunction (thus requires the 'type' nested typedef, which equals result_type)
+// It is both a unary function, and a metafunction (thus requires the 'type' nested alias, which equals result_type)
 template <typename ChannelValue>     // Model ChannelValueConcept
 struct channel_convert_from_unsigned : public detail::identity<ChannelValue> {
     using type = ChannelValue;

--- a/include/boost/gil/channel_algorithm.hpp
+++ b/include/boost/gil/channel_algorithm.hpp
@@ -119,8 +119,8 @@ namespace detail {
 /// \brief This is the default implementation. Performance specializatons are provided
 template <typename SrcChannelV, typename DstChannelV, bool SrcIsIntegral, bool DstIsIntegral>
 struct channel_converter_unsigned_impl {
-    typedef SrcChannelV argument_type;
-    typedef DstChannelV result_type;
+    using argument_type = SrcChannelV;
+    using result_type = DstChannelV;
     DstChannelV operator()(SrcChannelV src) const {
         return DstChannelV(channel_traits<DstChannelV>::min_value() +
             (src - channel_traits<SrcChannelV>::min_value()) / channel_range<SrcChannelV>() * channel_range<DstChannelV>());
@@ -164,7 +164,7 @@ struct channel_converter_unsigned_integral<SrcChannelV,DstChannelV,false>
 template <typename SrcChannelV, typename DstChannelV>
 struct channel_converter_unsigned_integral_impl<SrcChannelV,DstChannelV,true,true> {
     DstChannelV operator()(SrcChannelV src) const {
-        typedef typename unsigned_integral_max_value<DstChannelV>::value_type integer_t;
+        using integer_t = typename unsigned_integral_max_value<DstChannelV>::value_type;
         static const integer_t mul = unsigned_integral_max_value<DstChannelV>::value / unsigned_integral_max_value<SrcChannelV>::value;
         return DstChannelV(src * mul);
     }
@@ -176,7 +176,7 @@ struct channel_converter_unsigned_integral_impl<SrcChannelV,DstChannelV,true,tru
 template <typename SrcChannelV, typename DstChannelV>
 struct channel_converter_unsigned_integral_impl<SrcChannelV,DstChannelV,false,true> {
     DstChannelV operator()(SrcChannelV src) const {
-        typedef typename unsigned_integral_max_value<SrcChannelV>::value_type integer_t;
+        using integer_t = typename unsigned_integral_max_value<SrcChannelV>::value_type;
         static const integer_t div = unsigned_integral_max_value<SrcChannelV>::value / unsigned_integral_max_value<DstChannelV>::value;
         static const integer_t div2 = div/2;
         return DstChannelV((src + div2) / div);
@@ -214,7 +214,7 @@ struct channel_converter_unsigned_integral_impl<SrcChannelV,DstChannelV,SrcLessT
 template <typename SrcChannelV, typename DstChannelV>
 struct channel_converter_unsigned_integral_nondivisible<SrcChannelV,DstChannelV,true,false> {
     DstChannelV operator()(SrcChannelV src) const {
-        typedef typename base_channel_type<DstChannelV>::type dest_t;
+        using dest_t = typename base_channel_type<DstChannelV>::type;
         return DstChannelV(static_cast<dest_t>( src * unsigned_integral_max_value<DstChannelV>::value) / unsigned_integral_max_value<SrcChannelV>::value);
     }
 };
@@ -238,8 +238,8 @@ template <typename SrcChannelV, typename DstChannelV, bool CannotFit>
 struct channel_converter_unsigned_integral_nondivisible<SrcChannelV,DstChannelV,false,CannotFit> {
     DstChannelV operator()(SrcChannelV src) const {
 
-        typedef typename detail::unsigned_integral_max_value< SrcChannelV >::value_type src_integer_t;
-        typedef typename detail::unsigned_integral_max_value< DstChannelV >::value_type dst_integer_t;
+        using src_integer_t = typename detail::unsigned_integral_max_value<SrcChannelV>::value_type;
+        using dst_integer_t = typename detail::unsigned_integral_max_value<DstChannelV>::value_type;
 
         static const double div = unsigned_integral_max_value<SrcChannelV>::value
                                 / static_cast< double >( unsigned_integral_max_value<DstChannelV>::value );
@@ -257,32 +257,32 @@ struct channel_converter_unsigned_integral_nondivisible<SrcChannelV,DstChannelV,
 /////////////////////////////////////////////////////
 
 template <typename DstChannelV> struct channel_converter_unsigned<float32_t,DstChannelV> {
-    typedef float32_t argument_type;
-    typedef DstChannelV result_type;
+    using argument_type = float32_t;
+    using result_type = DstChannelV;
     DstChannelV operator()(float32_t x) const
     {
-        typedef typename detail::unsigned_integral_max_value< DstChannelV >::value_type dst_integer_t;
+        using dst_integer_t = typename detail::unsigned_integral_max_value<DstChannelV>::value_type;
         return DstChannelV( static_cast< dst_integer_t >(x*channel_traits<DstChannelV>::max_value()+0.5f ));
     }
 };
 
 template <typename SrcChannelV> struct channel_converter_unsigned<SrcChannelV,float32_t> {
-    typedef float32_t argument_type;
-    typedef SrcChannelV result_type;
+    using argument_type = float32_t;
+    using result_type = SrcChannelV;
     float32_t operator()(SrcChannelV   x) const { return float32_t(x/float(channel_traits<SrcChannelV>::max_value())); }
 };
 
 template <> struct channel_converter_unsigned<float32_t,float32_t> {
-    typedef float32_t argument_type;
-    typedef float32_t result_type;
+    using argument_type = float32_t;
+    using result_type = float32_t;
     float32_t operator()(float32_t   x) const { return x; }
 };
 
 
 /// \brief 32 bit <-> float channel conversion
 template <> struct channel_converter_unsigned<uint32_t,float32_t> {
-    typedef uint32_t argument_type;
-    typedef float32_t result_type;
+    using argument_type = uint32_t;
+    using result_type = float32_t;
     float32_t operator()(uint32_t x) const {
         // unfortunately without an explicit check it is possible to get a round-off error. We must ensure that max_value of uint32_t matches max_value of float32_t
         if (x>=channel_traits<uint32_t>::max_value()) return channel_traits<float32_t>::max_value();
@@ -291,8 +291,8 @@ template <> struct channel_converter_unsigned<uint32_t,float32_t> {
 };
 /// \brief 32 bit <-> float channel conversion
 template <> struct channel_converter_unsigned<float32_t,uint32_t> {
-    typedef float32_t argument_type;
-    typedef uint32_t result_type;
+    using argument_type = float32_t;
+    using result_type = uint32_t;
     uint32_t operator()(float32_t x) const {
         // unfortunately without an explicit check it is possible to get a round-off error. We must ensure that max_value of uint32_t matches max_value of float32_t
         if (x>=channel_traits<float32_t>::max_value())
@@ -311,31 +311,31 @@ namespace detail {
 // It is both a unary function, and a metafunction (thus requires the 'type' nested typedef, which equals result_type)
 template <typename ChannelValue>     // Model ChannelValueConcept
 struct channel_convert_to_unsigned : public detail::identity<ChannelValue> {
-    typedef ChannelValue type;
+    using type = ChannelValue;
 };
 
 template <> struct channel_convert_to_unsigned<int8_t> {
-    typedef int8_t argument_type;
-    typedef uint8_t result_type;
-    typedef uint8_t type;
+    using argument_type = int8_t;
+    using result_type = uint8_t;
+    using type = uint8_t;
     type operator()(int8_t val) const {
         return static_cast<uint8_t>(static_cast<uint32_t>(val) + 128u);
     }
 };
 
 template <> struct channel_convert_to_unsigned<int16_t> {
-    typedef int16_t argument_type;
-    typedef uint16_t result_type;
-    typedef uint16_t type;
+    using argument_type = int16_t;
+    using result_type = uint16_t;
+    using type = uint16_t;
     type operator()(int16_t val) const {
         return static_cast<uint16_t>(static_cast<uint32_t>(val) + 32768u);
     }
 };
 
 template <> struct channel_convert_to_unsigned<int32_t> {
-    typedef int32_t argument_type;
-    typedef uint32_t result_type;
-    typedef uint32_t type;
+    using argument_type = int32_t;
+    using result_type = uint32_t;
+    using type = uint32_t;
     type operator()(int32_t val) const {
         return static_cast<uint32_t>(val)+(1u<<31);
     }
@@ -346,31 +346,31 @@ template <> struct channel_convert_to_unsigned<int32_t> {
 // It is both a unary function, and a metafunction (thus requires the 'type' nested typedef, which equals result_type)
 template <typename ChannelValue>     // Model ChannelValueConcept
 struct channel_convert_from_unsigned : public detail::identity<ChannelValue> {
-    typedef ChannelValue type;
+    using type = ChannelValue;
 };
 
 template <> struct channel_convert_from_unsigned<int8_t> {
-    typedef uint8_t argument_type;
-    typedef int8_t result_type;
-    typedef int8_t type;
+    using argument_type = uint8_t;
+    using result_type = int8_t;
+    using type = int8_t;
     type  operator()(uint8_t val) const {
         return static_cast<int8_t>(static_cast<int32_t>(val) - 128);
     }
 };
 
 template <> struct channel_convert_from_unsigned<int16_t> {
-    typedef uint16_t argument_type;
-    typedef int16_t result_type;
-    typedef int16_t type;
+    using argument_type = uint16_t;
+    using result_type = int16_t;
+    using type = int16_t;
     type operator()(uint16_t val) const {
         return static_cast<int16_t>(static_cast<int32_t>(val) - 32768);
     }
 };
 
 template <> struct channel_convert_from_unsigned<int32_t> {
-    typedef uint32_t argument_type;
-    typedef int32_t result_type;
-    typedef int32_t type;
+    using argument_type = uint32_t;
+    using result_type = int32_t;
+    using type = int32_t;
     type operator()(uint32_t val) const {
         return static_cast<int32_t>(val - (1u<<31));
     }
@@ -382,12 +382,12 @@ template <> struct channel_convert_from_unsigned<int32_t> {
 /// \brief A unary function object converting between channel types
 template <typename SrcChannelV, typename DstChannelV> // Model ChannelValueConcept
 struct channel_converter {
-    typedef SrcChannelV argument_type;
-    typedef DstChannelV result_type;
+    using argument_type = SrcChannelV;
+    using result_type = DstChannelV;
     DstChannelV operator()(const SrcChannelV& src) const {
-        typedef detail::channel_convert_to_unsigned<SrcChannelV> to_unsigned;
-        typedef detail::channel_convert_from_unsigned<DstChannelV>   from_unsigned;
-        typedef channel_converter_unsigned<typename to_unsigned::result_type, typename from_unsigned::argument_type> converter_unsigned;
+        using to_unsigned = detail::channel_convert_to_unsigned<SrcChannelV>;
+        using from_unsigned = detail::channel_convert_from_unsigned<DstChannelV>;
+        using converter_unsigned = channel_converter_unsigned<typename to_unsigned::result_type, typename from_unsigned::argument_type>;
         return from_unsigned()(converter_unsigned()(to_unsigned()(src)));
     }
 };
@@ -437,9 +437,9 @@ assert(mul == 64);    // 64 = 128 * 128 / 255
 /// \brief This is the default implementation. Performance specializatons are provided
 template <typename ChannelValue>
 struct channel_multiplier_unsigned {
-    typedef ChannelValue first_argument_type;
-    typedef ChannelValue second_argument_type;
-    typedef ChannelValue result_type;
+    using first_argument_type = ChannelValue;
+    using second_argument_type = ChannelValue;
+    using result_type = ChannelValue;
     ChannelValue operator()(ChannelValue a, ChannelValue b) const {
         return ChannelValue(static_cast<typename base_channel_type<ChannelValue>::type>(a / double(channel_traits<ChannelValue>::max_value()) * b));
     }
@@ -447,38 +447,38 @@ struct channel_multiplier_unsigned {
 
 /// \brief Specialization of channel_multiply for 8-bit unsigned channels
 template<> struct channel_multiplier_unsigned<uint8_t> {
-    typedef uint8_t first_argument_type;
-    typedef uint8_t second_argument_type;
-    typedef uint8_t result_type;
+    using first_argument_type = uint8_t;
+    using second_argument_type = uint8_t;
+    using result_type = uint8_t;
     uint8_t operator()(uint8_t a, uint8_t b) const { return uint8_t(detail::div255(uint32_t(a) * uint32_t(b))); }
 };
 
 /// \brief Specialization of channel_multiply for 16-bit unsigned channels
 template<> struct channel_multiplier_unsigned<uint16_t> {
-    typedef uint16_t first_argument_type;
-    typedef uint16_t second_argument_type;
-    typedef uint16_t result_type;
+    using first_argument_type = uint16_t;
+    using second_argument_type = uint16_t;
+    using result_type = uint16_t;
     uint16_t operator()(uint16_t a, uint16_t b) const { return uint16_t((uint32_t(a) * uint32_t(b))/65535); }
 };
 
 /// \brief Specialization of channel_multiply for float 0..1 channels
 template<> struct channel_multiplier_unsigned<float32_t> {
-    typedef float32_t first_argument_type;
-    typedef float32_t second_argument_type;
-    typedef float32_t result_type;
+    using first_argument_type = float32_t;
+    using second_argument_type = float32_t;
+    using result_type = float32_t;
     float32_t operator()(float32_t a, float32_t b) const { return a*b; }
 };
 
 /// \brief A function object to multiply two channels. result = a * b / max_value
 template <typename ChannelValue>
 struct channel_multiplier {
-    typedef ChannelValue first_argument_type;
-    typedef ChannelValue second_argument_type;
-    typedef ChannelValue result_type;
+    using first_argument_type = ChannelValue;
+    using second_argument_type = ChannelValue;
+    using result_type = ChannelValue;
     ChannelValue operator()(ChannelValue a, ChannelValue b) const {
-        typedef detail::channel_convert_to_unsigned<ChannelValue> to_unsigned;
-        typedef detail::channel_convert_from_unsigned<ChannelValue>   from_unsigned;
-        typedef channel_multiplier_unsigned<typename to_unsigned::result_type> multiplier_unsigned;
+        using to_unsigned = detail::channel_convert_to_unsigned<ChannelValue>;
+        using from_unsigned = detail::channel_convert_from_unsigned<ChannelValue>;
+        using multiplier_unsigned = channel_multiplier_unsigned<typename to_unsigned::result_type>;
         return from_unsigned()(multiplier_unsigned()(to_unsigned()(a), to_unsigned()(b)));
     }
 };

--- a/include/boost/gil/cmyk.hpp
+++ b/include/boost/gil/cmyk.hpp
@@ -34,7 +34,7 @@ struct black_t {};
 /// \}
 
 /// \ingroup ColorSpaceModel
-typedef mpl::vector4<cyan_t,magenta_t,yellow_t,black_t>  cmyk_t;
+using cmyk_t = mpl::vector4<cyan_t,magenta_t,yellow_t,black_t>;
 
 /// \ingroup LayoutModel
 using cmyk_layout_t = layout<cmyk_t>;
@@ -43,9 +43,10 @@ using cmyk_layout_t = layout<cmyk_t>;
 /// \brief from raw CMYK planar data
 template <typename IC>
 inline typename type_from_x_iterator<planar_pixel_iterator<IC,cmyk_t> >::view_t
-planar_cmyk_view(std::size_t width, std::size_t height, IC c, IC m, IC y, IC k, std::ptrdiff_t rowsize_in_bytes) {
-    typedef typename type_from_x_iterator<planar_pixel_iterator<IC,cmyk_t> >::view_t RView;
-    return RView(width, height, typename RView::locator(planar_pixel_iterator<IC,cmyk_t>(c,m,y,k), rowsize_in_bytes));
+planar_cmyk_view(std::size_t width, std::size_t height, IC c, IC m, IC y, IC k, std::ptrdiff_t rowsize_in_bytes)
+{
+    using view_t = typename type_from_x_iterator<planar_pixel_iterator<IC,cmyk_t> >::view_t;
+    return view_t(width, height, typename view_t::locator(planar_pixel_iterator<IC,cmyk_t>(c,m,y,k), rowsize_in_bytes));
 }
 
 } }  // namespace gil

--- a/include/boost/gil/cmyk.hpp
+++ b/include/boost/gil/cmyk.hpp
@@ -37,7 +37,7 @@ struct black_t {};
 typedef mpl::vector4<cyan_t,magenta_t,yellow_t,black_t>  cmyk_t;
 
 /// \ingroup LayoutModel
-typedef layout<cmyk_t> cmyk_layout_t;
+using cmyk_layout_t = layout<cmyk_t>;
 
 /// \ingroup ImageViewConstructors
 /// \brief from raw CMYK planar data

--- a/include/boost/gil/color_base.hpp
+++ b/include/boost/gil/color_base.hpp
@@ -66,7 +66,7 @@ struct homogeneous_color_base<Element,Layout,1> {
 private:
     Element _v0;
 public:
-    typedef Layout layout_t;
+    using layout_t = Layout;
     typename element_reference_type<homogeneous_color_base>::type       at(mpl::int_<0>)       { return _v0; }
     typename element_const_reference_type<homogeneous_color_base>::type at(mpl::int_<0>) const { return _v0; }
 
@@ -87,7 +87,7 @@ struct homogeneous_color_base<Element,Layout,2> {
 private:
     Element _v0, _v1;
 public:
-    typedef Layout layout_t;
+    using layout_t = Layout;
     typename element_reference_type<homogeneous_color_base>::type       at(mpl::int_<0>)       { return _v0; }
     typename element_const_reference_type<homogeneous_color_base>::type at(mpl::int_<0>) const { return _v0; }
     typename element_reference_type<homogeneous_color_base>::type       at(mpl::int_<1>)       { return _v1; }
@@ -133,7 +133,7 @@ struct homogeneous_color_base<Element,Layout,3> {
 private:
     Element _v0, _v1, _v2;
 public:
-    typedef Layout layout_t;
+    using layout_t = Layout;
     typename element_reference_type<homogeneous_color_base>::type       at(mpl::int_<0>)       { return _v0; }
     typename element_const_reference_type<homogeneous_color_base>::type at(mpl::int_<0>) const { return _v0; }
     typename element_reference_type<homogeneous_color_base>::type       at(mpl::int_<1>)       { return _v1; }
@@ -189,7 +189,7 @@ struct homogeneous_color_base<Element,Layout,4> {
 private:
     Element _v0, _v1, _v2, _v3;
 public:
-    typedef Layout layout_t;
+    using layout_t = Layout;
     typename element_reference_type<homogeneous_color_base>::type       at(mpl::int_<0>)       { return _v0; }
     typename element_const_reference_type<homogeneous_color_base>::type at(mpl::int_<0>) const { return _v0; }
     typename element_reference_type<homogeneous_color_base>::type       at(mpl::int_<1>)       { return _v1; }
@@ -253,7 +253,7 @@ struct homogeneous_color_base<Element,Layout,5> {
 private:
     Element _v0, _v1, _v2, _v3, _v4;
 public:
-    typedef Layout layout_t;
+    using layout_t = Layout;
     typename element_reference_type<homogeneous_color_base>::type       at(mpl::int_<0>)       { return _v0; }
     typename element_const_reference_type<homogeneous_color_base>::type at(mpl::int_<0>) const { return _v0; }
     typename element_reference_type<homogeneous_color_base>::type       at(mpl::int_<1>)       { return _v1; }
@@ -365,7 +365,7 @@ dynamic_at_c(const homogeneous_color_base<const Element&,Layout,K>& cb, std::siz
 
 template <typename Element, typename Layout, int K1, int K>
 struct kth_element_type<detail::homogeneous_color_base<Element,Layout,K1>, K> {
-    typedef Element type;
+    using type = Element;
 };
 
 template <typename Element, typename Layout, int K1, int K>

--- a/include/boost/gil/color_base_algorithm.hpp
+++ b/include/boost/gil/color_base_algorithm.hpp
@@ -62,10 +62,10 @@ All GIL color base algorithms taking multiple color bases use semantic indexing 
 Example:
 \code
 // 16-bit BGR pixel, 4 bits for the blue, 3 bits for the green, 2 bits for the red channel and 7 unused bits
-typedef packed_pixel_type<uint16_t, mpl::vector3_c<unsigned,4,3,2>, bgr_layout_t>::type bgr432_pixel_t;
+using bgr432_pixel_t = packed_pixel_type<uint16_t, mpl::vector3_c<unsigned,4,3,2>, bgr_layout_t>::type;
 
 // A reference to its red channel. Although the red channel is the third, its semantic index is 0 in the RGB color space
-typedef kth_semantic_element_reference_type<bgr432_pixel_t, 0>::type red_channel_reference_t;
+using red_channel_reference_t = kth_semantic_element_reference_type<bgr432_pixel_t, 0>::type;
 
 // Initialize the pixel to black
 bgr432_pixel_t red_pixel(0,0,0);
@@ -80,22 +80,23 @@ red_channel = channel_traits<red_channel_reference_t>::max_value();
 /// \ingroup ColorBaseAlgorithmSemanticAtC
 template <typename ColorBase, int K> struct kth_semantic_element_type {
     BOOST_STATIC_CONSTANT(int, semantic_index = (mpl::at_c<typename ColorBase::layout_t::channel_mapping_t,K>::type::value));
-    typedef typename kth_element_type<ColorBase, semantic_index>::type type;
+    using type = typename kth_element_type<ColorBase, semantic_index>::type;
 };
 
 /// \brief Specifies the return type of the mutable semantic_at_c<K>(color_base);
 /// \ingroup ColorBaseAlgorithmSemanticAtC
 template <typename ColorBase, int K> struct kth_semantic_element_reference_type {
     BOOST_STATIC_CONSTANT(int, semantic_index = (mpl::at_c<typename ColorBase::layout_t::channel_mapping_t,K>::type::value));
-    typedef typename kth_element_reference_type<ColorBase,semantic_index>::type type;
+    using type = typename kth_element_reference_type<ColorBase,semantic_index>::type;
     static type       get(ColorBase& cb) { return gil::at_c<semantic_index>(cb); }
 };
 
 /// \brief Specifies the return type of the constant semantic_at_c<K>(color_base);
 /// \ingroup ColorBaseAlgorithmSemanticAtC
-template <typename ColorBase, int K> struct kth_semantic_element_const_reference_type {
+template <typename ColorBase, int K> struct kth_semantic_element_const_reference_type
+{
 	BOOST_STATIC_CONSTANT(int, semantic_index = (mpl::at_c<typename ColorBase::layout_t::channel_mapping_t,K>::type::value));
-	typedef typename kth_element_const_reference_type<ColorBase,semantic_index>::type type;
+    using type = typename kth_element_const_reference_type<ColorBase,semantic_index>::type;
     static type       get(const ColorBase& cb) { return gil::at_c<semantic_index>(cb); }
 };
 
@@ -134,7 +135,7 @@ void set_red_to_max(Pixel& pixel) {
     boost::function_requires<MutablePixelConcept<Pixel> >();
     BOOST_STATIC_ASSERT((contains_color<Pixel, red_t>::value));
 
-    typedef typename color_element_type<Pixel, red_t>::type red_channel_t;
+    using red_channel_t = typename color_element_type<Pixel, red_t>::type;
     get_color(pixel, red_t()) = channel_traits<red_channel_t>::max_value();
 }
 \endcode
@@ -190,7 +191,7 @@ typename color_element_const_reference_type<ColorBase,Color>::type get_color(con
 
 Example:
 \code
-typedef element_type<rgb8c_planar_ptr_t>::type element_t;
+using element_t = element_type<rgb8c_planar_ptr_t>::type;
 BOOST_STATIC_ASSERT((boost::is_same<element_t, const uint8_t*>::value));
 \endcode
 */
@@ -583,7 +584,7 @@ struct my_plus {
 
 template <typename Pixel1, typename Pixel2, typename Pixel3>
 void sum_channels(const Pixel1& p1, const Pixel2& p2, Pixel3& result) {
-    typedef typename channel_type<Pixel3>::type result_channel_t;
+    using result_channel_t = typename channel_type<Pixel3>::type;
     static_transform(p1,p2,result,my_plus<result_channel_t>());
 }
 

--- a/include/boost/gil/color_convert.hpp
+++ b/include/boost/gil/color_convert.hpp
@@ -139,7 +139,7 @@ template <>
 struct default_color_converter_impl<rgb_t,cmyk_t> {
     template <typename P1, typename P2>
     void operator()(const P1& src, P2& dst) const {
-        typedef typename channel_type<P2>::type T2;
+        using T2 = typename channel_type<P2>::type;
         get_color(dst,cyan_t())    = channel_invert(channel_convert<T2>(get_color(src,red_t())));          // c = 1 - r
         get_color(dst,magenta_t()) = channel_invert(channel_convert<T2>(get_color(src,green_t())));        // m = 1 - g
         get_color(dst,yellow_t())  = channel_invert(channel_convert<T2>(get_color(src,blue_t())));         // y = 1 - b
@@ -168,7 +168,7 @@ template <>
 struct default_color_converter_impl<cmyk_t,rgb_t> {
     template <typename P1, typename P2>
     void operator()(const P1& src, P2& dst) const {
-        typedef typename channel_type<P1>::type T1;
+        using T1 = typename channel_type<P1>::type;
         get_color(dst,red_t())  =
             channel_convert<typename color_element_type<P2,red_t>::type>(
                 channel_invert<T1>(
@@ -234,7 +234,7 @@ template <typename C1>
 struct default_color_converter_impl<C1,rgba_t> {
     template <typename P1, typename P2>
     void operator()(const P1& src, P2& dst) const {
-        typedef typename channel_type<P2>::type T2;
+        using T2 = typename channel_type<P2>::type;
         pixel<T2,rgb_layout_t> tmp;
         default_color_converter_impl<C1,rgb_t>()(src,tmp);
         get_color(dst,red_t())  =get_color(tmp,red_t());
@@ -254,7 +254,7 @@ template <typename C2>
 struct default_color_converter_impl<rgba_t,C2> {
     template <typename P1, typename P2>
     void operator()(const P1& src, P2& dst) const {
-        typedef typename channel_type<P1>::type T1;
+        using T1 = typename channel_type<P1>::type;
         default_color_converter_impl<rgb_t,C2>()(
             pixel<T1,rgb_layout_t>(channel_multiply(get_color(src,red_t()),  get_color(src,alpha_t())),
                                    channel_multiply(get_color(src,green_t()),get_color(src,alpha_t())),
@@ -282,8 +282,8 @@ struct default_color_converter_impl<rgba_t,rgba_t> {
 struct default_color_converter {
     template <typename SrcP, typename DstP>
     void operator()(const SrcP& src,DstP& dst) const {
-        typedef typename color_space_type<SrcP>::type SrcColorSpace;
-        typedef typename color_space_type<DstP>::type DstColorSpace;
+        using SrcColorSpace = typename color_space_type<SrcP>::type;
+        using DstColorSpace = typename color_space_type<DstP>::type;
         default_color_converter_impl<SrcColorSpace,DstColorSpace>()(src,dst);
     }
 };

--- a/include/boost/gil/concepts/basic.hpp
+++ b/include/boost/gil/concepts/basic.hpp
@@ -153,7 +153,7 @@ struct Metafunction
 {
     void constraints()
     {
-        typedef typename T::type type;
+        using type = typename T::type;
     }
 };
 

--- a/include/boost/gil/concepts/channel.hpp
+++ b/include/boost/gil/concepts/channel.hpp
@@ -70,11 +70,11 @@ struct ChannelConcept
     {
         gil_function_requires<boost::EqualityComparableConcept<T>>();
 
-        typedef typename channel_traits<T>::value_type v;
-        typedef typename channel_traits<T>::reference r;
-        typedef typename channel_traits<T>::pointer p;
-        typedef typename channel_traits<T>::const_reference cr;
-        typedef typename channel_traits<T>::const_pointer cp;
+        using v = typename channel_traits<T>::value_type;
+        using r = typename channel_traits<T>::reference;
+        using p = typename channel_traits<T>::pointer;
+        using cr = typename channel_traits<T>::const_reference;
+        using cp = typename channel_traits<T>::const_pointer;
 
         channel_traits<T>::min_value();
         channel_traits<T>::max_value();

--- a/include/boost/gil/device_n.hpp
+++ b/include/boost/gil/device_n.hpp
@@ -53,36 +53,40 @@ template <int N> struct devicen_layout_t : public layout<devicen_t<N> > {};
 /// \ingroup ImageViewConstructors
 /// \brief from 2-channel planar data
 template <typename IC>
-inline typename type_from_x_iterator<planar_pixel_iterator<IC,devicen_t<2> > >::view_t
-planar_devicen_view(std::size_t width, std::size_t height, IC c0, IC c1, std::ptrdiff_t rowsize_in_bytes) {
-    typedef typename type_from_x_iterator<planar_pixel_iterator<IC,devicen_t<2> > >::view_t view_t;
+inline typename type_from_x_iterator<planar_pixel_iterator<IC,devicen_t<2>>>::view_t
+planar_devicen_view(std::size_t width, std::size_t height, IC c0, IC c1, std::ptrdiff_t rowsize_in_bytes)
+{
+    using view_t = typename type_from_x_iterator<planar_pixel_iterator<IC,devicen_t<2>>>::view_t;
     return view_t(width, height, typename view_t::locator(typename view_t::x_iterator(c0,c1), rowsize_in_bytes));
 }
 
 /// \ingroup ImageViewConstructors
 /// \brief from 3-channel planar data
 template <typename IC>
-inline typename type_from_x_iterator<planar_pixel_iterator<IC,devicen_t<3> > >::view_t
-planar_devicen_view(std::size_t width, std::size_t height, IC c0, IC c1, IC c2, std::ptrdiff_t rowsize_in_bytes) {
-    typedef typename type_from_x_iterator<planar_pixel_iterator<IC,devicen_t<3> > >::view_t view_t;
+inline typename type_from_x_iterator<planar_pixel_iterator<IC,devicen_t<3>>>::view_t
+planar_devicen_view(std::size_t width, std::size_t height, IC c0, IC c1, IC c2, std::ptrdiff_t rowsize_in_bytes)
+{
+    using view_t = typename type_from_x_iterator<planar_pixel_iterator<IC,devicen_t<3>>>::view_t;
     return view_t(width, height, typename view_t::locator(typename view_t::x_iterator(c0,c1,c2), rowsize_in_bytes));
 }
 
 /// \ingroup ImageViewConstructors
 /// \brief from 4-channel planar data
 template <typename IC>
-inline typename type_from_x_iterator<planar_pixel_iterator<IC,devicen_t<4> > >::view_t
-planar_devicen_view(std::size_t width, std::size_t height, IC c0, IC c1, IC c2, IC c3, std::ptrdiff_t rowsize_in_bytes) {
-    typedef typename type_from_x_iterator<planar_pixel_iterator<IC,devicen_t<4> > >::view_t view_t;
+inline typename type_from_x_iterator<planar_pixel_iterator<IC,devicen_t<4>>>::view_t
+planar_devicen_view(std::size_t width, std::size_t height, IC c0, IC c1, IC c2, IC c3, std::ptrdiff_t rowsize_in_bytes)
+{
+    using view_t = typename type_from_x_iterator<planar_pixel_iterator<IC,devicen_t<4>>>::view_t;
     return view_t(width, height, typename view_t::locator(typename view_t::x_iterator(c0,c1,c2,c3), rowsize_in_bytes));
 }
 
 /// \ingroup ImageViewConstructors
 /// \brief from 5-channel planar data
 template <typename IC>
-inline typename type_from_x_iterator<planar_pixel_iterator<IC,devicen_t<5> > >::view_t
-planar_devicen_view(std::size_t width, std::size_t height, IC c0, IC c1, IC c2, IC c3, IC c4, std::ptrdiff_t rowsize_in_bytes) {
-    typedef typename type_from_x_iterator<planar_pixel_iterator<IC,devicen_t<5> > >::view_t view_t;
+inline typename type_from_x_iterator<planar_pixel_iterator<IC,devicen_t<5>>>::view_t
+planar_devicen_view(std::size_t width, std::size_t height, IC c0, IC c1, IC c2, IC c3, IC c4, std::ptrdiff_t rowsize_in_bytes)
+{
+    using view_t = typename type_from_x_iterator<planar_pixel_iterator<IC,devicen_t<5>>>::view_t;
     return view_t(width, height, typename view_t::locator(typename view_t::x_iterator(c0,c1,c2,c3,c4), rowsize_in_bytes));
 }
 

--- a/include/boost/gil/gray.hpp
+++ b/include/boost/gil/gray.hpp
@@ -21,10 +21,10 @@ namespace boost { namespace gil {
 struct gray_color_t {};
 
 /// \ingroup ColorSpaceModel
-typedef mpl::vector1<gray_color_t> gray_t;
+using gray_t = mpl::vector1<gray_color_t>;
 
 /// \ingroup LayoutModel
-typedef layout<gray_t> gray_layout_t;
+using gray_layout_t = layout<gray_t>;
 
 } }  // namespace boost::gil
 

--- a/include/boost/gil/image.hpp
+++ b/include/boost/gil/image.hpp
@@ -39,17 +39,17 @@ template< typename Pixel, bool IsPlanar = false, typename Alloc=std::allocator<u
 class image {
 public:
 #if defined(BOOST_NO_CXX11_ALLOCATOR)
-    typedef typename Alloc::template rebind<unsigned char>::other allocator_type;
+    using allocator_type = typename Alloc::template rebind<unsigned char>::other;
 #else
-    typedef typename std::allocator_traits<Alloc>::template rebind_alloc<unsigned char> allocator_type;
+    using allocator_type = typename std::allocator_traits<Alloc>::template rebind_alloc<unsigned char>;
 #endif
-    typedef typename view_type_from_pixel<Pixel, IsPlanar>::type view_t;
-    typedef typename view_t::const_t                 const_view_t;
-    typedef typename view_t::point_t                 point_t;
-    typedef typename view_t::coord_t                 coord_t;
-    typedef typename view_t::value_type              value_type;
-    typedef coord_t                                  x_coord_t;
-    typedef coord_t                                  y_coord_t;
+    using view_t = typename view_type_from_pixel<Pixel, IsPlanar>::type;
+    using const_view_t = typename view_t::const_t;
+    using point_t = typename view_t::point_t;
+    using coord_t = typename view_t::coord_t;
+    using value_type = typename view_t::value_type;
+    using x_coord_t = coord_t;
+    using y_coord_t = coord_t;
 
     const point_t&          dimensions()            const { return _view.dimensions(); }
     x_coord_t               width()                 const { return _view.width(); }
@@ -335,7 +335,7 @@ private:
 
     std::size_t total_allocated_size_in_bytes(const point_t& dimensions) const {
 
-        typedef typename view_t::x_iterator x_iterator;
+        using x_iterator = typename view_t::x_iterator;
 
         // when value_type is a non-pixel, like int or float, num_channels< ... > doesn't work.
         const std::size_t _channels_in_image = mpl::eval_if< is_pixel< value_type >

--- a/include/boost/gil/image_view.hpp
+++ b/include/boost/gil/image_view.hpp
@@ -50,36 +50,41 @@ template <typename Loc>     // Models 2D Pixel Locator
 class image_view {
 public:
 
-// typedefs required by ConstRandomAccessNDImageViewConcept
+// aliases required by ConstRandomAccessNDImageViewConcept
     static const std::size_t num_dimensions=2;
-    typedef typename Loc::value_type                 value_type;
-    typedef typename Loc::reference                  reference;       // result of dereferencing
-    typedef typename Loc::coord_t                    coord_t;      // 1D difference type (same for all dimensions)
-    typedef coord_t                                  difference_type; // result of operator-(1d_iterator,1d_iterator)
-    typedef typename Loc::point_t                    point_t;
-    typedef Loc                                      locator;
-    typedef image_view<typename Loc::const_t>        const_t;      // same as this type, but over const values
-    template <std::size_t D> struct axis {
-        typedef typename Loc::template axis<D>::coord_t  coord_t;     // difference_type along each dimension
-        typedef typename Loc::template axis<D>::iterator iterator;       // 1D iterator type along each dimension
+    using value_type = typename Loc::value_type;
+    using reference = typename Loc::reference;       // result of dereferencing
+    using coord_t = typename Loc::coord_t;      // 1D difference type (same for all dimensions)
+    using difference_type = coord_t; // result of operator-(1d_iterator,1d_iterator)
+    using point_t = typename Loc::point_t;
+    using locator = Loc;
+    using const_t = image_view<typename Loc::const_t>;      // same as this type, but over const values
+    template <std::size_t D> struct axis
+    {
+        using coord_t = typename Loc::template axis<D>::coord_t; // difference_type along each dimension
+        using iterator = typename Loc::template axis<D>::iterator; // 1D iterator type along each dimension
     };
-    typedef iterator_from_2d<Loc>                    iterator;       // 1D iterator type for each pixel left-to-right inside top-to-bottom
-    typedef typename const_t::iterator               const_iterator;  // may be used to examine, but not to modify values
-    typedef typename const_t::reference              const_reference; // behaves as a const reference
-    typedef typename std::iterator_traits<iterator>::pointer pointer; // behaves as a pointer to the value type
-    typedef std::reverse_iterator<iterator>          reverse_iterator;
-    typedef std::size_t                              size_type;
+    using iterator = iterator_from_2d<Loc>;       // 1D iterator type for each pixel left-to-right inside top-to-bottom
+    using const_iterator = typename const_t::iterator;  // may be used to examine, but not to modify values
+    using const_reference = typename const_t::reference; // behaves as a const reference
+    using pointer = typename std::iterator_traits<iterator>::pointer; // behaves as a pointer to the value type
+    using reverse_iterator = std::reverse_iterator<iterator>;
+    using size_type = std::size_t;
 
-// typedefs required by ConstRandomAccess2DImageViewConcept
-    typedef locator                                  xy_locator;
-    typedef typename xy_locator::x_iterator          x_iterator;     // pixel iterator along a row
-    typedef typename xy_locator::y_iterator          y_iterator;     // pixel iterator along a column
-    typedef typename xy_locator::x_coord_t           x_coord_t;
-    typedef typename xy_locator::y_coord_t           y_coord_t;
+// aliases required by ConstRandomAccess2DImageViewConcept
+    using xy_locator = locator;
+    using x_iterator = typename xy_locator::x_iterator;     // pixel iterator along a row
+    using y_iterator = typename xy_locator::y_iterator;     // pixel iterator along a column
+    using x_coord_t = typename xy_locator::x_coord_t;
+    using y_coord_t = typename xy_locator::y_coord_t;
 
-    template <typename Deref> struct add_deref {
-        typedef image_view<typename Loc::template add_deref<Deref>::type> type;
-        static type make(const image_view<Loc>& iv, const Deref& d) { return type(iv.dimensions(), Loc::template add_deref<Deref>::make(iv.pixels(),d)); }
+    template <typename Deref> struct add_deref
+    {
+        using type = image_view<typename Loc::template add_deref<Deref>::type>;
+        static type make(const image_view<Loc>& iv, const Deref& d)
+        {
+            return type(iv.dimensions(), Loc::template add_deref<Deref>::make(iv.pixels(),d));
+        }
     };
 
     image_view() : _dimensions(0,0) {}
@@ -207,7 +212,7 @@ struct is_planar<image_view<L> > : public is_planar<L> {};
 
 template <typename L>
 struct dynamic_x_step_type<image_view<L> > {
-    typedef image_view<typename dynamic_x_step_type<L>::type> type;
+    using type = image_view<typename dynamic_x_step_type<L>::type>;
 };
 
 /////////////////////////////
@@ -216,7 +221,7 @@ struct dynamic_x_step_type<image_view<L> > {
 
 template <typename L>
 struct dynamic_y_step_type<image_view<L> > {
-    typedef image_view<typename dynamic_y_step_type<L>::type> type;
+    using type = image_view<typename dynamic_y_step_type<L>::type>;
 };
 
 /////////////////////////////
@@ -225,7 +230,7 @@ struct dynamic_y_step_type<image_view<L> > {
 
 template <typename L>
 struct transposed_type<image_view<L> > {
-    typedef image_view<typename transposed_type<L>::type> type;
+    using type = image_view<typename transposed_type<L>::type>;
 };
 
 }}  // namespace boost::gil

--- a/include/boost/gil/image_view_factory.hpp
+++ b/include/boost/gil/image_view_factory.hpp
@@ -52,7 +52,7 @@ template <typename Iterator>
 typename type_from_x_iterator<Iterator>::view_t
 interleaved_view(std::size_t width, std::size_t height,
                  Iterator pixels, std::ptrdiff_t rowsize_in_bytes) {
-    typedef typename type_from_x_iterator<Iterator>::view_t RView;
+    using RView = typename type_from_x_iterator<Iterator>::view_t;
     return RView(width, height, typename RView::locator(pixels, rowsize_in_bytes));
 }
 
@@ -75,10 +75,10 @@ namespace detail {
     template <typename View, bool IsMutable> struct channel_pointer_type_impl;
 
     template <typename View> struct channel_pointer_type_impl<View, true> {
-        typedef       typename channel_type<View>::type* type;
+        using type = typename channel_type<View>::type *;
     };
     template <typename View> struct channel_pointer_type_impl<View, false> {
-        typedef const typename channel_type<View>::type* type;
+        using type = const typename channel_type<View>::type *;
     };
 
     template <typename View> struct channel_pointer_type
@@ -132,17 +132,17 @@ namespace detail {
     template <typename SrcView, typename CC, typename DstP, typename SrcP>
     struct _color_converted_view_type {
     private:
-        typedef color_convert_deref_fn<typename SrcView::const_t::reference,DstP,CC> deref_t;
-        typedef typename SrcView::template add_deref<deref_t> add_ref_t;
+        using deref_t = color_convert_deref_fn<typename SrcView::const_t::reference,DstP,CC>;
+        using add_ref_t = typename SrcView::template add_deref<deref_t>;
     public:
-        typedef typename add_ref_t::type type;
+        using type = typename add_ref_t::type;
         static type make(const SrcView& sv,CC cc) {return add_ref_t::make(sv,deref_t(cc));}
     };
 
     // If the Src view has the same pixel type as the target, there is no need for color conversion
     template <typename SrcView, typename CC, typename DstP>
     struct _color_converted_view_type<SrcView,CC,DstP,DstP> {
-        typedef SrcView type;
+        using type = SrcView;
         static type make(const SrcView& sv,CC) {return sv;}
     };
 } // namespace detail
@@ -181,7 +181,7 @@ color_converted_view(const View& src) {
 /// \ingroup ImageViewTransformationsFlipUD
 template <typename View>
 inline typename dynamic_y_step_type<View>::type flipped_up_down_view(const View& src) {
-    typedef typename dynamic_y_step_type<View>::type RView;
+    using RView = typename dynamic_y_step_type<View>::type;
     return RView(src.dimensions(),typename RView::xy_locator(src.xy_at(0,src.height()-1),-1));
 }
 
@@ -192,7 +192,7 @@ inline typename dynamic_y_step_type<View>::type flipped_up_down_view(const View&
 /// \ingroup ImageViewTransformationsFlipLR
 template <typename View>
 inline typename dynamic_x_step_type<View>::type flipped_left_right_view(const View& src) {
-    typedef typename dynamic_x_step_type<View>::type RView;
+    using RView = typename dynamic_x_step_type<View>::type;
     return RView(src.dimensions(),typename RView::xy_locator(src.xy_at(src.width()-1,0),-1,1));
 }
 
@@ -203,7 +203,7 @@ inline typename dynamic_x_step_type<View>::type flipped_left_right_view(const Vi
 /// \ingroup ImageViewTransformationsTransposed
 template <typename View>
 inline typename dynamic_xy_step_transposed_type<View>::type transposed_view(const View& src) {
-    typedef typename dynamic_xy_step_transposed_type<View>::type RView;
+    using RView = typename dynamic_xy_step_transposed_type<View>::type;
     return RView(src.height(),src.width(),typename RView::xy_locator(src.xy_at(0,0),1,1,true));
 }
 
@@ -214,7 +214,7 @@ inline typename dynamic_xy_step_transposed_type<View>::type transposed_view(cons
 /// \ingroup ImageViewTransformations90CW
 template <typename View>
 inline typename dynamic_xy_step_transposed_type<View>::type rotated90cw_view(const View& src) {
-    typedef typename dynamic_xy_step_transposed_type<View>::type RView;
+    using RView = typename dynamic_xy_step_transposed_type<View>::type;
     return RView(src.height(),src.width(),typename RView::xy_locator(src.xy_at(0,src.height()-1),-1,1,true));
 }
 
@@ -225,7 +225,7 @@ inline typename dynamic_xy_step_transposed_type<View>::type rotated90cw_view(con
 /// \ingroup ImageViewTransformations90CCW
 template <typename View>
 inline typename dynamic_xy_step_transposed_type<View>::type rotated90ccw_view(const View& src) {
-    typedef typename dynamic_xy_step_transposed_type<View>::type RView;
+    using RView = typename dynamic_xy_step_transposed_type<View>::type;
     return RView(src.height(),src.width(),typename RView::xy_locator(src.xy_at(src.width()-1,0),1,-1,true));
 }
 
@@ -236,7 +236,7 @@ inline typename dynamic_xy_step_transposed_type<View>::type rotated90ccw_view(co
 /// \ingroup ImageViewTransformations180
 template <typename View>
 inline typename dynamic_xy_step_type<View>::type rotated180_view(const View& src) {
-    typedef typename dynamic_xy_step_type<View>::type RView;
+    using RView = typename dynamic_xy_step_type<View>::type;
     return RView(src.dimensions(),typename RView::xy_locator(src.xy_at(src.width()-1,src.height()-1),-1,-1));
 }
 
@@ -264,7 +264,7 @@ inline View subimage_view(const View& src, int xMin, int yMin, int width, int he
 template <typename View>
 inline typename dynamic_xy_step_type<View>::type subsampled_view(const View& src, typename View::coord_t xStep, typename View::coord_t yStep) {
     assert(xStep>0 && yStep>0);
-    typedef typename dynamic_xy_step_type<View>::type RView;
+    using RView = typename dynamic_xy_step_type<View>::type;
     return RView((src.width()+(xStep-1))/xStep,(src.height()+(yStep-1))/yStep,
                                           typename RView::xy_locator(src.xy_at(0,0),xStep,yStep));
 }
@@ -286,12 +286,12 @@ namespace detail {
     // or images with a step
     template <typename View>
     struct __nth_channel_view_basic<View,false> {
-        typedef typename view_type<typename channel_type<View>::type, gray_layout_t, false, true, view_is_mutable<View>::value>::type type;
+        using type = typename view_type<typename channel_type<View>::type, gray_layout_t, false, true, view_is_mutable<View>::value>::type;
 
         static type make(const View& src, int n) {
-            typedef typename type::xy_locator                             locator_t;
-            typedef typename type::x_iterator                            x_iterator_t;
-            typedef typename iterator_adaptor_get_base<x_iterator_t>::type x_iterator_base_t;
+            using locator_t = typename type::xy_locator;
+            using x_iterator_t = typename type::x_iterator;
+            using x_iterator_base_t = typename iterator_adaptor_get_base<x_iterator_t>::type;
             x_iterator_t sit(x_iterator_base_t(&(src(0,0)[n])),src.pixels().pixel_size());
             return type(src.dimensions(),locator_t(sit, src.pixels().row_size()));
         }
@@ -300,9 +300,9 @@ namespace detail {
     // nth_channel_view when the channels are together in memory (true for simple grayscale or planar images)
     template <typename View>
     struct __nth_channel_view_basic<View,true> {
-        typedef typename view_type<typename channel_type<View>::type, gray_layout_t, false, false, view_is_mutable<View>::value>::type type;
+        using type = typename view_type<typename channel_type<View>::type, gray_layout_t, false, false, view_is_mutable<View>::value>::type;
         static type make(const View& src, int n) {
-            typedef typename type::x_iterator x_iterator_t;
+            using x_iterator_t = typename type::x_iterator;
             return interleaved_view(src.width(),src.height(),(x_iterator_t)&(src(0,0)[n]), src.pixels().row_size());
         }
     };
@@ -312,7 +312,7 @@ namespace detail {
     // For basic (memory-based) views dispatch to __nth_channel_view_basic
     template <typename View> struct __nth_channel_view<View,true> {
     private:
-        typedef typename View::x_iterator src_x_iterator;
+        using src_x_iterator = typename View::x_iterator;
 
         // Determines whether the channels of a given pixel iterator are adjacent in memory.
         // Planar and grayscale iterators have channels adjacent in memory, whereas multi-channel interleaved and iterators with non-fundamental step do not.
@@ -321,7 +321,7 @@ namespace detail {
                               (is_planar<src_x_iterator>::value ||
                               num_channels<View>::value==1));
     public:
-        typedef typename __nth_channel_view_basic<View,adjacent>::type type;
+        using type = typename __nth_channel_view_basic<View,adjacent>::type;
 
         static type make(const View& src, int n) {
             return __nth_channel_view_basic<View,adjacent>::make(src,n);
@@ -337,17 +337,17 @@ namespace detail {
     struct nth_channel_deref_fn {
         BOOST_STATIC_CONSTANT(bool, is_mutable=pixel_is_reference<SrcP>::value && pixel_reference_is_mutable<SrcP>::value);
     private:
-        typedef typename remove_reference<SrcP>::type src_pixel_t;
-        typedef typename channel_type<src_pixel_t>::type channel_t;
-        typedef typename src_pixel_t::const_reference const_ref_t;
-        typedef typename pixel_reference_type<channel_t,gray_layout_t,false,is_mutable>::type ref_t;
+        using src_pixel_t = typename remove_reference<SrcP>::type;
+        using channel_t = typename channel_type<src_pixel_t>::type;
+        using const_ref_t = typename src_pixel_t::const_reference;
+        using ref_t = typename pixel_reference_type<channel_t,gray_layout_t,false,is_mutable>::type;
     public:
-        typedef nth_channel_deref_fn<const_ref_t>                                        const_t;
-        typedef typename pixel_value_type<channel_t,gray_layout_t>::type                 value_type;
-        typedef typename pixel_reference_type<channel_t,gray_layout_t,false,false>::type const_reference;
-        typedef SrcP                                                                     argument_type;
-        typedef typename mpl::if_c<is_mutable, ref_t, value_type>::type                  reference;
-        typedef reference                                                                result_type;
+        using const_t = nth_channel_deref_fn<const_ref_t>;
+        using value_type = typename pixel_value_type<channel_t,gray_layout_t>::type;
+        using const_reference = typename pixel_reference_type<channel_t,gray_layout_t,false,false>::type;
+        using argument_type = SrcP;
+        using reference = typename mpl::if_c<is_mutable, ref_t, value_type>::type;
+        using result_type = reference;
 
         nth_channel_deref_fn(int n=0) : _n(n) {}
         template <typename P> nth_channel_deref_fn(const nth_channel_deref_fn<P>& d) : _n(d._n) {}
@@ -361,10 +361,10 @@ namespace detail {
 
     template <typename View> struct __nth_channel_view<View,false> {
     private:
-        typedef nth_channel_deref_fn<typename View::reference> deref_t;
-        typedef typename View::template add_deref<deref_t>   AD;
+        using deref_t = nth_channel_deref_fn<typename View::reference>;
+        using AD = typename View::template add_deref<deref_t>;
     public:
-        typedef typename AD::type type;
+        using type = typename AD::type;
         static type make(const View& src, int n) {
             return AD::make(src, deref_t(n));
         }
@@ -381,9 +381,9 @@ template <typename View>
 struct nth_channel_view_type {
 private:
     GIL_CLASS_REQUIRE(View, boost::gil, ImageViewConcept)
-    typedef detail::__nth_channel_view<View,view_is_basic<View>::value> VB;
+    using VB = detail::__nth_channel_view<View,view_is_basic<View>::value>;
 public:
-    typedef typename VB::type type;
+    using type = typename VB::type;
     static type make(const View& src, int n) { return VB::make(src,n); }
 };
 
@@ -412,14 +412,14 @@ namespace detail {
     template <int K, typename View>
     struct __kth_channel_view_basic<K,View,false> {
     private:
-        typedef typename kth_element_type<typename View::value_type,K>::type channel_t;
+        using channel_t = typename kth_element_type<typename View::value_type,K>::type;
     public:
-        typedef typename view_type<channel_t, gray_layout_t, false, true, view_is_mutable<View>::value>::type type;
+        using type = typename view_type<channel_t, gray_layout_t, false, true, view_is_mutable<View>::value>::type;
 
         static type make(const View& src) {
-            typedef typename type::xy_locator                             locator_t;
-            typedef typename type::x_iterator                            x_iterator_t;
-            typedef typename iterator_adaptor_get_base<x_iterator_t>::type x_iterator_base_t;
+            using locator_t = typename type::xy_locator;
+            using x_iterator_t = typename type::x_iterator;
+            using x_iterator_base_t = typename iterator_adaptor_get_base<x_iterator_t>::type;
             x_iterator_t sit(x_iterator_base_t(&gil::at_c<K>(src(0,0))),src.pixels().pixel_size());
             return type(src.dimensions(),locator_t(sit, src.pixels().row_size()));
         }
@@ -429,11 +429,11 @@ namespace detail {
     template <int K, typename View>
     struct __kth_channel_view_basic<K,View,true> {
     private:
-        typedef typename kth_element_type<typename View::value_type, K>::type channel_t;
+        using channel_t = typename kth_element_type<typename View::value_type, K>::type;
     public:
-        typedef typename view_type<channel_t, gray_layout_t, false, false, view_is_mutable<View>::value>::type type;
+        using type = typename view_type<channel_t, gray_layout_t, false, false, view_is_mutable<View>::value>::type;
         static type make(const View& src) {
-            typedef typename type::x_iterator x_iterator_t;
+            using x_iterator_t = typename type::x_iterator;
             return interleaved_view(src.width(),src.height(),(x_iterator_t)&gil::at_c<K>(src(0,0)), src.pixels().row_size());
         }
     };
@@ -443,7 +443,7 @@ namespace detail {
     // For basic (memory-based) views dispatch to __kth_channel_view_basic
     template <int K, typename View> struct __kth_channel_view<K,View,true> {
     private:
-        typedef typename View::x_iterator src_x_iterator;
+        using src_x_iterator = typename View::x_iterator;
 
         // Determines whether the channels of a given pixel iterator are adjacent in memory.
         // Planar and grayscale iterators have channels adjacent in memory, whereas multi-channel interleaved and iterators with non-fundamental step do not.
@@ -452,7 +452,7 @@ namespace detail {
                               (is_planar<src_x_iterator>::value ||
                               num_channels<View>::value==1));
     public:
-        typedef typename __kth_channel_view_basic<K,View,adjacent>::type type;
+        using type = typename __kth_channel_view_basic<K,View,adjacent>::type;
 
         static type make(const View& src) {
             return __kth_channel_view_basic<K,View,adjacent>::make(src);
@@ -468,17 +468,17 @@ namespace detail {
     struct kth_channel_deref_fn {
         BOOST_STATIC_CONSTANT(bool, is_mutable=pixel_is_reference<SrcP>::value && pixel_reference_is_mutable<SrcP>::value);
     private:
-        typedef typename remove_reference<SrcP>::type src_pixel_t;
-        typedef typename kth_element_type<src_pixel_t, K>::type channel_t;
-        typedef typename src_pixel_t::const_reference const_ref_t;
-        typedef typename pixel_reference_type<channel_t,gray_layout_t,false,is_mutable>::type ref_t;
+        using src_pixel_t = typename remove_reference<SrcP>::type;
+        using channel_t = typename kth_element_type<src_pixel_t, K>::type;
+        using const_ref_t = typename src_pixel_t::const_reference;
+        using ref_t = typename pixel_reference_type<channel_t,gray_layout_t,false,is_mutable>::type;
     public:
-        typedef kth_channel_deref_fn<K,const_ref_t>                               const_t;
-        typedef typename pixel_value_type<channel_t,gray_layout_t>::type          value_type;
-        typedef typename pixel_reference_type<channel_t,gray_layout_t,false,false>::type const_reference;
-        typedef SrcP                                                              argument_type;
-        typedef typename mpl::if_c<is_mutable, ref_t, value_type>::type           reference;
-        typedef reference                                                         result_type;
+        using const_t = kth_channel_deref_fn<K,const_ref_t>;
+        using value_type = typename pixel_value_type<channel_t,gray_layout_t>::type;
+        using const_reference = typename pixel_reference_type<channel_t,gray_layout_t,false,false>::type;
+        using argument_type = SrcP;
+        using reference = typename mpl::if_c<is_mutable, ref_t, value_type>::type;
+        using result_type = reference;
 
         kth_channel_deref_fn() {}
         template <typename P> kth_channel_deref_fn(const kth_channel_deref_fn<K,P>&) {}
@@ -490,10 +490,10 @@ namespace detail {
 
     template <int K, typename View> struct __kth_channel_view<K,View,false> {
     private:
-        typedef kth_channel_deref_fn<K,typename View::reference> deref_t;
-        typedef typename View::template add_deref<deref_t>   AD;
+        using deref_t = kth_channel_deref_fn<K,typename View::reference>;
+        using AD = typename View::template add_deref<deref_t>;
     public:
-        typedef typename AD::type type;
+        using type = typename AD::type;
         static type make(const View& src) {
             return AD::make(src, deref_t());
         }
@@ -510,9 +510,9 @@ template <int K, typename View>
 struct kth_channel_view_type {
 private:
     GIL_CLASS_REQUIRE(View, boost::gil, ImageViewConcept)
-    typedef detail::__kth_channel_view<K,View,view_is_basic<View>::value> VB;
+    using VB = detail::__kth_channel_view<K,View,view_is_basic<View>::value>;
 public:
-    typedef typename VB::type type;
+    using type = typename VB::type;
     static type make(const View& src) { return VB::make(src); }
 };
 

--- a/include/boost/gil/iterator_from_2d.hpp
+++ b/include/boost/gil/iterator_from_2d.hpp
@@ -47,15 +47,15 @@ class iterator_from_2d : public iterator_facade<iterator_from_2d<Loc2>,
                                                 typename Loc2::coord_t> {
     GIL_CLASS_REQUIRE(Loc2, boost::gil, PixelLocatorConcept)
 public:
-    typedef iterator_facade<iterator_from_2d<Loc2>,
+    using parent_t = iterator_facade<iterator_from_2d<Loc2>,
                             typename Loc2::value_type,
                             std::random_access_iterator_tag,
                             typename Loc2::reference,
-                            typename Loc2::coord_t> parent_t;
-    typedef typename parent_t::reference       reference;
-    typedef typename parent_t::difference_type difference_type;
-    typedef typename Loc2::x_iterator          x_iterator;
-    typedef typename Loc2::point_t             point_t;
+                            typename Loc2::coord_t>;
+    using reference = typename parent_t::reference;
+    using difference_type = typename parent_t::difference_type;
+    using x_iterator = typename Loc2::x_iterator;
+    using point_t = typename Loc2::point_t;
 
     std::ptrdiff_t width()         const { return _width; }            // number of pixels per image row
     std::ptrdiff_t x_pos()         const { return _coords.x; }         // current x position
@@ -128,7 +128,7 @@ private:
 
 template <typename Loc> // Models PixelLocatorConcept
 struct const_iterator_type<iterator_from_2d<Loc> > {
-    typedef iterator_from_2d<typename Loc::const_t> type;
+    using type = iterator_from_2d<typename Loc::const_t>;
 };
 
 template <typename Loc> // Models PixelLocatorConcept
@@ -141,7 +141,7 @@ struct iterator_is_mutable<iterator_from_2d<Loc> > : public iterator_is_mutable<
 
 template <typename Loc>
 struct dynamic_x_step_type<iterator_from_2d<Loc> > {
-    typedef iterator_from_2d<typename dynamic_x_step_type<Loc>::type>  type;
+    using type = iterator_from_2d<typename dynamic_x_step_type<Loc>::type>;
 };
 
 

--- a/include/boost/gil/locator.hpp
+++ b/include/boost/gil/locator.hpp
@@ -38,9 +38,8 @@ template <typename T> struct is_planar;
 template <typename T> struct num_channels;
 
 // The type of a locator or a view that has X and Y swapped. By default it is the same
-template <typename T> struct transposed_type {
-    typedef T type;
-};
+template <typename T>
+struct transposed_type { using type = T; };
 
 /// \class pixel_2d_locator_base
 /// \brief base class for models of PixelLocatorConcept
@@ -61,16 +60,16 @@ template <typename T> struct transposed_type {
 /// For example, increment and decrement operations don't make sense (no way to specify dimension).
 /// Also 2D difference between two locators cannot be computed without knowledge of the X position within the image.
 ///
-/// This base class provides most of the methods and typedefs needed to create a model of a locator. GIL provides two
+/// This base class provides most of the methods and type aliases needed to create a model of a locator. GIL provides two
 /// locator models as subclasses of \p pixel_2d_locator_base. A memory-based locator, \p memory_based_2d_locator and a virtual
 /// locator, \p virtual_2d_locator.
 /// The minimum functionality a subclass must provide is this:
 /// \code
 /// class my_locator : public pixel_2d_locator_base<my_locator, ..., ...> {  // supply the types for x-iterator and y-iterator
-///        typedef ... const_t;                      // read-only locator
+///        using const_t = ...;                      // read-only locator
 ///
 ///        template <typename Deref> struct add_deref {
-///            typedef ... type;                     // locator that invokes the Deref dereference object upon pixel access
+///            using type = ...;                     // locator that invokes the Deref dereference object upon pixel access
 ///            static type make(const my_locator& loc, const Deref& d);
 ///        };
 ///
@@ -102,26 +101,28 @@ template <typename T> struct transposed_type {
 ///
 
 template <typename Loc, typename XIterator, typename YIterator>    // The concrete subclass, the X-iterator and the Y-iterator
-class pixel_2d_locator_base {
+class pixel_2d_locator_base
+{
 public:
-    typedef XIterator           x_iterator;
-    typedef YIterator           y_iterator;
+    using x_iterator = XIterator;
+    using y_iterator = YIterator;
 
-    // typedefs required by ConstRandomAccessNDLocatorConcept
+    // aliasesrequired by ConstRandomAccessNDLocatorConcept
     static const std::size_t num_dimensions=2;
-    typedef typename std::iterator_traits<x_iterator>::value_type       value_type;
-    typedef typename std::iterator_traits<x_iterator>::reference        reference;    // result of dereferencing
-    typedef typename std::iterator_traits<x_iterator>::difference_type  coord_t;      // 1D difference type (same for all dimensions)
-    typedef point<coord_t>                                              difference_type; // result of operator-(locator,locator)
-    typedef difference_type                                             point_t;
-    template <std::size_t D> struct axis {
-        typedef typename detail::locator_axis<D,Loc>::coord_t           coord_t;
-        typedef typename detail::locator_axis<D,Loc>::iterator          iterator;
+    using value_type = typename std::iterator_traits<x_iterator>::value_type;
+    using reference = typename std::iterator_traits<x_iterator>::reference;    // result of dereferencing
+    using coord_t = typename std::iterator_traits<x_iterator>::difference_type;      // 1D difference type (same for all dimensions)
+    using difference_type = point<coord_t>; // result of operator-(locator,locator)
+    using point_t = difference_type;
+    template <std::size_t D> struct axis
+    {
+        using coord_t = typename detail::locator_axis<D,Loc>::coord_t;
+        using iterator = typename detail::locator_axis<D,Loc>::iterator;
     };
 
-// typedefs required by ConstRandomAccess2DLocatorConcept
-    typedef typename point_t::template axis<0>::coord_t                 x_coord_t;
-    typedef typename point_t::template axis<1>::coord_t                 y_coord_t;
+// aliases required by ConstRandomAccess2DLocatorConcept
+    using x_coord_t = typename point_t::template axis<0>::coord_t;
+    using y_coord_t = typename point_t::template axis<1>::coord_t;
 
     bool              operator!=(const Loc& p)          const { return !(concrete()==p); }
 
@@ -148,7 +149,7 @@ public:
     Loc               operator-(const difference_type& d)    const { return xy_at(-d); }
 
     // Some locators can cache 2D coordinates for faster subsequent access. By default there is no caching
-    typedef difference_type    cached_location_t;
+    using cached_location_t = difference_type;
     cached_location_t cache_location(const difference_type& d)  const { return d; }
     cached_location_t cache_location(x_coord_t dx, y_coord_t dy)const { return difference_type(dx,dy); }
 
@@ -163,10 +164,10 @@ private:
 namespace detail {
     template <typename Loc>
     class locator_axis<0,Loc> {
-        typedef typename Loc::point_t                       point_t;
+        using point_t = typename Loc::point_t;
     public:
-        typedef typename point_t::template axis<0>::coord_t coord_t;
-        typedef typename Loc::x_iterator                    iterator;
+        using coord_t = typename point_t::template axis<0>::coord_t;
+        using iterator = typename Loc::x_iterator;
 
         inline iterator&        operator()(      Loc& loc)                   const { return loc.x(); }
         inline iterator  const& operator()(const Loc& loc)                   const { return loc.x(); }
@@ -176,10 +177,10 @@ namespace detail {
 
     template <typename Loc>
     class locator_axis<1,Loc> {
-        typedef typename Loc::point_t                       point_t;
+        using point_t = typename Loc::point_t;
     public:
-        typedef typename point_t::template axis<1>::coord_t coord_t;
-        typedef typename Loc::y_iterator                    iterator;
+        using coord_t = typename point_t::template axis<1>::coord_t;
+        using iterator = typename Loc::y_iterator;
 
         inline iterator&        operator()(      Loc& loc)               const { return loc.y(); }
         inline iterator const&  operator()(const Loc& loc)               const { return loc.y(); }
@@ -223,22 +224,23 @@ struct is_planar<pixel_2d_locator_base<Loc,XIt,YIt> > : public is_planar<XIt> {}
 
 template <typename StepIterator>
 class memory_based_2d_locator : public pixel_2d_locator_base<memory_based_2d_locator<StepIterator>, typename iterator_adaptor_get_base<StepIterator>::type, StepIterator> {
-    typedef memory_based_2d_locator<StepIterator>  this_t;
+    using this_t = memory_based_2d_locator<StepIterator>;
     GIL_CLASS_REQUIRE(StepIterator, boost::gil, StepIteratorConcept)
 public:
-    typedef pixel_2d_locator_base<memory_based_2d_locator<StepIterator>, typename iterator_adaptor_get_base<StepIterator>::type, StepIterator> parent_t;
-    typedef memory_based_2d_locator<typename const_iterator_type<StepIterator>::type> const_t; // same as this type, but over const values
+    using parent_t = pixel_2d_locator_base<memory_based_2d_locator<StepIterator>, typename iterator_adaptor_get_base<StepIterator>::type, StepIterator>;
+    using const_t = memory_based_2d_locator<typename const_iterator_type<StepIterator>::type>; // same as this type, but over const values
 
-    typedef typename parent_t::coord_t          coord_t;
-    typedef typename parent_t::x_coord_t        x_coord_t;
-    typedef typename parent_t::y_coord_t        y_coord_t;
-    typedef typename parent_t::x_iterator       x_iterator;
-    typedef typename parent_t::y_iterator       y_iterator;
-    typedef typename parent_t::difference_type  difference_type;
-    typedef typename parent_t::reference        reference;
+    using coord_t = typename parent_t::coord_t;
+    using x_coord_t = typename parent_t::x_coord_t;
+    using y_coord_t = typename parent_t::y_coord_t;
+    using x_iterator = typename parent_t::x_iterator;
+    using y_iterator = typename parent_t::y_iterator;
+    using difference_type = typename parent_t::difference_type;
+    using reference = typename parent_t::reference;
 
-    template <typename Deref> struct add_deref {
-        typedef memory_based_2d_locator<typename iterator_add_deref<StepIterator,Deref>::type> type;
+    template <typename Deref> struct add_deref
+    {
+        using type = memory_based_2d_locator<typename iterator_add_deref<StepIterator,Deref>::type>;
         static type make(const memory_based_2d_locator<StepIterator>& loc, const Deref& nderef) {
             return type(iterator_add_deref<StepIterator,Deref>::make(loc.y(),nderef));
         }
@@ -273,7 +275,7 @@ public:
     this_t&    operator-=(const difference_type& d)          { memunit_advance(x(),offset(-d.x,-d.y)); return *this; }
 
     // Memory-based locators can have 1D caching of 2D relative coordinates
-    typedef std::ptrdiff_t cached_location_t; // type used to store relative location (to allow for more efficient repeated access)
+    using cached_location_t = std::ptrdiff_t; // type used to store relative location (to allow for more efficient repeated access)
     cached_location_t cache_location(const difference_type& d)  const { return offset(d.x,d.y); }
     cached_location_t cache_location(x_coord_t dx, y_coord_t dy)const { return offset(dx,dy); }
     reference         operator[](const cached_location_t& loc)  const { return memunit_advanced_ref(x(),loc); }
@@ -325,11 +327,11 @@ struct channel_type<memory_based_2d_locator<SI> > : public channel_type<typename
 template <typename SI>
 struct dynamic_x_step_type<memory_based_2d_locator<SI> > {
 private:
-    typedef typename iterator_adaptor_get_base<SI>::type                        base_iterator_t;
-    typedef typename dynamic_x_step_type<base_iterator_t>::type                 base_iterator_step_t;
-    typedef typename iterator_adaptor_rebind<SI, base_iterator_step_t>::type    dynamic_step_base_t;
+    using base_iterator_t = typename iterator_adaptor_get_base<SI>::type;
+    using base_iterator_step_t = typename dynamic_x_step_type<base_iterator_t>::type;
+    using dynamic_step_base_t = typename iterator_adaptor_rebind<SI, base_iterator_step_t>::type;
 public:
-    typedef memory_based_2d_locator<dynamic_step_base_t> type;
+    using type = memory_based_2d_locator<dynamic_step_base_t>;
 };
 
 /////////////////////////////
@@ -338,7 +340,7 @@ public:
 
 template <typename SI>
 struct dynamic_y_step_type<memory_based_2d_locator<SI> > {
-    typedef memory_based_2d_locator<SI> type;
+    using type = memory_based_2d_locator<SI>;
 };
 } }  // namespace boost::gil
 

--- a/include/boost/gil/metafunctions.hpp
+++ b/include/boost/gil/metafunctions.hpp
@@ -201,61 +201,61 @@ template <typename V> struct view_is_mutable : public iterator_is_mutable<typena
 /// \ingroup TypeFactoryFromElements
 /// \brief Returns the type of a homogeneous pixel reference given the channel type, layout, whether it operates on planar data and whether it is mutable
 template <typename T, typename L, bool IsPlanar=false, bool IsMutable=true> struct pixel_reference_type{};
-template <typename T, typename L> struct pixel_reference_type<T,L,false,true > { typedef pixel<T,L>& type; };
-template <typename T, typename L> struct pixel_reference_type<T,L,false,false> { typedef const pixel<T,L>& type; };
-template <typename T, typename L> struct pixel_reference_type<T,L,true,true> { typedef const planar_pixel_reference<typename channel_traits<T>::reference,typename color_space_type<L>::type> type; };       // TODO: Assert M=identity
-template <typename T, typename L> struct pixel_reference_type<T,L,true,false> { typedef const planar_pixel_reference<typename channel_traits<T>::const_reference,typename color_space_type<L>::type> type; };// TODO: Assert M=identity
+template <typename T, typename L> struct pixel_reference_type<T,L,false,true > { using type = pixel<T,L>&; };
+template <typename T, typename L> struct pixel_reference_type<T,L,false,false> { using type = pixel<T,L> const&; };
+template <typename T, typename L> struct pixel_reference_type<T,L,true,true> { using type = planar_pixel_reference<typename channel_traits<T>::reference,typename color_space_type<L>::type> const; };       // TODO: Assert M=identity
+template <typename T, typename L> struct pixel_reference_type<T,L,true,false> { using type = planar_pixel_reference<typename channel_traits<T>::const_reference,typename color_space_type<L>::type> const; };// TODO: Assert M=identity
 
 /// \ingroup TypeFactoryFromPixel
 /// \brief Returns the type of a pixel iterator given the pixel type, whether it operates on planar data, whether it is a step iterator, and whether it is mutable
 template <typename Pixel, bool IsPlanar=false, bool IsStep=false, bool IsMutable=true> struct iterator_type_from_pixel{};
-template <typename Pixel> struct iterator_type_from_pixel<Pixel,false,false,true > { typedef Pixel* type; };
-template <typename Pixel> struct iterator_type_from_pixel<Pixel,false,false,false> { typedef const Pixel* type; };
+template <typename Pixel> struct iterator_type_from_pixel<Pixel,false,false,true > { using type = Pixel *; };
+template <typename Pixel> struct iterator_type_from_pixel<Pixel,false,false,false> { using type = const Pixel *; };
 template <typename Pixel> struct iterator_type_from_pixel<Pixel,true,false,true> {
-    typedef planar_pixel_iterator<typename channel_traits<typename channel_type<Pixel>::type>::pointer,typename color_space_type<Pixel>::type> type;
+    using type = planar_pixel_iterator<typename channel_traits<typename channel_type<Pixel>::type>::pointer,typename color_space_type<Pixel>::type>;
 };
 template <typename Pixel> struct iterator_type_from_pixel<Pixel,true,false,false> {
-    typedef planar_pixel_iterator<typename channel_traits<typename channel_type<Pixel>::type>::const_pointer,typename color_space_type<Pixel>::type> type;
+    using type = planar_pixel_iterator<typename channel_traits<typename channel_type<Pixel>::type>::const_pointer,typename color_space_type<Pixel>::type>;
 };
 template <typename Pixel, bool IsPlanar, bool IsMutable> struct iterator_type_from_pixel<Pixel,IsPlanar,true,IsMutable> {
-    typedef memory_based_step_iterator<typename iterator_type_from_pixel<Pixel,IsPlanar,false,IsMutable>::type> type;
+    using type = memory_based_step_iterator<typename iterator_type_from_pixel<Pixel,IsPlanar,false,IsMutable>::type>;
 };
 
 /// \ingroup TypeFactoryFromElements
 /// \brief Returns the type of a homogeneous iterator given the channel type, layout, whether it operates on planar data, whether it is a step iterator, and whether it is mutable
 template <typename T, typename L, bool IsPlanar=false, bool IsStep=false, bool IsMutable=true> struct iterator_type{};
-template <typename T, typename L> struct iterator_type<T,L,false,false,true > { typedef pixel<T,L>* type; };
-template <typename T, typename L> struct iterator_type<T,L,false,false,false> { typedef const pixel<T,L>* type; };
-template <typename T, typename L> struct iterator_type<T,L,true,false,true> { typedef planar_pixel_iterator<T*,typename L::color_space_t> type; };               // TODO: Assert M=identity
-template <typename T, typename L> struct iterator_type<T,L,true,false,false> { typedef planar_pixel_iterator<const T*,typename L::color_space_t> type; };        // TODO: Assert M=identity
+template <typename T, typename L> struct iterator_type<T,L,false,false,true > { using type = pixel<T,L>*; };
+template <typename T, typename L> struct iterator_type<T,L,false,false,false> { using type = pixel<T,L> const*; };
+template <typename T, typename L> struct iterator_type<T,L,true,false,true> { using type = planar_pixel_iterator<T*,typename L::color_space_t>; };               // TODO: Assert M=identity
+template <typename T, typename L> struct iterator_type<T,L,true,false,false> { using type = planar_pixel_iterator<const T*,typename L::color_space_t>; };        // TODO: Assert M=identity
 template <typename T, typename L, bool IsPlanar, bool IsMutable> struct iterator_type<T,L,IsPlanar,true,IsMutable> {
-    typedef memory_based_step_iterator<typename iterator_type<T,L,IsPlanar,false,IsMutable>::type> type;
+    using type = memory_based_step_iterator<typename iterator_type<T,L,IsPlanar,false,IsMutable>::type>;
 };
 
 /// \brief Given a pixel iterator defining access to pixels along a row, returns the types of the corresponding built-in step_iterator, xy_locator, image_view
 /// \ingroup TypeFactory
 template <typename XIterator>
 struct type_from_x_iterator {
-    typedef memory_based_step_iterator<XIterator>    step_iterator_t;
-    typedef memory_based_2d_locator<step_iterator_t> xy_locator_t;
-    typedef image_view<xy_locator_t>                     view_t;
+    using step_iterator_t = memory_based_step_iterator<XIterator>;
+    using xy_locator_t = memory_based_2d_locator<step_iterator_t>;
+    using view_t = image_view<xy_locator_t>;
 };
 
 namespace detail {
     template <typename BitField, typename FirstBit, typename NumBits>
     struct packed_channel_reference_type {
-        typedef const packed_channel_reference<BitField,FirstBit::value,NumBits::value,true> type;
+        using type = packed_channel_reference<BitField,FirstBit::value,NumBits::value,true> const;
     };
 
     template <typename BitField, typename ChannelBitSizesVector>
     class packed_channel_references_vector_type {
         // If ChannelBitSizesVector is mpl::vector<int,7,7,2>
         // Then first_bits_vector will be mpl::vector<int,0,7,14,16>
-        typedef typename mpl::accumulate<ChannelBitSizesVector, mpl::vector1<mpl::int_<0> >,
-            mpl::push_back<mpl::_1, mpl::plus<mpl::back<mpl::_1>, mpl::_2> > >::type first_bits_vector;
+        using first_bits_vector = typename mpl::accumulate<ChannelBitSizesVector, mpl::vector1<mpl::int_<0> >,
+            mpl::push_back<mpl::_1, mpl::plus<mpl::back<mpl::_1>, mpl::_2> > >::type;
     public:
-        typedef typename mpl::transform<typename mpl::pop_back<first_bits_vector>::type, ChannelBitSizesVector,
-               packed_channel_reference_type<BitField, mpl::_1,mpl::_2> >::type type;
+        using type = typename mpl::transform<typename mpl::pop_back<first_bits_vector>::type, ChannelBitSizesVector,
+               packed_channel_reference_type<BitField, mpl::_1,mpl::_2> >::type;
     };
 
 }
@@ -269,8 +269,9 @@ namespace detail {
 /// The sum of bit sizes for all channels must be less than or equal to the number of bits in BitField (and cannot exceed 64).
 ///  If it is less than the number of bits in BitField, the last bits will be unused.
 template <typename BitField, typename ChannelBitSizeVector, typename Layout>
-struct packed_pixel_type {
-    typedef packed_pixel<BitField, typename detail::packed_channel_references_vector_type<BitField,ChannelBitSizeVector>::type, Layout> type;
+struct packed_pixel_type
+{
+    using type = packed_pixel<BitField, typename detail::packed_channel_references_vector_type<BitField,ChannelBitSizeVector>::type, Layout>;
 };
 
 /// \defgroup TypeFactoryPacked packed_image_type,bit_aligned_image_type
@@ -286,7 +287,7 @@ struct packed_pixel_type {
 /// \brief Returns the type of an interleaved packed image: an image whose channels may not be byte-aligned, but whose pixels are byte aligned.
 template <typename BitField, typename ChannelBitSizeVector, typename Layout, typename Alloc=std::allocator<unsigned char> >
 struct packed_image_type {
-    typedef image<typename packed_pixel_type<BitField,ChannelBitSizeVector,Layout>::type,false,Alloc> type;
+    using type = image<typename packed_pixel_type<BitField,ChannelBitSizeVector,Layout>::type,false,Alloc>;
 };
 
 /// \ingroup TypeFactoryPacked
@@ -325,10 +326,10 @@ template <typename ChannelBitSizeVector, typename Layout, typename Alloc=std::al
 struct bit_aligned_image_type {
 private:
     BOOST_STATIC_CONSTANT(int, bit_size = (mpl::accumulate<ChannelBitSizeVector, mpl::int_<0>, mpl::plus<mpl::_1, mpl::_2> >::type::value));
-    typedef typename detail::min_fast_uint<bit_size+7>::type                        bitfield_t;
-    typedef const bit_aligned_pixel_reference<bitfield_t, ChannelBitSizeVector, Layout, true> bit_alignedref_t;
+    using bitfield_t = typename detail::min_fast_uint<bit_size + 7>::type;
+    using bit_alignedref_t = bit_aligned_pixel_reference<bitfield_t, ChannelBitSizeVector, Layout, true> const;
 public:
-    typedef image<bit_alignedref_t,false,Alloc> type;
+    using type = image<bit_alignedref_t,false,Alloc>;
 };
 
 /// \ingroup TypeFactoryPacked
@@ -362,7 +363,7 @@ struct bit_aligned_image5_type : public bit_aligned_image_type<mpl::vector5_c<un
 /// \brief Returns the type of a homogeneous pixel given the channel type and layout
 template <typename Channel, typename Layout>
 struct pixel_value_type {
-    typedef pixel<Channel,Layout> type;     // by default use gil::pixel. Specializations are provided for
+    using type = pixel<Channel,Layout>;     // by default use gil::pixel. Specializations are provided for
 };
 
 // Specializations for packed channels
@@ -389,28 +390,28 @@ struct pixel_value_type<packed_channel_value<NumBits>,Layout> :
 /// \brief Returns the type of a homogeneous locator given the channel type, layout, whether it operates on planar data and whether it has a step horizontally
 template <typename T, typename L, bool IsPlanar=false, bool IsStepX=false, bool IsMutable=true>
 struct locator_type {
-    typedef typename type_from_x_iterator<typename iterator_type<T,L,IsPlanar,IsStepX,IsMutable>::type>::xy_locator_type type;
+    using type = typename type_from_x_iterator<typename iterator_type<T,L,IsPlanar,IsStepX,IsMutable>::type>::xy_locator_type;
 };
 
 /// \ingroup TypeFactoryFromElements
 /// \brief Returns the type of a homogeneous view given the channel type, layout, whether it operates on planar data and whether it has a step horizontally
 template <typename T, typename L, bool IsPlanar=false, bool IsStepX=false, bool IsMutable=true>
 struct view_type {
-    typedef typename type_from_x_iterator<typename iterator_type<T,L,IsPlanar,IsStepX,IsMutable>::type>::view_t type;
+    using type = typename type_from_x_iterator<typename iterator_type<T,L,IsPlanar,IsStepX,IsMutable>::type>::view_t;
 };
 
 /// \ingroup TypeFactoryFromElements
 /// \brief Returns the type of a homogeneous image given the channel type, layout, and whether it operates on planar data
 template <typename T, typename L, bool IsPlanar=false, typename Alloc=std::allocator<unsigned char> >
 struct image_type {
-    typedef image<pixel<T,L>, IsPlanar, Alloc> type;
+    using type = image<pixel<T,L>, IsPlanar, Alloc>;
 };
 
 /// \ingroup TypeFactoryFromPixel
 /// \brief Returns the type of a view the pixel type, whether it operates on planar data and whether it has a step horizontally
 template <typename Pixel, bool IsPlanar=false, bool IsStepX=false, bool IsMutable=true>
 struct view_type_from_pixel {
-    typedef typename type_from_x_iterator<typename iterator_type_from_pixel<Pixel,IsPlanar,IsStepX,IsMutable>::type>::view_t type;
+    using type = typename type_from_x_iterator<typename iterator_type_from_pixel<Pixel,IsPlanar,IsStepX,IsMutable>::type>::view_t;
 };
 
 
@@ -419,14 +420,14 @@ struct view_type_from_pixel {
 ///  Use use_default for the properties of the source view that you want to keep
 template <typename Ref, typename T=use_default, typename L=use_default, typename IsPlanar=use_default, typename IsMutable=use_default>
 class derived_pixel_reference_type {
-    typedef typename remove_reference<Ref>::type pixel_t;
-    typedef typename  mpl::if_<is_same<T, use_default>, typename channel_type<pixel_t>::type,     T >::type channel_t;
-    typedef typename  mpl::if_<is_same<L, use_default>,
-        layout<typename color_space_type<pixel_t>::type, typename channel_mapping_type<pixel_t>::type>, L>::type           layout_t;
+    using pixel_t = typename remove_reference<Ref>::type;
+    using channel_t = typename  mpl::if_<is_same<T, use_default>, typename channel_type<pixel_t>::type, T>::type;
+    using layout_t = typename  mpl::if_<is_same<L, use_default>,
+        layout<typename color_space_type<pixel_t>::type, typename channel_mapping_type<pixel_t>::type>, L>::type;
     static const bool mut   =mpl::if_<is_same<IsMutable,use_default>, pixel_reference_is_mutable<Ref>, IsMutable>::type::value;
     static const bool planar=mpl::if_<is_same<IsPlanar,use_default>,  is_planar<pixel_t>,  IsPlanar>::type::value;
 public:
-    typedef typename pixel_reference_type<channel_t, layout_t, planar, mut>::type type;
+    using type = typename pixel_reference_type<channel_t, layout_t, planar, mut>::type;
 };
 
 /// \brief Constructs a pixel iterator type from a source pixel iterator type by changing some of the properties.
@@ -434,15 +435,15 @@ public:
 ///  Use use_default for the properties of the source view that you want to keep
 template <typename Iterator, typename T=use_default, typename L=use_default, typename IsPlanar=use_default, typename IsStep=use_default, typename IsMutable=use_default>
 class derived_iterator_type {
-    typedef typename  mpl::if_<is_same<T ,use_default>, typename channel_type<Iterator>::type,     T >::type channel_t;
-    typedef typename  mpl::if_<is_same<L,use_default>,
-        layout<typename color_space_type<Iterator>::type, typename channel_mapping_type<Iterator>::type>, L>::type layout_t;
+    using channel_t = typename  mpl::if_<is_same<T ,use_default>, typename channel_type<Iterator>::type, T>::type;
+    using layout_t = typename  mpl::if_<is_same<L,use_default>,
+        layout<typename color_space_type<Iterator>::type, typename channel_mapping_type<Iterator>::type>, L>::type;
 
     static const bool mut   =mpl::if_<is_same<IsMutable,use_default>, iterator_is_mutable<Iterator>, IsMutable>::type::value;
     static const bool planar=mpl::if_<is_same<IsPlanar,use_default>,         is_planar<Iterator>,  IsPlanar>::type::value;
     static const bool step  =mpl::if_<is_same<IsStep  ,use_default>,  iterator_is_step<Iterator>,    IsStep>::type::value;
 public:
-    typedef typename iterator_type<channel_t, layout_t, planar, step, mut>::type type;
+    using type = typename iterator_type<channel_t, layout_t, planar, step, mut>::type;
 };
 
 /// \brief Constructs an image view type from a source view type by changing some of the properties.
@@ -450,14 +451,14 @@ public:
 ///  Use use_default for the properties of the source view that you want to keep
 template <typename View, typename T=use_default, typename L=use_default, typename IsPlanar=use_default, typename StepX=use_default, typename IsMutable=use_default>
 class derived_view_type {
-    typedef typename  mpl::if_<is_same<T ,use_default>, typename channel_type<View>::type, T>::type channel_t;
-    typedef typename  mpl::if_<is_same<L,use_default>,
-        layout<typename color_space_type<View>::type, typename channel_mapping_type<View>::type>, L>::type layout_t;
+    using channel_t = typename  mpl::if_<is_same<T ,use_default>, typename channel_type<View>::type, T>::type;
+    using layout_t = typename  mpl::if_<is_same<L,use_default>,
+        layout<typename color_space_type<View>::type, typename channel_mapping_type<View>::type>, L>::type;
     static const bool mut   =mpl::if_<is_same<IsMutable,use_default>, view_is_mutable<View>, IsMutable>::type::value;
     static const bool planar=mpl::if_<is_same<IsPlanar,use_default>,  is_planar<View>,  IsPlanar>::type::value;
     static const bool step  =mpl::if_<is_same<StepX ,use_default>,  view_is_step_in_x<View>,StepX>::type::value;
 public:
-    typedef typename view_type<channel_t, layout_t, planar, step, mut>::type type;
+    using type = typename view_type<channel_t, layout_t, planar, step, mut>::type;
 };
 
 /// \brief Constructs a homogeneous image type from a source image type by changing some of the properties.
@@ -465,12 +466,12 @@ public:
 ///  Use use_default for the properties of the source image that you want to keep
 template <typename Image, typename T=use_default, typename L=use_default, typename IsPlanar=use_default>
 class derived_image_type {
-    typedef typename  mpl::if_<is_same<T ,use_default>, typename channel_type<Image>::type,     T >::type channel_t;
-    typedef typename  mpl::if_<is_same<L,use_default>,
-        layout<typename color_space_type<Image>::type, typename channel_mapping_type<Image>::type>, L>::type layout_t;
+    using channel_t = typename  mpl::if_<is_same<T ,use_default>, typename channel_type<Image>::type, T>::type;
+    using layout_t = typename  mpl::if_<is_same<L,use_default>,
+        layout<typename color_space_type<Image>::type, typename channel_mapping_type<Image>::type>, L>::type;
     static const bool planar=mpl::if_<is_same<IsPlanar,use_default>,  is_planar<Image>,  IsPlanar>::type::value;
 public:
-    typedef typename image_type<channel_t, layout_t, planar>::type type;
+    using type = typename image_type<channel_t, layout_t, planar>::type;
 };
 
 }}  // namespace boost::gil

--- a/include/boost/gil/packed_pixel.hpp
+++ b/include/boost/gil/packed_pixel.hpp
@@ -33,7 +33,7 @@ namespace boost { namespace gil {
 
 Example:
 \code
-typedef packed_pixel_type<uint16_t, mpl::vector3_c<unsigned,5,6,5>, rgb_layout_t>::type rgb565_pixel_t;
+using rgb565_pixel_t = packed_pixel_type<uint16_t, mpl::vector3_c<unsigned,5,6,5>, rgb_layout_t>::type;
 BOOST_STATIC_ASSERT((sizeof(rgb565_pixel_t)==2));
 
 rgb565_pixel_t r565;
@@ -50,13 +50,14 @@ assert(r565 == rgb565_pixel_t((uint16_t)0xFFFF));
 template <typename BitField,      // A type that holds the bits of the pixel. Typically an integral type, like std::uint16_t
           typename ChannelRefVec, // An MPL vector whose elements are packed channels. They must be constructible from BitField. GIL uses packed_channel_reference
           typename Layout>        // Layout defining the color space and ordering of the channels. Example value: rgb_layout_t
-struct packed_pixel {
+struct packed_pixel
+{
     BitField _bitfield;
 
-    typedef Layout                layout_t;
-    typedef packed_pixel          value_type;
-    typedef value_type&           reference;
-    typedef const value_type&     const_reference;
+    using layout_t = Layout;
+    using value_type = packed_pixel<BitField, ChannelRefVec, Layout>;
+    using reference = value_type&;
+    using const_reference = value_type const&;
 
     BOOST_STATIC_CONSTANT(bool, is_mutable = channel_traits<typename mpl::front<ChannelRefVec>::type>::is_mutable);
 
@@ -120,8 +121,9 @@ template <typename BitField, typename ChannelRefVec, typename Layout, int K>
 struct kth_element_reference_type<packed_pixel<BitField,ChannelRefVec,Layout>,K> : public mpl::at_c<ChannelRefVec,K> {};
 
 template <typename BitField, typename ChannelRefVec, typename Layout, int K>
-struct kth_element_const_reference_type<packed_pixel<BitField,ChannelRefVec,Layout>,K> {
-    typedef typename channel_traits<typename mpl::at_c<ChannelRefVec,K>::type>::const_reference type;
+struct kth_element_const_reference_type<packed_pixel<BitField,ChannelRefVec,Layout>,K>
+{
+    using type = typename channel_traits<typename mpl::at_c<ChannelRefVec,K>::type>::const_reference;
 };
 
 template <int K, typename P, typename C, typename L> inline
@@ -150,12 +152,12 @@ struct is_pixel<packed_pixel<BitField,ChannelRefVec,Layout> > : public mpl::true
 
 template <typename P, typename C, typename Layout>
 struct color_space_type<packed_pixel<P,C,Layout> > {
-    typedef typename Layout::color_space_t type;
+    using type = typename Layout::color_space_t;
 };
 
 template <typename P, typename C, typename Layout>
 struct channel_mapping_type<packed_pixel<P,C,Layout> > {
-    typedef typename Layout::channel_mapping_t type;
+    using type = typename Layout::channel_mapping_t;
 };
 
 template <typename P, typename C, typename Layout>

--- a/include/boost/gil/pixel.hpp
+++ b/include/boost/gil/pixel.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace gil {
 
 // Forward-declare gray_t
 struct gray_color_t;
-typedef mpl::vector1<gray_color_t> gray_t;
+using gray_t = mpl::vector1<gray_color_t>;
 template <typename PixelBased> struct color_space_type;
 template <typename PixelBased> struct channel_mapping_type;
 template <typename PixelBased> struct channel_type;
@@ -92,12 +92,12 @@ BOOST_STATIC_ASSERT((is_same<channel_type<bgr8_pixel_t>::type, uint8_t>::value))
 template <typename ChannelValue, typename Layout> // = mpl::range_c<int,0,ColorSpace::size> >
 struct pixel : public detail::homogeneous_color_base<ChannelValue,Layout,mpl::size<typename Layout::color_space_t>::value> {
 private:
-    typedef ChannelValue channel_t;
-    typedef detail::homogeneous_color_base<ChannelValue,Layout,mpl::size<typename Layout::color_space_t>::value> parent_t;
+    using channel_t = ChannelValue;
+    using parent_t = detail::homogeneous_color_base<ChannelValue,Layout,mpl::size<typename Layout::color_space_t>::value>;
 public:
-    typedef pixel                               value_type;
-    typedef value_type&                         reference;
-    typedef const value_type&                   const_reference;
+    using value_type = pixel<ChannelValue, Layout>;
+    using reference = value_type&;
+    using const_reference = value_type const&;
     BOOST_STATIC_CONSTANT(bool,                 is_mutable = channel_traits<channel_t>::is_mutable);
 
     pixel(){}
@@ -148,22 +148,22 @@ public:
 
 template <typename ChannelValue, typename Layout, int K>
 struct kth_element_type<pixel<ChannelValue,Layout>, K> {
-    typedef ChannelValue type;
+    using type = ChannelValue;
 };
 
 template <typename ChannelValue, typename Layout, int K>
 struct kth_element_reference_type<pixel<ChannelValue,Layout>, K> {
-    typedef typename channel_traits<ChannelValue>::reference type;
+    using type = typename channel_traits<ChannelValue>::reference;
 };
 
 template <typename ChannelValue, typename Layout, int K>
 struct kth_element_reference_type<const pixel<ChannelValue,Layout>, K> {
-    typedef typename channel_traits<ChannelValue>::const_reference type;
+    using type = typename channel_traits<ChannelValue>::const_reference;
 };
 
 template <typename ChannelValue, typename Layout, int K>
 struct kth_element_const_reference_type<pixel<ChannelValue,Layout>, K> {
-    typedef typename channel_traits<ChannelValue>::const_reference type;
+    using type = typename channel_traits<ChannelValue>::const_reference;
 };
 
 /////////////////////////////
@@ -179,12 +179,12 @@ struct is_pixel<pixel<ChannelValue,Layout> > : public mpl::true_{};
 
 template <typename ChannelValue, typename Layout>
 struct color_space_type<pixel<ChannelValue,Layout> > {
-    typedef typename Layout::color_space_t type;
+    using type = typename Layout::color_space_t;
 };
 
 template <typename ChannelValue, typename Layout>
 struct channel_mapping_type<pixel<ChannelValue,Layout> > {
-    typedef typename Layout::channel_mapping_t type;
+    using type = typename Layout::channel_mapping_t;
 };
 
 template <typename ChannelValue, typename Layout>
@@ -192,7 +192,7 @@ struct is_planar<pixel<ChannelValue,Layout> > : public mpl::false_ {};
 
 template <typename ChannelValue, typename Layout>
 struct channel_type<pixel<ChannelValue,Layout> > {
-    typedef ChannelValue type;
+    using type = ChannelValue;
 };
 
 }}  // namespace boost::gil

--- a/include/boost/gil/pixel_iterator.hpp
+++ b/include/boost/gil/pixel_iterator.hpp
@@ -41,8 +41,8 @@ template <typename It>
 struct const_iterator_type;
 
 // The default implementation when the iterator is a C pointer is to use the standard constness semantics
-template <typename T> struct const_iterator_type<      T*> { typedef const T* type; };
-template <typename T> struct const_iterator_type<const T*> { typedef const T* type; };
+template <typename T> struct const_iterator_type<T*>       { using type = T const*; };
+template <typename T> struct const_iterator_type<T const*> { using type = T const*; };
 
 /// \brief Metafunction predicate returning whether the given iterator allows for changing its values
 /// \ingroup GILIsMutable
@@ -67,13 +67,13 @@ template <typename T> struct iterator_is_mutable<const T*> : public mpl::false_{
 /// \ingroup PixelIteratorModelInterleavedPtr
 template <typename Pixel>
 struct dynamic_x_step_type<Pixel*> {
-    typedef memory_based_step_iterator<Pixel*> type;
+    using type = memory_based_step_iterator<Pixel *>;
 };
 
 /// \ingroup PixelIteratorModelInterleavedPtr
 template <typename Pixel>
 struct dynamic_x_step_type<const Pixel*> {
-    typedef memory_based_step_iterator<const Pixel*> type;
+    using type = memory_based_step_iterator<const Pixel *>;
 };
 
 

--- a/include/boost/gil/pixel_iterator_adaptor.hpp
+++ b/include/boost/gil/pixel_iterator_adaptor.hpp
@@ -34,15 +34,15 @@ class dereference_iterator_adaptor : public iterator_adaptor<dereference_iterato
                                                              use_default> {
     DFn _deref_fn;
 public:
-    typedef iterator_adaptor<dereference_iterator_adaptor<Iterator,DFn>,
+    using parent_t = iterator_adaptor<dereference_iterator_adaptor<Iterator,DFn>,
                                     Iterator,
                                     typename DFn::value_type,
                                     typename std::iterator_traits<Iterator>::iterator_category,
                                     typename DFn::reference,
-                                    use_default> parent_t;
-    typedef typename DFn::result_type                         reference;
-    typedef typename std::iterator_traits<Iterator>::difference_type difference_type;
-    typedef DFn                                               dereference_fn;
+                                    use_default>;
+    using reference = typename DFn::result_type;
+    using difference_type = typename std::iterator_traits<Iterator>::difference_type;
+    using dereference_fn = DFn;
 
     dereference_iterator_adaptor() {}
     template <typename Iterator1>
@@ -76,7 +76,7 @@ private:
 
 template <typename I, typename DFn>
 struct const_iterator_type<dereference_iterator_adaptor<I,DFn> > {
-    typedef dereference_iterator_adaptor<typename const_iterator_type<I>::type,typename DFn::const_t> type;
+    using type = dereference_iterator_adaptor<typename const_iterator_type<I>::type,typename DFn::const_t>;
 };
 
 template <typename I, typename DFn>
@@ -88,12 +88,12 @@ struct is_iterator_adaptor<dereference_iterator_adaptor<I,DFn> > : public mpl::t
 
 template <typename I, typename DFn>
 struct iterator_adaptor_get_base<dereference_iterator_adaptor<I,DFn> > {
-    typedef I type;
+    using type = I;
 };
 
 template <typename I, typename DFn, typename NewBaseIterator>
 struct iterator_adaptor_rebind<dereference_iterator_adaptor<I,DFn>,NewBaseIterator> {
-    typedef dereference_iterator_adaptor<NewBaseIterator,DFn> type;
+    using type = dereference_iterator_adaptor<NewBaseIterator,DFn>;
 };
 
 /////////////////////////////
@@ -161,7 +161,7 @@ memunit_advanced_ref(const dereference_iterator_adaptor<Iterator,DFn>& p,
 
 template <typename Iterator, typename DFn>
 struct dynamic_x_step_type<dereference_iterator_adaptor<Iterator,DFn> > {
-    typedef dereference_iterator_adaptor<typename dynamic_x_step_type<Iterator>::type,DFn> type;
+    using type = dereference_iterator_adaptor<typename dynamic_x_step_type<Iterator>::type,DFn>;
 };
 
 /// \brief Returns the type (and creates an instance) of an iterator that invokes the given dereference adaptor upon dereferencing
@@ -170,7 +170,7 @@ template <typename Iterator, typename Deref>
 struct iterator_add_deref {
     GIL_CLASS_REQUIRE(Deref, boost::gil, PixelDereferenceAdaptorConcept)
 
-    typedef dereference_iterator_adaptor<Iterator, Deref> type;
+    using type = dereference_iterator_adaptor<Iterator, Deref>;
 
     static type make(const Iterator& it, const Deref& d) { return type(it,d); }
 };
@@ -181,7 +181,7 @@ template <typename Iterator, typename PREV_DEREF, typename Deref>
 struct iterator_add_deref<dereference_iterator_adaptor<Iterator, PREV_DEREF>,Deref> {
 //    GIL_CLASS_REQUIRE(Deref, boost::gil, PixelDereferenceAdaptorConcept)
 
-    typedef dereference_iterator_adaptor<Iterator, deref_compose<Deref,PREV_DEREF> > type;
+    using type = dereference_iterator_adaptor<Iterator, deref_compose<Deref,PREV_DEREF>>;
 
     static type make(const dereference_iterator_adaptor<Iterator, PREV_DEREF>& it, const Deref& d) {
         return type(it.base(),deref_compose<Deref,PREV_DEREF>(d,it.deref_fn()));

--- a/include/boost/gil/planar_pixel_iterator.hpp
+++ b/include/boost/gil/planar_pixel_iterator.hpp
@@ -44,16 +44,16 @@ struct planar_pixel_iterator : public iterator_facade<planar_pixel_iterator<Chan
                                                       const planar_pixel_reference<typename std::iterator_traits<ChannelPtr>::reference,ColorSpace> >,
                                public detail::homogeneous_color_base<ChannelPtr,layout<ColorSpace>,mpl::size<ColorSpace>::value > {
 private:
-    typedef iterator_facade<planar_pixel_iterator<ChannelPtr,ColorSpace>,
-                            pixel<typename std::iterator_traits<ChannelPtr>::value_type,layout<ColorSpace> >,
+    using parent_t = iterator_facade<planar_pixel_iterator<ChannelPtr,ColorSpace>,
+                            pixel<typename std::iterator_traits<ChannelPtr>::value_type,layout<ColorSpace>>,
                             std::random_access_iterator_tag,
-                            const planar_pixel_reference<typename std::iterator_traits<ChannelPtr>::reference,ColorSpace> > parent_t;
-    typedef detail::homogeneous_color_base<ChannelPtr,layout<ColorSpace>,mpl::size<ColorSpace>::value> color_base_parent_t;
-    typedef typename std::iterator_traits<ChannelPtr>::value_type channel_t;
+                            const planar_pixel_reference<typename std::iterator_traits<ChannelPtr>::reference,ColorSpace>>;
+    using color_base_parent_t = detail::homogeneous_color_base<ChannelPtr,layout<ColorSpace>,mpl::size<ColorSpace>::value>;
+    using channel_t = typename std::iterator_traits<ChannelPtr>::value_type;
 public:
-    typedef typename parent_t::value_type                 value_type;
-    typedef typename parent_t::reference                  reference;
-    typedef typename parent_t::difference_type            difference_type;
+    using value_type = typename parent_t::value_type;
+    using reference = typename parent_t::reference;
+    using difference_type = typename parent_t::difference_type;
 
     planar_pixel_iterator() : color_base_parent_t(0) {}
     planar_pixel_iterator(bool) {}        // constructor that does not fill with zero (for performance)
@@ -116,9 +116,9 @@ namespace detail {
 template <typename IC, typename C>
 struct const_iterator_type<planar_pixel_iterator<IC,C> > {
 private:
-    typedef typename std::iterator_traits<IC>::value_type channel_t;
+    using channel_t = typename std::iterator_traits<IC>::value_type;
 public:
-    typedef planar_pixel_iterator<typename channel_traits<channel_t>::const_pointer,C> type;
+    using type = planar_pixel_iterator<typename channel_traits<channel_t>::const_pointer,C>;
 };
 
 // The default implementation when the iterator is a C pointer is to use the standard constness semantics
@@ -131,7 +131,7 @@ struct iterator_is_mutable<planar_pixel_iterator<IC,C> > : public detail::channe
 
 template <typename IC, typename C, int K>
 struct kth_element_type<planar_pixel_iterator<IC,C>, K> {
-    typedef IC type;
+    using type = IC;
 };
 
 template <typename IC, typename C, int K>
@@ -146,7 +146,7 @@ struct kth_element_const_reference_type<planar_pixel_iterator<IC,C>, K> : public
 
 template <typename IC, typename C>
 struct color_space_type<planar_pixel_iterator<IC,C> > {
-    typedef C type;
+    using type = C;
 };
 
 template <typename IC, typename C>
@@ -157,7 +157,7 @@ struct is_planar<planar_pixel_iterator<IC,C> > : public mpl::true_ {};
 
 template <typename IC, typename C>
 struct channel_type<planar_pixel_iterator<IC,C> > {
-    typedef typename std::iterator_traits<IC>::value_type type;
+    using type = typename std::iterator_traits<IC>::value_type;
 };
 
 /////////////////////////////
@@ -204,7 +204,7 @@ inline planar_pixel_reference<typename std::iterator_traits<ChannelPtr>::referen
 
 template <typename IC, typename C>
 struct dynamic_x_step_type<planar_pixel_iterator<IC,C> > {
-    typedef memory_based_step_iterator<planar_pixel_iterator<IC,C> > type;
+    using type = memory_based_step_iterator<planar_pixel_iterator<IC,C>>;
 };
 } }  // namespace boost::gil
 

--- a/include/boost/gil/planar_pixel_reference.hpp
+++ b/include/boost/gil/planar_pixel_reference.hpp
@@ -35,17 +35,18 @@ namespace boost { namespace gil {
 ///
 template <typename ChannelReference, typename ColorSpace>        // ChannelReference is a channel reference (const or mutable)
 struct planar_pixel_reference
-   : public detail::homogeneous_color_base<ChannelReference,layout<ColorSpace>,mpl::size<ColorSpace>::value> {
-    typedef detail::homogeneous_color_base<ChannelReference,layout<ColorSpace>,mpl::size<ColorSpace>::value> parent_t;
+   : public detail::homogeneous_color_base<ChannelReference,layout<ColorSpace>,mpl::size<ColorSpace>::value>
+{
+    using parent_t = detail::homogeneous_color_base<ChannelReference,layout<ColorSpace>,mpl::size<ColorSpace>::value>;
 private:
     // These three are only defined for homogeneous pixels
-    typedef typename channel_traits<ChannelReference>::value_type      channel_t;
-    typedef typename channel_traits<ChannelReference>::const_reference channel_const_reference;
+    using channel_t = typename channel_traits<ChannelReference>::value_type;
+    using channel_const_reference = typename channel_traits<ChannelReference>::const_reference;
 public:
     BOOST_STATIC_CONSTANT(bool, is_mutable = channel_traits<ChannelReference>::is_mutable);
-    typedef pixel<channel_t,layout<ColorSpace> >                       value_type;
-    typedef planar_pixel_reference                                     reference;
-    typedef planar_pixel_reference<channel_const_reference,ColorSpace> const_reference;
+    using value_type = pixel<channel_t,layout<ColorSpace>>;
+    using reference = planar_pixel_reference<ChannelReference, ColorSpace>;
+    using const_reference = planar_pixel_reference<channel_const_reference,ColorSpace>;
 
     planar_pixel_reference(ChannelReference v0, ChannelReference v1) : parent_t(v0,v1) {}
     planar_pixel_reference(ChannelReference v0, ChannelReference v1, ChannelReference v2) : parent_t(v0,v1,v2) {}
@@ -93,19 +94,19 @@ private:
 
 template <typename ChannelReference, typename ColorSpace, int K>
 struct kth_element_type<planar_pixel_reference<ChannelReference,ColorSpace>, K> {
-    typedef ChannelReference type;
+    using type = ChannelReference;
 };
 
 template <typename ChannelReference, typename ColorSpace, int K>
 struct kth_element_reference_type<planar_pixel_reference<ChannelReference,ColorSpace>, K> {
-    typedef ChannelReference type;
+    using type = ChannelReference;
 };
 
 template <typename ChannelReference, typename ColorSpace, int K>
 struct kth_element_const_reference_type<planar_pixel_reference<ChannelReference,ColorSpace>, K>
     : public add_reference<typename add_const<ChannelReference>::type>
 {
-//    typedef typename channel_traits<ChannelReference>::const_reference type;
+//    using type = typename channel_traits<ChannelReference>::const_reference;
 };
 
 /////////////////////////////
@@ -125,14 +126,14 @@ struct is_pixel< planar_pixel_reference<ChannelReference,ColorSpace> > : public 
 /// \ingroup PixelModelPlanarRef
 template <typename ChannelReference, typename ColorSpace>
 struct color_space_type<planar_pixel_reference<ChannelReference,ColorSpace> > {
-    typedef ColorSpace type;
+    using type = ColorSpace;
 };
 
 /// \brief Specifies the color space type of a planar pixel reference. Required by PixelBasedConcept
 /// \ingroup PixelModelPlanarRef
 template <typename ChannelReference, typename ColorSpace>
 struct channel_mapping_type<planar_pixel_reference<ChannelReference,ColorSpace> > {
-    typedef typename layout<ColorSpace>::channel_mapping_t type;
+    using type = typename layout<ColorSpace>::channel_mapping_t;
 };
 
 /// \brief Specifies that planar_pixel_reference represents a planar construct. Required by PixelBasedConcept
@@ -144,7 +145,7 @@ struct is_planar<planar_pixel_reference<ChannelReference,ColorSpace> > : mpl::tr
 /// \ingroup PixelModelPlanarRef
 template <typename ChannelReference, typename ColorSpace>
 struct channel_type<planar_pixel_reference<ChannelReference,ColorSpace> > {
-    typedef typename channel_traits<ChannelReference>::value_type type;
+    using type = typename channel_traits<ChannelReference>::value_type;
 };
 
 }}  // namespace boost::gil

--- a/include/boost/gil/position_iterator.hpp
+++ b/include/boost/gil/position_iterator.hpp
@@ -34,9 +34,9 @@ struct position_iterator : public iterator_facade<position_iterator<Deref,Dim>,
                             std::random_access_iterator_tag,
                             typename Deref::reference,
                             typename Deref::argument_type::template axis<Dim>::coord_t> parent_t;
-    typedef typename parent_t::difference_type difference_type;
-    typedef typename parent_t::reference       reference;
-    typedef typename Deref::argument_type      point_t;
+    using difference_type = typename parent_t::difference_type;
+    using reference = typename parent_t::reference;
+    using point_t = typename Deref::argument_type;
 
     position_iterator() {}
     position_iterator(const point_t& p, const point_t& step, const Deref& d) : _p(p), _step(step), _d(d) {}

--- a/include/boost/gil/position_iterator.hpp
+++ b/include/boost/gil/position_iterator.hpp
@@ -29,11 +29,11 @@ struct position_iterator : public iterator_facade<position_iterator<Deref,Dim>,
                                                   std::random_access_iterator_tag,
                                                   typename Deref::reference,
                                                   typename Deref::argument_type::template axis<Dim>::coord_t> {
-    typedef iterator_facade<position_iterator<Deref,Dim>,
+    using parent_t = iterator_facade<position_iterator<Deref,Dim>,
                             typename Deref::value_type,
                             std::random_access_iterator_tag,
                             typename Deref::reference,
-                            typename Deref::argument_type::template axis<Dim>::coord_t> parent_t;
+                            typename Deref::argument_type::template axis<Dim>::coord_t>;
     using difference_type = typename parent_t::difference_type;
     using reference = typename parent_t::reference;
     using point_t = typename Deref::argument_type;
@@ -71,7 +71,7 @@ private:
 
 template <typename Deref,int Dim>
 struct const_iterator_type<position_iterator<Deref,Dim> > {
-    typedef position_iterator<typename Deref::const_t,Dim> type;
+    using type = position_iterator<typename Deref::const_t,Dim>;
 };
 
 template <typename Deref,int Dim>
@@ -100,7 +100,7 @@ struct channel_type<position_iterator<Deref,Dim> > : public channel_type<typenam
 
 template <typename Deref,int Dim>
 struct dynamic_x_step_type<position_iterator<Deref,Dim> > {
-    typedef position_iterator<Deref,Dim> type;
+    using type = position_iterator<Deref,Dim>;
 };
 
 } }  // namespace boost::gil

--- a/include/boost/gil/premultiply.hpp
+++ b/include/boost/gil/premultiply.hpp
@@ -57,11 +57,11 @@ struct premultiply
     template <typename SrcP, typename DstP>
     void operator()(const SrcP& src, DstP& dst) const
     {
-        typedef typename color_space_type<SrcP>::type src_colour_space_t;
-        typedef typename color_space_type<DstP>::type dst_colour_space_t;
-        typedef typename mpl::remove <src_colour_space_t, alpha_t>::type src_colour_channels;
+        using src_colour_space_t = typename color_space_type<SrcP>::type;
+        using dst_colour_space_t = typename color_space_type<DstP>::type;
+        using src_colour_channels = typename mpl::remove <src_colour_space_t, alpha_t>::type;
 
-        typedef mpl::bool_<mpl::contains<dst_colour_space_t, alpha_t>::value> has_alpha_t;
+        using has_alpha_t = mpl::bool_<mpl::contains<dst_colour_space_t, alpha_t>::value>;
         mpl::for_each<src_colour_channels>(channel_premultiply<SrcP, DstP>(src, dst));
         detail::assign_alpha_if(has_alpha_t(), src, dst);
     }
@@ -72,12 +72,12 @@ template <typename SrcConstRefP,  // const reference to the source pixel
 class premultiply_deref_fn
 {
 public:
-    typedef premultiply_deref_fn const_t;
-    typedef DstP                value_type;
-    typedef value_type          reference;      // read-only dereferencing
-    typedef const value_type&   const_reference;
-    typedef SrcConstRefP        argument_type;
-    typedef reference           result_type;
+    using const_t = premultiply_deref_fn<SrcConstRefP, DstP>;
+    using value_type = DstP;
+    using reference = value_type;      // read-only dereferencing
+    using const_reference = const value_type &;
+    using argument_type = SrcConstRefP;
+    using result_type = reference;
     BOOST_STATIC_CONSTANT(bool, is_mutable=false);
 
     result_type operator()(argument_type srcP) const
@@ -92,11 +92,11 @@ template <typename SrcView, typename DstP>
 struct premultiplied_view_type
 {
 private:
-    typedef typename SrcView::const_t::reference src_pix_ref;  // const reference to pixel in SrcView
-    typedef premultiply_deref_fn<src_pix_ref, DstP> deref_t; // the dereference adaptor that performs color conversion
-    typedef typename SrcView::template add_deref<deref_t> add_ref_t;
+    using src_pix_ref = typename SrcView::const_t::reference;  // const reference to pixel in SrcView
+    using deref_t = premultiply_deref_fn<src_pix_ref, DstP>; // the dereference adaptor that performs color conversion
+    using add_ref_t = typename SrcView::template add_deref<deref_t>;
 public:
-    typedef typename add_ref_t::type type; // the color converted view type
+    using type = typename add_ref_t::type; // the color converted view type
     static type make(const SrcView& sv) { return add_ref_t::make(sv, deref_t()); }
 };
 

--- a/include/boost/gil/promote_integral.hpp
+++ b/include/boost/gil/promote_integral.hpp
@@ -55,7 +55,7 @@ struct promote_to_larger
 {
     using current_type = typename boost::mpl::deref<Iterator>::type;
 
-    typedef typename std::conditional
+    using type = typename std::conditional
         <
             (bit_size<current_type>::type::value >= MinSize),
             current_type,
@@ -66,7 +66,7 @@ struct promote_to_larger
                     EndIterator,
                     MinSize
                 >::type
-        >::type type;
+        >::type;
 };
 
 // The following specialization is required to finish the loop over
@@ -134,7 +134,7 @@ private:
     // * if T is unsigned and P is unsigned: 2 * b
     // * if T is signed and P is signed: 2 * b - 1
     // * if T is unsigned and P is signed: 2 * b + 1
-    typedef typename std::conditional
+    using min_bit_size_type = typename std::conditional
         <
             (PromoteUnsignedToUnsigned && is_unsigned),
             std::integral_constant<std::size_t, (2 * bit_size_type::value)>,
@@ -144,46 +144,46 @@ private:
                     std::integral_constant<std::size_t, (2 * bit_size_type::value + 1)>,
                     std::integral_constant<std::size_t, (2 * bit_size_type::value - 1)>
                 >::type
-        >::type min_bit_size_type;
+        >::type;
 
     // Define the list of signed integral types we are going to use
     // for promotion
-    typedef boost::mpl::list
+    using signed_integral_types = boost::mpl::list
         <
             short, int, long
 #if defined(BOOST_HAS_LONG_LONG)
             , boost::long_long_type
 #endif
-        > signed_integral_types;
+        >;
 
     // Define the list of unsigned integral types we are going to use
     // for promotion
-    typedef boost::mpl::list
+    using unsigned_integral_types = boost::mpl::list
         <
             unsigned short, unsigned int, unsigned long, std::size_t
 #if defined(BOOST_HAS_LONG_LONG)
             , boost::ulong_long_type
 #endif
-        > unsigned_integral_types;
+        >;
 
     // Define the list of integral types that will be used for
     // promotion (depending in whether we was to promote unsigned to
     // unsigned or not)
-    typedef typename std::conditional
+    using integral_types = typename std::conditional
         <
             (is_unsigned && PromoteUnsignedToUnsigned),
             unsigned_integral_types,
             signed_integral_types
-        >::type integral_types;
+        >::type;
 
 public:
-    typedef typename detail::promote_integral::promote_to_larger
+    using type = typename detail::promote_integral::promote_to_larger
         <
             T,
             typename boost::mpl::begin<integral_types>::type,
             typename boost::mpl::end<integral_types>::type,
             min_bit_size_type::value
-        >::type type;
+        >::type;
 };
 
 

--- a/include/boost/gil/promote_integral.hpp
+++ b/include/boost/gil/promote_integral.hpp
@@ -53,7 +53,7 @@ template
 >
 struct promote_to_larger
 {
-    typedef typename boost::mpl::deref<Iterator>::type current_type;
+    using current_type = typename boost::mpl::deref<Iterator>::type;
 
     typedef typename std::conditional
         <
@@ -76,7 +76,7 @@ struct promote_to_larger<T, EndIterator, EndIterator, MinSize>
 {
     // if promotion fails, keep the number T
     // (and cross fingers that overflow will not occur)
-    typedef T type;
+    using type = T;
 };
 
 }} // namespace detail::promote_integral
@@ -125,7 +125,7 @@ class promote_integral
 private:
     static bool const is_unsigned = std::is_unsigned<T>::type::value;
 
-    typedef detail::promote_integral::bit_size<T> bit_size_type;
+    using bit_size_type = detail::promote_integral::bit_size<T>;
 
     // Define the minimum size (in bits) needed for the promoted type
     // If T is the input type and P the promoted type, then the
@@ -194,7 +194,7 @@ class promote_integral
     >
 {
 public:
-    typedef T type;
+    using type = T;
 };
 
 }} // namespace boost::gil

--- a/include/boost/gil/rgb.hpp
+++ b/include/boost/gil/rgb.hpp
@@ -32,12 +32,12 @@ struct blue_t {};
 /// \}
 
 /// \ingroup ColorSpaceModel
-typedef mpl::vector3<red_t,green_t,blue_t> rgb_t;
+using rgb_t = mpl::vector3<red_t,green_t,blue_t>;
 
 /// \ingroup LayoutModel
-typedef layout<rgb_t> rgb_layout_t;
+using rgb_layout_t = layout<rgb_t>;
 /// \ingroup LayoutModel
-typedef layout<rgb_t, mpl::vector3_c<int,2,1,0> > bgr_layout_t;
+using bgr_layout_t = layout<rgb_t, mpl::vector3_c<int,2,1,0>>;
 
 /// \ingroup ImageViewConstructors
 /// \brief from raw RGB planar data
@@ -46,10 +46,11 @@ inline
 typename type_from_x_iterator<planar_pixel_iterator<IC,rgb_t> >::view_t
 planar_rgb_view(std::size_t width, std::size_t height,
                 IC r, IC g, IC b,
-                std::ptrdiff_t rowsize_in_bytes) {
-    typedef typename type_from_x_iterator<planar_pixel_iterator<IC,rgb_t> >::view_t RView;
-    return RView(width, height,
-                 typename RView::locator(planar_pixel_iterator<IC,rgb_t>(r,g,b),
+                std::ptrdiff_t rowsize_in_bytes)
+{
+    using view_t = typename type_from_x_iterator<planar_pixel_iterator<IC,rgb_t>>::view_t;
+    return view_t(width, height,
+                 typename view_t::locator(planar_pixel_iterator<IC,rgb_t>(r,g,b),
                                          rowsize_in_bytes));
 }
 

--- a/include/boost/gil/rgba.hpp
+++ b/include/boost/gil/rgba.hpp
@@ -23,16 +23,16 @@ namespace boost { namespace gil {
 struct alpha_t {};
 
 /// \ingroup ColorSpaceModel
-typedef mpl::vector4<red_t,green_t,blue_t,alpha_t> rgba_t;
+using rgba_t = mpl::vector4<red_t,green_t,blue_t,alpha_t>;
 
 /// \ingroup LayoutModel
-typedef layout<rgba_t> rgba_layout_t;
+using rgba_layout_t = layout<rgba_t>;
 /// \ingroup LayoutModel
-typedef layout<rgba_t, mpl::vector4_c<int,2,1,0,3> > bgra_layout_t;
+using bgra_layout_t = layout<rgba_t, mpl::vector4_c<int,2,1,0,3>>;
 /// \ingroup LayoutModel
-typedef layout<rgba_t, mpl::vector4_c<int,1,2,3,0> > argb_layout_t;
+using argb_layout_t = layout<rgba_t, mpl::vector4_c<int,1,2,3,0>>;
 /// \ingroup LayoutModel
-typedef layout<rgba_t, mpl::vector4_c<int,3,2,1,0> > abgr_layout_t;
+using abgr_layout_t = layout<rgba_t, mpl::vector4_c<int,3,2,1,0>>;
 
 /// \ingroup ImageViewConstructors
 /// \brief from raw RGBA planar data
@@ -43,9 +43,9 @@ planar_rgba_view(std::size_t width, std::size_t height,
                  IC r, IC g, IC b, IC a,
                  std::ptrdiff_t rowsize_in_bytes)
 {
-    typedef typename type_from_x_iterator<planar_pixel_iterator<IC,rgba_t> >::view_t RView;
+    using view_t = typename type_from_x_iterator<planar_pixel_iterator<IC,rgba_t> >::view_t;
     return RView(width, height,
-                 typename RView::locator(planar_pixel_iterator<IC,rgba_t>(r,g,b,a),
+                 typename view_t::locator(planar_pixel_iterator<IC,rgba_t>(r,g,b,a),
                                          rowsize_in_bytes));
 }
 

--- a/include/boost/gil/step_iterator.hpp
+++ b/include/boost/gil/step_iterator.hpp
@@ -36,12 +36,13 @@ template <typename Derived,  // type of the derived class
           typename Iterator, // Models Iterator
           typename SFn>      // A policy object that can compute the distance between two iterators of type Iterator
                              // and can advance an iterator of type Iterator a given number of Iterator's units
-class step_iterator_adaptor : public iterator_adaptor<Derived, Iterator, use_default, use_default, use_default, typename SFn::difference_type> {
+class step_iterator_adaptor : public iterator_adaptor<Derived, Iterator, use_default, use_default, use_default, typename SFn::difference_type>
+{
 public:
-    typedef iterator_adaptor<Derived, Iterator, use_default, use_default, use_default, typename SFn::difference_type> parent_t;
-    typedef typename std::iterator_traits<Iterator>::difference_type base_difference_type;
-    typedef typename SFn::difference_type                           difference_type;
-    typedef typename std::iterator_traits<Iterator>::reference       reference;
+    using parent_t = iterator_adaptor<Derived, Iterator, use_default, use_default, use_default, typename SFn::difference_type>;
+    using base_difference_type = typename std::iterator_traits<Iterator>::difference_type;
+    using difference_type = typename SFn::difference_type;
+    using reference = typename std::iterator_traits<Iterator>::reference;
 
     step_iterator_adaptor() {}
     step_iterator_adaptor(const Iterator& it, SFn step_fn=SFn()) : parent_t(it), _step_fn(step_fn) {}
@@ -117,7 +118,7 @@ bool operator!=(const step_iterator_adaptor<D,Iterator,SFn>& p1, const step_iter
 /// \brief function object that returns the memory unit distance between two iterators and advances a given iterator a given number of mem units (bytes or bits)
 template <typename Iterator>
 struct memunit_step_fn {
-    typedef std::ptrdiff_t difference_type;
+    using difference_type = std::ptrdiff_t;
 
     memunit_step_fn(difference_type step=memunit_step(Iterator())) : _step(step) {}
 
@@ -134,15 +135,16 @@ private:
 template <typename Iterator>
 class memory_based_step_iterator : public detail::step_iterator_adaptor<memory_based_step_iterator<Iterator>,
                                                                             Iterator,
-                                                                            memunit_step_fn<Iterator> > {
+                                                                            memunit_step_fn<Iterator>>
+{
     GIL_CLASS_REQUIRE(Iterator, boost::gil, MemoryBasedIteratorConcept)
 public:
-    typedef detail::step_iterator_adaptor<memory_based_step_iterator<Iterator>,
+    using parent_t = detail::step_iterator_adaptor<memory_based_step_iterator<Iterator>,
                                           Iterator,
-                                          memunit_step_fn<Iterator> > parent_t;
-    typedef typename parent_t::reference                            reference;
-    typedef typename parent_t::difference_type                      difference_type;
-    typedef Iterator                                                x_iterator;
+                                          memunit_step_fn<Iterator>>;
+    using reference = typename parent_t::reference;
+    using difference_type = typename parent_t::difference_type;
+    using x_iterator = Iterator;
 
     memory_based_step_iterator() : parent_t(Iterator()) {}
     memory_based_step_iterator(Iterator it, std::ptrdiff_t memunit_step) : parent_t(it, memunit_step_fn<Iterator>(memunit_step)) {}
@@ -162,7 +164,7 @@ public:
 
 template <typename Iterator>
 struct const_iterator_type<memory_based_step_iterator<Iterator> > {
-    typedef memory_based_step_iterator<typename const_iterator_type<Iterator>::type>  type;
+    using type = memory_based_step_iterator<typename const_iterator_type<Iterator>::type>;
 };
 
 template <typename Iterator>
@@ -178,12 +180,12 @@ struct is_iterator_adaptor<memory_based_step_iterator<Iterator> > : public mpl::
 
 template <typename Iterator>
 struct iterator_adaptor_get_base<memory_based_step_iterator<Iterator> > {
-    typedef Iterator type;
+    using type = Iterator;
 };
 
 template <typename Iterator, typename NewBaseIterator>
 struct iterator_adaptor_rebind<memory_based_step_iterator<Iterator>,NewBaseIterator> {
-    typedef memory_based_step_iterator<NewBaseIterator> type;
+    using type = memory_based_step_iterator<NewBaseIterator>;
 };
 
 /////////////////////////////
@@ -243,7 +245,7 @@ memunit_advanced_ref(const memory_based_step_iterator<Iterator>& p,
 
 template <typename Iterator>
 struct dynamic_x_step_type<memory_based_step_iterator<Iterator> > {
-    typedef memory_based_step_iterator<Iterator> type;
+    using type = memory_based_step_iterator<Iterator>;
 };
 
 // For step iterators, pass the function object to the base
@@ -251,7 +253,7 @@ template <typename Iterator, typename Deref>
 struct iterator_add_deref<memory_based_step_iterator<Iterator>,Deref> {
     GIL_CLASS_REQUIRE(Deref, boost::gil, PixelDereferenceAdaptorConcept)
 
-    typedef memory_based_step_iterator<typename iterator_add_deref<Iterator, Deref>::type> type;
+    using type = memory_based_step_iterator<typename iterator_add_deref<Iterator, Deref>::type>;
 
     static type make(const memory_based_step_iterator<Iterator>& it, const Deref& d) { return type(iterator_add_deref<Iterator, Deref>::make(it.base(),d),it.step()); }
 };

--- a/include/boost/gil/typedefs.hpp
+++ b/include/boost/gil/typedefs.hpp
@@ -96,27 +96,27 @@ template <typename T> struct float_point_one;
 //////////////////////////////////////////////////////////////////////////////////////////
 
 /// \ingroup ChannelModel
-/// \brief 8-bit unsigned integral channel type (typedef from uint8_t). Models ChannelValueConcept
+/// \brief 8-bit unsigned integral channel type (alias from uint8_t). Models ChannelValueConcept
 using std::uint8_t;
 
 /// \ingroup ChannelModel
-/// \brief 16-bit unsigned integral channel type (typedef from uint16_t). Models ChannelValueConcept
+/// \brief 16-bit unsigned integral channel type (alias from uint16_t). Models ChannelValueConcept
 using std::uint16_t;
 
 /// \ingroup ChannelModel
-/// \brief 32-bit unsigned integral channel type  (typedef from uint32_t). Models ChannelValueConcept
+/// \brief 32-bit unsigned integral channel type  (alias from uint32_t). Models ChannelValueConcept
 using std::uint32_t;
 
 /// \ingroup ChannelModel
-/// \brief 8-bit signed integral channel type (typedef from int8_t). Models ChannelValueConcept
+/// \brief 8-bit signed integral channel type (alias from int8_t). Models ChannelValueConcept
 using std::int8_t;
 
 /// \ingroup ChannelModel
-/// \brief 16-bit signed integral channel type (typedef from int16_t). Models ChannelValueConcept
+/// \brief 16-bit signed integral channel type (alias from int16_t). Models ChannelValueConcept
 using std::int16_t;
 
 /// \ingroup ChannelModel
-/// \brief 32-bit signed integral channel type (typedef from int32_t). Models ChannelValueConcept
+/// \brief 32-bit signed integral channel type (alias from int32_t). Models ChannelValueConcept
 using std::int32_t;
 
 /// \ingroup ChannelModel

--- a/include/boost/gil/utilities.hpp
+++ b/include/boost/gil/utilities.hpp
@@ -89,16 +89,16 @@ template
 >
 struct deref_base
 {
-    typedef ArgType        argument_type;
-    typedef ResultType     result_type;
-    typedef ConstT         const_t;
-    typedef Value          value_type;
-    typedef Reference      reference;
-    typedef ConstReference const_reference;
+    using argument_type = ArgType;
+    using result_type = ResultType;
+    using const_t = ConstT;
+    using value_type = Value;
+    using reference = Reference;
+    using const_reference = ConstReference;
     BOOST_STATIC_CONSTANT(bool, is_mutable = IsMutable);
 };
 
-/// \brief Composes two dereference function objects. Similar to std::unary_compose but needs to pull some typedefs from the component types.  Models: PixelDereferenceAdaptorConcept
+/// \brief Composes two dereference function objects. Similar to std::unary_compose but needs to pull some aliases from the component types.  Models: PixelDereferenceAdaptorConcept
 /// \ingroup PixelDereferenceAdaptorModel
 ///
 template <typename D1, typename D2>
@@ -117,8 +117,8 @@ public:
     D1 _fn1;
     D2 _fn2;
 
-    typedef typename D2::argument_type   argument_type;
-    typedef typename D1::result_type     result_type;
+    using argument_type = typename D2::argument_type;
+    using result_type = typename D1::result_type;
 
     deref_compose() = default;
     deref_compose(const D1& x, const D2& y) : _fn1(x), _fn2(y) {}
@@ -192,17 +192,17 @@ copy_n(InputIter first, Size count, OutputIter result)
 template <typename T>
 struct identity
 {
-    typedef T argument_type;
-    typedef T result_type;
+    using argument_type = T;
+    using result_type = T;
     const T& operator()(const T& val) const { return val; }
 };
 
 /// \brief plus function object whose arguments may be of different type.
 template <typename T1, typename T2>
 struct plus_asymmetric {
-    typedef T1 first_argument_type;
-    typedef T2 second_argument_type;
-    typedef T1 result_type;
+    using first_argument_type = T1;
+    using second_argument_type = T2;
+    using result_type = T1;
     T1 operator()(T1 f1, T2 f2) const
     {
         return f1+f2;
@@ -213,8 +213,8 @@ struct plus_asymmetric {
 template <typename T>
 struct inc
 {
-    typedef T argument_type;
-    typedef T result_type;
+    using argument_type = T;
+    using result_type = T;
     T operator()(T x) const { return ++x; }
 };
 
@@ -222,8 +222,8 @@ struct inc
 template <typename T>
 struct dec
 {
-    typedef T argument_type;
-    typedef T result_type;
+    using argument_type = T;
+    using result_type = T;
     T operator()(T x) const { return --x; }
 };
 
@@ -245,8 +245,8 @@ struct type_to_index
 template <typename ColorSpace, typename ChannelMapping = mpl::range_c<int,0,mpl::size<ColorSpace>::value>>
 struct layout
 {
-    typedef ColorSpace      color_space_t;
-    typedef ChannelMapping  channel_mapping_t;
+    using color_space_t = ColorSpace;
+    using channel_mapping_t = ChannelMapping;
 };
 
 /// \brief A version of swap that also works with reference proxy objects

--- a/include/boost/gil/virtual_locator.hpp
+++ b/include/boost/gil/virtual_locator.hpp
@@ -18,23 +18,25 @@ namespace boost { namespace gil {
 /// \ingroup PixelLocatorModel PixelBasedModel
 ///
 template <typename Deref, bool IsTransposed>        // A function object that given a point returns a reference. Models PixelDereferenceAdaptorConcept
-class virtual_2d_locator : public pixel_2d_locator_base<virtual_2d_locator<Deref,IsTransposed>, position_iterator<Deref,IsTransposed>, position_iterator<Deref,1-IsTransposed> > {
-    typedef virtual_2d_locator<Deref,IsTransposed>  this_t;
+class virtual_2d_locator : public pixel_2d_locator_base<virtual_2d_locator<Deref,IsTransposed>, position_iterator<Deref,IsTransposed>, position_iterator<Deref,1-IsTransposed>>
+{
+    using this_t = virtual_2d_locator<Deref,IsTransposed>;
 public:
-    typedef pixel_2d_locator_base<virtual_2d_locator<Deref,IsTransposed>, position_iterator<Deref,IsTransposed>, position_iterator<Deref,1-IsTransposed> > parent_t;
-    typedef virtual_2d_locator<typename Deref::const_t,IsTransposed>        const_t;
+    using parent_t = pixel_2d_locator_base<virtual_2d_locator<Deref,IsTransposed>, position_iterator<Deref,IsTransposed>, position_iterator<Deref,1-IsTransposed>>;
+    using const_t = virtual_2d_locator<typename Deref::const_t,IsTransposed>;
 
-    typedef Deref                                  deref_fn_t;
-    typedef typename parent_t::point_t             point_t;
+    using deref_fn_t = Deref;
+    using point_t = typename parent_t::point_t;
 
-    typedef typename parent_t::coord_t             coord_t;
-    typedef typename parent_t::x_coord_t           x_coord_t;
-    typedef typename parent_t::y_coord_t           y_coord_t;
-    typedef typename parent_t::x_iterator          x_iterator;
-    typedef typename parent_t::y_iterator          y_iterator;
+    using coord_t = typename parent_t::coord_t;
+    using x_coord_t = typename parent_t::x_coord_t;
+    using y_coord_t = typename parent_t::y_coord_t;
+    using x_iterator = typename parent_t::x_iterator;
+    using y_iterator = typename parent_t::y_iterator;
 
-    template <typename NewDeref> struct add_deref {
-        typedef virtual_2d_locator<deref_compose<NewDeref,Deref>,IsTransposed > type;
+    template <typename NewDeref> struct add_deref
+    {
+        using type = virtual_2d_locator<deref_compose<NewDeref,Deref>,IsTransposed>;
         static type make(const virtual_2d_locator<Deref,IsTransposed>& loc, const NewDeref& nderef) {
             return type(loc.pos(), loc.step(), deref_compose<NewDeref,Deref>(nderef,loc.deref_fn()));
         }
@@ -96,8 +98,9 @@ struct is_planar<virtual_2d_locator<D,TR> > : public is_planar<typename virtual_
 /////////////////////////////
 
 template <typename D, bool TR>
-struct dynamic_x_step_type<virtual_2d_locator<D,TR> > {
-    typedef virtual_2d_locator<D,TR> type;
+struct dynamic_x_step_type<virtual_2d_locator<D,TR>>
+{
+    using type = virtual_2d_locator<D,TR>;
 };
 
 /////////////////////////////
@@ -105,8 +108,9 @@ struct dynamic_x_step_type<virtual_2d_locator<D,TR> > {
 /////////////////////////////
 
 template <typename D, bool TR>
-struct dynamic_y_step_type<virtual_2d_locator<D,TR> > {
-    typedef virtual_2d_locator<D,TR> type;
+struct dynamic_y_step_type<virtual_2d_locator<D,TR>>
+{
+    using type = virtual_2d_locator<D,TR>;
 };
 
 /////////////////////////////
@@ -114,8 +118,9 @@ struct dynamic_y_step_type<virtual_2d_locator<D,TR> > {
 /////////////////////////////
 
 template <typename D, bool IsTransposed>
-struct transposed_type<virtual_2d_locator<D,IsTransposed> > {
-    typedef virtual_2d_locator<D,1-IsTransposed> type;
+struct transposed_type<virtual_2d_locator<D,IsTransposed>>
+{
+    using type = virtual_2d_locator<D,1-IsTransposed>;
 };
 
 }}  // namespace boost::gil


### PR DESCRIPTION
Run [clang-tidy 7.0](http://clang.llvm.org/extra/clang-tidy/) with `-checks='-*,modernize-use-using' -fix` against single TU with `#include <boost/gil/concepts/*.hpp>`.

-----

The `modernize-use-using` check is not bulletproof, works 50/50, so manual review and modifications have been applied.

The 1-3 headers modernization per commit is applied for easier review in chunks.

### References

- [[cfe-users] [run-clang-tidy] new replacement overlaps with an existing replacement](http://lists.llvm.org/pipermail/cfe-users/2018-December/001450.html)

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed
