### PR TITLE
Apply clang-tidy modernize-use-using to io

### DIFF
--- a/include/boost/gil/io/base.hpp
+++ b/include/boost/gil/io/base.hpp
@@ -31,7 +31,7 @@ struct format_tag {};
 template< typename Property >
 struct property_base
 {
-    typedef Property type;
+    using type = Property;
 };
 
 template<typename FormatTag> struct is_format_tag : is_base_and_derived< format_tag
@@ -87,7 +87,7 @@ namespace detail {
 template< typename Property >
 struct property_base
 {
-    typedef Property type;
+    using type = Property;
 };
 
 } // namespace detail

--- a/include/boost/gil/io/conversion_policies.hpp
+++ b/include/boost/gil/io/conversion_policies.hpp
@@ -19,7 +19,7 @@ namespace boost{namespace gil{ namespace detail {
 struct read_and_no_convert
 {
 public:
-    typedef void* color_converter_type;
+    using color_converter_type = void *;
 
     template< typename InIterator
             , typename OutIterator
@@ -60,7 +60,7 @@ template<typename CC>
 struct read_and_convert
 {
 public:
-    typedef CC color_converter_type;
+    using color_converter_type = default_color_converter;
     CC _cc;
 
     read_and_convert()
@@ -78,10 +78,10 @@ public:
              , OutIterator       out
              )
     {
-        typedef color_convert_deref_fn< typename std::iterator_traits<InIterator>::reference
+        using deref_t = color_convert_deref_fn<typename std::iterator_traits<InIterator>::reference
                                       , typename std::iterator_traits<OutIterator>::value_type //reference?
                                       , CC
-                                      > deref_t;
+                                      >;
 
         std::transform( begin
                       , end

--- a/include/boost/gil/io/device.hpp
+++ b/include/boost/gil/io/device.hpp
@@ -50,7 +50,7 @@ class file_stream_device
 {
 public:
 
-   typedef FormatTag format_tag_t;
+   using format_tag_t = FormatTag;
 
 public:
 
@@ -565,7 +565,7 @@ struct is_adaptable_input_device< FormatTag
                                                     >::type
                                 > : mpl::true_
 {
-    typedef istream_device< FormatTag > device_type;
+    using device_type = istream_device<FormatTag>;
 };
 
 template< typename FormatTag >
@@ -575,7 +575,7 @@ struct is_adaptable_input_device< FormatTag
                                 >
     : mpl::true_
 {
-    typedef file_stream_device< FormatTag > device_type;
+    using device_type = file_stream_device<FormatTag>;
 };
 
 ///
@@ -628,13 +628,13 @@ template< typename FormatTag
                                            >::type
         > : mpl::true_
 {
-    typedef ostream_device< FormatTag > device_type;
+    using device_type = ostream_device<FormatTag>;
 };
 
 template<typename FormatTag> struct is_adaptable_output_device<FormatTag,FILE*,void>
   : mpl::true_
 {
-    typedef file_stream_device< FormatTag > device_type;
+    using device_type = file_stream_device<FormatTag>;
 };
 
 

--- a/include/boost/gil/io/dynamic_io_new.hpp
+++ b/include/boost/gil/io/dynamic_io_new.hpp
@@ -70,7 +70,7 @@ class dynamic_io_fnobj {
 public:
     dynamic_io_fnobj(OpClass* op) : _op(op) {}
 
-    typedef void result_type;
+    using result_type = void;
 
     template <typename View>
     void operator()(const View& view) {apply(view,typename IsSupported::template apply<View>::type());}

--- a/include/boost/gil/io/get_read_device.hpp
+++ b/include/boost/gil/io/get_read_device.hpp
@@ -36,9 +36,11 @@ struct get_read_device< Device
                                           >::type
                  >
 {
-    typedef typename detail::is_adaptable_input_device< FormatTag
-                                                      , Device
-                                                      >::device_type type;
+    using type = typename detail::is_adaptable_input_device
+        <
+            FormatTag,
+            Device
+        >::device_type;
 };
 
 template< typename String
@@ -52,7 +54,7 @@ struct get_read_device< String
                                           >::type
                       >
 {
-    typedef detail::file_stream_device< FormatTag > type;
+    using type = detail::file_stream_device<FormatTag>;
 };
 
 } // namespace gil

--- a/include/boost/gil/io/get_reader.hpp
+++ b/include/boost/gil/io/get_reader.hpp
@@ -34,14 +34,8 @@ struct get_reader< String
                                      >::type
                  >
 {
-    typedef typename get_read_device< String
-                                    , FormatTag
-                                    >::type device_t;
-
-    typedef reader< device_t
-                  , FormatTag
-                  , ConversionPolicy
-                  > type;
+    using device_t = typename get_read_device<String, FormatTag>::type;
+    using type = reader<device_t, FormatTag, ConversionPolicy>;
 };
 
 template< typename Device
@@ -59,14 +53,8 @@ struct get_reader< Device
                                      >::type
                  >
 {
-    typedef typename get_read_device< Device
-                                    , FormatTag
-                                    >::type device_t;
-
-    typedef reader< device_t
-                  , FormatTag
-                  , ConversionPolicy
-                  > type;
+    using device_t = typename get_read_device<Device, FormatTag>::type;
+    using type = reader<device_t, FormatTag, ConversionPolicy>;
 };
 
 
@@ -89,13 +77,8 @@ struct get_dynamic_image_reader< String
                                                    >::type
                                >
 {
-    typedef typename get_read_device< String
-                                    , FormatTag
-                                    >::type device_t;
-
-    typedef dynamic_image_reader< device_t
-                                , FormatTag
-                                > type;
+    using device_t = typename get_read_device<String, FormatTag>::type;
+    using type = dynamic_image_reader<device_t, FormatTag>;
 };
 
 template< typename Device
@@ -111,13 +94,8 @@ struct get_dynamic_image_reader< Device
                                                    >::type
                                >
 {
-    typedef typename get_read_device< Device
-                                    , FormatTag
-                                    >::type device_t;
-
-    typedef dynamic_image_reader< device_t
-                                , FormatTag
-                                > type;
+    using device_t = typename get_read_device<Device, FormatTag>::type;
+    using type = dynamic_image_reader<device_t, FormatTag>;
 };
 
 
@@ -142,13 +120,8 @@ struct get_reader_backend< String
                                              >::type
                          >
 {
-    typedef typename get_read_device< String
-                                    , FormatTag
-                                    >::type device_t;
-
-    typedef reader_backend< device_t
-                          , FormatTag
-                          > type;
+    using device_t = typename get_read_device<String, FormatTag>::type;
+    using type = reader_backend<device_t, FormatTag>;
 };
 
 template< typename Device
@@ -164,13 +137,8 @@ struct get_reader_backend< Device
                                              >::type
                          >
 {
-    typedef typename get_read_device< Device
-                                    , FormatTag
-                                    >::type device_t;
-
-    typedef reader_backend< device_t
-                          , FormatTag
-                          > type;
+    using device_t = typename get_read_device<Device, FormatTag>::type;
+    using type = reader_backend<device_t, FormatTag>;
 };
 
 /// \brief Helper metafunction to generate image scanline_reader type.
@@ -179,13 +147,8 @@ template< typename T
         >
 struct get_scanline_reader
 {
-    typedef typename get_read_device< T
-                                    , FormatTag
-                                    >::type device_t;
-
-    typedef scanline_reader< device_t
-                           , FormatTag
-                           > type;
+    using device_t = typename get_read_device<T, FormatTag>::type;
+    using type = scanline_reader<device_t, FormatTag>;
 };
 
 } // namespace gil

--- a/include/boost/gil/io/get_write_device.hpp
+++ b/include/boost/gil/io/get_write_device.hpp
@@ -37,9 +37,11 @@ struct get_write_device< Device
                                            >::type
                        >
 {
-    typedef typename detail::is_adaptable_output_device< FormatTag
-                                                       , Device
-                                                       >::device_type type;
+    using type = typename detail::is_adaptable_output_device
+        <
+            FormatTag,
+            Device
+        >::device_type;
 };
 
 
@@ -54,7 +56,7 @@ struct get_write_device< String
                                            >::type
                        >
 {
-    typedef detail::file_stream_device< FormatTag > type;
+    using type = detail::file_stream_device<FormatTag>;
 };
 
 } // namespace gil

--- a/include/boost/gil/io/get_writer.hpp
+++ b/include/boost/gil/io/get_writer.hpp
@@ -32,13 +32,8 @@ struct get_writer< String
                                      >::type
                  >
 {
-    typedef typename get_write_device< String
-                                     , FormatTag
-                                     >::type device_t;
-
-    typedef writer< device_t
-                  , FormatTag
-                  > type;
+    using device_t = typename get_write_device<String, FormatTag>::type;
+    using type = writer<device_t, FormatTag>;
 };
 
 template< typename Device
@@ -54,13 +49,8 @@ struct get_writer< Device
                                      >::type
                  >
 {
-    typedef typename get_write_device< Device
-                                     , FormatTag
-                                     >::type device_t;
-
-    typedef writer< device_t
-                  , FormatTag
-                  > type;
+    using device_t = typename get_write_device<Device, FormatTag>::type;
+    using type = writer<device_t, FormatTag>;
 };
 
 
@@ -83,13 +73,8 @@ struct get_dynamic_image_writer< String
                                                    >::type
                                >
 {
-    typedef typename get_write_device< String
-                                     , FormatTag
-                                     >::type device_t;
-
-    typedef dynamic_image_writer< device_t
-                                , FormatTag
-                                > type;
+    using device_t = typename get_write_device<String, FormatTag>::type;
+    using type = dynamic_image_writer<device_t, FormatTag>;
 };
 
 template< typename Device
@@ -105,15 +90,9 @@ struct get_dynamic_image_writer< Device
                                                    >::type
                                >
 {
-    typedef typename get_write_device< Device
-                                     , FormatTag
-                                     >::type device_t;
-
-    typedef dynamic_image_writer< device_t
-                                , FormatTag
-                                > type;
+    using device_t = typename get_write_device<Device, FormatTag>::type;
+    using type = dynamic_image_writer<device_t, FormatTag>;
 };
-
 
 } // namespace gil
 } // namespace boost

--- a/include/boost/gil/io/make_backend.hpp
+++ b/include/boost/gil/io/make_backend.hpp
@@ -30,9 +30,7 @@ make_reader_backend( const String&                           file_name
                                        >::type* /* ptr */ = nullptr
                    )
 {
-    typedef typename get_read_device< String
-                                    , FormatTag
-                                    >::type device_t;
+    using device_t = typename get_read_device<String, FormatTag>::type;
 
     device_t device( detail::convert_to_native_string( file_name )
                    , typename detail::file_stream_device< FormatTag >::read_tag()
@@ -50,9 +48,7 @@ make_reader_backend( const std::wstring&                     file_name
                    , const image_read_settings< FormatTag >& settings
                    )
 {
-    typedef typename get_read_device< std::wstring
-                                    , FormatTag
-                                    >::type device_t;
+    using device_t = typename get_read_device<std::wstring, FormatTag>::type;
 
     const char* str = detail::convert_to_native_string( file_name );
 
@@ -60,7 +56,7 @@ make_reader_backend( const std::wstring&                     file_name
                    , typename detail::file_stream_device< FormatTag >::read_tag()
                    );
 
-    delete[] str;
+    delete[] str; // TODO: RAII
 
     return reader_backend< device_t, FormatTag >( device, settings );
 }
@@ -98,10 +94,7 @@ make_reader_backend( Device&                                 io_dev
                                        >::type* /* ptr */ = nullptr
                    )
 {
-    typedef typename get_read_device< Device
-                                    , FormatTag
-                                    >::type device_t;
-
+    using device_t = typename get_read_device< Device, FormatTag>::type;
     device_t device( io_dev );
 
     return reader_backend< device_t, FormatTag >( device, settings );

--- a/include/boost/gil/io/make_reader.hpp
+++ b/include/boost/gil/io/make_reader.hpp
@@ -67,7 +67,7 @@ make_reader( const std::wstring& file_name
                                           , typename detail::file_stream_device< FormatTag >::read_tag()
                                           );
 
-    delete[] str;
+    delete[] str; // TODO: RAII
 
     return typename get_reader< std::wstring
                               , FormatTag

--- a/include/boost/gil/io/read_and_convert_image.hpp
+++ b/include/boost/gil/io/read_and_convert_image.hpp
@@ -71,10 +71,12 @@ void read_and_convert_image( Device&                                 device
                                                 >::type* /* ptr */ = 0
                            )
 {
-    typedef typename get_reader< Device
-                               , FormatTag
-                               , detail::read_and_convert< ColorConverter >
-                               >::type reader_t;
+    using reader_t = typename get_reader
+        <
+            Device,
+            FormatTag,
+            detail::read_and_convert<ColorConverter>
+        >::type;
 
     reader_t reader = make_reader( device
                                  , settings
@@ -108,10 +110,12 @@ void read_and_convert_image( const String&                           file_name
                                                >::type* /* ptr */ = 0
                            )
 {
-    typedef typename get_reader< String
-                               , FormatTag
-                               , detail::read_and_convert< ColorConverter >
-                               >::type reader_t;
+    using reader_t = typename get_reader
+        <
+            String,
+            FormatTag,
+            detail::read_and_convert<ColorConverter>
+        >::type;
 
     reader_t reader = make_reader( file_name
                                  , settings
@@ -145,10 +149,12 @@ void read_and_convert_image( const String&         file_name
                                                >::type* /* ptr */ = 0
                            )
 {
-    typedef typename get_reader< String
-                               , FormatTag
-                               , detail::read_and_convert< ColorConverter >
-                               >::type reader_t;
+    using reader_t = typename get_reader
+        <
+            String,
+            FormatTag,
+            detail::read_and_convert<ColorConverter>
+        >::type;
 
     reader_t reader = make_reader( file_name
                                  , tag
@@ -184,10 +190,12 @@ void read_and_convert_image( Device&               device
                                                >::type* /* ptr */ = 0
                            )
 {
-    typedef typename get_reader< Device
-                               , FormatTag
-                               , detail::read_and_convert< ColorConverter >
-                               >::type reader_t;
+    using reader_t = typename get_reader
+        <
+            Device,
+            FormatTag,
+            detail::read_and_convert<ColorConverter>
+        >::type;
 
     reader_t reader = make_reader( device
                                  , tag
@@ -218,10 +226,11 @@ void read_and_convert_image( const String&                           file_name
                                                >::type* /* ptr */ = 0
                            )
 {
-    typedef typename get_reader< String
-                               , FormatTag
-                               , detail::read_and_convert< default_color_converter >
-                               >::type reader_t;
+    using reader_t = typename get_reader
+        <
+           String, FormatTag,
+           detail::read_and_convert<default_color_converter>
+       >::type;
 
     reader_t reader = make_reader( file_name
                                  , settings
@@ -254,10 +263,12 @@ void read_and_convert_image( Device&                                 device
                                                >::type* /* ptr */ = 0
                            )
 {
-    typedef typename get_reader< Device
-                               , FormatTag
-                               , detail::read_and_convert< default_color_converter >
-                               >::type reader_t;
+    using reader_t = typename get_reader
+        <
+            Device,
+            FormatTag,
+            detail::read_and_convert<default_color_converter>
+        >::type;
 
     reader_t reader = make_reader( device
                                  , settings
@@ -288,10 +299,12 @@ void read_and_convert_image( const String&    file_name
                                                >::type* /* ptr */ = nullptr
                            )
 {
-    typedef typename get_reader< String
-                               , FormatTag
-                               , detail::read_and_convert< default_color_converter >
-                               >::type reader_t;
+    using reader_t = typename get_reader
+        <
+            String,
+            FormatTag,
+            detail::read_and_convert<default_color_converter>
+        >::type;
 
     reader_t reader = make_reader( file_name
                                  , tag
@@ -324,10 +337,12 @@ void read_and_convert_image( Device&          device
                                                >::type* /* ptr */ = nullptr
                            )
 {
-    typedef typename get_reader< Device
-                               , FormatTag
-                               , detail::read_and_convert< default_color_converter >
-                               >::type reader_t;
+    using reader_t = typename get_reader
+        <
+            Device,
+            FormatTag,
+            detail::read_and_convert<default_color_converter>
+        >::type;
 
     reader_t reader = make_reader( device
                                  , tag

--- a/include/boost/gil/io/read_and_convert_view.hpp
+++ b/include/boost/gil/io/read_and_convert_view.hpp
@@ -74,10 +74,12 @@ void read_and_convert_view( Device&                                 device
 
                           )
 {
-    typedef typename get_reader< Device
-                               , FormatTag
-                               , detail::read_and_convert< ColorConverter >
-                               >::type reader_t;
+    using reader_t = typename get_reader
+        <
+            Device,
+            FormatTag,
+            detail::read_and_convert<ColorConverter>
+        >::type;
 
     reader_t reader = make_reader( device
                                  , settings
@@ -111,10 +113,12 @@ void read_and_convert_view( const String&                           file_name
                                             >::type* /* ptr */ = 0
                           )
 {
-    typedef typename get_reader< String
-                               , FormatTag
-                               , detail::read_and_convert< ColorConverter >
-                               >::type reader_t;
+    using reader_t = typename get_reader
+        <
+            String,
+            FormatTag,
+            detail::read_and_convert<ColorConverter>
+        >::type;
 
     reader_t reader = make_reader( file_name
                                  , settings
@@ -148,10 +152,12 @@ void read_and_convert_view( const String&         file_name
                                             >::type* /* ptr */ = 0
                           )
 {
-    typedef typename get_reader< String
-                               , FormatTag
-                               , detail::read_and_convert< ColorConverter >
-                               >::type reader_t;
+    using reader_t = typename get_reader
+        <
+            String,
+            FormatTag,
+            detail::read_and_convert<ColorConverter>
+        >::type;
 
     reader_t reader = make_reader( file_name
                                  , tag
@@ -187,10 +193,12 @@ void read_and_convert_view( Device&               device
                                                >::type* /* ptr */ = 0
                           )
 {
-    typedef typename get_reader< Device
-                               , FormatTag
-                               , detail::read_and_convert< ColorConverter >
-                               >::type reader_t;
+    using reader_t = typename get_reader
+        <
+            Device,
+            FormatTag,
+            detail::read_and_convert<ColorConverter>
+        >::type;
 
     reader_t reader = make_reader( device
                                  , tag
@@ -221,10 +229,12 @@ void read_and_convert_view( const String&                           file_name
                                             >::type* /* ptr */ = 0
                           )
 {
-    typedef typename get_reader< String
-                               , FormatTag
-                               , detail::read_and_convert< default_color_converter >
-                               >::type reader_t;
+    using reader_t = typename get_reader
+        <
+            String,
+            FormatTag,
+            detail::read_and_convert<default_color_converter>
+        >::type;
 
     reader_t reader = make_reader( file_name
                                  , settings
@@ -257,10 +267,12 @@ void read_and_convert_view( Device&                                 device
                                                >::type* /* ptr */ = 0
                           )
 {
-    typedef typename get_reader< Device
-                               , FormatTag
-                               , detail::read_and_convert< default_color_converter >
-                               >::type reader_t;
+    using reader_t = typename get_reader
+        <
+            Device,
+            FormatTag,
+            detail::read_and_convert<default_color_converter>
+        >::type;
 
     reader_t reader = make_reader( device
                                  , settings
@@ -292,10 +304,12 @@ void read_and_convert_view( const String&    file_name
                                               >::type* /* ptr */ = nullptr
                           )
 {
-    typedef typename get_reader< String
-                               , FormatTag
-                               , detail::read_and_convert< default_color_converter >
-                               >::type reader_t;
+    using reader_t = typename get_reader
+        <
+            String,
+            FormatTag,
+            detail::read_and_convert<default_color_converter>
+        >::type;
 
     reader_t reader = make_reader( file_name
                                  , tag
@@ -328,10 +342,12 @@ void read_and_convert_view( Device&          device
                                                >::type* /* ptr */ = nullptr
                           )
 {
-    typedef typename get_reader< Device
-                               , FormatTag
-                               , detail::read_and_convert< default_color_converter >
-                               >::type reader_t;
+    using reader_t = typename get_reader
+        <
+            Device,
+            FormatTag,
+            detail::read_and_convert<default_color_converter>
+        >::type;
 
     reader_t reader = make_reader( device
                                  , tag

--- a/include/boost/gil/io/read_image.hpp
+++ b/include/boost/gil/io/read_image.hpp
@@ -74,10 +74,12 @@ void read_image( Device&                                 file
                                    >::type* /* ptr */ = 0
                )
 {
-    typedef typename get_reader< Device
-                               , FormatTag
-                               , detail::read_and_no_convert
-                               >::type reader_t;
+    using reader_t = typename get_reader
+        <
+            Device,
+            FormatTag,
+            detail::read_and_no_convert
+        >::type;
 
     reader_t reader = make_reader( file
                                  , settings
@@ -113,10 +115,12 @@ void read_image( Device&          file
                                    >::type* /* ptr */ = nullptr
                )
 {
-    typedef typename get_reader< Device
-                               , FormatTag
-                               , detail::read_and_no_convert
-                               >::type reader_t;
+    using reader_t = typename get_reader
+        <
+            Device,
+            FormatTag,
+            detail::read_and_no_convert
+        >::type;
 
     reader_t reader = make_reader( file
                                  , tag
@@ -150,10 +154,12 @@ void read_image( const String&                           file_name
                                    >::type* /* ptr */ = nullptr
                )
 {
-    typedef typename get_reader< String
-                               , FormatTag
-                               , detail::read_and_no_convert
-                               >::type reader_t;
+    using reader_t = typename get_reader
+        <
+            String,
+            FormatTag,
+            detail::read_and_no_convert
+        >::type;
 
     reader_t reader = make_reader( file_name
                                  , settings
@@ -187,10 +193,12 @@ void read_image( const String&    file_name
                                    >::type* /* ptr */ = nullptr
                )
 {
-    typedef typename get_reader< String
-                               , FormatTag
-                               , detail::read_and_no_convert
-                               >::type reader_t;
+    using reader_t = typename get_reader
+        <
+            String,
+            FormatTag,
+            detail::read_and_no_convert
+        >::type;
 
     reader_t reader = make_reader( file_name
                                  , tag
@@ -240,9 +248,11 @@ void read_image( Device&                                 file
                                    >::type* /* ptr */ = 0
                )
 {
-    typedef typename get_dynamic_image_reader< Device
-                                             , FormatTag
-                                             >::type reader_t;
+    using reader_t = typename get_dynamic_image_reader
+        <
+            Device,
+            FormatTag
+        >::type;
 
     reader_t reader = make_dynamic_image_reader( file
                                                , settings
@@ -274,9 +284,11 @@ void read_image( Device&              file
                                    >::type* /* ptr */ = 0
                )
 {
-    typedef typename get_dynamic_image_reader< Device
-                                             , FormatTag
-                                             >::type reader_t;
+    using reader_t = typename get_dynamic_image_reader
+        <
+            Device,
+            FormatTag
+        >::type;
 
     reader_t reader = make_dynamic_image_reader( file
                                                , tag
@@ -306,9 +318,11 @@ void read_image( const String&                           file_name
                                    >::type* /* ptr */ = 0
                )
 {
-    typedef typename get_dynamic_image_reader< String
-                                             , FormatTag
-                                             >::type reader_t;
+    using reader_t = typename get_dynamic_image_reader
+        <
+            String,
+            FormatTag
+        >::type;
 
     reader_t reader = make_dynamic_image_reader( file_name
                                                , settings
@@ -338,9 +352,11 @@ void read_image( const String&        file_name
                                    >::type* /* ptr */ = nullptr
                )
 {
-    typedef typename get_dynamic_image_reader< String
-                                             , FormatTag
-                                             >::type reader_t;
+    using reader_t = typename get_dynamic_image_reader
+        <
+            String,
+            FormatTag
+        >::type;
 
     reader_t reader = make_dynamic_image_reader( file_name, tag );
 

--- a/include/boost/gil/io/read_view.hpp
+++ b/include/boost/gil/io/read_view.hpp
@@ -75,10 +75,12 @@ void read_view( Device&                                 file
                                   >::type* /* ptr */ = 0
               )
 {
-    typedef typename get_reader< Device
-                               , FormatTag
-                               , detail::read_and_no_convert
-                               >::type reader_t;
+    using reader_t = typename get_reader
+        <
+            Device,
+            FormatTag,
+            detail::read_and_no_convert
+        >::type;
 
     reader_t reader = make_reader( file
                                  , settings
@@ -114,10 +116,12 @@ void read_view( Device&          file
                                   >::type* /* ptr */ = nullptr
               )
 {
-    typedef typename get_reader< Device
-                               , FormatTag
-                               , detail::read_and_no_convert
-                               >::type reader_t;
+    using reader_t = typename get_reader
+        <
+            Device,
+            FormatTag,
+            detail::read_and_no_convert
+        >::type;
 
     reader_t reader = make_reader( file
                                  , tag
@@ -151,10 +155,12 @@ void read_view( const String&                           file_name
                                   >::type* /* ptr */ = 0
               )
 {
-    typedef typename get_reader< String
-                               , FormatTag
-                               , detail::read_and_no_convert
-                               >::type reader_t;
+    using reader_t = typename get_reader
+        <
+            String,
+            FormatTag,
+            detail::read_and_no_convert
+        >::type;
 
     reader_t reader = make_reader( file_name
                                  , settings
@@ -188,10 +194,12 @@ void read_view( const String&    file_name
                                   >::type* /* ptr */ = nullptr
               )
 {
-    typedef typename get_reader< String
-                               , FormatTag
-                               , detail::read_and_no_convert
-                               >::type reader_t;
+    using reader_t = typename get_reader
+        <
+            String,
+            FormatTag,
+            detail::read_and_no_convert
+        >::type;
 
     reader_t reader = make_reader( file_name
                                  , tag

--- a/include/boost/gil/io/reader_base.hpp
+++ b/include/boost/gil/io/reader_base.hpp
@@ -88,7 +88,7 @@ private:
 
     void check_coordinates( const point_t& /* dim */ )
     {
-       //typedef point_t::value_type int_t;
+       //using int_t = point_t::value_type;
 
        //int_t width  = static_cast< int_t >( _info._width  );
        //int_t height = static_cast< int_t >( _info._height );

--- a/include/boost/gil/io/row_buffer_helper.hpp
+++ b/include/boost/gil/io/row_buffer_helper.hpp
@@ -28,9 +28,9 @@ template< typename Pixel
         >
 struct row_buffer_helper
 {
-    typedef Pixel element_t;
-    typedef std::vector< element_t > buffer_t;
-    typedef typename buffer_t::iterator iterator_t;
+    using element_t = Pixel;
+    using buffer_t = std::vector<element_t>;
+    using iterator_t = typename buffer_t::iterator;
 
     row_buffer_helper( std::size_t width
                      , bool
@@ -55,10 +55,10 @@ struct row_buffer_helper< Pixel
                         , typename enable_if< typename is_bit_aligned< Pixel >::type >::type
                         >
 {
-    typedef byte_t element_t;
-    typedef std::vector< element_t > buffer_t;
-    typedef Pixel pixel_type;
-    typedef bit_aligned_pixel_iterator<pixel_type> iterator_t;
+    using element_t = byte_t;
+    using buffer_t = std::vector<element_t>;
+    using pixel_type = Pixel;
+    using iterator_t = bit_aligned_pixel_iterator<pixel_type>;
 
     row_buffer_helper( std::size_t width
                      , bool        in_bytes
@@ -121,10 +121,10 @@ struct row_buffer_helper
     >
 >
 {
-    typedef byte_t element_t;
-    typedef std::vector< element_t > buffer_t;
-    typedef Pixel pixel_type;
-    typedef bit_aligned_pixel_iterator<pixel_type> iterator_t;
+    using element_t = byte_t;
+    using buffer_t = std::vector<element_t>;
+    using pixel_type = Pixel;
+    using iterator_t = bit_aligned_pixel_iterator<pixel_type>;
 
     row_buffer_helper( std::size_t width
                      , bool        in_bytes

--- a/include/boost/gil/io/scanline_read_iterator.hpp
+++ b/include/boost/gil/io/scanline_read_iterator.hpp
@@ -33,10 +33,12 @@ class scanline_read_iterator : public boost::iterator_facade< scanline_read_iter
 {
 private:
 
-    typedef boost::iterator_facade< scanline_read_iterator< Reader >
-                                                          , byte_t*
-                                                          , std::input_iterator_tag
-                                                          > base_t;
+    using base_t = boost::iterator_facade
+        <
+            scanline_read_iterator<Reader>,
+            byte_t*,
+            std::input_iterator_tag
+        >;
 
 
 public:

--- a/include/boost/gil/io/typedefs.hpp
+++ b/include/boost/gil/io/typedefs.hpp
@@ -28,8 +28,7 @@ struct double_one  { static double apply() { return 1.0; } };
 using byte_t = unsigned char;
 using byte_vector_t = std::vector<byte_t>;
 
-} // namespace gil
-} // namespace boost
+}} // namespace boost::gil
 
 namespace boost {
 
@@ -41,44 +40,44 @@ template<> struct is_floating_point<gil::float64_t> : mpl::true_ {};
 namespace boost { namespace gil {
 
 ///@todo We should use boost::preprocessor here.
+/// TODO: NO! Please do not use preprocessor here! --mloskot
 
-typedef bit_aligned_image1_type<  1, gray_layout_t >::type gray1_image_t;
-typedef bit_aligned_image1_type<  2, gray_layout_t >::type gray2_image_t;
-typedef bit_aligned_image1_type<  4, gray_layout_t >::type gray4_image_t;
-typedef bit_aligned_image1_type<  6, gray_layout_t >::type gray6_image_t;
-typedef bit_aligned_image1_type< 10, gray_layout_t >::type gray10_image_t;
-typedef bit_aligned_image1_type< 12, gray_layout_t >::type gray12_image_t;
-typedef bit_aligned_image1_type< 14, gray_layout_t >::type gray14_image_t;
-typedef bit_aligned_image1_type< 24, gray_layout_t >::type gray24_image_t;
+using gray1_image_t = bit_aligned_image1_type<1, gray_layout_t>::type;
+using gray2_image_t = bit_aligned_image1_type<2, gray_layout_t>::type;
+using gray4_image_t = bit_aligned_image1_type<4, gray_layout_t>::type;
+using gray6_image_t = bit_aligned_image1_type<6, gray_layout_t>::type;
+using gray10_image_t = bit_aligned_image1_type<10, gray_layout_t>::type;
+using gray12_image_t = bit_aligned_image1_type<12, gray_layout_t>::type;
+using gray14_image_t = bit_aligned_image1_type<14, gray_layout_t>::type;
+using gray24_image_t = bit_aligned_image1_type<24, gray_layout_t>::type;
 
-typedef pixel< double, gray_layout_t       > gray64f_pixel_t;
-
-#ifdef BOOST_GIL_IO_ENABLE_GRAY_ALPHA
-typedef pixel<  uint8_t, gray_alpha_layout_t > gray_alpha8_pixel_t;
-typedef pixel< uint16_t, gray_alpha_layout_t > gray_alpha16_pixel_t;
-typedef pixel<   double, gray_alpha_layout_t > gray_alpha64f_pixel_t;
-#endif // BOOST_GIL_IO_ENABLE_GRAY_ALPHA
-
-typedef pixel< double, rgb_layout_t        > rgb64f_pixel_t;
-typedef pixel< double, rgba_layout_t       > rgba64f_pixel_t;
-typedef image< gray64f_pixel_t      , false > gray64f_image_t;
+using gray64f_pixel_t = pixel<double, gray_layout_t>;
 
 #ifdef BOOST_GIL_IO_ENABLE_GRAY_ALPHA
-typedef image<  gray_alpha8_pixel_t, false  > gray_alpha8_image_t;
-typedef image<  gray_alpha16_pixel_t, false > gray_alpha16_image_t;
-typedef image< gray_alpha32f_pixel_t, false > gray_alpha32f_image_t;
-typedef image< gray_alpha32f_pixel_t, true  > gray_alpha32f_planar_image_t;
-typedef image< gray_alpha64f_pixel_t, false > gray_alpha64f_image_t;
-typedef image< gray_alpha64f_pixel_t, true  > gray_alpha64f_planar_image_t;
+using gray_alpha8_pixel_t = pixel<uint8_t, gray_alpha_layout_t>;
+using gray_alpha16_pixel_t = pixel<uint16_t, gray_alpha_layout_t>;
+using gray_alpha64f_pixel_t = pixel<double, gray_alpha_layout_t>;
+#endif // BOOST_GIL_IO_ENABLE_GRAY_ALPHA
+
+using rgb64f_pixel_t = pixel<double, rgb_layout_t>;
+using rgba64f_pixel_t = pixel<double, rgba_layout_t>;
+using gray64f_image_t = image<gray64f_pixel_t, false>;
+
+#ifdef BOOST_GIL_IO_ENABLE_GRAY_ALPHA
+using gray_alpha8_image_t = image<gray_alpha8_pixel_t, false>;
+using gray_alpha16_image_t = image<gray_alpha16_pixel_t, false>;
+using gray_alpha32f_image_t = image<gray_alpha32f_pixel_t, false>;
+using gray_alpha32f_planar_image_t = image<gray_alpha32f_pixel_t, true>;
+using gray_alpha64f_image_t = image<gray_alpha64f_pixel_t, false>;
+using gray_alpha64f_planar_image_t = image<gray_alpha64f_pixel_t, true>;
 
 #endif // BOOST_GIL_IO_ENABLE_GRAY_ALPHA
 
-typedef image< rgb64f_pixel_t       , false > rgb64f_image_t;
-typedef image< rgb64f_pixel_t       , true  > rgb64f_planar_image_t;
-typedef image< rgba64f_pixel_t      , false > rgba64f_image_t;
-typedef image< rgba64f_pixel_t      , true  > rgba64f_planar_image_t;
+using rgb64f_image_t = image<rgb64f_pixel_t, false>;
+using rgb64f_planar_image_t = image<rgb64f_pixel_t, true>;
+using rgba64f_image_t = image<rgba64f_pixel_t, false>;
+using rgba64f_planar_image_t = image<rgba64f_pixel_t, true>;
 
-} // namespace gil
-} // namespace boost
+}} // namespace boost::gil
 
 #endif

--- a/include/boost/gil/io/write_view.hpp
+++ b/include/boost/gil/io/write_view.hpp
@@ -68,9 +68,7 @@ void write_view( Device&          device
                                    >::type* /* ptr */ = nullptr
                )
 {
-    typedef typename get_writer< Device
-                               , FormatTag
-                               >::type writer_t;
+    using writer_t = typename get_writer<Device, FormatTag>::type;
 
     writer_t writer = make_writer( device
                                  , tag
@@ -98,9 +96,7 @@ void write_view( const String&    file_name
                                    >::type* /* ptr */ = nullptr
                )
 {
-    typedef typename get_writer< String
-                               , FormatTag
-                               >::type writer_t;
+    using writer_t = typename get_writer<String, FormatTag>::type;
 
     writer_t writer = make_writer( file_name
                                  , tag
@@ -132,9 +128,7 @@ void write_view( Device&                                 device
                                    >::type* /* ptr */ = nullptr
                )
 {
-    typedef typename get_writer< Device
-                               , FormatTag
-                               >::type writer_t;
+    using writer_t = typename get_writer<Device, FormatTag>::type;
 
     writer_t writer = make_writer( device
                                  , info
@@ -163,9 +157,7 @@ void write_view( const String&                             file_name
                                    >::type* /* ptr */ = nullptr
                )
 {
-    typedef typename get_writer< String
-                               , FormatTag
-                               >::type writer_t;
+    using writer_t = typename get_writer<String, FormatTag>::type;
 
     writer_t writer = make_writer( file_name
                                  , info
@@ -213,9 +205,7 @@ void write_view( Device&                        device
                                    >::type* /* ptr */ = 0
                )
 {
-    typedef typename get_dynamic_image_writer< Device
-                                             , FormatTag
-                                             >::type writer_t;
+    using writer_t = typename get_dynamic_image_writer<Device, FormatTag>::type;
 
     writer_t writer = make_dynamic_image_writer( device
                                                , tag
@@ -240,9 +230,11 @@ void write_view( const String&                  file_name
                                    >::type* /* ptr */ = nullptr
                )
 {
-    typedef typename get_dynamic_image_writer< String
-                                             , FormatTag
-                                             >::type writer_t;
+    using writer_t = typename get_dynamic_image_writer
+        <
+            String,
+            FormatTag
+        >::type;
 
     writer_t writer = make_dynamic_image_writer( file_name
                                                , tag
@@ -274,9 +266,11 @@ void write_view( Device&                           device
                                    >::type* /* ptr */ = 0
                )
 {
-    typedef typename get_dynamic_image_writer< Device
-                                             , FormatTag
-                                             >::type writer_t;
+    using writer_t = typename get_dynamic_image_writer
+        <
+            Device,
+            FormatTag
+        >::type;
 
     writer_t writer = make_dynamic_image_writer( device
                                                , info
@@ -304,9 +298,11 @@ void write_view( const String&                      file_name
                                    >::type* /* ptr */ = nullptr
                )
 {
-    typedef typename get_dynamic_image_writer< String
-                                             , FormatTag
-                                             >::type writer_t;
+    using writer_t = typename get_dynamic_image_writer
+        <
+            String,
+            FormatTag
+        >::type;
 
     writer_t writer = make_dynamic_image_writer( file_name
                                                , info
@@ -317,7 +313,6 @@ void write_view( const String&                      file_name
               );
 }
 
-} // namespace gil
-} // namespace boost
+}} // namespace boost::gil
 
 #endif


### PR DESCRIPTION
Run clang-tidy 7.0 with `-checks='-*,modernize-use-using' -fix` against single TU with `#include <boost/gil/io/*.hpp>`.

Manually refactor numerous `typedef`-s
- where missed by modernize-use-using check, not uncommon
- in code snippets in comments

Outcome is that searching for lower-case whole word `typedef` in all `io/*.hpp` should return no matches.

### References

- #192
- #193

### Tasklist

- [ ] Review
- [ ] Adjust for comments
- [x] All CI builds and checks have passed
