### PR TITLE
Apply clang-tidy modernize-use-using to extension/numeric

### DIFF
--- a/include/boost/gil/extension/numeric/algorithm.hpp
+++ b/include/boost/gil/extension/numeric/algorithm.hpp
@@ -20,7 +20,7 @@
 
 namespace boost { namespace gil {
 
-/// \brief Returns the reference proxy associated with a type that has a \p "reference" member typedef.
+/// \brief Returns the reference proxy associated with a type that has a \p "reference" member type alias.
 ///
 /// The reference proxy is the reference type, but with stripped-out C++ reference. It models PixelConcept
 template <typename T>
@@ -88,9 +88,9 @@ template <typename PixelAccum,typename SrcIterator,typename KernelIterator,typen
 inline DstIterator correlate_pixels_n(SrcIterator src_begin,SrcIterator src_end,
                                       KernelIterator ker_begin,Integer ker_size,
                                       DstIterator dst_begin) {
-    typedef typename pixel_proxy<typename std::iterator_traits<SrcIterator>::value_type>::type PIXEL_SRC_REF;
-    typedef typename pixel_proxy<typename std::iterator_traits<DstIterator>::value_type>::type PIXEL_DST_REF;
-    typedef typename std::iterator_traits<KernelIterator>::value_type kernel_type;
+    using PIXEL_SRC_REF = typename pixel_proxy<typename std::iterator_traits<SrcIterator>::value_type>::type;
+    using PIXEL_DST_REF = typename pixel_proxy<typename std::iterator_traits<DstIterator>::value_type>::type;
+    using kernel_type = typename std::iterator_traits<KernelIterator>::value_type;
     PixelAccum acc_zero; pixel_zeros_t<PixelAccum>()(acc_zero);
     while(src_begin!=src_end) {
         pixel_assigns_t<PixelAccum,PIXEL_DST_REF>()(
@@ -108,9 +108,9 @@ template <std::size_t Size,typename PixelAccum,typename SrcIterator,typename Ker
 inline DstIterator correlate_pixels_k(SrcIterator src_begin,SrcIterator src_end,
                                       KernelIterator ker_begin,
                                       DstIterator dst_begin) {
-    typedef typename pixel_proxy<typename std::iterator_traits<SrcIterator>::value_type>::type PIXEL_SRC_REF;
-    typedef typename pixel_proxy<typename std::iterator_traits<DstIterator>::value_type>::type PIXEL_DST_REF;
-    typedef typename std::iterator_traits<KernelIterator>::value_type kernel_type;
+    using PIXEL_SRC_REF = typename pixel_proxy<typename std::iterator_traits<SrcIterator>::value_type>::type;
+    using PIXEL_DST_REF = typename pixel_proxy<typename std::iterator_traits<DstIterator>::value_type>::type;
+    using kernel_type = typename std::iterator_traits<KernelIterator>::value_type;
     PixelAccum acc_zero; pixel_zeros_t<PixelAccum>()(acc_zero);
     while(src_begin!=src_end) {
         pixel_assigns_t<PixelAccum,PIXEL_DST_REF>()(
@@ -127,8 +127,8 @@ inline DstIterator correlate_pixels_k(SrcIterator src_begin,SrcIterator src_end,
 template <typename PixelAccum,typename SrcView,typename Scalar,typename DstView>
 inline void view_multiplies_scalar(const SrcView& src,const Scalar& scalar,const DstView& dst) {
     assert(src.dimensions()==dst.dimensions());
-    typedef typename pixel_proxy<typename SrcView::value_type>::type PIXEL_SRC_REF;
-    typedef typename pixel_proxy<typename DstView::value_type>::type PIXEL_DST_REF;
+    using PIXEL_SRC_REF = typename pixel_proxy<typename SrcView::value_type>::type;
+    using PIXEL_DST_REF = typename pixel_proxy<typename DstView::value_type>::type;
     int height=src.height();
     for(int rr=0;rr<height;++rr) {
         typename SrcView::x_iterator it_src=src.row_begin(rr);

--- a/include/boost/gil/extension/numeric/convolve.hpp
+++ b/include/boost/gil/extension/numeric/convolve.hpp
@@ -44,8 +44,8 @@ void correlate_rows_imp(const SrcView& src, const Kernel& ker, const DstView& ds
     assert(src.dimensions()==dst.dimensions());
     assert(ker.size()!=0);
 
-    typedef typename pixel_proxy<typename SrcView::value_type>::type PIXEL_SRC_REF;
-    typedef typename pixel_proxy<typename DstView::value_type>::type PIXEL_DST_REF;
+    using PIXEL_SRC_REF = typename pixel_proxy<typename SrcView::value_type>::type;
+    using PIXEL_DST_REF = typename pixel_proxy<typename DstView::value_type>::type;
 
     if(ker.size()==1) {//reduces to a multiplication
         view_multiplies_scalar<PixelAccum>(src,*ker.begin(),dst);

--- a/include/boost/gil/extension/numeric/kernel.hpp
+++ b/include/boost/gil/extension/numeric/kernel.hpp
@@ -52,8 +52,9 @@ public:
 
 /// \brief variable-size kernel
 template <typename T, typename Alloc = std::allocator<T> >
-class kernel_1d : public detail::kernel_1d_adaptor<std::vector<T,Alloc> > {
-    typedef detail::kernel_1d_adaptor<std::vector<T,Alloc> > parent_t;
+class kernel_1d : public detail::kernel_1d_adaptor<std::vector<T,Alloc>>
+{
+    using parent_t = detail::kernel_1d_adaptor<std::vector<T,Alloc>>;
 public:
     kernel_1d() {}
     kernel_1d(std::size_t size_in,std::size_t center_in) : parent_t(size_in,center_in) {}
@@ -66,8 +67,9 @@ public:
 
 /// \brief static-size kernel
 template <typename T,std::size_t Size>
-class kernel_1d_fixed : public detail::kernel_1d_adaptor<std::array<T,Size> > {
-    typedef detail::kernel_1d_adaptor<std::array<T,Size> > parent_t;
+class kernel_1d_fixed : public detail::kernel_1d_adaptor<std::array<T,Size>>
+{
+    using parent_t = detail::kernel_1d_adaptor<std::array<T,Size>>;
 public:
     kernel_1d_fixed() {}
     explicit kernel_1d_fixed(std::size_t center_in) : parent_t(center_in) {}

--- a/include/boost/gil/extension/numeric/sampler.hpp
+++ b/include/boost/gil/extension/numeric/sampler.hpp
@@ -50,7 +50,7 @@ bool sample(nearest_neighbor_sampler, SrcView const& src, point<F> const& p, Dst
 struct cast_channel_fn {
     template <typename SrcChannel, typename DstChannel>
     void operator()(const SrcChannel& src, DstChannel& dst) {
-        typedef typename channel_traits<DstChannel>::value_type dst_value_t;
+        using dst_value_t = typename channel_traits<DstChannel>::value_type;
         dst = dst_value_t(src);
     }
 };


### PR DESCRIPTION
Run clang-tidy 7.0 with `-checks='-*,modernize-use-using' -fix` against
single TU with `#include <boost/gil/extension/numeric/*.hpp>`.

Manually refactor numerous `typedef`-s
- where missed by modernize-use-using check, not uncommon
- in code snippets in comments

Outcome is that searching for lower-case whole word `typedef`
in all the `extension/numeric/*.hpp` should return no matches,

### References

- #192
- #193
- #195

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed
