### PR TITLE
Apply clang-tidy modernize-use-using to extension/io

### DIFF
--- a/include/boost/gil/extension/io/bmp/detail/is_allowed.hpp
+++ b/include/boost/gil/extension/io/bmp/detail/is_allowed.hpp
@@ -64,7 +64,7 @@ bool is_allowed( const image_read_info< bmp_tag >& info
         }
     }
 
-    typedef typename channel_traits< typename element_type< typename View::value_type >::type >::value_type channel_t;
+    using channel_t = typename channel_traits<typename element_type<typename View::value_type>::type>::value_type;
     bmp_bits_per_pixel::type dst_bits_per_pixel = detail::unsigned_integral_num_bits< channel_t >::value
                                                 * num_channels< View >::value;
 

--- a/include/boost/gil/extension/io/bmp/detail/read.hpp
+++ b/include/boost/gil/extension/io/bmp/detail/read.hpp
@@ -52,16 +52,12 @@ class reader< Device
 {
 private:
 
-    typedef reader< Device
-                  , bmp_tag
-                  , ConversionPolicy
-                  > this_t;
-
-    typedef typename ConversionPolicy::color_converter_type cc_t;
+    using this_t = reader<Device, bmp_tag, ConversionPolicy>;
+    using cc_t = typename ConversionPolicy::color_converter_type;
 
 public:
 
-    typedef reader_backend< Device, bmp_tag > backend_t;
+    using backend_t = reader_backend< Device, bmp_tag>;
 
 public:
 
@@ -103,9 +99,11 @@ public:
             io_error( "Image header was not read." );
         }
 
-        typedef typename is_same< ConversionPolicy
-                                , detail::read_and_no_convert
-                                >::type is_read_and_convert_t;
+        using is_read_and_convert_t = typename is_same
+            <
+                ConversionPolicy,
+                detail::read_and_no_convert
+            >::type;
 
         io_error_if( !detail::is_allowed< View >( this->_info
                                                 , is_read_and_convert_t()
@@ -263,8 +261,8 @@ private:
     {
         this->read_palette();
 
-        typedef detail::row_buffer_helper_view< View_Src > rh_t;
-        typedef typename rh_t::iterator_t          it_t;
+        using rh_t = detail::row_buffer_helper_view<View_Src>;
+        using it_t = typename rh_t::iterator_t;
 
         rh_t rh( _pitch, true );
 
@@ -347,8 +345,8 @@ private:
             io_error( "bmp_reader::apply(): unsupported BMP compression" );
         }
 
-        typedef rgb8_image_t image_t;
-        typedef typename image_t::view_t::x_iterator it_t;
+        using image_t = rgb8_image_t;
+        using it_t = typename image_t::view_t::x_iterator;
 
         for( std::ptrdiff_t y = 0
            ; y < this->_settings._dim.y
@@ -463,7 +461,7 @@ private:
         // we need to know the stream position for padding purposes
         std::size_t stream_pos = this->_info._offset;
 
-        typedef std::vector< rgba8_pixel_t > Buf_type;
+        using Buf_type = std::vector<rgba8_pixel_t>;
         Buf_type buf( this->_settings._dim.x );
         Buf_type::iterator dst_it  = buf.begin();
         Buf_type::iterator dst_end = buf.end();
@@ -695,10 +693,7 @@ class dynamic_image_reader< Device
                    , detail::read_and_no_convert
                    >
 {
-    typedef reader< Device
-                  , bmp_tag
-                  , detail::read_and_no_convert
-                  > parent_t;
+    using parent_t = reader<Device, bmp_tag, detail::read_and_no_convert>;
 
 public:
 

--- a/include/boost/gil/extension/io/bmp/detail/reader_backend.hpp
+++ b/include/boost/gil/extension/io/bmp/detail/reader_backend.hpp
@@ -44,7 +44,7 @@ struct reader_backend< Device
 {
 public:
 
-    typedef bmp_tag format_tag_t;
+    using format_tag_t = bmp_tag;
 
 public:
 

--- a/include/boost/gil/extension/io/bmp/detail/scanline_read.hpp
+++ b/include/boost/gil/extension/io/bmp/detail/scanline_read.hpp
@@ -39,10 +39,10 @@ class scanline_reader< Device
 {
 public:
 
-    typedef bmp_tag tag_t;
-    typedef reader_backend < Device, tag_t > backend_t;
-    typedef scanline_reader< Device, tag_t > this_t;
-    typedef scanline_read_iterator< this_t > iterator_t;
+    using tag_t = bmp_tag;
+    using backend_t = reader_backend<Device, tag_t>;
+    using this_t = scanline_reader<Device, tag_t>;
+    using iterator_t = scanline_read_iterator<this_t>;
 
 public:
 
@@ -302,8 +302,8 @@ private:
     template< typename View >
     void read_bit_row( byte_t* dst )
     {
-        typedef View src_view_t;
-        typedef rgba8_image_t::view_t dst_view_t;
+        using src_view_t = View;
+        using dst_view_t = rgba8_image_t::view_t;
 
         src_view_t src_view = interleaved_view( this->_info._width
                                               , 1
@@ -360,7 +360,7 @@ private:
     /// Read 15 or 16 bits image.
     void read_15_bits_row( byte_t* dst )
     {
-        typedef rgb8_view_t dst_view_t;
+        using dst_view_t = rgb8_view_t;
 
         dst_view_t dst_view = interleaved_view( this->_info._width
                                               , 1

--- a/include/boost/gil/extension/io/bmp/detail/supported_types.hpp
+++ b/include/boost/gil/extension/io/bmp/detail/supported_types.hpp
@@ -116,9 +116,11 @@ struct is_read_supported< Pixel
                                           >::is_supported
                 >
 {
-    typedef detail::bmp_read_support< typename channel_type< Pixel >::type
-                                    , typename color_space_type< Pixel >::type
-                                    > parent_t;
+    using parent_t = detail::bmp_read_support
+        <
+            typename channel_type<Pixel>::type,
+            typename color_space_type<Pixel>::type
+        >;
 
     static const typename bmp_bits_per_pixel::type bpp = parent_t::bpp;
 };

--- a/include/boost/gil/extension/io/bmp/detail/write.hpp
+++ b/include/boost/gil/extension/io/bmp/detail/write.hpp
@@ -37,9 +37,9 @@ struct bmp_write_is_supported
 };
 
 template < int N > struct get_bgr_cs {};
-template <> struct get_bgr_cs< 1 > { typedef gray8_view_t type; };
-template <> struct get_bgr_cs< 3 > { typedef bgr8_view_t type;  };
-template <> struct get_bgr_cs< 4 > { typedef bgra8_view_t type; };
+template <> struct get_bgr_cs< 1 > { using type = gray8_view_t; };
+template <> struct get_bgr_cs< 3 > { using type = bgr8_view_t;  };
+template <> struct get_bgr_cs< 4 > { using type = bgra8_view_t; };
 
 } // namespace detail
 
@@ -72,15 +72,15 @@ public:
 
 private:
 
-    typedef writer_backend< Device, bmp_tag > backend_t;
+    using backend_t = writer_backend<Device, bmp_tag>;
 
     template< typename View >
     void write( const View& view )
     {
-        // typedef typename channel_type<
-        //             typename get_pixel_type< View >::type >::type channel_t;
+        // using channel_t = typename channel_type<
+        //             typename get_pixel_type<View>::type>::type;
 
-        // typedef typename color_space_type< View >::type color_space_t;
+        // using color_space_t = typename color_space_type<View>::type;
 
         // check if supported
 /*
@@ -182,9 +182,7 @@ class dynamic_image_writer< Device
                    , bmp_tag
                    >
 {
-    typedef writer< Device
-                  , bmp_tag
-                  > parent_t;
+    using parent_t = writer<Device, bmp_tag>;
 
 public:
 

--- a/include/boost/gil/extension/io/bmp/detail/writer_backend.hpp
+++ b/include/boost/gil/extension/io/bmp/detail/writer_backend.hpp
@@ -27,7 +27,7 @@ struct writer_backend< Device
 {
 public:
 
-    typedef bmp_tag format_tag_t;
+    using format_tag_t = bmp_tag;
 
 public:
 

--- a/include/boost/gil/extension/io/jpeg/detail/read.hpp
+++ b/include/boost/gil/extension/io/jpeg/detail/read.hpp
@@ -49,16 +49,12 @@ class reader< Device
 {
 private:
 
-    typedef reader< Device
-                  , jpeg_tag
-                  , ConversionPolicy
-                  > this_t;
-
-    typedef typename ConversionPolicy::color_converter_type cc_t;
+    using this_t = reader<Device, jpeg_tag, ConversionPolicy>;
+    using cc_t = typename ConversionPolicy::color_converter_type;
 
 public:
 
-    typedef reader_backend< Device, jpeg_tag > backend_t;
+    using backend_t = reader_backend<Device, jpeg_tag>;
 
 public:
 
@@ -103,9 +99,11 @@ public:
 
         this->get()->dct_method = this->_settings._dct_method;
 
-        typedef typename is_same< ConversionPolicy
-                                , detail::read_and_no_convert
-                                >::type is_read_and_convert_t;
+        using is_read_and_convert_t = typename is_same
+            <
+                ConversionPolicy,
+                detail::read_and_no_convert
+            >::type;
 
         io_error_if( !detail::is_allowed< View >( this->_info
                                                 , is_read_and_convert_t()
@@ -162,7 +160,7 @@ private:
             >
     void read_rows( const View& view )
     {
-        typedef std::vector<ImagePixel> buffer_t;
+        using buffer_t = std::vector<ImagePixel>;
         buffer_t buffer( this->_info._width );
 
         // In case of an error we'll jump back to here and fire an exception.
@@ -265,10 +263,7 @@ class dynamic_image_reader< Device
                    , detail::read_and_no_convert
                    >
 {
-    typedef reader< Device
-                  , jpeg_tag
-                  , detail::read_and_no_convert
-                  > parent_t;
+    using parent_t = reader<Device, jpeg_tag, detail::read_and_no_convert>;
 
 public:
 

--- a/include/boost/gil/extension/io/jpeg/detail/reader_backend.hpp
+++ b/include/boost/gil/extension/io/jpeg/detail/reader_backend.hpp
@@ -80,7 +80,7 @@ struct reader_backend< Device
 {
 public:
 
-    typedef jpeg_tag format_tag_t;
+    using format_tag_t = jpeg_tag;
 
 public:
     //

--- a/include/boost/gil/extension/io/jpeg/detail/scanline_read.hpp
+++ b/include/boost/gil/extension/io/jpeg/detail/scanline_read.hpp
@@ -43,10 +43,10 @@ class scanline_reader< Device
 {
 public:
 
-    typedef jpeg_tag tag_t;
-    typedef reader_backend < Device, tag_t > backend_t;
-    typedef scanline_reader< Device, tag_t > this_t;
-    typedef scanline_read_iterator< this_t > iterator_t;
+    using tag_t = jpeg_tag;
+    using backend_t = reader_backend<Device, tag_t>;
+    using this_t = scanline_reader<Device, tag_t>;
+    using iterator_t = scanline_read_iterator<this_t>;
 
 public:
     scanline_reader( Device&                                device

--- a/include/boost/gil/extension/io/jpeg/detail/supported_types.hpp
+++ b/include/boost/gil/extension/io/jpeg/detail/supported_types.hpp
@@ -87,9 +87,11 @@ struct is_read_supported< Pixel
                                            >::is_supported
                 >
 {
-    typedef detail::jpeg_read_support< typename channel_type< Pixel >::type
-                                     , typename color_space_type< Pixel >::type
-                                     > parent_t;
+    using parent_t = detail::jpeg_read_support
+        <
+            typename channel_type<Pixel>::type,
+            typename color_space_type<Pixel>::type
+        >;
 
     static const typename jpeg_color_space::type _color_space = parent_t::_color_space;
 };

--- a/include/boost/gil/extension/io/jpeg/detail/write.hpp
+++ b/include/boost/gil/extension/io/jpeg/detail/write.hpp
@@ -53,9 +53,7 @@ class writer< Device
 {
 public:
 
-    typedef writer_backend< Device
-                          , jpeg_tag
-                          > backend_t;
+    using backend_t = writer_backend<Device, jpeg_tag>;
 
 public:
 
@@ -89,7 +87,7 @@ private:
         //       the setjmp.
         if( setjmp( this->_mark )) { this->raise_error(); }
 
-        typedef typename channel_type< typename View::value_type >::type channel_t;
+        using channel_t = typename channel_type<typename View::value_type>::type;
 
         this->get()->image_width      = JDIMENSION( view.width()  );
         this->get()->image_height     = JDIMENSION( view.height() );
@@ -148,9 +146,7 @@ class dynamic_image_writer< Device
                    , jpeg_tag
                    >
 {
-    typedef writer< Device
-                  , jpeg_tag
-                  > parent_t;
+    using parent_t = writer<Device, jpeg_tag>;
 
 public:
 

--- a/include/boost/gil/extension/io/jpeg/detail/writer_backend.hpp
+++ b/include/boost/gil/extension/io/jpeg/detail/writer_backend.hpp
@@ -79,7 +79,7 @@ struct writer_backend< Device
 {
 public:
 
-    typedef jpeg_tag format_tag_t;
+    using format_tag_t = jpeg_tag;
 
 public:
     ///

--- a/include/boost/gil/extension/io/png/detail/is_allowed.hpp
+++ b/include/boost/gil/extension/io/png/detail/is_allowed.hpp
@@ -20,10 +20,9 @@ bool is_allowed( const image_read_info< png_tag >& info
                , mpl::true_   // is read_and_no_convert
                )
 {
-    typedef typename get_pixel_type< View >::type pixel_t;
+    using pixel_t = typename get_pixel_type<View>::type;
 
-    typedef typename channel_traits<
-                typename element_type< pixel_t >::type >::value_type channel_t;
+    using channel_t = typename channel_traits<typename element_type<pixel_t>::type>::value_type;
 
     const png_num_channels::type dst_num_channels = num_channels< pixel_t >::value;
     const png_bitdepth::type     dst_bit_depth    = detail::unsigned_integral_num_bits< channel_t >::value;

--- a/include/boost/gil/extension/io/png/detail/read.hpp
+++ b/include/boost/gil/extension/io/png/detail/read.hpp
@@ -46,16 +46,12 @@ class reader< Device
 {
 private:
 
-    typedef reader< Device
-                  , png_tag
-                  , ConversionPolicy
-                  > this_t;
-
-    typedef typename ConversionPolicy::color_converter_type cc_t;
+    using this_t = reader<Device, png_tag, ConversionPolicy>;
+    using cc_t = typename ConversionPolicy::color_converter_type;
 
 public:
 
-    typedef reader_backend< Device, png_tag > backend_t;
+    using backend_t = reader_backend<Device, png_tag>;
 
 public:
 
@@ -232,13 +228,15 @@ private:
             >
     void read_rows( const View& view )
     {
-        typedef detail::row_buffer_helper_view< ImagePixel > row_buffer_helper_t;
+        using row_buffer_helper_t = detail::row_buffer_helper_view<ImagePixel>;
 
-        typedef typename row_buffer_helper_t::iterator_t it_t;
+        using it_t = typename row_buffer_helper_t::iterator_t;
 
-        typedef typename is_same< ConversionPolicy
-                                , detail::read_and_no_convert
-                                >::type is_read_and_convert_t;
+        using is_read_and_convert_t = typename is_same
+            <
+                ConversionPolicy,
+                detail::read_and_no_convert
+            >::type;
 
         io_error_if( !detail::is_allowed< View >( this->_info
                                                 , is_read_and_convert_t()
@@ -338,9 +336,11 @@ struct png_type_format_checker
     template< typename Image >
     bool apply()
     {
-        typedef is_read_supported< typename get_pixel_type< typename Image::view_t >::type
-                                 , png_tag
-                                 > is_supported_t;
+        using is_supported_t = is_read_supported
+            <
+                typename get_pixel_type<typename Image::view_t>::type,
+                png_tag
+            >;
 
         return is_supported_t::_bit_depth  == _bit_depth
             && is_supported_t::_color_type == _color_type;
@@ -377,10 +377,12 @@ class dynamic_image_reader< Device
                    , detail::read_and_no_convert
                    >
 {
-    typedef reader< Device
-                  , png_tag
-                  , detail::read_and_no_convert
-                  > parent_t;
+    using parent_t = reader
+        <
+            Device,
+            png_tag,
+            detail::read_and_no_convert
+        >;
 
 public:
 

--- a/include/boost/gil/extension/io/png/detail/reader_backend.hpp
+++ b/include/boost/gil/extension/io/png/detail/reader_backend.hpp
@@ -31,14 +31,8 @@ struct reader_backend< Device
 {
 public:
 
-    typedef png_tag format_tag_t;
-
-public:
-
-    typedef reader_backend< Device
-                          , png_tag
-                          > this_t;
-
+    using format_tag_t = png_tag;
+    using this_t = reader_backend<Device, png_tag>;
 
 public:
 

--- a/include/boost/gil/extension/io/png/detail/scanline_read.hpp
+++ b/include/boost/gil/extension/io/png/detail/scanline_read.hpp
@@ -35,12 +35,10 @@ class scanline_reader< Device
 {
 public:
 
-    typedef png_tag tag_t;
-    typedef reader_backend < Device, tag_t > backend_t;
-    typedef scanline_reader< Device, tag_t > this_t;
-    typedef scanline_read_iterator< this_t > iterator_t;
-
-public:
+    using tag_t = png_tag;
+    using backend_t = reader_backend<Device, tag_t>;
+    using this_t = scanline_reader<Device, tag_t>;
+    using iterator_t = scanline_read_iterator<this_t>;
 
     //
     // Constructor

--- a/include/boost/gil/extension/io/png/detail/supported_types.hpp
+++ b/include/boost/gil/extension/io/png/detail/supported_types.hpp
@@ -327,9 +327,11 @@ struct is_read_supported< Pixel
                                           >::is_supported
                 >
 {
-    typedef detail::png_read_support< typename channel_type< Pixel >::type
-                                    , typename color_space_type< Pixel >::type
-                                    > parent_t;
+    using parent_t = detail::png_read_support
+        <
+            typename channel_type<Pixel>::type,
+            typename color_space_type<Pixel>::type
+        >;
 
     static const png_bitdepth::type   _bit_depth  = parent_t::_bit_depth;
     static const png_color_type::type _color_type = parent_t::_color_type;
@@ -344,9 +346,11 @@ struct is_write_supported< Pixel
                                            >::is_supported
                 >
 {
-    typedef detail::png_write_support< typename channel_type< Pixel >::type
-                                     , typename color_space_type< Pixel >::type
-                                     > parent_t;
+    using parent_t = detail::png_write_support
+        <
+            typename channel_type<Pixel>::type,
+            typename color_space_type<Pixel>::type
+        >;
 
     static const png_bitdepth::type   _bit_depth  = parent_t::_bit_depth;
     static const png_color_type::type _color_type = parent_t::_color_type;

--- a/include/boost/gil/extension/io/png/detail/write.hpp
+++ b/include/boost/gil/extension/io/png/detail/write.hpp
@@ -54,7 +54,7 @@ class writer< Device
 
 public:
 
-    typedef writer_backend< Device , png_tag > backend_t;
+    using backend_t = writer_backend<Device, png_tag>;
 
     writer( const Device&                      io_dev
           , const image_write_info< png_tag >& info
@@ -86,11 +86,13 @@ private:
                    ,  mpl::false_       // is bit aligned
                    )
     {
-        typedef typename get_pixel_type< View >::type pixel_t;
+        using pixel_t = typename get_pixel_type<View>::type;
 
-        typedef detail::png_write_support< typename channel_type    < pixel_t >::type
-                                         , typename color_space_type< pixel_t >::type
-                                         > png_rw_info;
+        using png_rw_info = detail::png_write_support
+            <
+                typename channel_type<pixel_t>::type,
+                typename color_space_type<pixel_t>::type
+            >;
 
         if( little_endian() )
         {
@@ -124,11 +126,11 @@ private:
                    , mpl::true_         // is bit aligned
                    )
     {
-        typedef detail::png_write_support< typename kth_semantic_element_type< typename View::value_type
-                                                                             , 0
-                                                                             >::type
-                                         , typename color_space_type<View>::type
-                                         > png_rw_info;
+        using png_rw_info = detail::png_write_support
+            <
+                typename kth_semantic_element_type<typename View::value_type, 0>::type,
+                typename color_space_type<View>::type
+            >;
 
         if (little_endian() )
         {
@@ -197,9 +199,7 @@ class dynamic_image_writer< Device
                    , png_tag
                    >
 {
-    typedef writer< Device
-                  , png_tag
-                  > parent_t;
+    using parent_t = writer<Device, png_tag>;
 
 public:
 

--- a/include/boost/gil/extension/io/png/detail/writer_backend.hpp
+++ b/include/boost/gil/extension/io/png/detail/writer_backend.hpp
@@ -35,15 +35,11 @@ struct writer_backend< Device
 
 private:
 
-    typedef writer_backend< Device
-                          , png_tag
-                          > this_t;
+    using this_t = writer_backend<Device, png_tag>;
 
 public:
 
-    typedef png_tag format_tag_t;
-
-public:
+    using format_tag_t = png_tag;
 
     ///
     /// Constructor
@@ -102,9 +98,11 @@ protected:
     template< typename View >
     void write_header( const View& view )
     {
-        typedef detail::png_write_support< typename channel_type< typename get_pixel_type< View >::type >::type
-                                         , typename color_space_type< View >::type
-                                         > png_rw_info_t;
+        using png_rw_info_t = detail::png_write_support
+            <
+                typename channel_type<typename get_pixel_type<View>::type>::type,
+                typename color_space_type<View>::type
+            >;
 
         // Set the image information here.  Width and height are up to 2^31,
         // bit_depth is one of 1, 2, 4, 8, or 16, but valid values also depend on

--- a/include/boost/gil/extension/io/pnm/detail/read.hpp
+++ b/include/boost/gil/extension/io/pnm/detail/read.hpp
@@ -53,18 +53,12 @@ class reader< Device
 
 private:
 
-    typedef reader< Device
-                  , pnm_tag
-                  , ConversionPolicy
-                  > this_t;
-
-    typedef typename ConversionPolicy::color_converter_type cc_t;
+    using this_t = reader<Device, pnm_tag, ConversionPolicy>;
+    using cc_t = typename ConversionPolicy::color_converter_type;
 
 public:
 
-    typedef reader_backend< Device, pnm_tag > backend_t;
-
-public:
+    using backend_t = reader_backend<Device, pnm_tag>;
 
     reader( const Device&                         io_dev
           , const image_read_settings< pnm_tag >& settings
@@ -92,9 +86,11 @@ public:
     template<typename View>
     void apply( const View& view )
     {
-        typedef typename is_same< ConversionPolicy
-                                , detail::read_and_no_convert
-                                >::type is_read_and_convert_t;
+        using is_read_and_convert_t = typename is_same
+            <
+                ConversionPolicy,
+                detail::read_and_no_convert
+            >::type;
 
         io_error_if( !detail::is_allowed< View >( this->_info
                                                 , is_read_and_convert_t()
@@ -162,7 +158,7 @@ private:
             >
     void read_text_data( const View_Dst& dst )
     {
-        typedef typename View_Dst::y_coord_t y_t;
+        using y_t = typename View_Dst::y_coord_t;
 
         byte_vector_t row( this->_scanline_length );
 
@@ -220,7 +216,7 @@ private:
 
                 if( this->_info._max_value == 1 )
                 {
-                    typedef typename channel_type< typename get_pixel_type< View_Dst >::type >::type channel_t;
+                    using channel_t = typename channel_type<typename get_pixel_type<View_Dst>::type>::type;
 
                     // for pnm format 0 is white
                     row[x] = ( value != 0 )
@@ -304,11 +300,10 @@ private:
             >
     void read_bin_data( const View_Dst& view )
     {
-        typedef typename View_Dst::y_coord_t y_t;
-        typedef typename is_bit_aligned<
-                    typename View_Src::value_type >::type is_bit_aligned_t;
+        using y_t = typename View_Dst::y_coord_t;
+        using is_bit_aligned_t = typename is_bit_aligned<typename View_Src::value_type>::type;
 
-        typedef detail::row_buffer_helper_view< View_Src > rh_t;
+        using rh_t = detail::row_buffer_helper_view<View_Src>;
         rh_t rh( this->_scanline_length, true );
 
         typename rh_t::iterator_t beg = rh.begin() + this->_settings._top_left.x;
@@ -366,9 +361,11 @@ struct pnm_type_format_checker
     template< typename Image >
     bool apply()
     {
-        typedef is_read_supported< typename get_pixel_type< typename Image::view_t >::type
-                                 , pnm_tag
-                                 > is_supported_t;
+        using is_supported_t = is_read_supported
+            <
+                typename get_pixel_type<typename Image::view_t>::type,
+                pnm_tag
+            >;
 
         return is_supported_t::_asc_type == _type
             || is_supported_t::_bin_type == _type;
@@ -403,10 +400,12 @@ class dynamic_image_reader< Device
                    , detail::read_and_no_convert
                    >
 {
-    typedef reader< Device
-                  , pnm_tag
-                  , detail::read_and_no_convert
-                  > parent_t;
+    using parent_t = reader
+        <
+            Device,
+            pnm_tag,
+            detail::read_and_no_convert
+        >;
 
 public:
 

--- a/include/boost/gil/extension/io/pnm/detail/reader_backend.hpp
+++ b/include/boost/gil/extension/io/pnm/detail/reader_backend.hpp
@@ -27,7 +27,7 @@ struct reader_backend< Device
 {
 public:
 
-    typedef pnm_tag format_tag_t;
+    using format_tag_t = pnm_tag;
 
 public:
 

--- a/include/boost/gil/extension/io/pnm/detail/scanline_read.hpp
+++ b/include/boost/gil/extension/io/pnm/detail/scanline_read.hpp
@@ -41,11 +41,10 @@ class scanline_reader< Device
 {
 public:
 
-    typedef pnm_tag tag_t;
-    typedef reader_backend < Device, tag_t > backend_t;
-    typedef scanline_reader< Device, tag_t > this_t;
-    typedef scanline_read_iterator< this_t > iterator_t;
-
+    using tag_t = pnm_tag;
+    using backend_t = reader_backend<Device, tag_t>;
+    using this_t = scanline_reader<Device, tag_t>;
+    using iterator_t = scanline_read_iterator<this_t>;
 
 public:
     scanline_reader( Device&                                device

--- a/include/boost/gil/extension/io/pnm/detail/supported_types.hpp
+++ b/include/boost/gil/extension/io/pnm/detail/supported_types.hpp
@@ -114,9 +114,11 @@ struct is_read_supported< Pixel
                                           >::is_supported
                 >
 {
-    typedef detail::pnm_read_support< typename channel_type    < Pixel >::type
-                                    , typename color_space_type< Pixel >::type
-                                    > parent_t;
+    using parent_t = detail::pnm_read_support
+        <
+            typename channel_type<Pixel>::type,
+            typename color_space_type<Pixel>::type
+        >;
 
     static const pnm_image_type::type _asc_type = parent_t::_asc_type;
     static const pnm_image_type::type _bin_type = parent_t::_bin_type;

--- a/include/boost/gil/extension/io/pnm/detail/write.hpp
+++ b/include/boost/gil/extension/io/pnm/detail/write.hpp
@@ -52,7 +52,7 @@ class writer< Device
                            >
 {
 private:
-    typedef writer_backend< Device, pnm_tag > backend_t;
+    using backend_t = writer_backend<Device, pnm_tag>;
 
 public:
 
@@ -67,7 +67,7 @@ public:
     template< typename View >
     void apply( const View& view )
     {
-        typedef typename get_pixel_type< View >::type pixel_t;
+        using pixel_t = typename get_pixel_type<View>::type;
 
         std::size_t width  = view.width();
         std::size_t height = view.height();
@@ -138,7 +138,7 @@ private:
 
         byte_vector_t row( pitch / 8 );
 
-        typedef typename View::x_iterator x_it_t;
+        using x_it_t = typename View::x_iterator;
         x_it_t row_it = x_it_t( &( *row.begin() ));
 
         detail::negate_bits< byte_vector_t
@@ -177,8 +177,8 @@ private:
                           >
                    > buf( src.width() );
 
-        // typedef typename View::value_type pixel_t;
-        // typedef typename view_type_from_pixel< pixel_t >::type view_t;
+        // using pixel_t = typename View::value_type;
+        // using view_t = typename view_type_from_pixel< pixel_t >::type;
 
         //view_t row = interleaved_view( src.width()
         //                             , 1
@@ -223,9 +223,7 @@ class dynamic_image_writer< Device
                    , pnm_tag
                    >
 {
-    typedef writer< Device
-                  , pnm_tag
-                  > parent_t;
+    using parent_t = writer<Device, pnm_tag>;
 
 public:
 

--- a/include/boost/gil/extension/io/pnm/detail/writer_backend.hpp
+++ b/include/boost/gil/extension/io/pnm/detail/writer_backend.hpp
@@ -27,7 +27,7 @@ struct writer_backend< Device
 {
 public:
 
-    typedef pnm_tag format_tag_t;
+    using format_tag_t = pnm_tag;
 
 public:
 

--- a/include/boost/gil/extension/io/pnm/tags.hpp
+++ b/include/boost/gil/extension/io/pnm/tags.hpp
@@ -24,13 +24,13 @@ struct pnm_tag : format_tag {};
 /// Defines type for image type property.
 struct pnm_image_type : property_base< uint32_t >
 {
-    typedef boost::mpl::integral_c< type, 1 > mono_asc_t;
-    typedef boost::mpl::integral_c< type, 2 > gray_asc_t;
-    typedef boost::mpl::integral_c< type, 3 > color_asc_t;
+    using mono_asc_t = boost::mpl::integral_c<type, 1>;
+    using gray_asc_t = boost::mpl::integral_c<type, 2>;
+    using color_asc_t = boost::mpl::integral_c<type, 3>;
 
-    typedef boost::mpl::integral_c< type, 4 > mono_bin_t;
-    typedef boost::mpl::integral_c< type, 5 > gray_bin_t;
-    typedef boost::mpl::integral_c< type, 6 > color_bin_t;
+    using mono_bin_t = boost::mpl::integral_c<type, 4>;
+    using gray_bin_t = boost::mpl::integral_c<type, 5>;
+    using color_bin_t = boost::mpl::integral_c<type, 6>;
 };
 
 /// Defines type for image width property.

--- a/include/boost/gil/extension/io/raw/detail/device.hpp
+++ b/include/boost/gil/extension/io/raw/detail/device.hpp
@@ -125,7 +125,7 @@ struct is_adaptable_input_device< FormatTag
                                 >
     : mpl::true_
 {
-    typedef file_stream_device< FormatTag > device_type;
+    using device_type = file_stream_device<FormatTag>;
 };
 
 

--- a/include/boost/gil/extension/io/raw/detail/is_allowed.hpp
+++ b/include/boost/gil/extension/io/raw/detail/is_allowed.hpp
@@ -18,9 +18,9 @@ bool is_allowed( const image_read_info< raw_tag >& info
                , mpl::true_   // is read_and_no_convert
                )
 {
-    typedef typename get_pixel_type< View >::type pixel_t;
-    typedef typename num_channels< pixel_t >::value_type num_channel_t;
-    typedef typename channel_traits< typename element_type< typename View::value_type >::type >::value_type channel_t;
+    using pixel_t = typename get_pixel_type<View>::type;
+    using num_channel_t = typename num_channels<pixel_t>::value_type;
+    using channel_t = typename channel_traits<typename element_type<typename View::value_type>::type>::value_type;
 
     const num_channel_t dst_samples_per_pixel = num_channels< pixel_t >::value;
     const unsigned int  dst_bits_per_pixel    = detail::unsigned_integral_num_bits< channel_t >::value;

--- a/include/boost/gil/extension/io/raw/detail/read.hpp
+++ b/include/boost/gil/extension/io/raw/detail/read.hpp
@@ -58,18 +58,12 @@ class reader< Device
 {
 private:
 
-    typedef reader< Device
-                  , raw_tag
-                  , ConversionPolicy
-                  > this_t;
-
-    typedef typename ConversionPolicy::color_converter_type cc_t;
+    using this_t = reader<Device, raw_tag, ConversionPolicy>;
+    using cc_t = typename ConversionPolicy::color_converter_type;
 
 public:
 
-    typedef reader_backend< Device, raw_tag > backend_t;
-
-public:
+    using backend_t = reader_backend<Device, raw_tag>;
 
     //
     // Constructor
@@ -105,9 +99,11 @@ public:
             io_error( "Image header was not read." );
         }
 
-        typedef typename is_same< ConversionPolicy
-                                , detail::read_and_no_convert
-                                >::type is_read_and_convert_t;
+        using is_read_and_convert_t = typename is_same
+            <
+                ConversionPolicy,
+                detail::read_and_no_convert
+            >::type;
 
         io_error_if( !detail::is_allowed< View >( this->_info
                                                 , is_read_and_convert_t()
@@ -167,7 +163,7 @@ struct raw_type_format_checker
     template< typename Image >
     bool apply()
     {
-        typedef typename Image::view_t view_t;
+        using view_t = typename Image::view_t;
 
         return is_allowed< view_t >( _info
                                    , mpl::true_()
@@ -193,10 +189,7 @@ class dynamic_image_reader< Device
                    , detail::read_and_no_convert
                    >
 {
-    typedef reader< Device
-                  , raw_tag
-                  , detail::read_and_no_convert
-                  > parent_t;
+    using parent_t = reader<Device, raw_tag, detail::read_and_no_convert>;
 
 public:
 

--- a/include/boost/gil/extension/io/raw/detail/reader_backend.hpp
+++ b/include/boost/gil/extension/io/raw/detail/reader_backend.hpp
@@ -27,7 +27,7 @@ struct reader_backend< Device
 {
 public:
 
-    typedef raw_tag format_tag_t;
+    using format_tag_t = raw_tag;
 
 public:
 

--- a/include/boost/gil/extension/io/targa/detail/is_allowed.hpp
+++ b/include/boost/gil/extension/io/targa/detail/is_allowed.hpp
@@ -34,7 +34,7 @@ bool is_allowed( const image_read_info< targa_tag >& info
         }
     }
 
-    typedef typename channel_traits< typename element_type< typename View::value_type >::type >::value_type channel_t;
+    using channel_t = typename channel_traits<typename element_type<typename View::value_type>::type>::value_type;
     targa_depth::type dst_bits_per_pixel = detail::unsigned_integral_num_bits< channel_t >::value * num_channels< View >::value;
 
     return ( dst_bits_per_pixel == src_bits_per_pixel );

--- a/include/boost/gil/extension/io/targa/detail/read.hpp
+++ b/include/boost/gil/extension/io/targa/detail/read.hpp
@@ -49,18 +49,12 @@ class reader< Device
 {
 private:
 
-    typedef reader< Device
-                  , targa_tag
-                  , ConversionPolicy
-                  > this_t;
-
-    typedef typename ConversionPolicy::color_converter_type cc_t;
+    using this_t = reader<Device, targa_tag, ConversionPolicy>;
+    using cc_t = typename ConversionPolicy::color_converter_type;
 
 public:
 
-    typedef reader_backend< Device, targa_tag > backend_t;
-
-public:
+    using backend_t = reader_backend<Device, targa_tag>;
 
     reader( const Device&                           io_dev
           , const image_read_settings< targa_tag >& settings
@@ -88,9 +82,11 @@ public:
     template< typename View >
     void apply( const View& dst_view )
     {
-        typedef typename is_same< ConversionPolicy
-                                , detail::read_and_no_convert
-                                >::type is_read_and_convert_t;
+        using is_read_and_convert_t = typename is_same
+            <
+                ConversionPolicy,
+                detail::read_and_no_convert
+            >::type;
 
         io_error_if( !detail::is_allowed< View >( this->_info, is_read_and_convert_t() )
                    , "Image types aren't compatible."
@@ -353,10 +349,7 @@ class dynamic_image_reader< Device
                    , detail::read_and_no_convert
                    >
 {
-    typedef reader< Device
-                  , targa_tag
-                  , detail::read_and_no_convert
-                  > parent_t;
+    using parent_t = reader<Device, targa_tag, detail::read_and_no_convert>;
 
 public:
 

--- a/include/boost/gil/extension/io/targa/detail/reader_backend.hpp
+++ b/include/boost/gil/extension/io/targa/detail/reader_backend.hpp
@@ -27,7 +27,7 @@ struct reader_backend< Device
 {
 public:
 
-    typedef targa_tag format_tag_t;
+    using format_tag_t = targa_tag;
 
 public:
 

--- a/include/boost/gil/extension/io/targa/detail/scanline_read.hpp
+++ b/include/boost/gil/extension/io/targa/detail/scanline_read.hpp
@@ -37,13 +37,10 @@ class scanline_reader< Device
 {
 public:
 
-
-    typedef targa_tag tag_t;
-    typedef reader_backend < Device, tag_t > backend_t;
-    typedef scanline_reader< Device, tag_t > this_t;
-    typedef scanline_read_iterator< this_t > iterator_t;
-
-public:
+    using tag_t = targa_tag;
+    using backend_t = reader_backend<Device, tag_t>;
+    using this_t = scanline_reader<Device, tag_t>;
+    using iterator_t = scanline_read_iterator<this_t>;
 
     //
     // Constructor

--- a/include/boost/gil/extension/io/targa/detail/supported_types.hpp
+++ b/include/boost/gil/extension/io/targa/detail/supported_types.hpp
@@ -77,9 +77,11 @@ struct is_read_supported< Pixel
                                             >::is_supported
                 >
 {
-    typedef detail::targa_read_support< typename channel_type< Pixel >::type
-                                      , typename color_space_type< Pixel >::type
-                                      > parent_t;
+    using parent_t = detail::targa_read_support
+        <
+            typename channel_type<Pixel>::type,
+            typename color_space_type<Pixel>::type
+        >;
 
     static const typename targa_depth::type bpp = parent_t::bpp;
 };

--- a/include/boost/gil/extension/io/targa/detail/write.hpp
+++ b/include/boost/gil/extension/io/targa/detail/write.hpp
@@ -27,8 +27,8 @@ namespace boost { namespace gil {
 namespace detail {
 
 template < int N > struct get_targa_view_type {};
-template <> struct get_targa_view_type< 3 > { typedef bgr8_view_t type; };
-template <> struct get_targa_view_type< 4 > { typedef bgra8_view_t type; };
+template <> struct get_targa_view_type< 3 > { using type = bgr8_view_t; };
+template <> struct get_targa_view_type< 4 > { using type = bgra8_view_t; };
 
 struct targa_write_is_supported
 {
@@ -54,7 +54,7 @@ class writer< Device
                            >
 {
 private:
-     typedef writer_backend< Device, targa_tag > backend_t;
+    using backend_t = writer_backend<Device, targa_tag>;
 
 public:
 
@@ -151,9 +151,7 @@ class dynamic_image_writer< Device
                    , targa_tag
                    >
 {
-    typedef writer< Device
-                  , targa_tag
-                  > parent_t;
+    using parent_t = writer<Device, targa_tag>;
 
 public:
 

--- a/include/boost/gil/extension/io/targa/detail/writer_backend.hpp
+++ b/include/boost/gil/extension/io/targa/detail/writer_backend.hpp
@@ -27,7 +27,7 @@ struct writer_backend< Device
 {
 public:
 
-    typedef targa_tag format_tag_t;
+    using format_tag_t = targa_tag;
 
 public:
 

--- a/include/boost/gil/extension/io/tiff/detail/device.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/device.hpp
@@ -442,7 +442,7 @@ struct is_adaptable_input_device< FormatTag
                                 >
     : mpl::true_
 {
-    typedef file_stream_device< FormatTag > device_type;
+    using device_type = file_stream_device<FormatTag>;
 };
 
 template< typename FormatTag >
@@ -452,7 +452,7 @@ struct is_adaptable_output_device< FormatTag
                                  >
     : mpl::true_
 {
-    typedef file_stream_device< FormatTag > device_type;
+    using device_type = file_stream_device<FormatTag>;
 };
 
 

--- a/include/boost/gil/extension/io/tiff/detail/is_allowed.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/is_allowed.hpp
@@ -15,7 +15,7 @@
 
 namespace boost { namespace gil { namespace detail {
 
-typedef std::vector< tiff_bits_per_sample::type > channel_sizes_t;
+using channel_sizes_t = std::vector<tiff_bits_per_sample::type>;
 
 template< typename View, typename Channel, typename Enable = void > struct Format_Type {};
 
@@ -99,9 +99,8 @@ bool compare_channel_sizes( const channel_sizes_t& channel_sizes // in bits
                           , mpl::true_                           // is_homogeneous
                           )
 {
-    typedef typename View::value_type pixel_t;
-    typedef typename channel_traits<
-                typename element_type< pixel_t >::type >::value_type channel_t;
+    using pixel_t = typename View::value_type;
+    using channel_t = typename channel_traits<typename element_type<pixel_t>::type>::value_type;
 
     unsigned int s = detail::unsigned_integral_num_bits< channel_t >::value;
 
@@ -115,9 +114,9 @@ bool compare_channel_sizes( const channel_sizes_t& channel_sizes // in bits
                           , mpl::true_                           // is_homogeneous
                           )
 {
-    typedef typename View::reference ref_t;
+    using ref_t = typename View::reference;
 
-    typedef typename channel_traits< typename element_type< ref_t >::type >::value_type channel_t;
+    using channel_t = typename channel_traits<typename element_type<ref_t>::type>::value_type;
     channel_t c;
 
     unsigned int s = detail::unsigned_integral_num_bits< channel_t >::value;
@@ -149,10 +148,10 @@ template< typename T >
 struct channel_sizes_type {};
 
 template< typename B, typename C, typename L, bool M >
-struct channel_sizes_type< bit_aligned_pixel_reference< B, C, L, M > > { typedef C type; };
+struct channel_sizes_type< bit_aligned_pixel_reference< B, C, L, M > > { using type = C; };
 
 template< typename B, typename C, typename L, bool M >
-struct channel_sizes_type< const bit_aligned_pixel_reference< B, C, L, M > > { typedef C type; };
+struct channel_sizes_type< const bit_aligned_pixel_reference< B, C, L, M > > { using type = C; };
 
 template< typename View >
 bool compare_channel_sizes( channel_sizes_t& channel_sizes // in bits
@@ -162,8 +161,8 @@ bool compare_channel_sizes( channel_sizes_t& channel_sizes // in bits
 {
     // loop through all channels and compare
 
-    typedef typename View::reference ref_t;
-    typedef typename channel_sizes_type< ref_t >::type cs_t;
+    using ref_t = typename View::reference;
+    using cs_t = typename channel_sizes_type<ref_t>::type;
 
     compare_channel_sizes_fn fn( &channel_sizes.front() );
     mpl::for_each< cs_t >( fn );
@@ -180,11 +179,10 @@ bool is_allowed( const image_read_info< tiff_tag >& info
                                  , info._bits_per_sample
                                  );
 
-    typedef typename get_pixel_type< View >::type pixel_t;
-    typedef typename channel_traits<
-                typename element_type< pixel_t >::type >::value_type channel_t;
+    using pixel_t = typename get_pixel_type<View>::type;
+    using channel_t = typename channel_traits<typename element_type<pixel_t>::type>::value_type;
 
-    typedef typename num_channels< pixel_t >::value_type num_channel_t;
+    using num_channel_t = typename num_channels<pixel_t>::value_type;
 
     const num_channel_t dst_samples_per_pixel = num_channels< pixel_t >::value;
 

--- a/include/boost/gil/extension/io/tiff/detail/read.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/read.hpp
@@ -59,12 +59,12 @@ struct plane_recursion
                           , ConversionPolicy >* p
                   )
    {
-      typedef typename kth_channel_view_type< K, View >::type plane_t;
-      plane_t plane = kth_channel_view<K>( dst_view );
+        using plane_t = typename kth_channel_view_type<K, View>::type;
+        plane_t plane = kth_channel_view<K>( dst_view );
 
-      p->template read_data< detail::row_buffer_helper_view< plane_t > >( plane, K );
+        p->template read_data< detail::row_buffer_helper_view< plane_t > >( plane, K );
 
-      plane_recursion< K - 1 >::read_plane( dst_view, p );
+        plane_recursion< K - 1 >::read_plane( dst_view, p );
    }
 };
 
@@ -104,18 +104,12 @@ class reader< Device
 {
 private:
 
-    typedef reader< Device
-                  , tiff_tag
-                  , ConversionPolicy
-                  > this_t;
-
-    typedef typename ConversionPolicy::color_converter_type cc_t;
+    using this_t = reader<Device, tiff_tag, ConversionPolicy>;
+    using cc_t = typename ConversionPolicy::color_converter_type;
 
 public:
 
-    typedef reader_backend< Device, tiff_tag > backend_t;
-
-public:
+    using backend_t = reader_backend<Device, tiff_tag>;
 
     reader( const Device&                          io_dev
           , const image_read_settings< tiff_tag >& settings
@@ -179,9 +173,11 @@ public:
             // the tiff type need to compatible. Which means:
             // color_spaces_are_compatible && channels_are_pairwise_compatible
 
-            typedef typename is_same< ConversionPolicy
-                                    , detail::read_and_no_convert
-                                    >::type is_read_only;
+            using is_read_only = typename is_same
+                <
+                    ConversionPolicy,
+                    detail::read_and_no_convert
+                >::type;
 
             io_error_if( !detail::is_allowed< View >( this->_info
                                                     , is_read_only()
@@ -327,9 +323,7 @@ private:
 
       this->_io_dev.get_field_defaulted( red, green, blue );
 
-      typedef typename channel_traits<
-                    typename element_type<
-                            typename Indices_View::value_type >::type >::value_type channel_t;
+      using channel_t = typename channel_traits<typename element_type<typename Indices_View::value_type>::type>::value_type;
 
       int num_colors = channel_traits< channel_t >::max_value();
 
@@ -432,12 +426,12 @@ private:
                                 )
    {
        ///@todo: why is
-       /// typedef Buffer row_buffer_helper_t;
+       /// using row_buffer_helper_t = Buffer;
        /// not working? I get compiler error with MSVC10.
        /// read_stripped_data IS working.
-       typedef detail::row_buffer_helper_view< View > row_buffer_helper_t;
+       using row_buffer_helper_t = detail::row_buffer_helper_view<View>;
 
-       typedef typename row_buffer_helper_t::iterator_t it_t;
+       using it_t = typename row_buffer_helper_t::iterator_t;
 
        tiff_image_width::type  image_width  = this->_info._width;
        tiff_image_height::type image_height = this->_info._height;
@@ -555,12 +549,12 @@ private:
                             )
    {
        ///@todo: why is
-       /// typedef Buffer row_buffer_helper_t;
+       /// using row_buffer_helper_t = Buffer;
        /// not working? I get compiler error with MSVC10.
        /// read_stripped_data IS working.
-       typedef detail::row_buffer_helper_view< View > row_buffer_helper_t;
+       using row_buffer_helper_t = detail::row_buffer_helper_view<View>;
 
-       typedef typename row_buffer_helper_t::iterator_t it_t;
+       using it_t = typename row_buffer_helper_t::iterator_t;
 
        tiff_image_width::type  image_width  = this->_info._width;
        tiff_image_height::type image_height = this->_info._height;
@@ -616,12 +610,11 @@ private:
    void read_stripped_data( const View& dst_view
                           , int         plane     )
    {
-      typedef typename is_bit_aligned< typename View::value_type >::type is_view_bit_aligned_t;
+      using is_view_bit_aligned_t = typename is_bit_aligned<typename View::value_type>::type;
 
-      //typedef detail::row_buffer_helper_view< View > row_buffer_helper_t;
-      typedef Buffer row_buffer_helper_t;
-
-      typedef typename row_buffer_helper_t::iterator_t it_t;
+      //using row_buffer_helper_t =detail::row_buffer_helper_view<View>;
+      using row_buffer_helper_t = Buffer;
+      using it_t = typename row_buffer_helper_t::iterator_t;
 
       std::size_t size_to_allocate = buffer_size< typename View::value_type >( dst_view.width()
                                                                              , is_view_bit_aligned_t() );
@@ -698,7 +691,7 @@ struct tiff_type_format_checker
     template< typename Image >
     bool apply()
     {
-        typedef typename Image::view_t view_t;
+        using view_t = typename Image::view_t;
 
         return is_allowed< view_t >( _info
                                    , mpl::true_()
@@ -737,10 +730,7 @@ class dynamic_image_reader< Device
                    , detail::read_and_no_convert
                    >
 {
-    typedef reader< Device
-                  , tiff_tag
-                  , detail::read_and_no_convert
-                  > parent_t;
+    using parent_t = reader<Device, tiff_tag, detail::read_and_no_convert>;
 
 public:
 

--- a/include/boost/gil/extension/io/tiff/detail/reader_backend.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/reader_backend.hpp
@@ -27,7 +27,7 @@ struct reader_backend< Device
 {
 public:
 
-    typedef tiff_tag format_tag_t;
+    using format_tag_t = tiff_tag;
 
 public:
 

--- a/include/boost/gil/extension/io/tiff/detail/scanline_read.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/scanline_read.hpp
@@ -54,13 +54,10 @@ class scanline_reader< Device
 {
 public:
 
-
-    typedef tiff_tag tag_t;
-    typedef reader_backend < Device, tag_t > backend_t;
-    typedef scanline_reader< Device, tag_t > this_t;
-    typedef scanline_read_iterator< this_t > iterator_t;
-
-public:
+    using tag_t = tiff_tag;
+    using backend_t = reader_backend<Device, tag_t>;
+    using this_t = scanline_reader<Device, tag_t>;
+    using iterator_t = scanline_read_iterator<this_t>;
 
     scanline_reader( Device&                                device
                    , const image_read_settings< tiff_tag >& settings
@@ -113,7 +110,7 @@ private:
             {
                 case 1:
                 {
-                    typedef channel_type< get_pixel_type< gray1_image_t::view_t >::type >::type channel_t;
+                    using channel_t = channel_type<get_pixel_type<gray1_image_t::view_t>::type>::type;
 
                     int num_colors = channel_traits< channel_t >::max_value() + 1;
 
@@ -132,7 +129,7 @@ private:
 
                 case 2:
                 {
-                    typedef channel_type< get_pixel_type< gray2_image_t::view_t >::type >::type channel_t;
+                    using channel_t = channel_type<get_pixel_type<gray2_image_t::view_t>::type>::type;
 
                     int num_colors = channel_traits< channel_t >::max_value() + 1;
 
@@ -150,7 +147,7 @@ private:
                 }
                 case 4:
                 {
-                    typedef channel_type< get_pixel_type< gray4_image_t::view_t >::type >::type channel_t;
+                    using channel_t = channel_type<get_pixel_type<gray4_image_t::view_t>::type>::type;
 
                     int num_colors = channel_traits< channel_t >::max_value() + 1;
 
@@ -169,7 +166,7 @@ private:
 
                 case 8:
                 {
-                    typedef channel_type< get_pixel_type< gray8_image_t::view_t >::type >::type channel_t;
+                    using channel_t = channel_type<get_pixel_type<gray8_image_t::view_t>::type>::type;
 
                     int num_colors = channel_traits< channel_t >::max_value() + 1;
 
@@ -188,7 +185,7 @@ private:
 
                 case 16:
                 {
-                    typedef channel_type< get_pixel_type< gray16_image_t::view_t >::type >::type channel_t;
+                    using channel_t = channel_type<get_pixel_type<gray16_image_t::view_t>::type>::type;
 
                     int num_colors = channel_traits< channel_t >::max_value() + 1;
 
@@ -207,7 +204,7 @@ private:
 
                 case 24:
                 {
-                    typedef channel_type< get_pixel_type< gray24_image_t::view_t >::type >::type channel_t;
+                    using channel_t = channel_type<get_pixel_type<gray24_image_t::view_t>::type>::type;
 
                     int num_colors = channel_traits< channel_t >::max_value() + 1;
 
@@ -226,7 +223,7 @@ private:
 
                 case 32:
                 {
-                    typedef channel_type< get_pixel_type< gray32_image_t::view_t >::type >::type channel_t;
+                    using channel_t = channel_type<get_pixel_type<gray32_image_t::view_t>::type>::type;
 
                     int num_colors = channel_traits< channel_t >::max_value() + 1;
 
@@ -362,7 +359,7 @@ private:
     template< typename Src_View >
     void read_n_bits_row( byte_t* dst, int pos )
     {
-        typedef rgb16_view_t dst_view_t;
+        using dst_view_t = rgb16_view_t;
 
         this->_io_dev.read_scanline( _buffer
                                    , pos

--- a/include/boost/gil/extension/io/tiff/detail/write.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/write.hpp
@@ -41,13 +41,15 @@ template <typename PixelReference>
 struct my_interleaved_pixel_iterator_type_from_pixel_reference
 {
 private:
-    typedef typename remove_reference< PixelReference >::type::value_type pixel_t;
+    using pixel_t = typename remove_reference<PixelReference>::type::value_type;
 public:
-    typedef typename iterator_type_from_pixel< pixel_t
-                                             , false
-                                             , false
-                                             , true
-                                             >::type type;
+    using type = typename iterator_type_from_pixel
+        <
+            pixel_t,
+            false,
+            false,
+            true
+        >::type;
 };
 
 
@@ -96,7 +98,8 @@ class writer< Device
                            >
 {
 private:
-    typedef writer_backend< Device, tiff_tag > backend_t;
+    using backend_t = writer_backend<Device, tiff_tag>;
+
 public:
 
     writer( const Device&                       io_dev
@@ -118,9 +121,9 @@ private:
     template< typename View >
     void write_view( const View& view )
     {
-        typedef typename View::value_type pixel_t;
+        using pixel_t = typename View::value_type;
         // get the type of the first channel (heterogeneous pixels might be broken for now!)
-        typedef typename channel_traits< typename element_type< pixel_t >::type >::value_type channel_t;
+        using channel_t = typename channel_traits<typename element_type<pixel_t>::type>::value_type;
         tiff_bits_per_sample::type bits_per_sample = detail::unsigned_integral_num_bits< channel_t >::value;
 
         tiff_samples_per_pixel::type samples_per_pixel = num_channels< pixel_t >::value;
@@ -166,7 +169,7 @@ private:
     {
         byte_vector_t row( row_size_in_bytes );
 
-        typedef typename View::x_iterator x_it_t;
+        using x_it_t = typename View::x_iterator;
         x_it_t row_it = x_it_t( &(*row.begin()));
 
 		auto pm_view = premultiply_view <typename View:: value_type> (view);
@@ -196,7 +199,7 @@ private:
     {
         byte_vector_t row( row_size_in_bytes );
 
-        typedef typename View::x_iterator x_it_t;
+        using x_it_t = typename View::x_iterator;
         x_it_t row_it = x_it_t( &(*row.begin()));
 
         for( typename View::y_coord_t y = 0; y < view.height(); ++y )
@@ -224,11 +227,10 @@ private:
                    , const mpl::true_&    // bit_aligned
                    )
     {
-      typedef typename color_space_type<typename View::value_type>::type colour_space_t;
-      typedef mpl::bool_<mpl::contains<colour_space_t, alpha_t>::value> has_alpha_t;
+        using colour_space_t = typename color_space_type<typename View::value_type>::type;
+        using has_alpha_t = mpl::bool_<mpl::contains<colour_space_t, alpha_t>::value>;
 
         write_bit_aligned_view_to_dev(view, row_size_in_bytes, has_alpha_t());
-
     }
 
     template< typename View>
@@ -240,7 +242,7 @@ private:
     {
         byte_vector_t row( this->_io_dev.get_tile_size() );
 
-        typedef typename View::x_iterator x_it_t;
+        using x_it_t = typename View::x_iterator;
         x_it_t row_it = x_it_t( &(*row.begin()));
 
         internal_write_tiled_data(view, tw, th, row, row_it);
@@ -288,8 +290,7 @@ private:
     {
         byte_vector_t row( this->_io_dev.get_tile_size() );
 
-        typedef typename detail::my_interleaved_pixel_iterator_type_from_pixel_reference< typename View::reference
-                                                                                >::type x_iterator;
+        using x_iterator = typename detail::my_interleaved_pixel_iterator_type_from_pixel_reference<typename View::reference>::type;
         x_iterator row_it = x_iterator( &(*row.begin()));
 
         internal_write_tiled_data(view, tw, th, row, row_it);
@@ -359,8 +360,8 @@ private:
                                                       , static_cast< int >( th )
                                                       );
 
-		    typedef typename color_space_type<typename View::value_type>::type colour_space_t;
-		    typedef mpl::bool_<mpl::contains<colour_space_t, alpha_t>::value> has_alpha_t;
+                    using colour_space_t = typename color_space_type<typename View::value_type>::type;
+                    using has_alpha_t = mpl::bool_<mpl::contains<colour_space_t, alpha_t>::value>;
 
                     write_tiled_view_to_dev(tile_subimage_view, it, has_alpha_t());
                 }
@@ -417,9 +418,7 @@ class dynamic_image_writer< Device
                    , tiff_tag
                    >
 {
-    typedef writer< Device
-                  , tiff_tag
-                  > parent_t;
+    using parent_t = writer<Device, tiff_tag>;
 
 public:
 

--- a/include/boost/gil/extension/io/tiff/detail/writer_backend.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/writer_backend.hpp
@@ -30,7 +30,7 @@ struct writer_backend< Device
 {
 public:
 
-    typedef tiff_tag format_tag_t;
+    using format_tag_t = tiff_tag;
 
 public:
 
@@ -46,11 +46,11 @@ protected:
     template< typename View >
     void write_header( const View& view )
     {
-        typedef typename View::value_type pixel_t;
+        using pixel_t = typename View::value_type;
 
         // get the type of the first channel (heterogeneous pixels might be broken for now!)
-        typedef typename channel_traits< typename element_type< pixel_t >::type >::value_type channel_t;
-				typedef typename color_space_type< View >::type color_space_t;
+        using channel_t = typename channel_traits<typename element_type<pixel_t>::type>::value_type;
+				using color_space_t = typename color_space_type<View>::type;
 
         if(! this->_info._photometric_interpretation_user_defined )
         {

--- a/include/boost/gil/extension/io/tiff/tags.hpp
+++ b/include/boost/gil/extension/io/tiff/tags.hpp
@@ -44,7 +44,7 @@ struct tiff_property_base : property_base< T >
     /// this property:
     /// http://www.remotesensing.org/libtiff/man/TIFFGetField.3tiff.html
     /// http://www.remotesensing.org/libtiff/man/TIFFSetField.3tiff.html
-    typedef mpl:: vector <typename property_base <T>:: type> arg_types;
+    using arg_types = mpl::vector<typename property_base<unsigned short>::type>;
 };
 
 /// baseline tags
@@ -145,16 +145,17 @@ struct tiff_host_computer : tiff_property_base< std::string, TIFFTAG_HOSTCOMPUTE
 /// Helper structure for reading a color mapper.
 struct tiff_color_map
 {
-   typedef uint16_t* red_t;
-   typedef uint16_t* green_t;
-   typedef uint16_t* blue_t;
+   using red_t = uint16_t *;
+   using green_t = uint16_t *;
+   using blue_t = uint16_t *;
 
    static const unsigned int tag = TIFFTAG_COLORMAP;
 };
 
 /// Defines type for extra samples property.
-struct tiff_extra_samples : tiff_property_base< std:: vector <uint16_t>, TIFFTAG_EXTRASAMPLES > {
-  typedef mpl:: vector <uint16_t, uint16_t const *> arg_types;
+struct tiff_extra_samples : tiff_property_base<std:: vector <uint16_t>, TIFFTAG_EXTRASAMPLES>
+{
+    using arg_types = mpl::vector<uint16_t, uint16_t const *>;
 };
 
 /// Defines type for copyright property.
@@ -184,14 +185,15 @@ struct tiff_tile_length : tiff_property_base< long, TIFFTAG_TILELENGTH > {};
 #include <boost/mpl/integral_c.hpp>
 struct tiff_directory : property_base< tdir_t >
 {
-    typedef boost::mpl::integral_c< type, 0 > default_value;
+    using default_value = boost::mpl::integral_c<type, 0>;
 };
 
 /// Non-baseline tags
 
 /// Defines type for icc profile property.
-struct tiff_icc_profile : tiff_property_base< std:: vector <uint8_t>, TIFFTAG_ICCPROFILE > {
-  typedef mpl:: vector <uint32_t, void const *> arg_types;
+struct tiff_icc_profile : tiff_property_base<std::vector<uint8_t>, TIFFTAG_ICCPROFILE>
+{
+    using arg_types = mpl::vector<uint32_t, void const *>;
 };
 
 /// Read information for tiff images.


### PR DESCRIPTION
Run clang-tidy 7.0 with `-checks='-*,modernize-use-using' -fix` against
single TU with `#include <boost/gil/extension/io/*.hpp>`.

Manually refactor numerous `typedef`-s
- where missed by modernize-use-using check, not uncommon
- in code snippets in comments

Outcome is that searching for lower-case whole word `typedef`
in all the `extension/io/*.hpp` should return no matches.

### References

- #192
- #193
- #195
- #196

### Tasklist

- [ ] Review
- [ ] Adjust for comments
- [ ] All CI builds and checks have passed
