### PR TITLE
Apply clang-tidy modernize-use-using to extension/toolbox

### DIFF
--- a/include/boost/gil/extension/toolbox/color_converters/gray_to_rgba.hpp
+++ b/include/boost/gil/extension/toolbox/color_converters/gray_to_rgba.hpp
@@ -26,7 +26,7 @@ struct default_color_converter_impl<gray_t,rgba_t>
         get_color(dst,blue_t()) =
             channel_convert<typename color_element_type<P2, blue_t >::type>(get_color(src,gray_color_t()));
 
-        typedef typename channel_type< P2 >::type channel_t;
+        using channel_t = typename channel_type<P2>::type;
         get_color(dst,alpha_t()) = channel_traits< channel_t >::max_value();
     }
 };

--- a/include/boost/gil/extension/toolbox/color_spaces/cmyka.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/cmyka.hpp
@@ -37,7 +37,7 @@ GIL_DEFINE_ALL_TYPEDEFS(32f, float32_t, cmyka)
 //struct default_color_converter_impl<cmyka_t,C2> {
 //    template <typename P1, typename P2>
 //    void operator()(const P1& src, P2& dst) const {
-//        typedef typename channel_type<P1>::type T1;
+//        using T1 = typename channel_type<P1>::type;
 //        default_color_converter_impl<cmyk_t,C2>()(
 //            pixel<T1,cmyk_layout_t>(channel_multiply(get_color(src,cyan_t()),  get_color(src,alpha_t())),
 //                                    channel_multiply(get_color(src,magenta_t()),get_color(src,alpha_t())),
@@ -50,7 +50,7 @@ template <>
 struct default_color_converter_impl<cmyka_t,rgba_t> {
     template <typename P1, typename P2>
     void operator()(const P1& src, P2& dst) const {
-        typedef typename channel_type<P1>::type T1;
+        using T1 = typename channel_type<P1>::type;
         default_color_converter_impl<cmyk_t,rgba_t>()(
             pixel<T1,cmyk_layout_t>(get_color(src,cyan_t()),
                                     get_color(src,magenta_t()),

--- a/include/boost/gil/extension/toolbox/color_spaces/gray_alpha.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/gray_alpha.hpp
@@ -17,10 +17,10 @@
 
 namespace boost{ namespace gil {
 
-typedef mpl::vector2<gray_color_t,alpha_t> gray_alpha_t;
+using gray_alpha_t = mpl::vector2<gray_color_t,alpha_t>;
 
-typedef layout<gray_alpha_t> gray_alpha_layout_t;
-typedef layout<gray_alpha_layout_t, mpl::vector2_c<int,1,0> > alpha_gray_layout_t;
+using gray_alpha_layout_t = layout<gray_alpha_t>;
+using alpha_gray_layout_t = layout<gray_alpha_layout_t, mpl::vector2_c<int,1,0>>;
 
 GIL_DEFINE_BASE_TYPEDEFS(8, uint8_t, alpha_gray)
 GIL_DEFINE_BASE_TYPEDEFS(8s, int8_t, alpha_gray)

--- a/include/boost/gil/extension/toolbox/color_spaces/hsl.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/hsl.hpp
@@ -27,13 +27,15 @@ struct lightness_t {};
 /// \}
 
 /// \ingroup ColorSpaceModel
-typedef mpl::vector3< hsl_color_space::hue_t
-                    , hsl_color_space::saturation_t
-                    , hsl_color_space::lightness_t
-                    > hsl_t;
+using hsl_t = mpl::vector3
+    <
+        hsl_color_space::hue_t,
+        hsl_color_space::saturation_t,
+        hsl_color_space::lightness_t
+    >;
 
 /// \ingroup LayoutModel
-typedef layout<hsl_t> hsl_layout_t;
+using hsl_layout_t = layout<hsl_t>;
 
 
 GIL_DEFINE_ALL_TYPEDEFS(32f, float32_t, hsl)

--- a/include/boost/gil/extension/toolbox/color_spaces/hsv.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/hsv.hpp
@@ -34,13 +34,15 @@ struct value_t {};
 /// \}
 
 /// \ingroup ColorSpaceModel
-typedef mpl::vector3< hsv_color_space::hue_t
-                    , hsv_color_space::saturation_t
-                    , hsv_color_space::value_t
-                    > hsv_t;
+using hsv_t = mpl::vector3
+    <
+        hsv_color_space::hue_t,
+        hsv_color_space::saturation_t,
+        hsv_color_space::value_t
+    >;
 
 /// \ingroup LayoutModel
-typedef layout<hsv_t> hsv_layout_t;
+using hsv_layout_t = layout<hsv_t>;
 
 GIL_DEFINE_ALL_TYPEDEFS(32f, float32_t, hsv)
 

--- a/include/boost/gil/extension/toolbox/color_spaces/lab.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/lab.hpp
@@ -31,13 +31,15 @@ struct b_color_opponent_t {};
 /// \}
 
 /// \ingroup ColorSpaceModel
-typedef mpl::vector3< lab_color_space::luminance_t
-                    , lab_color_space::a_color_opponent_t
-                    , lab_color_space::b_color_opponent_t
-                    > lab_t;
+using lab_t = mpl::vector3
+    <
+        lab_color_space::luminance_t,
+        lab_color_space::a_color_opponent_t,
+        lab_color_space::b_color_opponent_t
+    >;
 
 /// \ingroup LayoutModel
-typedef layout<lab_t> lab_layout_t;
+using lab_layout_t = layout<lab_t>;
 
 GIL_DEFINE_ALL_TYPEDEFS(32f, float32_t, lab)
 

--- a/include/boost/gil/extension/toolbox/color_spaces/xyz.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/xyz.hpp
@@ -29,13 +29,15 @@ struct z_t {};
 /// \}
 
 /// \ingroup ColorSpaceModel
-typedef mpl::vector3< xyz_color_space::x_t
-                    , xyz_color_space::y_t
-                    , xyz_color_space::z_t
-                    > xyz_t;
+using xyz_t = mpl::vector3
+    <
+        xyz_color_space::x_t,
+        xyz_color_space::y_t,
+        xyz_color_space::z_t
+    >;
 
 /// \ingroup LayoutModel
-typedef layout<xyz_t> xyz_layout_t;
+using xyz_layout_t = layout<xyz_t>;
 
 GIL_DEFINE_ALL_TYPEDEFS(32f, float32_t, xyz)
 

--- a/include/boost/gil/extension/toolbox/color_spaces/ycbcr.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/ycbcr.hpp
@@ -46,12 +46,24 @@ struct cr_t {};
 /// \}
 
 /// \ingroup ColorSpaceModel
-typedef boost::mpl::vector3< ycbcr_601_color_space::y_t, ycbcr_601_color_space::cb_t, ycbcr_601_color_space::cr_t > ycbcr_601__t;
-typedef boost::mpl::vector3< ycbcr_709_color_space::y_t, ycbcr_709_color_space::cb_t, ycbcr_709_color_space::cr_t > ycbcr_709__t;
+using ycbcr_601__t = boost::mpl::vector3
+    <
+        ycbcr_601_color_space::y_t,
+        ycbcr_601_color_space::cb_t,
+        ycbcr_601_color_space::cr_t>
+    ;
+
+/// \ingroup ColorSpaceModel
+using ycbcr_709__t = boost::mpl::vector3
+    <
+        ycbcr_709_color_space::y_t,
+        ycbcr_709_color_space::cb_t,
+        ycbcr_709_color_space::cr_t
+    >;
 
 /// \ingroup LayoutModel
-typedef boost::gil::layout<ycbcr_601__t> ycbcr_601__layout_t;
-typedef boost::gil::layout<ycbcr_709__t> ycbcr_709__layout_t;
+using ycbcr_601__layout_t = boost::gil::layout<ycbcr_601__t>;
+using ycbcr_709__layout_t = boost::gil::layout<ycbcr_709__t>;
 
 //The channel depth is ALWAYS 8bits ofr YCbCr!
 GIL_DEFINE_ALL_TYPEDEFS(8, uint8_t, ycbcr_601_)
@@ -89,7 +101,7 @@ struct default_color_converter_impl<ycbcr_601__t, rgb_t>
 	template < typename SRCP, typename DSTP >
 	void operator()( const SRCP& src, DSTP& dst ) const
 	{
-        typedef typename channel_type< DSTP >::type dst_channel_t;
+        using dst_channel_t = typename channel_type<DSTP>::type;
         convert( src, dst
                , typename boost::is_same< typename mpl::int_< sizeof( dst_channel_t ) >::type
                                         , typename mpl::int_<1>::type
@@ -110,8 +122,8 @@ private:
     {
         using namespace ycbcr_601_color_space;
 
-        typedef typename channel_type< Src_Pixel >::type src_channel_t;
-        typedef typename channel_type< Dst_Pixel >::type dst_channel_t;
+        using src_channel_t = typename channel_type<Src_Pixel>::type;
+        using dst_channel_t = typename channel_type<Dst_Pixel>::type;
 
 		src_channel_t y  = channel_convert<src_channel_t>( get_color(src,  y_t()));
 		src_channel_t cb = channel_convert<src_channel_t>( get_color(src, cb_t()));
@@ -141,7 +153,7 @@ private:
     {
         using namespace ycbcr_601_color_space;
 
-        typedef typename channel_type< Dst_Pixel >::type dst_channel_t;
+        using dst_channel_t = typename channel_type<Dst_Pixel>::type;
 
         double  y = get_color( src,  y_t() );
         double cb = get_color( src, cb_t() );
@@ -174,8 +186,8 @@ struct default_color_converter_impl<rgb_t, ycbcr_601__t>
 	{
         using namespace ycbcr_601_color_space;
 
-        typedef typename channel_type< SRCP >::type src_channel_t;
-        typedef typename channel_type< DSTP >::type dst_channel_t;
+        using src_channel_t = typename channel_type<SRCP>::type;
+        using dst_channel_t = typename channel_type<DSTP>::type;
 
 		src_channel_t red   = channel_convert<src_channel_t>( get_color(src,   red_t()));
 		src_channel_t green = channel_convert<src_channel_t>( get_color(src, green_t()));
@@ -202,8 +214,8 @@ struct default_color_converter_impl<rgb_t, ycbcr_709__t>
 	{
         using namespace ycbcr_709_color_space;
 
-        typedef typename channel_type< SRCP >::type src_channel_t;
-        typedef typename channel_type< DSTP >::type dst_channel_t;
+        using src_channel_t = typename channel_type<SRCP>::type;
+        using dst_channel_t = typename channel_type<DSTP>::type;
 
 		src_channel_t red   = channel_convert<src_channel_t>( get_color(src,   red_t()));
 		src_channel_t green = channel_convert<src_channel_t>( get_color(src, green_t()));
@@ -230,8 +242,8 @@ struct default_color_converter_impl<ycbcr_709__t, rgb_t>
 	{
         using namespace ycbcr_709_color_space;
 
-        typedef typename channel_type< SRCP >::type src_channel_t;
-        typedef typename channel_type< DSTP >::type dst_channel_t;
+        using src_channel_t = typename channel_type<SRCP>::type;
+        using dst_channel_t = typename channel_type<DSTP>::type;
 
 		src_channel_t y           = channel_convert<src_channel_t>( get_color(src,  y_t())       );
 		src_channel_t cb_clipped  = channel_convert<src_channel_t>( get_color(src, cb_t()) - 128 );

--- a/include/boost/gil/extension/toolbox/dynamic_images.hpp
+++ b/include/boost/gil/extension/toolbox/dynamic_images.hpp
@@ -23,7 +23,7 @@ struct any_image_color_space_t {};
 template<>
 struct color_space_type< any_image_pixel_t >
 {
-    typedef any_image_color_space_t type;
+    using type = any_image_color_space_t;
 };
 
 }} // namespace boost::gil

--- a/include/boost/gil/extension/toolbox/image_types/indexed_image.hpp
+++ b/include/boost/gil/extension/toolbox/image_types/indexed_image.hpp
@@ -35,16 +35,16 @@ template< typename IndicesLoc
         >
 struct indexed_image_deref_fn_base
 {
-    typedef IndicesLoc indices_locator_t;
-    typedef PaletteLoc palette_locator_t;
-    //typedef typename get_pixel_type_locator< indices_locator_t >::type index_t;
+    using indices_locator_t = IndicesLoc;
+    using palette_locator_t = PaletteLoc;
+    //using index_t = typename get_pixel_type_locator<indices_locator_t>::type;
 
-    typedef indexed_image_deref_fn_base     const_t;
-    typedef typename PaletteLoc::value_type value_type;
-    typedef value_type                      reference;
-    typedef value_type                      const_reference;
-    typedef point_t                         argument_type;
-    typedef reference                       result_type;
+    using const_t = indexed_image_deref_fn_base<IndicesLoc, PaletteLoc>;
+    using value_type = typename PaletteLoc::value_type;
+    using reference = value_type;
+    using const_reference = value_type;
+    using argument_type = point_t;
+    using result_type = reference;
 
     static const bool is_mutable = false;
 
@@ -79,10 +79,11 @@ struct indexed_image_deref_fn : indexed_image_deref_fn_base< IndicesLoc
                                                            , PaletteLoc
                                                            >
 {
-    typedef indexed_image_deref_fn_base< IndicesLoc
-                                       , PaletteLoc
-                                       > base_t;
-
+    using base_t = indexed_image_deref_fn_base
+        <
+            IndicesLoc,
+            PaletteLoc
+        >;
 
     indexed_image_deref_fn()
     : base_t()
@@ -113,9 +114,11 @@ struct indexed_image_deref_fn< IndicesLoc
                                                             , PaletteLoc
                                                             >
 {
-    typedef indexed_image_deref_fn_base< IndicesLoc
-                                       , PaletteLoc
-                                       > base_t;
+    using base_t = indexed_image_deref_fn_base
+        <
+            IndicesLoc,
+            PaletteLoc
+        >;
 
     indexed_image_deref_fn()
     : base_t()
@@ -140,11 +143,11 @@ template< typename IndicesLoc
         >
 struct indexed_image_locator_type
 {
-    typedef virtual_2d_locator< indexed_image_deref_fn< IndicesLoc
-                                                      , PaletteLoc
-                                                      >
-                              , false
-                              > type;
+    using type = virtual_2d_locator
+        <
+            indexed_image_deref_fn<IndicesLoc, PaletteLoc>,
+            false
+        >;
 };
 
 template< typename Locator > // indexed_image_locator_type< ... >::type
@@ -152,14 +155,14 @@ class indexed_image_view : public image_view< Locator >
 {
 public:
 
-    typedef typename Locator::deref_fn_t deref_fn_t;
-    typedef typename deref_fn_t::indices_locator_t indices_locator_t;
-    typedef typename deref_fn_t::palette_locator_t palette_locator_t;
+    using deref_fn_t = typename Locator::deref_fn_t;
+    using indices_locator_t = typename deref_fn_t::indices_locator_t;
+    using palette_locator_t = typename deref_fn_t::palette_locator_t;
 
-    typedef indexed_image_view< Locator > const_t;
+    using const_t = indexed_image_view<Locator>;
 
-    typedef image_view< indices_locator_t > indices_view_t;
-    typedef image_view< palette_locator_t > palette_view_t;
+    using indices_view_t = image_view<indices_locator_t>;
+    using palette_view_t = image_view<palette_locator_t>;
 
     indexed_image_view()
     : image_view< Locator >()
@@ -212,17 +215,20 @@ indexed_image_view
 >
     view(Index_View iv, Palette_View pv)
 {
-    typedef indexed_image_view<
-        typename indexed_image_locator_type<
-            typename Index_View::locator
-            , typename Palette_View::locator
-        >::type
-    > view_t;
+    using view_t = indexed_image_view
+        <
+            typename indexed_image_locator_type
+                <
+                    typename Index_View::locator,
+                    typename Palette_View::locator
+                >::type
+        >;
 
-    typedef indexed_image_deref_fn<
-        typename Index_View::locator
-        , typename Palette_View::locator
-    > defer_fn_t;
+    using defer_fn_t = indexed_image_deref_fn
+        <
+            typename Index_View::locator,
+            typename Palette_View::locator
+        >;
 
     return view_t(
         iv.dimensions()
@@ -240,28 +246,30 @@ class indexed_image
 {
 public:
 
-    typedef image< Index, false, IndicesAllocator > indices_t;
-    typedef image< Pixel, false, PalleteAllocator > palette_t;
+    using indices_t = image<Index, false, IndicesAllocator>;
+    using palette_t = image<Pixel, false, PalleteAllocator>;
 
-    typedef typename indices_t::view_t indices_view_t;
-    typedef typename palette_t::view_t palette_view_t;
+    using indices_view_t = typename indices_t::view_t;
+    using palette_view_t = typename palette_t::view_t;
 
-    typedef typename indices_t::const_view_t indices_const_view_t;
-    typedef typename palette_t::const_view_t palette_const_view_t;
+    using indices_const_view_t = typename indices_t::const_view_t;
+    using palette_const_view_t = typename palette_t::const_view_t;
 
-    typedef typename indices_view_t::locator indices_locator_t;
-    typedef typename palette_view_t::locator palette_locator_t;
+    using indices_locator_t = typename indices_view_t::locator;
+    using palette_locator_t = typename palette_view_t::locator;
 
-    typedef typename indexed_image_locator_type< indices_locator_t
-                                               , palette_locator_t
-                                               >::type locator_t;
+    using locator_t = typename indexed_image_locator_type
+        <
+            indices_locator_t,
+            palette_locator_t
+        >::type;
 
-    typedef typename indices_t::coord_t x_coord_t;
-    typedef typename indices_t::coord_t y_coord_t;
+    using x_coord_t = typename indices_t::coord_t;
+    using y_coord_t = typename indices_t::coord_t;
 
 
-    typedef indexed_image_view< locator_t > view_t;
-    typedef typename view_t::const_t        const_view_t;
+    using view_t = indexed_image_view<locator_t>;
+    using const_view_t = typename view_t::const_t;
 
     indexed_image( const x_coord_t   width = 0
                  , const y_coord_t   height = 0
@@ -322,9 +330,11 @@ private:
              , const std::size_t num_colors
              )
     {
-        typedef indexed_image_deref_fn< indices_locator_t
-                                      , palette_locator_t
-                                      > defer_fn_t;
+        using defer_fn_t = indexed_image_deref_fn
+            <
+                indices_locator_t,
+                palette_locator_t
+            >;
 
         defer_fn_t deref_fn( view( _indices ).xy_at( 0, 0 )
                            , view( _palette ).xy_at( 0, 0 )
@@ -373,7 +383,7 @@ void fill_pixels( const indexed_image_view< Locator >& view
                 , const Value&                         value
                 )
 {
-    typedef indexed_image_view< Locator > view_t;
+    using view_t = indexed_image_view<Locator>;
 
     fill_pixels( view.get_indices_view(), typename view_t::indices_view_t::value_type( 0 ));
     *view.get_palette_view().begin() = value;

--- a/include/boost/gil/extension/toolbox/image_types/subchroma_image.hpp
+++ b/include/boost/gil/extension/toolbox/image_types/subchroma_image.hpp
@@ -76,14 +76,14 @@ template< typename Locator
         >
 struct subchroma_image_deref_fn
 {
-    typedef gray8_view_t::locator plane_locator_t;
+    using plane_locator_t = gray8_view_t::locator;
 
-    typedef subchroma_image_deref_fn     const_t;
-    typedef typename Locator::value_type value_type;
-    typedef value_type                   reference;
-    typedef value_type                   const_reference;
-    typedef point_t                      argument_type;
-    typedef reference                    result_type;
+    using const_t = subchroma_image_deref_fn<Locator, Factors>;
+    using value_type = typename Locator::value_type;
+    using reference = value_type;
+    using const_reference = value_type;
+    using argument_type = point_t;
+    using result_type = reference;
 
     static const bool is_mutable = false;
 
@@ -103,10 +103,12 @@ struct subchroma_image_deref_fn
     /// operator()
     result_type operator()( const point_t& p ) const
     {
-        typedef detail::scaling_factors< mpl::at_c< Factors, 0 >::type::value
-                               , mpl::at_c< Factors, 1 >::type::value
-                               , mpl::at_c< Factors, 2 >::type::value
-                               > scaling_factors_t;
+        using scaling_factors_t = detail::scaling_factors
+            <
+                mpl::at_c<Factors, 0>::type::value,
+                mpl::at_c<Factors, 1>::type::value,
+                mpl::at_c<Factors, 2>::type::value
+            >;
 
         plane_locator_t y = _y_locator.xy_at( p );
         plane_locator_t v = _v_locator.xy_at( p.x / scaling_factors_t::ss_X, p.y / scaling_factors_t::ss_X );
@@ -142,13 +144,12 @@ template< typename Locator
         >
 struct subchroma_image_locator
 {
-    typedef virtual_2d_locator< subchroma_image_deref_fn< Locator
-                                                        , Factors
-                                                        > // Deref
-                              , false // IsTransposed
-                              > type;
+    using type = virtual_2d_locator
+        <
+            subchroma_image_deref_fn<Locator, Factors>, // Deref
+            false // IsTransposed
+        >;
 };
-
 
 /////////////////////////////
 //  PixelBasedConcept
@@ -177,7 +178,7 @@ struct is_planar< subchroma_image_locator< Locator, Factors > >
 template < typename Locator, typename Factors >
 struct dynamic_x_step_type< subchroma_image_locator< Locator, Factors > >
 {
-    typedef typename subchroma_image_locator< Locator, Factors >::type type;
+    using type = typename subchroma_image_locator<Locator, Factors>::type;
 };
 
 /////////////////////////////
@@ -187,7 +188,7 @@ struct dynamic_x_step_type< subchroma_image_locator< Locator, Factors > >
 template < typename Locator, typename Factors >
 struct dynamic_y_step_type< subchroma_image_locator< Locator, Factors > >
 {
-    typedef typename subchroma_image_locator< Locator, Factors >::type type;
+    using type = typename subchroma_image_locator<Locator, Factors>::type;
 };
 
 /////////////////////////////
@@ -197,7 +198,7 @@ struct dynamic_y_step_type< subchroma_image_locator< Locator, Factors > >
 template < typename Locator, typename Factors >
 struct transposed_type< subchroma_image_locator< Locator, Factors > >
 {
-    typedef typename subchroma_image_locator< Locator, Factors >::type type;
+    using type = typename subchroma_image_locator<Locator, Factors>::type;
 };
 
 //////////////////////////////////
@@ -215,14 +216,14 @@ class subchroma_image_view : public image_view< Locator >
 {
 public:
 
-    typedef Locator                     locator;
-    typedef typename locator::deref_fn_t         deref_fn_t;
-    typedef typename deref_fn_t::plane_locator_t plane_locator_t;
+    using locator = Locator;
+    using deref_fn_t = typename locator::deref_fn_t;
+    using plane_locator_t = typename deref_fn_t::plane_locator_t;
 
 
-    typedef subchroma_image_view const_t;
+    using const_t = subchroma_image_view<Locator, Factors>;
 
-    typedef image_view< plane_locator_t > plane_view_t;
+    using plane_view_t = image_view<plane_locator_t>;
 
     /// default constructor
     subchroma_image_view()
@@ -302,7 +303,7 @@ struct is_planar< subchroma_image_view< Locator, Factors > >
 template < typename Locator, typename Factors >
 struct dynamic_x_step_type< subchroma_image_view< Locator, Factors > >
 {
-    typedef image_view< typename dynamic_x_step_type< Locator >::type > type;
+    using type = image_view<typename dynamic_x_step_type<Locator>::type>;
 };
 
 /////////////////////////////
@@ -312,7 +313,7 @@ struct dynamic_x_step_type< subchroma_image_view< Locator, Factors > >
 template < typename Locator, typename Factors >
 struct dynamic_y_step_type< subchroma_image_view< Locator, Factors > >
 {
-    typedef image_view< typename dynamic_y_step_type< Locator >::type > type;
+    using type = image_view<typename dynamic_y_step_type<Locator>::type>;
 };
 
 /////////////////////////////
@@ -322,7 +323,7 @@ struct dynamic_y_step_type< subchroma_image_view< Locator, Factors > >
 template < typename Locator, typename Factors >
 struct transposed_type< subchroma_image_view< Locator, Factors > >
 {
-    typedef image_view< typename transposed_type< Locator >::type > type;
+    using type = image_view<typename transposed_type<Locator>::type>;
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -350,27 +351,29 @@ private:
 
 public:
 
-    typedef typename channel_type< Pixel >::type channel_t;
-    typedef pixel< channel_t, gray_layout_t> pixel_t;
+    using channel_t = typename channel_type<Pixel>::type;
+    using pixel_t = pixel<channel_t, gray_layout_t>;
 
-    typedef image< pixel_t, false, Allocator > plane_image_t;
+    using plane_image_t = image<pixel_t, false, Allocator>;
 
-    typedef typename plane_image_t::view_t plane_view_t;
-    typedef typename plane_image_t::const_view_t plane_const_view_t;
-    typedef typename plane_view_t::locator plane_locator_t;
+    using plane_view_t = typename plane_image_t::view_t;
+    using plane_const_view_t = typename plane_image_t::const_view_t;
+    using plane_locator_t = typename plane_view_t::locator;
 
-    typedef typename view_type_from_pixel< Pixel >::type pixel_view_t;
-    typedef typename pixel_view_t::locator pixel_locator_t;
+    using pixel_view_t = typename view_type_from_pixel<Pixel>::type;
+    using pixel_locator_t = typename pixel_view_t::locator;
 
-    typedef typename subchroma_image_locator< pixel_locator_t
-                                            , Factors
-                                            >::type locator_t;
+    using locator_t = typename subchroma_image_locator
+        <
+            pixel_locator_t,
+            Factors
+        >::type;
 
-    typedef typename plane_image_t::coord_t x_coord_t;
-    typedef typename plane_image_t::coord_t y_coord_t;
+    using x_coord_t = typename plane_image_t::coord_t;
+    using y_coord_t = typename plane_image_t::coord_t;
 
-    typedef subchroma_image_view< locator_t, Factors > view_t;
-    typedef typename view_t::const_t                   const_view_t;
+    using view_t = subchroma_image_view<locator_t, Factors>;
+    using const_view_t = typename view_t::const_t;
 
 
     /// constructor
@@ -392,9 +395,7 @@ private:
 
     void init()
     {
-        typedef subchroma_image_deref_fn< pixel_locator_t
-                                        , Factors
-                                        > defer_fn_t;
+        using defer_fn_t = subchroma_image_deref_fn<pixel_locator_t, Factors>;
 
         defer_fn_t deref_fn( view( _y_plane ).xy_at( 0, 0 )
                            , view( _v_plane ).xy_at( 0, 0 )
@@ -480,7 +481,11 @@ void fill_pixels( const subchroma_image_view< Locator, Factors >& view
                 , const Pixel&                                    value
                 )
 {
-    typedef typename subchroma_image< Pixel, Factors >::plane_view_t::value_type channel_t;
+    using channel_t = typename subchroma_image
+        <
+            Pixel,
+            Factors
+        >::plane_view_t::value_type;
 
     fill_pixels( view.y_plane_view(), channel_t( at_c< 0 >( value )));
     fill_pixels( view.v_plane_view(), channel_t( at_c< 1 >( value )));
@@ -501,10 +506,12 @@ typename subchroma_image< Pixel
                                                 , unsigned char* y_base
                                                 )
 {
-    typedef detail::scaling_factors< mpl::at_c< Factors, 0 >::type::value
-                           , mpl::at_c< Factors, 1 >::type::value
-                           , mpl::at_c< Factors, 2 >::type::value
-                           > scaling_factors_t;
+    using scaling_factors_t = detail::scaling_factors
+        <
+            mpl::at_c<Factors, 0>::type::value,
+            mpl::at_c<Factors, 1>::type::value,
+            mpl::at_c<Factors, 2>::type::value
+        >;
 
     std::size_t y_channel_size = 1;
     std::size_t u_channel_size = 1;
@@ -513,7 +520,7 @@ typename subchroma_image< Pixel
     unsigned char* v_base = u_base + ( y_width  / scaling_factors_t::ss_X )
                                    * u_channel_size;
 
-    typedef typename subchroma_image< Pixel, Factors >::plane_view_t plane_view_t;
+    using plane_view_t = typename subchroma_image<Pixel, Factors>::plane_view_t;
 
     plane_view_t y_plane = interleaved_view( y_width
                                            , y_height
@@ -533,11 +540,11 @@ typename subchroma_image< Pixel
                                            , y_width                            // rowsize_in_bytes
                                            );
 
-    typedef subchroma_image_deref_fn< typename subchroma_image< Pixel
-                                                              , Factors
-                                                              >::pixel_locator_t
-                                    , Factors
-                                    > defer_fn_t;
+    using defer_fn_t = subchroma_image_deref_fn
+        <
+            typename subchroma_image<Pixel, Factors>::pixel_locator_t,
+            Factors
+        >;
 
     defer_fn_t deref_fn( y_plane.xy_at( 0, 0 )
                        , v_plane.xy_at( 0, 0 )
@@ -545,18 +552,14 @@ typename subchroma_image< Pixel
                        );
 
 
-    typedef typename subchroma_image< Pixel
-                           , Factors
-                           >::locator_t locator_t;
+    using locator_t = typename subchroma_image<Pixel, Factors>::locator_t;
 
     locator_t locator( point_t( 0, 0 ) // p
                      , point_t( 1, 1 ) // step
                      , deref_fn
                      );
 
-    typedef typename subchroma_image< Pixel
-                           , Factors
-                           >::view_t view_t;
+    using view_t = typename subchroma_image<Pixel, Factors>::view_t;
 
     return view_t( point_t(                           y_width,                           y_height )
                  , point_t( y_width / scaling_factors_t::ss_X, y_height / scaling_factors_t::ss_Y )

--- a/include/boost/gil/extension/toolbox/metafunctions/channel_type.hpp
+++ b/include/boost/gil/extension/toolbox/metafunctions/channel_type.hpp
@@ -26,10 +26,12 @@ namespace boost{ namespace gil {
 template <typename B, typename C, typename L, bool M>
 struct gen_chan_ref
 {
-    typedef packed_dynamic_channel_reference< B
-                                            , mpl::at_c< C, 0 >::type::value
-                                            , M
-                                            > type;
+    using type = packed_dynamic_channel_reference
+        <
+            B,
+            mpl::at_c<C, 0>::type::value,
+            M
+        >;
 };
 
 //! This implementation works for bit_algined_pixel_reference
@@ -53,10 +55,12 @@ struct channel_type<const bit_aligned_pixel_reference<B,C,L,M> >
 template <typename B, typename C, typename L>
 struct gen_chan_ref_p
 {
-    typedef packed_dynamic_channel_reference< B
-                                            , get_num_bits< typename mpl::at_c<C,0>::type>::value
-                                            , true
-                                            > type;
+    using type = packed_dynamic_channel_reference
+        <
+            B,
+            get_num_bits<typename mpl::at_c<C, 0>::type>::value,
+            true
+        >;
 };
 
 // packed_pixel
@@ -89,7 +93,7 @@ struct channel_type< const packed_pixel< B, C, L > >
 template<>
 struct channel_type< any_image_pixel_t >
 {
-    typedef any_image_channel_t type;
+    using type = any_image_channel_t;
 };
 
 } // namespace gil

--- a/include/boost/gil/extension/toolbox/metafunctions/channel_view.hpp
+++ b/include/boost/gil/extension/toolbox/metafunctions/channel_view.hpp
@@ -36,12 +36,8 @@ struct channel_view_type : public kth_channel_view_type< channel_type_to_index< 
                                                   , View
                                                   >::value;
 
-    typedef kth_channel_view_type< index
-                                 , View
-                                 > parent_t;
-
-    typedef typename parent_t::type type;
-
+    using parent_t = kth_channel_view_type<index, View>;
+    using type = typename parent_t::type;
 
     static type make( const View& src )
     {

--- a/include/boost/gil/extension/toolbox/metafunctions/get_pixel_type.hpp
+++ b/include/boost/gil/extension/toolbox/metafunctions/get_pixel_type.hpp
@@ -26,7 +26,7 @@ struct get_pixel_type : mpl::if_< typename is_bit_aligned< typename View::value_
 template< typename ImageViewTypes >
 struct get_pixel_type< any_image_view< ImageViewTypes > >
 {
-    typedef any_image_pixel_t type;
+    using type = any_image_pixel_t;
 };
 
 } // namespace gil


### PR DESCRIPTION
Run clang-tidy 7.0 with `-checks='-*,modernize-use-using' -fix` against
single TU with `#include <boost/gil/extension/toolbox/*.hpp>`.

Manually refactor numerous `typedef`-s
- where missed by modernize-use-using check, not uncommon
- in code snippets in comments

Outcome is that searching for lower-case whole word `typedef`
in all the `extension/toolbox/*.hpp` should return no matches.

### References

-    #192
-   #193
-    #195
-    #196

### Tasklist

- [ ] Review
- [ ] Adjust for comments
- [ ] All CI builds and checks have passed
