### PR TITLE
Apply clang-tidy modernize-use-using to extension/dynamic_image

### DIFF
--- a/include/boost/gil/extension/dynamic_image/algorithm.hpp
+++ b/include/boost/gil/extension/dynamic_image/algorithm.hpp
@@ -149,7 +149,7 @@ template <typename Value>
 struct fill_pixels_fn {
     fill_pixels_fn(const Value& val) : _val(val) {}
 
-    typedef void result_type;
+    using result_type = void;
     template <typename V> result_type operator()(const V& img_view) const {
         fill_pixels_fn1<pixels_are_compatible<typename V::value_type, Value>::value>::apply(img_view,_val);
     }

--- a/include/boost/gil/extension/dynamic_image/any_image.hpp
+++ b/include/boost/gil/extension/dynamic_image/any_image.hpp
@@ -22,15 +22,15 @@
 namespace boost { namespace gil {
 
 namespace detail {
-    template <typename T> struct get_view_t       { typedef typename T::view_t type; };
+    template <typename T> struct get_view_t       { using type = typename T::view_t; };
     template <typename Images> struct images_get_views_t : public mpl::transform<Images, get_view_t<mpl::_1> > {};
 
-    template <typename T> struct get_const_view_t { typedef typename T::const_view_t type; };
+    template <typename T> struct get_const_view_t { using type = typename T::const_view_t; };
     template <typename Images> struct images_get_const_views_t : public mpl::transform<Images, get_const_view_t<mpl::_1> > {};
 
     struct recreate_image_fnobj
     {
-        typedef void result_type;
+        using result_type = void;
         point<std::ptrdiff_t> const& _dimensions;
         unsigned _alignment;
 
@@ -41,13 +41,13 @@ namespace detail {
 
     template <typename AnyView>  // Models AnyViewConcept
     struct any_image_get_view {
-        typedef AnyView result_type;
+        using result_type = AnyView;
         template <typename Image> result_type operator()(      Image& img) const { return result_type(view(img)); }
     };
 
     template <typename AnyConstView>  // Models AnyConstViewConcept
     struct any_image_get_const_view {
-        typedef AnyConstView result_type;
+        using result_type = AnyConstView;
         template <typename Image> result_type operator()(const Image& img) const { return result_type(const_view(img)); }
     };
 }
@@ -58,19 +58,19 @@ namespace detail {
 ///
 /// Represents an image whose type (color space, layout, planar/interleaved organization, etc) can be specified at run time.
 /// It is the runtime equivalent of \p image.
-/// Some of the requirements of ImageConcept, such as the \p value_type typedef cannot be fulfilled, since the language does not allow runtime type specification.
+/// Some of the requirements of ImageConcept, such as the \p value_type alias cannot be fulfilled, since the language does not allow runtime type specification.
 /// Other requirements, such as access to the pixels, would be inefficient to provide. Thus \p any_image does not fully model ImageConcept.
 /// In particular, its \p view and \p const_view methods return \p any_image_view, which does not fully model ImageViewConcept. See \p any_image_view for more.
 ////////////////////////////////////////////////////////////////////////////////////////
 template <typename ImageTypes>
 class any_image : public variant<ImageTypes> {
-    typedef variant<ImageTypes> parent_t;
+    using parent_t = variant<ImageTypes>;
 public:
-    typedef any_image_view<typename detail::images_get_const_views_t<ImageTypes>::type> const_view_t;
-    typedef any_image_view<typename detail::images_get_views_t<ImageTypes>::type>       view_t;
-    typedef std::ptrdiff_t x_coord_t;
-    typedef std::ptrdiff_t y_coord_t;
-    typedef point<std::ptrdiff_t> point_t;
+    using const_view_t = any_image_view<typename detail::images_get_const_views_t<ImageTypes>::type>;
+    using view_t = any_image_view<typename detail::images_get_views_t<ImageTypes>::type>;
+    using x_coord_t = std::ptrdiff_t;
+    using y_coord_t = std::ptrdiff_t;
+    using point_t = point<std::ptrdiff_t>;
 
     any_image()                                                          : parent_t() {}
     template <typename T> explicit any_image(const T& obj)               : parent_t(obj) {}

--- a/include/boost/gil/extension/dynamic_image/any_image_view.hpp
+++ b/include/boost/gil/extension/dynamic_image/any_image_view.hpp
@@ -17,7 +17,7 @@
 namespace boost { namespace gil {
 
 namespace detail {
-    template <typename View> struct get_const_t { typedef typename View::const_t type; };
+    template <typename View> struct get_const_t { using type = typename View::const_t; };
     template <typename Views> struct views_get_const_t : public mpl::transform<Views, get_const_t<mpl::_1> > {};
 }
 template <typename View> struct dynamic_xy_step_type;
@@ -28,7 +28,7 @@ namespace detail {
      // works for both image_view and image
     struct any_type_get_num_channels
     {
-        typedef int result_type;
+        using result_type = int;
         template <typename T>
         result_type operator()(const T&) const { return num_channels<T>::value; }
     };
@@ -50,7 +50,7 @@ namespace detail {
 ///
 /// Represents a view whose type (color space, layout, planar/interleaved organization, etc) can be specified at run time.
 /// It is the runtime equivalent of \p image_view.
-/// Some of the requirements of ImageViewConcept, such as the \p value_type typedef cannot be fulfilled, since the language does not allow runtime type specification.
+/// Some of the requirements of ImageViewConcept, such as the \p value_type alias cannot be fulfilled, since the language does not allow runtime type specification.
 /// Other requirements, such as access to the pixels, would be inefficient to provide. Thus \p any_image_view does not fully model ImageViewConcept.
 /// However, many algorithms provide overloads taking runtime specified views and thus in many cases \p any_image_view can be used in places taking a view.
 ///
@@ -58,12 +58,12 @@ namespace detail {
 ////////////////////////////////////////////////////////////////////////////////////////
 template <typename ImageViewTypes>
 class any_image_view : public variant<ImageViewTypes> {
-    typedef variant<ImageViewTypes> parent_t;
+    using parent_t = variant<ImageViewTypes>;
 public:
-    typedef any_image_view<typename detail::views_get_const_t<ImageViewTypes>::type> const_t;
-    typedef std::ptrdiff_t x_coord_t;
-    typedef std::ptrdiff_t y_coord_t;
-    typedef point<std::ptrdiff_t> point_t;
+    using const_t = any_image_view<typename detail::views_get_const_t<ImageViewTypes>::type>;
+    using x_coord_t = std::ptrdiff_t;
+    using y_coord_t = std::ptrdiff_t;
+    using point_t = point<std::ptrdiff_t>;
 
     any_image_view()                                                          : parent_t() {}
     template <typename T> explicit any_image_view(const T& obj)               : parent_t(obj) {}
@@ -85,8 +85,9 @@ public:
 /////////////////////////////
 
 template <typename IVTypes>
-struct dynamic_x_step_type<any_image_view<IVTypes> > {
-    typedef any_image_view<typename mpl::transform<IVTypes, dynamic_x_step_type<mpl::_1> >::type> type;
+struct dynamic_x_step_type<any_image_view<IVTypes>>
+{
+    using type = any_image_view<typename mpl::transform<IVTypes, dynamic_x_step_type<mpl::_1>>::type>;
 };
 
 /////////////////////////////
@@ -94,18 +95,21 @@ struct dynamic_x_step_type<any_image_view<IVTypes> > {
 /////////////////////////////
 
 template <typename IVTypes>
-struct dynamic_y_step_type<any_image_view<IVTypes> > {
-    typedef any_image_view<typename mpl::transform<IVTypes, dynamic_y_step_type<mpl::_1> >::type> type;
+struct dynamic_y_step_type<any_image_view<IVTypes>>
+{
+    using type = any_image_view<typename mpl::transform<IVTypes, dynamic_y_step_type<mpl::_1>>::type>;
 };
 
 template <typename IVTypes>
-struct dynamic_xy_step_type<any_image_view<IVTypes> > {
-    typedef any_image_view<typename mpl::transform<IVTypes, dynamic_xy_step_type<mpl::_1> >::type> type;
+struct dynamic_xy_step_type<any_image_view<IVTypes>>
+{
+    using type = any_image_view<typename mpl::transform<IVTypes, dynamic_xy_step_type<mpl::_1>>::type>;
 };
 
 template <typename IVTypes>
-struct dynamic_xy_step_transposed_type<any_image_view<IVTypes> > {
-    typedef any_image_view<typename mpl::transform<IVTypes, dynamic_xy_step_transposed_type<mpl::_1> >::type> type;
+struct dynamic_xy_step_transposed_type<any_image_view<IVTypes>>
+{
+    using type = any_image_view<typename mpl::transform<IVTypes, dynamic_xy_step_transposed_type<mpl::_1>>::type>;
 };
 
 }}  // namespace boost::gil

--- a/include/boost/gil/extension/dynamic_image/apply_operation_base.hpp
+++ b/include/boost/gil/extension/dynamic_image/apply_operation_base.hpp
@@ -29,9 +29,9 @@ GENERATE_APPLY_FWD_OPS generates for every N functions that look like this (for 
     template <> struct apply_operation_fwd_fn<3> {
         template <typename Types, typename Bits, typename UnaryOp>
         typename UnaryOp::result_type apply(Bits& bits, std::size_t index, UnaryOp op) const {
-            typedef typename mpl::begin<Types>::type T0;
-            typedef typename mpl::next<T0>::type T1;
-            typedef typename mpl::next<T1>::type T2;
+            using T0 = typename mpl::begin<Types>::type;
+            using T1 = typename mpl::next<T0>::type;
+            using T2 = typename mpl::next<T1>::type;
             switch (index) {
                 case 0: return op(reinterpret_cast<typename mpl::deref<T0>::type&>(bits));
                 case 1: return op(reinterpret_cast<typename mpl::deref<T1>::type&>(bits));
@@ -42,9 +42,9 @@ GENERATE_APPLY_FWD_OPS generates for every N functions that look like this (for 
 
         template <typename Types, typename Bits, typename UnaryOp>
         typename UnaryOp::result_type applyc(const Bits& bits, std::size_t index, UnaryOp op) const {
-            typedef typename mpl::begin<Types>::type T0;
-            typedef typename mpl::next<T0>::type T1;
-            typedef typename mpl::next<T1>::type T2;
+            using T0 = typename mpl::begin<Types>::type;
+            using T1 = typename mpl::next<T0>::type;
+            using T2 = typename mpl::next<T1>::type;
             switch (index) {
                 case 0: return op(reinterpret_cast<const typename mpl::deref<T0>::type&>(bits));
                 case 1: return op(reinterpret_cast<const typename mpl::deref<T1>::type&>(bits));
@@ -55,6 +55,7 @@ GENERATE_APPLY_FWD_OPS generates for every N functions that look like this (for 
     };
 */
 
+// TODO: Review, simplify, refactor, modernize (e.g. typedef to using) --mloskot
 #define GIL_FWD_TYPEDEFS(z, N, text)   T##N; typedef typename mpl::next<T##N>::type
 #define GIL_FWD_CASE(z, N, SUM)       case N: return op(*gil_reinterpret_cast<typename mpl::deref<T##N>::type*>(&bits));
 #define GIL_FWD_CONST_CASE(z, N, SUM) case N: return op(*gil_reinterpret_cast_c<const typename mpl::deref<T##N>::type*>(&bits));
@@ -133,7 +134,7 @@ namespace detail {
         const T2& _t2;
         Op&  _op;
 
-        typedef typename Op::result_type result_type;
+        using result_type = typename Op::result_type;
 
         reduce_bind1(const T2& t2, Op& op) : _t2(t2), _op(op) {}
 
@@ -146,7 +147,7 @@ namespace detail {
         std::size_t _index1;
         Op&  _op;
 
-        typedef typename Op::result_type result_type;
+        using result_type = typename Op::result_type;
 
         reduce_bind2(const Bits1& bits1, std::size_t index1, Op& op) : _bits1(bits1), _index1(index1), _op(op) {}
 

--- a/include/boost/gil/extension/dynamic_image/image_view_factory.hpp
+++ b/include/boost/gil/extension/dynamic_image/image_view_factory.hpp
@@ -20,34 +20,34 @@ namespace boost { namespace gil {
 
 namespace detail {
 template <typename Result> struct flipped_up_down_view_fn {
-    typedef Result result_type;
+    using result_type = Result;
     template <typename View> result_type operator()(const View& src) const { return result_type(flipped_up_down_view(src)); }
 };
 template <typename Result> struct flipped_left_right_view_fn {
-    typedef Result result_type;
+    using result_type = Result;
     template <typename View> result_type operator()(const View& src) const { return result_type(flipped_left_right_view(src)); }
 };
 template <typename Result> struct rotated90cw_view_fn {
-    typedef Result result_type;
+    using result_type = Result;
     template <typename View> result_type operator()(const View& src) const { return result_type(rotated90cw_view(src)); }
 };
 template <typename Result> struct rotated90ccw_view_fn {
-    typedef Result result_type;
+    using result_type = Result;
     template <typename View> result_type operator()(const View& src) const { return result_type(rotated90ccw_view(src)); }
 };
 template <typename Result> struct tranposed_view_fn {
-    typedef Result result_type;
+    using result_type = Result;
     template <typename View> result_type operator()(const View& src) const { return result_type(tranposed_view(src)); }
 };
 template <typename Result> struct rotated180_view_fn {
-    typedef Result result_type;
+    using result_type = Result;
     template <typename View> result_type operator()(const View& src) const { return result_type(rotated180_view(src)); }
 };
 
 template <typename Result>
 struct subimage_view_fn
 {
-    typedef Result result_type;
+    using result_type = Result;
     subimage_view_fn(point_t const& topleft, point_t const& dimensions)
         : _topleft(topleft), _size2(dimensions)
     {}
@@ -65,7 +65,7 @@ struct subimage_view_fn
 template <typename Result>
 struct subsampled_view_fn
 {
-    typedef Result result_type;
+    using result_type = Result;
     subsampled_view_fn(point_t const& step) : _step(step) {}
 
     template <typename View>
@@ -78,13 +78,13 @@ struct subsampled_view_fn
 };
 
 template <typename Result> struct nth_channel_view_fn {
-    typedef Result result_type;
+    using result_type = Result;
     nth_channel_view_fn(int n) : _n(n) {}
     int _n;
     template <typename View> result_type operator()(const View& src) const { return result_type(nth_channel_view(src,_n)); }
 };
 template <typename DstP, typename Result, typename CC = default_color_converter> struct color_converted_view_fn {
-    typedef Result result_type;
+    using result_type = Result;
     color_converted_view_fn(CC cc = CC()): _cc(cc) {}
 
     template <typename View> result_type operator()(const View& src) const { return result_type(color_converted_view<DstP>(src, _cc)); }
@@ -180,7 +180,7 @@ inline auto subsampled_view(any_image_view<ViewTypes> const& src, int xStep, int
 }
 
 namespace detail {
-    template <typename View> struct get_nthchannel_type { typedef typename nth_channel_view_type<View>::type type; };
+    template <typename View> struct get_nthchannel_type { using type = typename nth_channel_view_type<View>::type; };
     template <typename Views> struct views_get_nthchannel_type : public mpl::transform<Views, get_nthchannel_type<mpl::_1> > {};
 }
 
@@ -188,7 +188,7 @@ namespace detail {
 /// \brief Given a runtime source image view, returns the type of a runtime image view over a single channel of the source view
 template <typename ViewTypes>
 struct nth_channel_view_type<any_image_view<ViewTypes> > {
-    typedef any_image_view<typename detail::views_get_nthchannel_type<ViewTypes>::type> type;
+    using type = any_image_view<typename detail::views_get_nthchannel_type<ViewTypes>::type>;
 };
 
 /// \ingroup ImageViewTransformationsNthChannel
@@ -205,8 +205,9 @@ namespace detail {
 /// \ingroup ImageViewTransformationsColorConvert
 /// \brief Returns the type of a runtime-specified view, color-converted to a given pixel type with user specified color converter
 template <typename ViewTypes, typename DstP, typename CC>
-struct color_converted_view_type<any_image_view<ViewTypes>,DstP,CC> {
-    typedef any_image_view<typename detail::views_get_ccv_type<ViewTypes, DstP, CC>::type> type;
+struct color_converted_view_type<any_image_view<ViewTypes>,DstP,CC>
+{
+    using type = any_image_view<typename detail::views_get_ccv_type<ViewTypes, DstP, CC>::type>;
 };
 
 /// \ingroup ImageViewTransformationsColorConvert
@@ -219,8 +220,9 @@ typename color_converted_view_type<any_image_view<ViewTypes>, DstP, CC>::type co
 /// \ingroup ImageViewTransformationsColorConvert
 /// \brief Returns the type of a runtime-specified view, color-converted to a given pixel type with the default coor converter
 template <typename ViewTypes, typename DstP>
-struct color_converted_view_type<any_image_view<ViewTypes>,DstP> {
-    typedef any_image_view<typename detail::views_get_ccv_type<ViewTypes, DstP, default_color_converter>::type> type;
+struct color_converted_view_type<any_image_view<ViewTypes>,DstP>
+{
+    using type = any_image_view<typename detail::views_get_ccv_type<ViewTypes, DstP, default_color_converter>::type>;
 };
 
 /// \ingroup ImageViewTransformationsColorConvert

--- a/include/boost/gil/extension/dynamic_image/reduce.hpp
+++ b/include/boost/gil/extension/dynamic_image/reduce.hpp
@@ -49,14 +49,16 @@ template <typename SrcTypes, typename DstTypes>
 struct mapping_vector {};
 
 template <typename SrcTypes, typename DstTypes, long K>
-struct at_c<mapping_vector<SrcTypes,DstTypes>, K> {
+struct at_c<mapping_vector<SrcTypes,DstTypes>, K>
+{
     static const std::size_t value=size<DstTypes>::value - order<DstTypes, typename gil::at_c<SrcTypes,K>::type>::type::value +1;
-    typedef size_t<value> type;
+    using type = size_t<value>;
 };
 
 template <typename SrcTypes, typename DstTypes>
-struct size<mapping_vector<SrcTypes,DstTypes> > {
-    typedef typename size<SrcTypes>::type type;
+struct size<mapping_vector<SrcTypes,DstTypes>>
+{
+    using type = typename size<SrcTypes>::type;
     static const std::size_t value=type::value;
 };
 
@@ -65,7 +67,7 @@ struct size<mapping_vector<SrcTypes,DstTypes> > {
 ///
 /// Temporary solution because I couldn't get mpl::copy to do this.
 /// This is what I tried:
-/// mpl::copy<SET, mpl::back_inserter<mpl::vector<> > >::type;
+/// mpl::copy<SET, mpl::back_inserter<mpl::vector<>>>::type;
 /// It works when SET is mpl::vector, but not when SET is mpl::set...
 ///////////////////////////////////////////////////////
 
@@ -73,27 +75,30 @@ namespace detail {
     template <typename SFirst, std::size_t NLeft>
     struct copy_to_vector_impl {
     private:
-        typedef typename deref<SFirst>::type T;
-        typedef typename next<SFirst>::type next;
-        typedef typename copy_to_vector_impl<next, NLeft-1>::type rest;
+        using T = typename deref<SFirst>::type;
+        using next = typename next<SFirst>::type;
+        using rest = typename copy_to_vector_impl<next, NLeft-1>::type;
     public:
-        typedef typename push_front<rest, T>::type type;
+        using type = typename push_front<rest, T>::type;
     };
 
     template <typename SFirst>
-    struct copy_to_vector_impl<SFirst,1> {
-        typedef vector<typename deref<SFirst>::type> type;
+    struct copy_to_vector_impl<SFirst,1>
+    {
+        using type = vector<typename deref<SFirst>::type>;
     };
 }
 
 template <typename Src>
-struct copy_to_vector {
-    typedef typename detail::copy_to_vector_impl<typename begin<Src>::type, size<Src>::value>::type type;
+struct copy_to_vector
+{
+    using type = typename detail::copy_to_vector_impl<typename begin<Src>::type, size<Src>::value>::type;
 };
 
 template <>
-struct copy_to_vector<set<> > {
-    typedef vector0<> type;
+struct copy_to_vector<set<>>
+{
+    using type = vector0<>;
 };
 
 } } // boost::mpl
@@ -124,18 +129,20 @@ namespace boost { namespace gil {
 
 template <typename Types, typename Op>
 struct unary_reduce_impl {
-    typedef typename mpl::transform<Types, detail::reduce<Op, mpl::_1> >::type reduced_t;
-    typedef typename mpl::copy<reduced_t, mpl::inserter<mpl::set<>, mpl::insert<mpl::_1,mpl::_2> > >::type unique_t;
+    using reduced_t = typename mpl::transform<Types, detail::reduce<Op, mpl::_1> >::type;
+    using unique_t = typename mpl::copy<reduced_t, mpl::inserter<mpl::set<>, mpl::insert<mpl::_1,mpl::_2>>>::type;
     static const bool is_single=mpl::size<unique_t>::value==1;
 };
 
 template <typename Types, typename Op, bool IsSingle=unary_reduce_impl<Types,Op>::is_single>
-struct unary_reduce : public unary_reduce_impl<Types,Op> {
-    typedef typename unary_reduce_impl<Types,Op>::reduced_t reduced_t;
-    typedef typename unary_reduce_impl<Types,Op>::unique_t unique_t;
+struct unary_reduce : public unary_reduce_impl<Types,Op>
+{
+    using reduced_t = typename unary_reduce_impl<Types,Op>::reduced_t;
+    using unique_t = typename unary_reduce_impl<Types,Op>::unique_t;
 
-    static unsigned short inline map_index(std::size_t index) {
-        typedef typename mpl::mapping_vector<reduced_t, unique_t> indices_t;
+    static unsigned short inline map_index(std::size_t index)
+    {
+        using indices_t = typename mpl::mapping_vector<reduced_t, unique_t>;
         return gil::at_c<indices_t, unsigned short>(index);
     }
     template <typename Bits> BOOST_FORCEINLINE static typename Op::result_type applyc(const Bits& bits, std::size_t index, Op op) {
@@ -149,7 +156,7 @@ struct unary_reduce : public unary_reduce_impl<Types,Op> {
 
 template <typename Types, typename Op>
 struct unary_reduce<Types,Op,true> : public unary_reduce_impl<Types,Op> {
-    typedef typename unary_reduce_impl<Types,Op>::unique_t unique_t;
+    using unique_t = typename unary_reduce_impl<Types,Op>::unique_t;
     static unsigned short inline map_index(std::size_t index) { return 0; }
 
     template <typename Bits> BOOST_FORCEINLINE static typename Op::result_type applyc(const Bits& bits, std::size_t index, Op op) {
@@ -177,20 +184,22 @@ struct unary_reduce<Types,Op,true> : public unary_reduce_impl<Types,Op> {
 
 namespace detail {
     struct pair_generator {
-        template <typename Vec2> struct apply {
-            typedef std::pair<const typename mpl::at_c<Vec2,0>::type*, const typename mpl::at_c<Vec2,1>::type*> type;
+        template <typename Vec2> struct apply
+        {
+            using type = std::pair<const typename mpl::at_c<Vec2,0>::type*, const typename mpl::at_c<Vec2,1>::type*>;
         };
     };
 
     // When the types are not too large, applies reduce on their cross product
     template <typename Unary1, typename Unary2, typename Op, bool IsComplex>
-    struct binary_reduce_impl {
+    struct binary_reduce_impl
+    {
     //private:
-        typedef typename mpl::copy_to_vector<typename Unary1::unique_t>::type vec1_types;
-        typedef typename mpl::copy_to_vector<typename Unary2::unique_t>::type vec2_types;
+        using vec1_types = typename mpl::copy_to_vector<typename Unary1::unique_t>::type;
+        using vec2_types = typename mpl::copy_to_vector<typename Unary2::unique_t>::type;
 
-        typedef mpl::cross_vector<mpl::vector2<vec1_types, vec2_types>, pair_generator> BIN_TYPES;
-        typedef unary_reduce<BIN_TYPES,Op> bin_reduced_t;
+        using BIN_TYPES = mpl::cross_vector<mpl::vector2<vec1_types, vec2_types>, pair_generator>;
+        using bin_reduced_t = unary_reduce<BIN_TYPES,Op>;
 
         static unsigned short inline map_index(std::size_t index1, std::size_t index2) {
             unsigned short r1=Unary1::map_index(index1);
@@ -198,7 +207,7 @@ namespace detail {
             return bin_reduced_t::map_index(r2*mpl::size<vec1_types>::value + r1);
         }
     public:
-        typedef typename bin_reduced_t::unique_t unique_t;
+        using unique_t = typename bin_reduced_t::unique_t
 
         template <typename Bits1, typename Bits2>
         static typename Op::result_type inline apply(const Bits1& bits1, std::size_t index1, const Bits2& bits2, std::size_t index2, Op op) {
@@ -219,15 +228,16 @@ namespace detail {
 
 
 template <typename Types1, typename Types2, typename Op>
-struct binary_reduce {
+struct binary_reduce
+{
 //private:
-    typedef unary_reduce<Types1,Op> unary1_t;
-    typedef unary_reduce<Types2,Op> unary2_t;
+    using unary1_t = unary_reduce<Types1,Op>;
+    using unary2_t = unary_reduce<Types2,Op>;
 
     static const std::size_t CROSS_SIZE = mpl::size<typename unary1_t::unique_t>::value *
                                           mpl::size<typename unary2_t::unique_t>::value;
 
-    typedef detail::binary_reduce_impl<unary1_t,unary2_t,Op, (CROSS_SIZE>GIL_BINARY_REDUCE_LIMIT)> impl;
+    using impl = detail::binary_reduce_impl<unary1_t,unary2_t,Op, (CROSS_SIZE>GIL_BINARY_REDUCE_LIMIT)>;
 public:
     template <typename Bits1, typename Bits2>
     static typename Op::result_type inline apply(const Bits1& bits1, std::size_t index1, const Bits2& bits2, std::size_t index2, Op op) {
@@ -281,8 +291,9 @@ struct cross_vector {};
 /// \brief Iterator of cross_vector
 /// \ingroup CrossVectorIterator
 template <typename VecOfVecs, typename TypeGen, std::size_t K>
-struct cross_iterator {
-    typedef mpl::random_access_iterator_tag category;
+struct cross_iterator
+{
+    using category = mpl::random_access_iterator_tag;
 };
 
 ///////////////////////////////////////////////////////
@@ -295,40 +306,45 @@ struct cross_iterator {
 /// to represent the iterator's position K as a vector of indices. Extracts the corresponding type of
 /// each input vector and passes the element types to the type generation function, which returns the dereferenced type
 template <typename VecOfVecs, typename TypeGen, std::size_t K>
-struct deref<cross_iterator<VecOfVecs,TypeGen,K> > {
+struct deref<cross_iterator<VecOfVecs,TypeGen,K>>
+{
 private:
-    typedef typename detail::select_subvector_c<VecOfVecs, K>::type DerefTypes;
+    using DerefTypes = typename detail::select_subvector_c<VecOfVecs, K>::type;
 public:
-    typedef typename TypeGen::template apply<DerefTypes>::type type;
+    using type = typename TypeGen::template apply<DerefTypes>::type;
 };
 
 /// \brief Increments a cross-vector iterator.
 /// \ingroup CrossVectorIterator
 template <typename VecOfVecs, typename TypeGen, std::size_t K>
-struct next<cross_iterator<VecOfVecs,TypeGen,K> > {
-    typedef cross_iterator<VecOfVecs,TypeGen,K+1> type;
+struct next<cross_iterator<VecOfVecs,TypeGen,K>>
+{
+    using type = cross_iterator<VecOfVecs,TypeGen,K+1>;
 };
 
 /// \brief Decrements a cross-vector iterator.
 /// \ingroup CrossVectorIterator
 template <typename VecOfVecs, typename TypeGen, std::size_t K>
-struct prior<cross_iterator<VecOfVecs,TypeGen,K> > {
-    typedef cross_iterator<VecOfVecs,TypeGen,K-1> type;
+struct prior<cross_iterator<VecOfVecs,TypeGen,K>>
+{
+    using type = cross_iterator<VecOfVecs,TypeGen,K-1>;
 };
 
 /// \brief Advances a cross-vector iterator.
 /// \ingroup CrossVectorIterator
 template <typename VecOfVecs, typename TypeGen, std::size_t K, typename Distance>
-struct advance<cross_iterator<VecOfVecs,TypeGen,K>, Distance > {
-    typedef cross_iterator<VecOfVecs,TypeGen,K+Distance::value> type;
+struct advance<cross_iterator<VecOfVecs,TypeGen,K>, Distance>
+{
+    using type = cross_iterator<VecOfVecs,TypeGen,K+Distance::value>;
 };
 
 /// \brief Computes the distance between two cross-vector iterator-s.
 /// \ingroup CrossVectorIterator
 // (shortened the names of the template arguments - otherwise doxygen cannot parse this...)
 template <typename VecOfVecs, typename TypeGen, std::size_t K1, std::size_t K2>
-struct distance<cross_iterator<VecOfVecs,TypeGen,K1>, cross_iterator<VecOfVecs,TypeGen,K2> > {
-    typedef size_t<K2-K1> type;
+struct distance<cross_iterator<VecOfVecs,TypeGen,K1>, cross_iterator<VecOfVecs,TypeGen,K2>>
+{
+    using type = size_t<K2-K1>;
 };
 
 ///////////////////////////////////////////////////////
@@ -337,80 +353,88 @@ struct distance<cross_iterator<VecOfVecs,TypeGen,K1>, cross_iterator<VecOfVecs,T
 /// \brief Computes the size of a cross vector as the product of the sizes of all vectors in VecOfVecs
 /// \ingroup CrossVector
 template <typename VecOfVecs, typename TypeGen>
-struct size<cross_vector<VecOfVecs,TypeGen> > {
-    typedef typename fold<VecOfVecs, size_t<1>, times<_1, size<_2> > >::type type;
+struct size<cross_vector<VecOfVecs,TypeGen>>
+{
+    using type = typename fold<VecOfVecs, size_t<1>, times<_1, size<_2>>>::type;
     static const std::size_t value=type::value;
 };
 
 /// \brief Determines whether a cross vector is empty
 /// \ingroup CrossVector
 template <typename VecOfVecs, typename TypeGen>
-struct empty<cross_vector<VecOfVecs,TypeGen> > {
-    typedef typename empty<VecOfVecs>::type type;
+struct empty<cross_vector<VecOfVecs,TypeGen>> {
+    using type = typename empty<VecOfVecs>::type;
 };
 
 /// \brief Returns the K-th element of a cross vector
 /// \ingroup CrossVector
 template <typename VecOfVecs, typename TypeGen, typename K>
-struct at<cross_vector<VecOfVecs,TypeGen>, K> {
+struct at<cross_vector<VecOfVecs,TypeGen>, K>
+{
 private:
-    typedef cross_iterator<VecOfVecs,TypeGen,K::value> KthIterator;
+    using KthIterator = cross_iterator<VecOfVecs,TypeGen,K::value>;
 public:
-    typedef typename deref<KthIterator>::type type;
+    using type = typename deref<KthIterator>::type;
 };
 
 /// \brief Returns an iterator to the first element of a cross vector
 /// \ingroup CrossVector
 template <typename VecOfVecs, typename TypeGen>
-struct begin<cross_vector<VecOfVecs,TypeGen> > {
-    typedef cross_iterator<VecOfVecs,TypeGen,0> type;
+struct begin<cross_vector<VecOfVecs,TypeGen>>
+{
+    using type = cross_iterator<VecOfVecs,TypeGen,0>;
 };
 
 /// \brief Returns an iterator to the last element of a cross vector
 /// \ingroup CrossVector
 template <typename VecOfVecs, typename TypeGen>
-struct end<cross_vector<VecOfVecs,TypeGen> > {
+struct end<cross_vector<VecOfVecs,TypeGen>>
+{
 private:
-    typedef cross_vector<VecOfVecs,TypeGen> this_t;
+    using this_t = cross_vector<VecOfVecs,TypeGen>;
 public:
-    typedef cross_iterator<VecOfVecs,TypeGen,size<this_t>::value> type;
+    using type = cross_iterator<VecOfVecs,TypeGen,size<this_t>::value>;
 };
 
 /// \brief Returns the first element of a cross vector
 /// \ingroup CrossVector
 template <typename VecOfVecs, typename TypeGen>
-struct front<cross_vector<VecOfVecs,TypeGen> > {
+struct front<cross_vector<VecOfVecs,TypeGen>> {
 private:
-    typedef cross_vector<VecOfVecs,TypeGen> this_t;
+    using this_t = cross_vector<VecOfVecs,TypeGen>;
 public:
-    typedef typename deref<typename begin<this_t>::type>::type type;
+    using type = typename deref<typename begin<this_t>::type>::type;
 };
 
 /// \brief Returns the last element of a cross vector
 /// \ingroup CrossVector
 template <typename VecOfVecs, typename TypeGen>
-struct back<cross_vector<VecOfVecs,TypeGen> > {
+struct back<cross_vector<VecOfVecs,TypeGen>>
+{
 private:
-    typedef cross_vector<VecOfVecs,TypeGen> this_t;
-    typedef typename size<this_t>::type            size;
-    typedef typename minus<size, size_t<1> >::type last_index;
+    using this_t = cross_vector<VecOfVecs,TypeGen>;
+    using size = typename size<this_t>::type;
+    using last_index = typename minus<size, size_t<1>>::type;
 public:
-    typedef typename at<this_t, last_index>::type type;
+    using type = typename at<this_t, last_index>::type;
 };
 
 /// \brief Transforms the elements of a cross vector
 /// \ingroup CrossVector
 template <typename VecOfVecs, typename TypeGen, typename OPP>
-struct transform<cross_vector<VecOfVecs,TypeGen>, OPP > {
-    typedef typename lambda<OPP>::type Op;
-    struct adapter {
+struct transform<cross_vector<VecOfVecs,TypeGen>, OPP>
+{
+    using Op = typename lambda<OPP>::type;
+    struct adapter
+    {
         template <typename Elements>
-        struct apply {
-            typedef typename TypeGen::template apply<Elements>::type orig_t;
-            typedef typename Op::template apply<orig_t>::type type;
+        struct apply
+        {
+            using orig_t = typename TypeGen::template apply<Elements>::type;
+            using type = typename Op::template apply<orig_t>::type;
         };
     };
-    typedef cross_vector<VecOfVecs, adapter > type;
+    using type = cross_vector<VecOfVecs, adapter>;
 };
 
 } } // boost::mpl
@@ -434,8 +458,9 @@ namespace detail {
     ////
     ////////////////////////////////////////////////////////
     template <typename Op, typename T>
-    struct reduce {
-        typedef T type;
+    struct reduce
+    {
+        using type = T;
     };
 
     ////////////////////////////////////////////////////////
@@ -446,13 +471,14 @@ namespace detail {
     ////////////////////////////////////////////////////////
 
     template <typename Op, typename View, bool IsBasic>
-    struct reduce_view_basic {
-        typedef View type;
+    struct reduce_view_basic
+    {
+        using type = View;
     };
 
     template <typename Op, typename Loc>
-    struct reduce<Op, image_view<Loc> >
-        : public reduce_view_basic<Op,image_view<Loc>,view_is_basic<image_view<Loc> >::value> {};
+    struct reduce<Op, image_view<Loc>>
+        : public reduce_view_basic<Op,image_view<Loc>,view_is_basic<image_view<Loc>>::value> {};
 
     ////////////////////////////////////////////////////////
     ////
@@ -462,12 +488,13 @@ namespace detail {
     ////////////////////////////////////////////////////////
 
     template <typename Op, typename Img, bool IsBasic>
-    struct reduce_image_basic {
-        typedef Img type;
+    struct reduce_image_basic
+    {
+        using type = Img;
     };
 
     template <typename Op, typename V, typename Alloc>
-    struct reduce<Op, image<V,Alloc> > : public reduce_image_basic<Op,image<V,Alloc>,image_is_basic<image<V,Alloc> >::value > {};
+    struct reduce<Op, image<V,Alloc>> : public reduce_image_basic<Op,image<V,Alloc>,image_is_basic<image<V,Alloc>>::value > {};
 
     ////////////////////////////////////////////////////////
     ////
@@ -477,14 +504,15 @@ namespace detail {
     ////////////////////////////////////////////////////////
 
     template <typename Op, typename V1, typename V2, bool AreBasic>
-    struct reduce_views_basic {
-        typedef std::pair<const V1*, const V2*> type;
+    struct reduce_views_basic
+    {
+        using type = std::pair<const V1*, const V2*>;
     };
 
     template <typename Op, typename L1, typename L2>
-    struct reduce<Op, std::pair<const image_view<L1>*, const image_view<L2>*> >
+    struct reduce<Op, std::pair<const image_view<L1>*, const image_view<L2>*>>
         : public reduce_views_basic<Op,image_view<L1>,image_view<L2>,
-                 mpl::and_<view_is_basic<image_view<L1> >, view_is_basic<image_view<L2> > >::value >
+                 mpl::and_<view_is_basic<image_view<L1>>, view_is_basic<image_view<L2>>>::value >
     {};
 
 
@@ -494,14 +522,15 @@ namespace detail {
     ////
     ////////////////////////////////////////////////////////
 
-    template <typename Cs>
-    struct reduce_color_space {
-        typedef Cs type;
+    template <typename CS>
+    struct reduce_color_space
+    {
+        using type = CS;
     };
 
-    template <> struct reduce_color_space<lab_t> { typedef rgb_t type; };
-    template <> struct reduce_color_space<hsb_t> { typedef rgb_t type; };
-    template <> struct reduce_color_space<cmyk_t> { typedef rgba_t type; };
+    template <> struct reduce_color_space<lab_t> { using type = rgb_t; };
+    template <> struct reduce_color_space<hsb_t> { using type = rgb_t; };
+    template <> struct reduce_color_space<cmyk_t> { using type = rgba_t; };
 
     /*
     ////////////////////////////////////////////////////////
@@ -514,8 +543,8 @@ namespace detail {
 
     template <typename Vec, int Basis, int VecSize>
     struct type_vec_to_integer_impl {
-        typedef typename mpl::back<Vec>::type     last;
-        typedef typename mpl::pop_back<Vec>::type rest;
+        using last = typename mpl::back<Vec>::type;
+        using rest = typename mpl::pop_back<Vec>::type;
         static const int value = type_vec_to_integer_impl<rest, Basis, VecSize-1>::value * Basis + last::value;
     };
 
@@ -533,86 +562,87 @@ namespace detail {
     // The default version performs no reduction
     template <typename SrcColorSpace, typename DstColorSpace, int Mapping>
     struct reduce_color_spaces_impl {
-        typedef SrcColorSpace first_t;
-        typedef DstColorSpace second_t;
+        using first_t = SrcColorSpace;
+        using second_t = DstColorSpace;
     };
 
     // 012: RGB-RGB, bgr-bgr, lab-lab, hsb-hsb
     template <typename SrcColorSpace, typename DstColorSpace>
     struct reduce_color_spaces_impl<SrcColorSpace,DstColorSpace,12> {
-        typedef rgb_t first_t;
-        typedef rgb_t second_t;
+        using first_t = rgb_t;
+        using second_t = rgb_t;
     };
 
     // 210: RGB-bgr, bgr-RGB
     template <typename SrcColorSpace, typename DstColorSpace>
     struct reduce_color_spaces_impl<SrcColorSpace,DstColorSpace,210> {
-        typedef rgb_t first_t;
-        typedef bgr_t second_t;
+        using first_t = rgb_t;
+        using second_t = bgr_t;
     };
 
     // 0123: RGBA-RGBA, bgra-bgra, argb-argb, abgr-abgr cmyk-cmyk
     template <typename SrcColorSpace, typename DstColorSpace>
     struct reduce_color_spaces_impl<SrcColorSpace,DstColorSpace,123> {
-        typedef rgba_t first_t;
-        typedef rgba_t second_t;
+        using first_t = rgba_t;
+        using second_t = rgba_t;
     };
 
     // 3210: RGBA-abgr, bgra-argb, argb-bgra, abgr-RGBA
     template <typename SrcColorSpace, typename DstColorSpace>
     struct reduce_color_spaces_impl<SrcColorSpace,DstColorSpace,3210> {
-        typedef rgba_t first_t;
-        typedef abgr_t second_t;
+        using first_t = rgba_t;
+        using second_t = abgr_t;
     };
 
     // 1230: RGBA-argb, bgra-abgr
     template <typename SrcColorSpace, typename DstColorSpace>
     struct reduce_color_spaces_impl<SrcColorSpace,DstColorSpace,1230> {
-        typedef rgba_t first_t;
-        typedef argb_t second_t;
+        using first_t = rgba_t;
+        using second_t = argb_t;
     };
 
     // 2103: RGBA-bgra, bgra-RGBA (uses subclass to ensure that base color space is not reduced to derived)
     template <typename SrcColorSpace, typename DstColorSpace>
     struct reduce_color_spaces_impl<SrcColorSpace,DstColorSpace,2103> {
-        typedef rgba_t first_t;
-        typedef bgra_t second_t;
+        using first_t = rgba_t;
+        using second_t = bgra_t;
     };
 
     // 3012: argb-RGBA, abgr-bgra
     template <typename SrcColorSpace, typename DstColorSpace>
     struct reduce_color_spaces_impl<SrcColorSpace,DstColorSpace,3012> {
-        typedef argb_t first_t;
-        typedef rgba_t second_t;
+        using first_t = argb_t;
+        using second_t = rgba_t;
     };
 
     // 0321: argb-abgr, abgr-argb
     template <typename SrcColorSpace, typename DstColorSpace>
     struct reduce_color_spaces_impl<SrcColorSpace,DstColorSpace,321> {
-        typedef argb_t first_t;
-        typedef abgr_t second_t;
+        using first_t = argb_t;
+        using second_t = abgr_t;
     };
 
     template <typename SrcColorSpace, typename DstColorSpace>
     struct reduce_color_spaces {
-        typedef typename channel_order<SrcColorSpace>::type src_order_t;
-        typedef typename channel_order<DstColorSpace>::type dst_order_t;
-        typedef typename mpl::transform<src_order_t, type_to_index<dst_order_t,mpl::_1> >::type mapping;
+        using src_order_t = typename channel_order<SrcColorSpace>::type;
+        using dst_order_t = typename channel_order<DstColorSpace>::type;
+        using mapping = typename mpl::transform<src_order_t, type_to_index<dst_order_t,mpl::_1>>::type;
         static const int mapping_val = type_vec_to_integer<mapping>::value;
 
-        typedef typename reduce_color_spaces_impl<SrcColorSpace,DstColorSpace,mapping_val>::first_t  _first_t;
-        typedef typename reduce_color_spaces_impl<SrcColorSpace,DstColorSpace,mapping_val>::second_t _second_t;
-        typedef typename mpl::and_<color_space_is_base<DstColorSpace>, mpl::not_< color_space_is_base<_second_t> > > swap_t;
+        using _first_t = typename reduce_color_spaces_impl<SrcColorSpace,DstColorSpace,mapping_val>::first_t;
+        using _second_t = typename reduce_color_spaces_impl<SrcColorSpace,DstColorSpace,mapping_val>::second_t;
+        using swap_t = typename mpl::and_<color_space_is_base<DstColorSpace>, mpl::not_< color_space_is_base<_second_t>>>;
     public:
-        typedef typename mpl::if_<swap_t, _second_t, _first_t>::type first_t;
-        typedef typename mpl::if_<swap_t, _first_t, _second_t>::type second_t;
+        using first_t = typename mpl::if_<swap_t, _second_t, _first_t>::type;
+        using second_t = typename mpl::if_<swap_t, _first_t, _second_t>::type;
     };
 */
 // TODO: Use the old code for reduce_color_spaces above to do color layout reduction
     template <typename SrcLayout, typename DstLayout>
-    struct reduce_color_layouts {
-        typedef SrcLayout first_t;
-        typedef DstLayout second_t;
+    struct reduce_color_layouts
+    {
+        using first_t = SrcLayout;
+        using second_t = DstLayout;
     };
 
     ////////////////////////////////////////////////////////
@@ -628,38 +658,40 @@ namespace detail {
     template <typename View>
     struct reduce_view_basic<copy_pixels_fn,View,true> {
     private:
-        typedef typename reduce_color_space<typename View::color_space_t>::type Cs;    // reduce the color space
-        typedef layout<Cs, typename View::channel_mapping_t> layout_t;
+        using color_space_t = typename reduce_color_space<typename View::color_space_t>::type color_space_t; // reduce the color space
+        using layout_t = layout<color_space_t, typename View::channel_mapping_t>;
     public:
-        typedef typename derived_view_type<View, use_default, layout_t, use_default, use_default, mpl::true_>::type type;
+        using type = typename derived_view_type<View, use_default, layout_t, use_default, use_default, mpl::true_>::type;
     };
 */
     // Incompatible views cannot be used in copy_pixels - will throw std::bad_cast
     template <typename V1, typename V2, bool Compatible>
-    struct reduce_copy_pixop_compat {
-        typedef error_t type;
+    struct reduce_copy_pixop_compat
+    {
+        using type = error_t;
     };
 
     // For compatible basic views, reduce their color spaces based on their channel mapping.
     // Make the source immutable and the destination mutable (they should already be that way)
     template <typename V1, typename V2>
-    struct reduce_copy_pixop_compat<V1,V2,true> {
-        typedef layout<typename V1::color_space_t, typename V1::channel_mapping_t> layout1;
-        typedef layout<typename V2::color_space_t, typename V2::channel_mapping_t> layout2;
+    struct reduce_copy_pixop_compat<V1,V2,true>
+    {
+        using layout1 = layout<typename V1::color_space_t, typename V1::channel_mapping_t>;
+        using layout2 = layout<typename V2::color_space_t, typename V2::channel_mapping_t>;
 
-        typedef typename reduce_color_layouts<layout1,layout2>::first_t L1;
-        typedef typename reduce_color_layouts<layout1,layout2>::second_t L2;
+        using L1 = typename reduce_color_layouts<layout1,layout2>::first_t;
+        using L2 = typename reduce_color_layouts<layout1,layout2>::second_t;
 
-        typedef typename derived_view_type<V1, use_default, L1, use_default, use_default, use_default, mpl::false_>::type DV1;
-        typedef typename derived_view_type<V2, use_default, L2, use_default, use_default, use_default, mpl::true_ >::type DV2;
+        using DV1 = typename derived_view_type<V1, use_default, L1, use_default, use_default, use_default, mpl::false_>::type;
+        using DV2 = typename derived_view_type<V2, use_default, L2, use_default, use_default, use_default, mpl::true_ >::type;
 
-        typedef std::pair<const DV1*, const DV2*> type;
+        using type = std::pair<const DV1*, const DV2*>;
     };
 
     // The general 2D version branches into compatible and incompatible views
     template <typename V1, typename V2>
     struct reduce_views_basic<copy_pixels_fn, V1, V2, true>
-        : public reduce_copy_pixop_compat<V1, V2, mpl::and_<views_are_compatible<V1,V2>, view_is_mutable<V2> >::value > {
+        : public reduce_copy_pixop_compat<V1, V2, mpl::and_<views_are_compatible<V1,V2>, view_is_mutable<V2>>::value > {
     };
 
     ////////////////////////////////////////////////////////
@@ -669,7 +701,11 @@ namespace detail {
     ////////////////////////////////////////////////////////
 
     struct destructor_op;
-    template <typename View> struct reduce_view_basic<destructor_op,View,true> { typedef gray8_view_t type; };
+    template <typename View>
+    struct reduce_view_basic<destructor_op,View,true>
+    {
+        using type = gray8_view_t;
+    };
 
     ////////////////////////////////////////////////////////
     ////
@@ -678,8 +714,18 @@ namespace detail {
     ////////////////////////////////////////////////////////
 
     struct any_type_get_dimensions;
-    template <typename View> struct reduce_view_basic<any_type_get_dimensions,View,true> { typedef gray8_view_t type; };
-    template <typename Img>  struct reduce_image_basic<any_type_get_dimensions,Img,true> { typedef gray8_image_t type; };
+
+    template <typename View>
+    struct reduce_view_basic<any_type_get_dimensions,View,true>
+    {
+        using type = gray8_view_t;
+    };
+
+    template <typename Img>
+    struct reduce_image_basic<any_type_get_dimensions,Img,true>
+    {
+        using type = gray8_image_t;
+    };
 
     ////////////////////////////////////////////////////////
     ////
@@ -688,13 +734,19 @@ namespace detail {
     ////////////////////////////////////////////////////////
 
     struct any_type_get_num_channels;
-    template <typename View> struct reduce_view_basic<any_type_get_num_channels,View,true> {
-        typedef typename View::color_space_t::base Cs;
-        typedef typename view_type<uint8_t,typename reduce_color_space<Cs>::type>::type type;
+
+    template <typename View>
+    struct reduce_view_basic<any_type_get_num_channels,View,true>
+    {
+        using color_space_t =  typename View::color_space_t::base;
+        using type = typename view_type<uint8_t,typename reduce_color_space<color_space_t>::type>::type;
     };
-    template <typename Img>  struct reduce_image_basic<any_type_get_num_channels,Img,true> {
-        typedef typename Img::color_space_t::base Cs;
-        typedef typename image_type<uint8_t,typename reduce_color_space<Cs>::type>::type type;
+
+    template <typename Img>
+    struct reduce_image_basic<any_type_get_num_channels,Img,true>
+    {
+        using color_space_t = typename Img::color_space_t::base;
+        using type = typename image_type<uint8_t,typename reduce_color_space<color_space_t>::type>::type;
     };
 
     ////////////////////////////////////////////////////////
@@ -730,17 +782,18 @@ namespace detail {
     // For 2D reduce, if they have the same channels and color spaces (i.e. the same pixels) then copy_and_convert is just copy.
     // In this case, reduce their common color space. In general make the first immutable and the second mutable
     template <typename CC, typename V1, typename V2, bool AreBasic>
-    struct reduce_views_basic<copy_and_convert_pixels_fn<CC>, V1, V2, AreBasic> {
-        typedef is_same<typename V1::pixel_t, typename V2::pixel_t> Same;
+    struct reduce_views_basic<copy_and_convert_pixels_fn<CC>, V1, V2, AreBasic>
+    {
+        using Same = is_same<typename V1::pixel_t, typename V2::pixel_t>;
 
-        typedef reduce_color_space<typename V1::color_space_t::base> CsR;
-        typedef typename mpl::if_<Same, typename CsR::type, typename V1::color_space_t>::type Cs1;
-        typedef typename mpl::if_<Same, typename CsR::type, typename V2::color_space_t>::type Cs2;
+        using CsR = reduce_color_space<typename V1::color_space_t::base>;
+        using Cs1 = typename mpl::if_<Same, typename CsR::type, typename V1::color_space_t>::type;
+        using Cs2 = typename mpl::if_<Same, typename CsR::type, typename V2::color_space_t>::type;
 
-        typedef typename derived_view_type<V1, use_default, layout<Cs1, typename V1::channel_mapping_t>, use_default, use_default, mpl::false_>::type DV1;
-        typedef typename derived_view_type<V2, use_default, layout<Cs2, typename V2::channel_mapping_t>, use_default, use_default, mpl::true_ >::type DV2;
+        using DV1 = typename derived_view_type<V1, use_default, layout<Cs1, typename V1::channel_mapping_t>, use_default, use_default, mpl::false_>::type;
+        using DV2 = typename derived_view_type<V2, use_default, layout<Cs2, typename V2::channel_mapping_t>, use_default, use_default, mpl::true_ >::type;
 
-        typedef std::pair<const DV1*, const DV2*> type;
+        using type = std::pair<const DV1*, const DV2*>;
     };
 
 
@@ -760,15 +813,15 @@ namespace detail {
 
     //detail::any_image_get_view<typename any_image<Types>::view_t>
     //detail::any_image_get_const_view<typename any_image<Types>::view_t>
-    //detail::flipped_up_down_view_fn<any_image_view<ViewTypes> >
+    //detail::flipped_up_down_view_fn<any_image_view<ViewTypes>>
     //detail::flipped_left_right_view_fn<typename any_image_view<ViewTypes>::dynamic_step_t>
     //detail::tranposed_view_fn<typename any_image_view<ViewTypes>::dynamic_step_t>
     //detail::rotated90cw_view_fn<typename any_image_view<ViewTypes>::dynamic_step_t>
     //detail::rotated90ccw_view_fn<typename any_image_view<ViewTypes>::dynamic_step_t>
     //detail::rotated180_view_fn<typename any_image_view<ViewTypes>::dynamic_step_t>
-    //detail::subimage_view_fn<any_image_view<ViewTypes> >
+    //detail::subimage_view_fn<any_image_view<ViewTypes>>
     //detail::subsampled_view_fn<typename any_image_view<ViewTypes>::dynamic_step_t>
-    //detail::nth_channel_view_fn<typename nth_channel_view_type<any_image_view<ViewTypes> >
+    //detail::nth_channel_view_fn<typename nth_channel_view_type<any_image_view<ViewTypes>>
     //detail::color_converted_view_fn<DstP,typename color_convert_view_type<any_image_view<ViewTypes>, DstP>::type >
 }
 

--- a/include/boost/gil/extension/dynamic_image/variant.hpp
+++ b/include/boost/gil/extension/dynamic_image/variant.hpp
@@ -35,7 +35,7 @@ namespace detail {
     template <typename Types, typename T> struct type_to_index;
     template <typename Op, typename T> struct reduce;
     struct destructor_op {
-        typedef void result_type;
+        using result_type = void;
         template <typename T> result_type operator()(const T& t) const { t.~T(); }
     };
     template <typename T, typename Bits> void copy_construct_in_place(const T& t, Bits& bits);
@@ -82,9 +82,9 @@ class variant {
     static const std::size_t MAX_SIZE  = mpl::fold<Types, mpl::size_t<0>, mpl::max<mpl::_1, mpl::sizeof_<mpl::_2> > >::type::value;
     static const std::size_t NUM_TYPES = mpl::size<Types>::value;
 public:
-    typedef Types                            types_t;
+    using types_t = Types;
 
-    typedef struct { char data[MAX_SIZE]; } base_t;    // empty space equal to the size of the largest type in Types
+    using base_t = struct { char data[MAX_SIZE]; }; // empty space equal to the size of the largest type in Types
 
     // Default constructor - default construct the first type
     variant() : _index(0)    { new(&_bits) typename mpl::at_c<Types,0>::type(); }
@@ -142,7 +142,7 @@ namespace detail {
 
     template <typename Bits>
     struct copy_construct_in_place_fn {
-        typedef void result_type;
+        using result_type = void;
         Bits& _dst;
         copy_construct_in_place_fn(Bits& dst) : _dst(dst) {}
 
@@ -154,7 +154,7 @@ namespace detail {
         const Bits& _dst;
         equal_to_fn(const Bits& dst) : _dst(dst) {}
 
-        typedef bool result_type;
+        using result_type = bool;
         template <typename T> result_type operator()(const T& x) const {
             return x==*gil_reinterpret_cast_c<const T*>(&_dst);
         }
@@ -162,7 +162,7 @@ namespace detail {
 
     template <typename Types>
     struct type_to_index_fn {
-        typedef std::size_t result_type;
+        using result_type = std::size_t;
 
         template <typename T> result_type operator()(const T&) const { return detail::type_to_index<Types,T>::value; }
     };


### PR DESCRIPTION
Run clang-tidy 7.0 with `-checks='-*,modernize-use-using' -fix`
against single TU with `#include <boost/gil/concepts/*.hpp>`.

Manually refactor numerous `typedef`-s
- where missed by `modernize-use-using` check, not uncommon
- in code snippets in comments

Outcome is that searching for lower-case whole word `typedef`
in all the `extension/dynamic_image/*.hpp` should return 5 matches,
in definitions of macros (TODO).

### References

- #192

### Tasklist

- [ ] Review
- [ ] Adjust for comments
- [ ] All CI builds and checks have passed
