### PR TITLE
Apply clang-tidy modernize-use-using to all tests

### DIFF
--- a/io/test/bmp_old_test.cpp
+++ b/io/test/bmp_old_test.cpp
@@ -73,12 +73,13 @@ BOOST_AUTO_TEST_CASE( old_write_view_test )
 
 BOOST_AUTO_TEST_CASE( old_dynamic_image_test )
 {
-    typedef mpl::vector< gray8_image_t
-                       , gray16_image_t
-                       , rgb8_image_t
-                       , rgba8_image_t
-                       > my_img_types;
-
+    using my_img_types = mpl::vector
+        <
+            gray8_image_t,
+            gray16_image_t,
+            rgb8_image_t,
+            rgba8_image_t
+        >;
 
     any_image< my_img_types > runtime_image;
 

--- a/io/test/bmp_read_test.cpp
+++ b/io/test/bmp_read_test.cpp
@@ -18,7 +18,7 @@
 using namespace std;
 using namespace boost::gil;
 
-typedef bmp_tag tag_t;
+using tag_t = bmp_tag;
 
 BOOST_AUTO_TEST_SUITE( gil_io_bmp_tests )
 
@@ -40,9 +40,7 @@ void write( Image&        img
 BOOST_AUTO_TEST_CASE( read_header_test )
 {
     {
-        typedef get_reader_backend< const std::string
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<std::string const, tag_t>::type;
 
         backend_t backend = read_image_info( bmp_filename
                                            , tag_t()

--- a/io/test/bmp_test.cpp
+++ b/io/test/bmp_test.cpp
@@ -25,7 +25,7 @@ using namespace boost;
 using namespace gil;
 namespace fs = boost::filesystem;
 
-typedef bmp_tag tag_t;
+using tag_t = bmp_tag;
 
 BOOST_AUTO_TEST_SUITE( gil_io_bmp_tests )
 
@@ -34,9 +34,7 @@ BOOST_AUTO_TEST_SUITE( gil_io_bmp_tests )
 BOOST_AUTO_TEST_CASE( read_image_info_using_string )
 {
     {
-        typedef get_reader_backend< const std::string
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<std::string const, tag_t>::type;
 
         backend_t backend = read_image_info( bmp_filename
                                            , tag_t()
@@ -49,9 +47,7 @@ BOOST_AUTO_TEST_CASE( read_image_info_using_string )
     {
         ifstream in( bmp_filename.c_str(), ios::binary );
 
-        typedef get_reader_backend< std::ifstream
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<std::ifstream, tag_t>::type;
 
         backend_t backend = read_image_info( in
                                            , tag_t()
@@ -64,9 +60,7 @@ BOOST_AUTO_TEST_CASE( read_image_info_using_string )
     {
         FILE* file = fopen( bmp_filename.c_str(), "rb" );
 
-        typedef get_reader_backend< FILE*
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<FILE*, tag_t>::type;
 
         backend_t backend = read_image_info( file
                                            , tag_t()
@@ -79,9 +73,7 @@ BOOST_AUTO_TEST_CASE( read_image_info_using_string )
     {
         fs::path my_path( bmp_filename );
 
-        typedef get_reader_backend< fs::path
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<fs::path, tag_t>::type;
 
         backend_t backend = read_image_info( my_path
                                            , tag_t()
@@ -331,12 +323,13 @@ BOOST_AUTO_TEST_CASE( subimage_test )
 
 BOOST_AUTO_TEST_CASE( dynamic_image_test )
 {
-    typedef mpl::vector< gray8_image_t
-                       , gray16_image_t
-                       , rgb8_image_t
-                       , rgba8_image_t
-                       > my_img_types;
-
+    using my_img_types = mpl::vector
+        <
+            gray8_image_t,
+            gray16_image_t,
+            rgb8_image_t,
+            rgba8_image_t
+        >;
 
     any_image< my_img_types > runtime_image;
 

--- a/io/test/bmp_write_test.cpp
+++ b/io/test/bmp_write_test.cpp
@@ -20,7 +20,7 @@
 using namespace std;
 using namespace boost::gil;
 
-typedef bmp_tag tag_t;
+using tag_t = bmp_tag;
 
 BOOST_AUTO_TEST_SUITE( gil_io_bmp_tests )
 

--- a/io/test/jpeg_old_test.cpp
+++ b/io/test/jpeg_old_test.cpp
@@ -73,12 +73,13 @@ BOOST_AUTO_TEST_CASE( old_write_view_test )
 
 BOOST_AUTO_TEST_CASE( old_dynamic_image_test )
 {
-    typedef mpl::vector< gray8_image_t
-                       , gray16_image_t
-                       , rgb8_image_t
-                       , rgba8_image_t
-                       > my_img_types;
-
+    using my_img_types = mpl::vector
+        <
+            gray8_image_t,
+            gray16_image_t,
+            rgb8_image_t,
+            rgba8_image_t
+        >;
 
     any_image< my_img_types > runtime_image;
 

--- a/io/test/jpeg_read_test.cpp
+++ b/io/test/jpeg_read_test.cpp
@@ -17,7 +17,7 @@
 using namespace std;
 using namespace boost::gil;
 
-typedef jpeg_tag tag_t;
+using tag_t = jpeg_tag;
 
 BOOST_AUTO_TEST_SUITE( gil_io_jpeg_tests )
 
@@ -26,9 +26,7 @@ BOOST_AUTO_TEST_SUITE( gil_io_jpeg_tests )
 BOOST_AUTO_TEST_CASE( read_header_test )
 {
     {
-        typedef get_reader_backend< const std::string
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<std::string const, tag_t>::type;
 
         backend_t backend = read_image_info( jpeg_filename
                                            , tag_t()
@@ -46,9 +44,7 @@ BOOST_AUTO_TEST_CASE( read_header_test )
 
 BOOST_AUTO_TEST_CASE( read_pixel_density_test )
 {
-    typedef get_reader_backend< const std::string
-                              , tag_t
-                              >::type backend_t;
+    using backend_t = get_reader_backend<std::string const, tag_t>::type;
 
     backend_t backend = read_image_info( jpeg_in + "EddDawson/36dpi.jpg"
                                        , tag_t()
@@ -67,9 +63,7 @@ BOOST_AUTO_TEST_CASE( read_pixel_density_test )
     stringstream in_memory( ios_base::in | ios_base::out | ios_base::binary );
     write_view( in_memory, view( img ), write_settings );
 
-    typedef get_reader_backend< stringstream
-                              , tag_t
-                              >::type backend2_t;
+    using backend2_t = get_reader_backend<stringstream, tag_t>::type;
 
     backend2_t backend2 = read_image_info( in_memory
                                          , tag_t()
@@ -86,7 +80,7 @@ BOOST_AUTO_TEST_CASE( read_pixel_density_test )
 
 BOOST_AUTO_TEST_CASE( read_reference_images_test )
 {
-    typedef rgb8_image_t image_t;
+    using image_t = rgb8_image_t;
     image_t img;
 
     read_image( jpeg_filename
@@ -104,7 +98,7 @@ BOOST_AUTO_TEST_CASE( read_reference_images_test )
 
 BOOST_AUTO_TEST_CASE( dct_method_read_test )
 {
-    typedef rgb8_image_t image_t;
+    using image_t = rgb8_image_t;
     image_t img;
 
     image_read_settings< jpeg_tag > settings;

--- a/io/test/jpeg_test.cpp
+++ b/io/test/jpeg_test.cpp
@@ -26,7 +26,7 @@ using namespace boost;
 using namespace gil;
 using namespace filesystem;
 
-typedef jpeg_tag tag_t;
+using tag_t = jpeg_tag;
 
 BOOST_AUTO_TEST_SUITE( gil_io_jpeg_tests )
 
@@ -36,9 +36,11 @@ BOOST_AUTO_TEST_CASE( read_image_info_test )
 {
 
     {
-        typedef get_reader_backend< const std::string
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend
+            <
+                std::string const,
+                tag_t
+            >::type;
 
         backend_t backend = read_image_info( jpeg_filename
                                            , tag_t()
@@ -51,9 +53,7 @@ BOOST_AUTO_TEST_CASE( read_image_info_test )
     {
         std::ifstream in( jpeg_filename.c_str(), ios::binary );
 
-        typedef get_reader_backend< std::ifstream
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<std::ifstream, tag_t>::type;
 
         backend_t backend = read_image_info( in
                                            , tag_t()
@@ -66,9 +66,7 @@ BOOST_AUTO_TEST_CASE( read_image_info_test )
     {
         FILE* file = fopen( jpeg_filename.c_str(), "rb" );
 
-        typedef get_reader_backend< FILE*
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<FILE*, tag_t>::type;
 
         backend_t backend = boost::gil::read_image_info( file
                                                        , tag_t()
@@ -79,9 +77,7 @@ BOOST_AUTO_TEST_CASE( read_image_info_test )
     }
 
     {
-        typedef get_reader_backend< path
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<path, tag_t>::type;
 
         backend_t backend = boost::gil::read_image_info( path( jpeg_filename )
                                                        , tag_t()
@@ -313,11 +309,13 @@ BOOST_AUTO_TEST_CASE( subimage_test )
 
 BOOST_AUTO_TEST_CASE( dynamic_image_test )
 {
-    typedef mpl::vector< gray8_image_t
-                       , gray16_image_t
-                       , rgb8_image_t
-                       , rgba8_image_t
-                       > my_img_types;
+    using my_img_types = mpl::vector
+        <
+            gray8_image_t,
+            gray16_image_t,
+            rgb8_image_t,
+            rgba8_image_t
+        >;
 
 
     any_image< my_img_types > runtime_image;

--- a/io/test/jpeg_write_test.cpp
+++ b/io/test/jpeg_write_test.cpp
@@ -18,7 +18,7 @@
 using namespace std;
 using namespace boost::gil;
 
-typedef jpeg_tag tag_t;
+using tag_t = jpeg_tag;
 
 BOOST_AUTO_TEST_SUITE( gil_io_jpeg_tests )
 
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE( write_test )
 BOOST_AUTO_TEST_CASE( dct_method_write_test )
 {
     {
-        typedef rgb8_image_t image_t;
+        using image_t = rgb8_image_t;
         image_t img;
 
         read_image( jpeg_filename

--- a/io/test/make.cpp
+++ b/io/test/make.cpp
@@ -131,9 +131,7 @@ BOOST_AUTO_TEST_CASE( make_dynamic_image_reader_test )
 BOOST_AUTO_TEST_CASE( make_writer_test )
 {
     {
-        typedef get_writer< const char*
-                          , bmp_tag
-                          >::type writer_t;
+        using writer_t = get_writer<char const*, bmp_tag>::type;
 
         BOOST_STATIC_ASSERT(( boost::is_same< gil::detail::is_writer< writer_t >::type, boost::mpl::true_ >::value ));
     }

--- a/io/test/mandel_view.hpp
+++ b/io/test/mandel_view.hpp
@@ -16,15 +16,16 @@ using namespace gil;
 
 // Models a Unary Function
 template <typename P>   // Models PixelValueConcept
-struct mandelbrot_fn {
+struct mandelbrot_fn
+{
     using point_t = boost::gil::point_t;
-    typedef mandelbrot_fn        const_t;
-    typedef P                    value_type;
-    typedef value_type           reference;
-    typedef value_type           const_reference;
-    typedef point_t              argument_type;
-    typedef reference            result_type;
-    BOOST_STATIC_CONSTANT(bool, is_mutable=false);
+    using const_t = mandelbrot_fn;
+    using value_type = P;
+    using reference = value_type;
+    using const_reference = value_type;
+    using argument_type = point_t;
+    using result_type = reference;
+    BOOST_STATIC_CONSTANT(bool, is_mutable = false);
 
     value_type                    _in_color,_out_color;
     point_t                       _img_size;
@@ -63,11 +64,10 @@ private:
 template< typename Pixel >
 struct mandel_view
 {
-    typedef mandelbrot_fn< Pixel > deref_t;
-    typedef virtual_2d_locator<deref_t,false> locator_t;
-    typedef image_view<locator_t> my_virt_view_t;
-
-    typedef my_virt_view_t type;
+    using deref_t = mandelbrot_fn<Pixel>;
+    using locator_t= virtual_2d_locator<deref_t, false>;
+    using my_virt_view_t = image_view<locator_t>;
+    using type = my_virt_view_t;
 };
 
 template< typename Pixel >
@@ -77,9 +77,9 @@ typename mandel_view< Pixel >::type create_mandel_view( unsigned int width
                                                       , const Pixel& out
                                                       )
 {
-    typedef typename mandel_view< Pixel >::type      view_t;
-    typedef typename mandel_view< Pixel >::deref_t   deref_t;
-    typedef typename mandel_view< Pixel >::locator_t locator_t;
+    using view_t = typename mandel_view<Pixel>::type;
+    using deref_t = typename mandel_view<Pixel>::deref_t;
+    using locator_t = typename mandel_view<Pixel>::locator_t;
 
     point_t dims( width, height );
     return view_t( dims

--- a/io/test/png_file_format_test.cpp
+++ b/io/test/png_file_format_test.cpp
@@ -21,7 +21,7 @@ using namespace std;
 using namespace boost::gil;
 namespace fs = boost::filesystem;
 
-typedef png_tag tag_t;
+using tag_t = png_tag;
 
 BOOST_AUTO_TEST_SUITE( gil_io_png_tests )
 

--- a/io/test/png_old_test.cpp
+++ b/io/test/png_old_test.cpp
@@ -73,12 +73,13 @@ BOOST_AUTO_TEST_CASE( old_write_view_test )
 
 BOOST_AUTO_TEST_CASE( old_dynamic_image_test )
 {
-    typedef mpl::vector< gray8_image_t
-                       , gray16_image_t
-                       , rgb8_image_t
-                       , rgba8_image_t
-                       > my_img_types;
-
+    using my_img_types = mpl::vector
+        <
+            gray8_image_t,
+            gray16_image_t,
+            rgb8_image_t,
+            rgba8_image_t
+        >;
 
     any_image< my_img_types > runtime_image;
 

--- a/io/test/png_read_test.cpp
+++ b/io/test/png_read_test.cpp
@@ -27,15 +27,15 @@ using namespace gil;
 using namespace boost::gil::detail;
 namespace fs = boost::filesystem;
 
-typedef png_tag tag_t;
+using tag_t = png_tag;
 
 BOOST_AUTO_TEST_SUITE( gil_io_png_tests )
 
-typedef pixel< uint8_t, gray_alpha_layout_t > gray_alpha8_pixel_t;
-typedef image< gray_alpha8_pixel_t, false   > gray_alpha8_image_t;
+using gray_alpha8_pixel_t = pixel<uint8_t, gray_alpha_layout_t>;
+using gray_alpha8_image_t= image<gray_alpha8_pixel_t, false>;
 
-typedef pixel< uint16_t, gray_alpha_layout_t > gray_alpha16_pixel_t;
-typedef image< gray_alpha16_pixel_t, false   > gray_alpha16_image_t;
+using gray_alpha16_pixel_t = pixel<uint16_t, gray_alpha_layout_t>;
+using gray_alpha16_image_t = image<gray_alpha16_pixel_t, false>;
 
 template< typename Image >
 void test_file( string filename )
@@ -47,9 +47,7 @@ void test_file( string filename )
     settings._read_transparency_data = true;
 
 
-    typedef get_reader_backend< const std::string
-                              , tag_t
-                              >::type backend_t;
+    using backend_t = get_reader_backend<std::string const, tag_t>::type;
 
     backend_t backend = read_image_info( png_in + filename
                                         , settings
@@ -91,9 +89,7 @@ void test_png_scanline_reader( string filename )
 
 BOOST_AUTO_TEST_CASE( read_header_test )
 {
-    typedef get_reader_backend< const std::string
-                              , tag_t
-                              >::type backend_t;
+    using backend_t = get_reader_backend<std::string const, tag_t>::type;
 
     backend_t backend = read_image_info( png_filename
                                        , tag_t()
@@ -121,9 +117,7 @@ BOOST_AUTO_TEST_CASE( read_pixel_per_meter )
     image_read_settings< png_tag > settings;
     settings.set_read_members_true();
 
-    typedef get_reader_backend< const std::string
-                             , tag_t
-                             >::type backend_t;
+    using backend_t = get_reader_backend<std::string const, tag_t>::type;
 
     backend_t backend = read_image_info( png_base_in + "EddDawson/36dpi.png"
                                       , settings

--- a/io/test/png_test.cpp
+++ b/io/test/png_test.cpp
@@ -25,7 +25,7 @@ using namespace std;
 using namespace boost;
 using namespace gil;
 
-typedef png_tag tag_t;
+using tag_t = png_tag;
 
 BOOST_AUTO_TEST_SUITE( gil_io_png_tests )
 
@@ -34,9 +34,7 @@ BOOST_AUTO_TEST_SUITE( gil_io_png_tests )
 BOOST_AUTO_TEST_CASE( read_image_info_using_string )
 {
     {
-        typedef get_reader_backend< const std::string
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<std::string const, tag_t>::type;
 
         backend_t backend = read_image_info( png_filename
                                            , tag_t()
@@ -49,9 +47,7 @@ BOOST_AUTO_TEST_CASE( read_image_info_using_string )
     {
         ifstream in( png_filename.c_str(), ios::binary );
 
-        typedef get_reader_backend< ifstream
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<ifstream, tag_t>::type;
 
         backend_t backend = read_image_info( in
                                            , tag_t()
@@ -64,9 +60,7 @@ BOOST_AUTO_TEST_CASE( read_image_info_using_string )
     {
         FILE* file = fopen( png_filename.c_str(), "rb" );
 
-        typedef get_reader_backend< FILE*
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<FILE*, tag_t>::type;
 
         backend_t backend = read_image_info( file
                                            , tag_t()
@@ -329,12 +323,13 @@ BOOST_AUTO_TEST_CASE( subimage_test )
 
 BOOST_AUTO_TEST_CASE( dynamic_image_test )
 {
-    typedef mpl::vector< gray8_image_t
-                       , gray16_image_t
-                       , rgb8_image_t
-                       , rgba8_image_t
-                       > my_img_types;
-
+    using my_img_types = mpl::vector
+        <
+            gray8_image_t,
+            gray16_image_t,
+            rgb8_image_t,
+            rgba8_image_t
+        >;
 
     any_image< my_img_types > runtime_image;
 

--- a/io/test/png_write_test.cpp
+++ b/io/test/png_write_test.cpp
@@ -28,7 +28,7 @@ using namespace gil;
 using namespace boost::gil::detail;
 namespace fs = boost::filesystem;
 
-typedef png_tag tag_t;
+using tag_t = png_tag;
 
 BOOST_AUTO_TEST_SUITE( gil_io_png_tests )
 

--- a/io/test/pnm_old_test.cpp
+++ b/io/test/pnm_old_test.cpp
@@ -80,12 +80,13 @@ BOOST_AUTO_TEST_CASE( old_write_view_test )
 
 BOOST_AUTO_TEST_CASE( old_dynamic_image_test )
 {
-    typedef mpl::vector< gray8_image_t
-                       , gray16_image_t
-                       , rgb8_image_t
-                       , gray1_image_t
-                       > my_img_types;
-
+    using my_img_types = mpl::vector
+        <
+            gray8_image_t,
+            gray16_image_t,
+            rgb8_image_t,
+            gray1_image_t
+        >;
 
     any_image< my_img_types > runtime_image;
 

--- a/io/test/pnm_read_test.cpp
+++ b/io/test/pnm_read_test.cpp
@@ -17,7 +17,7 @@
 using namespace std;
 using namespace boost::gil;
 
-typedef pnm_tag tag_t;
+using tag_t = pnm_tag;
 
 BOOST_AUTO_TEST_SUITE( gil_io_pnm_tests )
 
@@ -45,9 +45,7 @@ void test_pnm_scanline_reader( string filename )
 BOOST_AUTO_TEST_CASE( read_header_test )
 {
     {
-        typedef get_reader_backend< const std::string
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<std::string const, tag_t>::type;
 
         backend_t backend = read_image_info( pnm_filename
                                            , tag_t()

--- a/io/test/pnm_test.cpp
+++ b/io/test/pnm_test.cpp
@@ -23,7 +23,7 @@ using namespace std;
 using namespace boost;
 using namespace gil;
 
-typedef pnm_tag tag_t;
+using tag_t = pnm_tag;
 
 BOOST_AUTO_TEST_SUITE( gil_io_pnm_tests )
 
@@ -32,9 +32,7 @@ BOOST_AUTO_TEST_SUITE( gil_io_pnm_tests )
 BOOST_AUTO_TEST_CASE( read_image_info_using_string )
 {
     {
-        typedef get_reader_backend< const std::string
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<std::string const, tag_t>::type;
 
         backend_t backend = read_image_info( pnm_filename
                                            , tag_t()
@@ -47,9 +45,7 @@ BOOST_AUTO_TEST_CASE( read_image_info_using_string )
     {
         ifstream in( pnm_filename.c_str(), ios::binary );
 
-        typedef get_reader_backend< ifstream
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<ifstream, tag_t>::type;
 
         backend_t backend = read_image_info( in
                                            , tag_t()
@@ -62,9 +58,7 @@ BOOST_AUTO_TEST_CASE( read_image_info_using_string )
     {
         FILE* file = fopen( pnm_filename.c_str(), "rb" );
 
-        typedef get_reader_backend< FILE*
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<FILE*, tag_t>::type;
 
         backend_t backend = read_image_info( file
                                            , tag_t()
@@ -307,12 +301,13 @@ BOOST_AUTO_TEST_CASE( subimage_test )
 
 BOOST_AUTO_TEST_CASE( dynamic_image_test )
 {
-    typedef mpl::vector< gray8_image_t
-                       , gray16_image_t
-                       , rgb8_image_t
-                       , gray1_image_t
-                       > my_img_types;
-
+    using my_img_types = mpl::vector
+        <
+            gray8_image_t,
+            gray16_image_t,
+            rgb8_image_t,
+            gray1_image_t
+        >;
 
     any_image< my_img_types > runtime_image;
 

--- a/io/test/pnm_write_test.cpp
+++ b/io/test/pnm_write_test.cpp
@@ -18,7 +18,7 @@
 using namespace std;
 using namespace boost::gil;
 
-typedef pnm_tag tag_t;
+using tag_t = pnm_tag;
 
 BOOST_AUTO_TEST_SUITE( gil_io_pnm_tests )
 
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE( write_test )
 
     // test writing all supported image types
     {
-        typedef bit_aligned_image1_type< 1, gray_layout_t >::type gray1_image_t;
+        using gray1_image_t = bit_aligned_image1_type<1, gray_layout_t>::type;
         gray1_image_t dst( 200, 200 );
 
         copy_and_convert_pixels( v, view( dst ));

--- a/io/test/raw_test.cpp
+++ b/io/test/raw_test.cpp
@@ -26,7 +26,7 @@ using namespace boost;
 using namespace gil;
 namespace fs = boost::filesystem;
 
-typedef raw_tag tag_t;
+using tag_t = raw_tag;
 
 BOOST_AUTO_TEST_SUITE( gil_io_raw_tests )
 
@@ -37,7 +37,7 @@ BOOST_AUTO_TEST_CASE( read_image_info_using_string )
   {
     /// raw_tag reader's can only constructed with char*, std::string, and LibRaw object
 
-    typedef get_reader_backend<const char*, tag_t>::type backend_t;
+    using backend_t = get_reader_backend<char const*, tag_t>::type;
 
     backend_t b = make_reader_backend(raw_filename.c_str(),
 				      image_read_settings<raw_tag>());
@@ -48,16 +48,16 @@ BOOST_AUTO_TEST_CASE( read_image_info_using_string )
     BOOST_CHECK_EQUAL( backend._info._height, 1448 );
   }
 
-  {
-    fs::path my_path( raw_filename );
+    {
+        fs::path my_path( raw_filename );
 
-    typedef get_reader_backend<fs::path, tag_t>::type backend_t;
+        using backend_t = get_reader_backend<fs::path, tag_t>::type;
 
         backend_t backend = read_image_info(my_path, tag_t());
 
         BOOST_CHECK_EQUAL( backend._info._width , 2176 );
         BOOST_CHECK_EQUAL( backend._info._height, 1448 );
-  }
+    }
 }
 
 BOOST_AUTO_TEST_CASE( read_image_test )
@@ -110,8 +110,13 @@ BOOST_AUTO_TEST_CASE( read_and_convert_view_test )
 
 BOOST_AUTO_TEST_CASE( dynamic_image_test )
 {
-  typedef mpl::vector<gray8_image_t, gray16_image_t, rgb8_image_t, rgba8_image_t> my_img_types;
-
+  using my_img_types = mpl::vector
+      <
+          gray8_image_t,
+          gray16_image_t,
+          rgb8_image_t,
+          rgba8_image_t
+      >;
 
   any_image< my_img_types > runtime_image;
 

--- a/io/test/scanline_read_test.hpp
+++ b/io/test/scanline_read_test.hpp
@@ -20,17 +20,17 @@ void test_scanline_reader( const char* file_name )
     using namespace boost::gil;
 
     // read image using scanline_read_iterator
-    typedef scanline_reader< typename get_read_device< const char*
-                                                     , FormatTag
-                                                     >::type
-                           , FormatTag
-                           > reader_t;
+    using reader_t = scanline_reader
+        <
+            typename get_read_device<char const*, FormatTag>::type,
+            FormatTag
+        >;
 
     reader_t reader = make_scanline_reader( file_name, FormatTag() );
 
     Image dst( reader._info._width, reader._info._height );
 
-    typedef typename reader_t::iterator_t iterator_t;
+    using iterator_t = typename reader_t::iterator_t;
 
     iterator_t it  = reader.begin();
     iterator_t end = reader.end();

--- a/io/test/targa_old_test.cpp
+++ b/io/test/targa_old_test.cpp
@@ -74,12 +74,13 @@ BOOST_AUTO_TEST_CASE( old_write_view_test )
 
 BOOST_AUTO_TEST_CASE( old_dynamic_image_test )
 {
-    typedef mpl::vector< gray8_image_t
-                       , gray16_image_t
-                       , rgb8_image_t
-                       , rgba8_image_t
-                       > my_img_types;
-
+    using my_img_types = mpl::vector
+        <
+            gray8_image_t,
+            gray16_image_t,
+            rgb8_image_t,
+            rgba8_image_t
+        >;
 
     any_image< my_img_types > runtime_image;
 

--- a/io/test/targa_read_test.cpp
+++ b/io/test/targa_read_test.cpp
@@ -19,7 +19,7 @@
 using namespace std;
 using namespace boost::gil;
 
-typedef targa_tag tag_t;
+using tag_t = targa_tag;
 
 BOOST_AUTO_TEST_SUITE( gil_io_targa_tests )
 
@@ -47,9 +47,7 @@ void write( Image&        img
 BOOST_AUTO_TEST_CASE( read_header_test )
 {
     {
-        typedef get_reader_backend< const std::string
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<std::string const, tag_t>::type;
 
         backend_t backend = read_image_info( targa_filename
                                            , tag_t()

--- a/io/test/targa_test.cpp
+++ b/io/test/targa_test.cpp
@@ -25,7 +25,7 @@ using namespace boost;
 using namespace gil;
 namespace fs = boost::filesystem;
 
-typedef targa_tag tag_t;
+using tag_t = targa_tag;
 
 BOOST_AUTO_TEST_SUITE( gil_io_targa_tests )
 
@@ -35,9 +35,7 @@ BOOST_AUTO_TEST_CASE( read_image_info_using_string )
 {
 
     {
-        typedef get_reader_backend< const std::string
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<std::string const, tag_t>::type;
 
         backend_t backend = read_image_info( targa_filename
                                            , tag_t()
@@ -50,9 +48,7 @@ BOOST_AUTO_TEST_CASE( read_image_info_using_string )
     {
         ifstream in( targa_filename.c_str(), ios::binary );
 
-        typedef get_reader_backend< ifstream
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<ifstream, tag_t>::type;
 
         backend_t backend = read_image_info( in
                                            , tag_t()
@@ -65,9 +61,7 @@ BOOST_AUTO_TEST_CASE( read_image_info_using_string )
     {
         FILE* file = fopen( targa_filename.c_str(), "rb" );
 
-        typedef get_reader_backend< FILE*
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<FILE*, tag_t>::type;
 
         backend_t backend = read_image_info( file
                                            , tag_t()
@@ -80,9 +74,7 @@ BOOST_AUTO_TEST_CASE( read_image_info_using_string )
     {
         fs::path my_path( targa_filename );
 
-        typedef get_reader_backend< fs::path
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<fs::path, tag_t>::type;
 
         backend_t backend = read_image_info( my_path
                                            , tag_t()
@@ -312,12 +304,13 @@ BOOST_AUTO_TEST_CASE( subimage_test )
 
 BOOST_AUTO_TEST_CASE( dynamic_image_test )
 {
-    typedef mpl::vector< gray8_image_t
-                       , gray16_image_t
-                       , rgb8_image_t
-                       , rgba8_image_t
-                       > my_img_types;
-
+    using my_img_types = mpl::vector
+        <
+            gray8_image_t,
+            gray16_image_t,
+            rgb8_image_t,
+            rgba8_image_t
+        >;
 
     any_image< my_img_types > runtime_image;
 

--- a/io/test/targa_write_test.cpp
+++ b/io/test/targa_write_test.cpp
@@ -20,7 +20,7 @@
 using namespace std;
 using namespace boost::gil;
 
-typedef targa_tag tag_t;
+using tag_t = targa_tag;
 
 BOOST_AUTO_TEST_SUITE( gil_io_targa_tests )
 

--- a/io/test/tiff_file_format_test.cpp
+++ b/io/test/tiff_file_format_test.cpp
@@ -17,7 +17,7 @@
 using namespace std;
 using namespace boost::gil;
 
-typedef tiff_tag tag_t;
+using tag_t = tiff_tag;
 
 BOOST_AUTO_TEST_SUITE( gil_io_tiff_tests )
 
@@ -35,7 +35,7 @@ BOOST_AUTO_TEST_CASE( two_bit_minisblack_gray_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-minisblack-02.tif" );
 
     {
-        typedef bit_aligned_image1_type< 2, gray_layout_t >::type image_t;
+        using image_t = bit_aligned_image1_type<2, gray_layout_t>::type;
         image_t img;
 
         read_image( filename
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE( four_bit_minisblack_gray_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-minisblack-04.tif" );
 
     {
-        typedef bit_aligned_image1_type< 4, gray_layout_t >::type image_t;
+        using image_t = bit_aligned_image1_type<4, gray_layout_t>::type;
         image_t img;
 
         read_image( filename
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE( six_bit_minisblack_gray_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-minisblack-06.tif" );
 
     {
-        typedef bit_aligned_image1_type< 6, gray_layout_t >::type image_t;
+        using image_t = bit_aligned_image1_type<6, gray_layout_t>::type;
         image_t img;
 
         read_image( filename
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE( eight_bit_minisblack_gray_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-minisblack-08.tif" );
 
     {
-        typedef gray8_image_t image_t;
+        using image_t = gray8_image_t;
         image_t img;
 
         read_image( filename
@@ -127,7 +127,7 @@ BOOST_AUTO_TEST_CASE( ten_bit_minisblack_gray_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-minisblack-10.tif" );
 
     {
-        typedef bit_aligned_image1_type< 10, gray_layout_t >::type image_t;
+        using image_t = bit_aligned_image1_type<10, gray_layout_t>::type;
         image_t img;
 
         read_image( filename
@@ -150,7 +150,7 @@ BOOST_AUTO_TEST_CASE( twelve_bit_minisblack_gray_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-minisblack-12.tif" );
 
     {
-        typedef bit_aligned_image1_type< 12, gray_layout_t >::type image_t;
+        using image_t = bit_aligned_image1_type<12, gray_layout_t>::type;
         image_t img;
 
         read_image( filename
@@ -173,7 +173,7 @@ BOOST_AUTO_TEST_CASE( fourteen_bit_minisblack_gray_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-minisblack-14.tif" );
 
     {
-        typedef bit_aligned_image1_type< 14, gray_layout_t >::type image_t;
+        using image_t = bit_aligned_image1_type<14, gray_layout_t>::type;
         image_t img;
 
         read_image( filename
@@ -196,7 +196,7 @@ BOOST_AUTO_TEST_CASE( sixteen_bit_minisblack_gray_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-minisblack-16.tif" );
 
     {
-        typedef gray16_image_t image_t;
+        using image_t = gray16_image_t;
         image_t img;
 
         read_image( filename
@@ -219,7 +219,7 @@ BOOST_AUTO_TEST_CASE( twentyfour_bit_minisblack_gray_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-minisblack-24.tif" );
 
     {
-        typedef bit_aligned_image1_type< 24, gray_layout_t >::type image_t;
+        using image_t = bit_aligned_image1_type<24, gray_layout_t>::type;
         image_t img;
 
         read_image( filename
@@ -242,7 +242,7 @@ BOOST_AUTO_TEST_CASE( thirtytwo_bit_minisblack_gray_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-minisblack-32.tif" );
 
     {
-        typedef gray32_image_t image_t;
+        using image_t = gray32_image_t;
         image_t img;
 
         read_image( filename
@@ -265,7 +265,7 @@ BOOST_AUTO_TEST_CASE( four_entry_colormapped_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-palette-02.tif" );
 
     {
-        typedef rgb16_image_t image_t;
+        using image_t = rgb16_image_t;
         image_t img;
 
         read_image( filename
@@ -288,7 +288,7 @@ BOOST_AUTO_TEST_CASE( sixteen_entry_colormapped_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-palette-04.tif" );
 
     {
-        typedef rgb16_image_t image_t;
+        using image_t = rgb16_image_t;
         image_t img;
 
         read_image( filename
@@ -311,7 +311,7 @@ BOOST_AUTO_TEST_CASE( twohundred_twenty_five_entry_colormapped_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-palette-08.tif" );
 
     {
-        typedef rgb16_image_t image_t;
+        using image_t = rgb16_image_t;
         image_t img;
 
         read_image( filename
@@ -334,7 +334,7 @@ BOOST_AUTO_TEST_CASE( sixtyfive_thousand_entry_colormapped_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-palette-16.tif" );
 
     {
-        typedef rgb16_image_t image_t;
+        using image_t = rgb16_image_t;
         image_t img;
 
         read_image( filename
@@ -357,7 +357,7 @@ BOOST_AUTO_TEST_CASE( two_bit_contiguous_RGB_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-rgb-contig-02.tif" );
 
     {
-        typedef bit_aligned_image3_type< 2, 2, 2, rgb_layout_t >::type image_t;
+        using image_t = bit_aligned_image3_type<2, 2, 2, rgb_layout_t>::type;
         image_t img;
 
         read_image( filename
@@ -380,7 +380,7 @@ BOOST_AUTO_TEST_CASE( four_bit_contiguous_RGB_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-rgb-contig-04.tif" );
 
     {
-        typedef bit_aligned_image3_type< 4, 4, 4, rgb_layout_t >::type image_t;
+        using image_t = bit_aligned_image3_type<4, 4, 4, rgb_layout_t>::type;
         image_t img;
 
         read_image( filename
@@ -403,7 +403,7 @@ BOOST_AUTO_TEST_CASE( eight_bit_contiguous_RGB_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-rgb-contig-08.tif" );
 
     {
-        typedef rgb8_image_t image_t;
+        using image_t = rgb8_image_t;
         image_t img;
 
         read_image( filename
@@ -426,7 +426,7 @@ BOOST_AUTO_TEST_CASE( ten_bit_contiguous_RGB_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-rgb-contig-10.tif" );
 
     {
-        typedef bit_aligned_image3_type< 10, 10, 10, rgb_layout_t >::type image_t;
+        using image_t = bit_aligned_image3_type<10, 10, 10, rgb_layout_t>::type;
         image_t img;
 
         read_image( filename
@@ -449,7 +449,7 @@ BOOST_AUTO_TEST_CASE( twelve_bit_contiguous_RGB_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-rgb-contig-12.tif" );
 
     {
-        typedef bit_aligned_image3_type< 12, 12, 12, rgb_layout_t >::type image_t;
+        using image_t = bit_aligned_image3_type<12, 12, 12, rgb_layout_t>::type;
         image_t img;
 
         read_image( filename
@@ -472,7 +472,7 @@ BOOST_AUTO_TEST_CASE( fourteen_bit_contiguous_RGB_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-rgb-contig-14.tif" );
 
     {
-        typedef bit_aligned_image3_type< 14, 14, 14, rgb_layout_t >::type image_t;
+        using image_t = bit_aligned_image3_type<14, 14, 14, rgb_layout_t>::type;
         image_t img;
 
         read_image( filename
@@ -495,7 +495,7 @@ BOOST_AUTO_TEST_CASE( sixteen_bit_contiguous_RGB_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-rgb-contig-16.tif" );
 
     {
-        typedef rgb16_image_t image_t;
+        using image_t = rgb16_image_t;
         image_t img;
 
         read_image( filename
@@ -518,7 +518,7 @@ BOOST_AUTO_TEST_CASE( twenty_four_bit_contiguous_RGB_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-rgb-contig-24.tif" );
 
     {
-        typedef bit_aligned_image3_type< 24, 24, 24, rgb_layout_t >::type image_t;
+        using image_t = bit_aligned_image3_type<24, 24, 24, rgb_layout_t>::type;
         image_t img;
 
         read_image( filename
@@ -541,7 +541,7 @@ BOOST_AUTO_TEST_CASE( thirty_two_bit_contiguous_RGB_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-rgb-contig-32.tif" );
 
     {
-        typedef rgb32_image_t image_t;
+        using image_t = rgb32_image_t;
         image_t img;
 
         read_image( filename
@@ -564,7 +564,7 @@ BOOST_AUTO_TEST_CASE( two_bit_seperated_RGB_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-rgb-planar-02.tif" );
 
     {
-        typedef bit_aligned_image3_type< 2, 2, 2, rgb_layout_t >::type image_t;
+        using image_t = bit_aligned_image3_type<2, 2, 2, rgb_layout_t>::type;
         image_t img;
 
         read_image( filename
@@ -587,7 +587,7 @@ BOOST_AUTO_TEST_CASE( four_bit_seperated_RGB_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-rgb-planar-04.tif" );
 
     {
-        typedef bit_aligned_image3_type< 4, 4, 4, rgb_layout_t >::type image_t;
+        using image_t = bit_aligned_image3_type<4, 4, 4, rgb_layout_t>::type;
         image_t img;
 
         read_image( filename
@@ -610,7 +610,7 @@ BOOST_AUTO_TEST_CASE( eight_bit_seperated_RGB_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-rgb-planar-08.tif" );
 
     {
-        typedef rgb8_planar_image_t image_t;
+        using image_t = rgb8_planar_image_t;
         image_t img;
 
         read_image( filename
@@ -633,7 +633,7 @@ BOOST_AUTO_TEST_CASE( ten_bit_seperated_RGB_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-rgb-planar-10.tif" );
 
     {
-        typedef bit_aligned_image3_type< 10, 10, 10, rgb_layout_t >::type image_t;
+        using image_t = bit_aligned_image3_type<10, 10, 10, rgb_layout_t>::type;
         image_t img;
 
         read_image( filename
@@ -656,7 +656,7 @@ BOOST_AUTO_TEST_CASE( twelve_bit_seperated_RGB_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-rgb-planar-12.tif" );
 
     {
-        typedef bit_aligned_image3_type< 12, 12, 12, rgb_layout_t >::type image_t;
+        using image_t = bit_aligned_image3_type<12, 12, 12, rgb_layout_t>::type;
         image_t img;
 
         read_image( filename
@@ -679,7 +679,7 @@ BOOST_AUTO_TEST_CASE( fourteen_bit_seperated_RGB_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-rgb-planar-14.tif" );
 
     {
-        typedef bit_aligned_image3_type< 14, 14, 14, rgb_layout_t >::type image_t;
+        using image_t = bit_aligned_image3_type<14, 14, 14, rgb_layout_t>::type;
         image_t img;
 
         read_image( filename
@@ -702,7 +702,7 @@ BOOST_AUTO_TEST_CASE( sixteen_bit_seperated_RGB_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-rgb-planar-16.tif" );
 
     {
-        typedef rgb16_planar_image_t image_t;
+        using image_t = rgb16_planar_image_t;
         image_t img;
 
         read_image( filename
@@ -725,7 +725,7 @@ BOOST_AUTO_TEST_CASE( twenty_four_bit_seperated_RGB_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-rgb-planar-24.tif" );
 
     {
-        typedef bit_aligned_image3_type< 24, 24, 24, rgb_layout_t >::type image_t;
+        using image_t = bit_aligned_image3_type<24, 24, 24, rgb_layout_t>::type;
         image_t img;
 
         read_image( filename
@@ -748,7 +748,7 @@ BOOST_AUTO_TEST_CASE( thirty_two_bit_seperated_RGB_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-rgb-planar-32.tif" );
 
     {
-        typedef rgb32_planar_image_t image_t;
+        using image_t = rgb32_planar_image_t;
         image_t img;
 
         read_image( filename
@@ -771,7 +771,7 @@ BOOST_AUTO_TEST_CASE( eight_bit_contiguous_CMYK_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-separated-contig-08.tif" );
 
     {
-        typedef cmyk8_image_t image_t;
+        using image_t = cmyk8_image_t;
         image_t img;
 
         read_image( filename
@@ -794,7 +794,7 @@ BOOST_AUTO_TEST_CASE( sixteen_bit_contiguous_CMYK_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-separated-contig-16.tif" );
 
     {
-        typedef cmyk16_image_t image_t;
+        using image_t = cmyk16_image_t;
         image_t img;
 
         read_image( filename
@@ -817,7 +817,7 @@ BOOST_AUTO_TEST_CASE( eight_bit_separated_CMYK_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-separated-planar-08.tif" );
 
     {
-        typedef cmyk8_planar_image_t image_t;
+        using image_t = cmyk8_planar_image_t;
         image_t img;
 
         read_image( filename
@@ -840,7 +840,7 @@ BOOST_AUTO_TEST_CASE( sixteen_bit_separated_CMYK_image_test )
     std::string filename( tiff_in + "libtiffpic/depth/flower-separated-planar-16.tif" );
 
     {
-        typedef cmyk16_planar_image_t image_t;
+        using image_t = cmyk16_planar_image_t;
         image_t img;
 
         read_image( filename
@@ -866,7 +866,7 @@ BOOST_AUTO_TEST_CASE( tiger_separated_strip_contig_08 )
     std::string filename( tiff_in_GM + "tiger-separated-strip-contig-08.tif" );
 
     {
-        typedef cmyk8_planar_image_t image_t;
+        using image_t = cmyk8_planar_image_t;
         image_t img;
 
         read_image( filename
@@ -888,7 +888,7 @@ BOOST_AUTO_TEST_CASE( tiger_separated_strip_contig_16 )
     std::string filename( tiff_in_GM + "tiger-separated-strip-contig-16.tif" );
 
     {
-        typedef cmyk16_planar_image_t image_t;
+        using image_t = cmyk16_planar_image_t;
         image_t img;
 
         read_image( filename
@@ -910,7 +910,7 @@ BOOST_AUTO_TEST_CASE( tiger_separated_strip_planar_08 )
     std::string filename( tiff_in_GM + "tiger-separated-strip-planar-08.tif" );
 
     {
-        typedef cmyk8_planar_image_t image_t;
+        using image_t = cmyk8_planar_image_t;
         image_t img;
 
         read_image( filename
@@ -932,7 +932,7 @@ BOOST_AUTO_TEST_CASE( tiger_separated_strip_planar_16 )
     std::string filename( tiff_in_GM + "tiger-separated-strip-planar-16.tif" );
 
     {
-        typedef cmyk16_planar_image_t image_t;
+        using image_t = cmyk16_planar_image_t;
         image_t img;
 
         read_image( filename

--- a/io/test/tiff_old_test.cpp
+++ b/io/test/tiff_old_test.cpp
@@ -64,12 +64,13 @@ BOOST_AUTO_TEST_CASE( old_read_and_convert_view_test )
 
 BOOST_AUTO_TEST_CASE( old_dynamic_image_test )
 {
-    typedef mpl::vector< gray8_image_t
-                       , gray16_image_t
-                       , rgba8_image_t
-                       , gray1_image_t
-                       > my_img_types;
-
+    using my_img_types = mpl::vector
+        <
+            gray8_image_t,
+            gray16_image_t,
+            rgba8_image_t,
+            gray1_image_t
+        >;
 
     any_image< my_img_types > runtime_image;
 

--- a/io/test/tiff_subimage_test.cpp
+++ b/io/test/tiff_subimage_test.cpp
@@ -22,7 +22,7 @@ using namespace std;
 using namespace boost;
 using namespace gil;
 
-typedef tiff_tag tag_t;
+using tag_t = tiff_tag;
 
 #include <boost/preprocessor/cat.hpp>
 #include <boost/preprocessor/stringize.hpp>
@@ -99,7 +99,7 @@ BOOST_AUTO_TEST_CASE( subimage_test_16 )
 
 BOOST_AUTO_TEST_CASE( subimage_test_32 )
 {
-    typedef pixel< unsigned int, gray_layout_t > gray32_pixel_t;
+    using gray32_pixel_t = pixel<unsigned int, gray_layout_t>;
     image< gray32_pixel_t, false > img1, img2, img3;
 
     point_t top_left( 10, 10 );

--- a/io/test/tiff_test.cpp
+++ b/io/test/tiff_test.cpp
@@ -29,7 +29,7 @@ using namespace boost;
 using namespace gil;
 namespace fs = boost::filesystem;
 
-typedef tiff_tag tag_t;
+using tag_t = tiff_tag;
 
 BOOST_AUTO_TEST_SUITE( gil_io_tiff_tests )
 
@@ -38,9 +38,7 @@ BOOST_AUTO_TEST_SUITE( gil_io_tiff_tests )
 BOOST_AUTO_TEST_CASE( read_image_info_test )
 {
     {
-        typedef get_reader_backend< const std::string
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<std::string const, tag_t>::type;
 
         backend_t backend = read_image_info( tiff_filename
                                            , tag_t()
@@ -53,9 +51,7 @@ BOOST_AUTO_TEST_CASE( read_image_info_test )
     {
         ifstream in( tiff_filename.c_str(), ios::binary );
 
-        typedef get_reader_backend< ifstream
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<ifstream, tag_t>::type;
 
         backend_t backend = read_image_info( in
                                            , tag_t()
@@ -68,9 +64,7 @@ BOOST_AUTO_TEST_CASE( read_image_info_test )
     {
         TIFF* file = TIFFOpen( tiff_filename.c_str(), "r" );
 
-        typedef get_reader_backend< FILE*
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<FILE*, tag_t>::type;
 
         backend_t backend = read_image_info( file
                                            , tag_t()
@@ -83,9 +77,7 @@ BOOST_AUTO_TEST_CASE( read_image_info_test )
     {
         fs::path my_path( tiff_filename );
 
-        typedef get_reader_backend< fs::path
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<fs::path, tag_t>::type;
 
         backend_t backend = read_image_info( my_path
                                            , tag_t()
@@ -345,12 +337,13 @@ BOOST_AUTO_TEST_CASE( dynamic_image_test )
     // This test has been disabled for now because of
     // compilation issues with MSVC10.
 
-    typedef mpl::vector< gray8_image_t
-                       , gray16_image_t
-                       , rgba8_image_t
-                       , gray1_image_t
-                       > my_img_types;
-
+    using my_img_types = mpl::vector
+        <
+            gray8_image_t,
+            gray16_image_t,
+            rgb8_image_t,
+            gray1_image_t
+        >;
 
     any_image< my_img_types > runtime_image;
 

--- a/io/test/tiff_tiled_float_test.cpp
+++ b/io/test/tiff_tiled_float_test.cpp
@@ -17,7 +17,7 @@ using namespace std;
 using namespace boost;
 using namespace gil;
 
-typedef tiff_tag tag_t;
+using tag_t = tiff_tag;
 
 BOOST_AUTO_TEST_SUITE( gil_io_tiff_tests )
 

--- a/io/test/tiff_tiled_minisblack_test_21-31_32-64.cpp
+++ b/io/test/tiff_tiled_minisblack_test_21-31_32-64.cpp
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE( read_tile_and_compare_with_minisblack_strip_32 )
     string filename_strip( tiff_in_GM + "tiger-minisblack-strip-32.tif" );
     string filename_tile ( tiff_in_GM + "tiger-minisblack-tile-32.tif"  );
 
-    typedef pixel< unsigned int, gray_layout_t > gray32_pixel_t;
+    using gray32_pixel_t = pixel<unsigned int, gray_layout_t>;
     image< gray32_pixel_t, false > img_strip, img_tile;
 
     read_image( filename_strip, img_strip, tag_t() );
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE( read_tile_and_compare_with_minisblack_strip_64 )
     string filename_strip( tiff_in_GM + "tiger-minisblack-strip-64.tif" );
     string filename_tile ( tiff_in_GM + "tiger-minisblack-tile-64.tif"  );
 
-    typedef pixel< uint64_t, gray_layout_t > gray64_pixel_t;
+    using gray64_pixel_t = pixel<uint64_t, gray_layout_t>;
     image< gray64_pixel_t, false > img_strip, img_tile;
 
     read_image( filename_strip, img_strip, tag_t() );

--- a/io/test/tiff_tiled_minisblack_write_test_21-31_32-64.cpp
+++ b/io/test/tiff_tiled_minisblack_write_test_21-31_32-64.cpp
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE( write_tile_and_compare_with_minisblack_strip_32 )
 
     string filename_strip( tiff_in_GM + "tiger-minisblack-strip-32.tif" );
 
-    typedef pixel< unsigned int, gray_layout_t > gray32_pixel_t;
+    using gray32_pixel_t = pixel<unsigned int, gray_layout_t>;
     image< gray32_pixel_t, false > img_strip, img_saved;
 
     read_image( filename_strip, img_strip, tag_t() );
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE( write_tile_and_compare_with_minisblack_strip_64 )
 
     string filename_strip( tiff_in_GM + "tiger-minisblack-strip-64.tif" );
 
-    typedef pixel< uint64_t, gray_layout_t > gray64_pixel_t;
+    using gray64_pixel_t = pixel<uint64_t, gray_layout_t>;
     image< gray64_pixel_t, false > img_strip, img_saved;
 
     read_image( filename_strip, img_strip, tag_t() );

--- a/io/test/tiff_tiled_read_macros.hpp
+++ b/io/test/tiff_tiled_read_macros.hpp
@@ -20,7 +20,7 @@
 
 #include "paths.hpp"
 
-typedef boost::gil::tiff_tag tag_t;
+using tag_t = boost::gil::tiff_tag;
 
 #define GENERATE_TILE_STRIP_COMPARISON_BIT_ALIGNED_RGB(z, n, data)\
     BOOST_AUTO_TEST_CASE( BOOST_PP_CAT( \

--- a/io/test/tiff_tiled_rgb_contig_test_21-31_32_64.cpp
+++ b/io/test/tiff_tiled_rgb_contig_test_21-31_32_64.cpp
@@ -25,7 +25,7 @@ BOOST_AUTO_TEST_CASE( read_tile_and_compare_with_rgb_contig_strip_32 )
     string filename_strip( tiff_in_GM + "tiger-rgb-strip-contig-32.tif" );
     string filename_tile ( tiff_in_GM + "tiger-rgb-tile-contig-32.tif"  );
 
-    typedef pixel< unsigned int, rgb_layout_t > rgb32_pixel_t;
+    using rgb32_pixel_t= pixel<unsigned int, rgb_layout_t>;
     image< rgb32_pixel_t, false > img_strip, img_tile;
 
     read_image( filename_strip, img_strip, tag_t() );
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE( read_tile_and_compare_with_rgb_contig_strip_64 )
     string filename_strip( tiff_in_GM + "tiger-rgb-strip-contig-64.tif" );
     string filename_tile ( tiff_in_GM + "tiger-rgb-tile-contig-64.tif"  );
 
-    typedef pixel< uint64_t, rgb_layout_t > rgb64_pixel_t;
+    using rgb64_pixel_t = pixel<uint64_t, rgb_layout_t>;
     image< rgb64_pixel_t, false > img_strip, img_tile;
 
     read_image( filename_strip, img_strip, tag_t() );

--- a/io/test/tiff_tiled_rgb_contig_write_test_21-31_32_64.cpp
+++ b/io/test/tiff_tiled_rgb_contig_write_test_21-31_32_64.cpp
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE( write_tile_and_compare_with_rgb_strip_contig_32 )
 
     string filename_strip( tiff_in_GM + "tiger-rgb-strip-contig-32.tif" );
 
-    typedef pixel< unsigned int, rgb_layout_t > rgb32_pixel_t;
+    using rgb32_pixel_t = pixel<unsigned int, rgb_layout_t>;
     image< rgb32_pixel_t, false > img_strip, img_saved;
 
     read_image( filename_strip, img_strip, tag_t() );
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE( write_tile_and_compare_with_rgb_strip_contig_64 )
 
     string filename_strip( tiff_in_GM + "tiger-rgb-strip-contig-64.tif" );
 
-    typedef pixel< uint64_t, rgb_layout_t > rgb64_pixel_t;
+    using rgb64_pixel_t = pixel<uint64_t, rgb_layout_t>;
     image< rgb64_pixel_t, false > img_strip, img_saved;
 
     read_image( filename_strip, img_strip, tag_t() );

--- a/io/test/tiff_tiled_rgb_planar_test_21-31_32_64.cpp
+++ b/io/test/tiff_tiled_rgb_planar_test_21-31_32_64.cpp
@@ -25,7 +25,7 @@ BOOST_AUTO_TEST_CASE( read_tile_and_compare_with_rgb_planar_strip_32 )
     string filename_strip( tiff_in_GM + "tiger-rgb-strip-planar-32.tif" );
     string filename_tile ( tiff_in_GM + "tiger-rgb-tile-planar-32.tif"  );
 
-    typedef pixel< unsigned int, rgb_layout_t > rgb32_pixel_t;
+    using rgb32_pixel_t = pixel<unsigned int, rgb_layout_t>;
     image< rgb32_pixel_t, false > img_strip, img_tile;
 
     read_image( filename_strip, img_strip, tag_t() );
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE( read_tile_and_compare_with_rgb_planar_strip_64 )
     string filename_strip( tiff_in_GM + "tiger-rgb-strip-planar-64.tif" );
     string filename_tile ( tiff_in_GM + "tiger-rgb-tile-planar-64.tif"  );
 
-    typedef pixel< uint64_t, rgb_layout_t > rgb64_pixel_t;
+    using rgb64_pixel_t = pixel<uint64_t, rgb_layout_t>;
     image< rgb64_pixel_t, false > img_strip, img_tile;
 
     read_image( filename_strip, img_strip, tag_t() );

--- a/io/test/tiff_tiled_test.cpp
+++ b/io/test/tiff_tiled_test.cpp
@@ -15,7 +15,7 @@ using namespace std;
 using namespace boost;
 using namespace gil;
 
-typedef tiff_tag tag_t;
+using tag_t = tiff_tag;
 
 BOOST_AUTO_TEST_SUITE( gil_io_tiff_tests )
 
@@ -24,9 +24,7 @@ BOOST_AUTO_TEST_SUITE( gil_io_tiff_tests )
 BOOST_AUTO_TEST_CASE( read_tile_infos_test )
 {
     {
-        typedef get_reader_backend< const std::string
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<std::string const, tag_t>::type;
 
         backend_t backend = read_image_info( tiff_in_GM + "tiger-minisblack-float-tile-16.tif"
                                            , tag_t()
@@ -37,9 +35,7 @@ BOOST_AUTO_TEST_CASE( read_tile_infos_test )
     }
 
     {
-        typedef get_reader_backend< const std::string
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<std::string const, tag_t>::type;
 
         backend_t backend = read_image_info( tiff_in_GM + "tiger-minisblack-tile-08.tif"
                                            , tag_t()
@@ -50,9 +46,7 @@ BOOST_AUTO_TEST_CASE( read_tile_infos_test )
     }
 
     {
-        typedef get_reader_backend< const std::string
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<std::string const, tag_t>::type;
 
         backend_t backend = read_image_info( tiff_in_GM + "tiger-palette-tile-08.tif"
                                            , tag_t()
@@ -63,9 +57,7 @@ BOOST_AUTO_TEST_CASE( read_tile_infos_test )
     }
 
     {
-        typedef get_reader_backend< const std::string
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<std::string const, tag_t>::type;
 
         backend_t backend = read_image_info( tiff_in_GM + "tiger-rgb-tile-contig-08.tif"
                                            , tag_t()
@@ -76,9 +68,7 @@ BOOST_AUTO_TEST_CASE( read_tile_infos_test )
     }
 
     {
-        typedef get_reader_backend< const std::string
-                                  , tag_t
-                                  >::type backend_t;
+        using backend_t = get_reader_backend<std::string const, tag_t>::type;
 
         backend_t backend = read_image_info( tiff_in_GM + "tiger-rgb-tile-planar-08.tif"
                                            , tag_t()

--- a/io/test/tiff_tiled_write_macros.hpp
+++ b/io/test/tiff_tiled_write_macros.hpp
@@ -20,7 +20,7 @@
 
 #include "paths.hpp"
 
-typedef boost::gil::tiff_tag tag_t;
+using tag_t = boost::gil::tiff_tag;
 
 #ifdef BOOST_GIL_IO_TEST_ALLOW_WRITING_IMAGES
 

--- a/io/test/tiff_write_test.cpp
+++ b/io/test/tiff_write_test.cpp
@@ -18,7 +18,7 @@
 using namespace std;
 using namespace boost::gil;
 
-typedef tiff_tag tag_t;
+using tag_t = tiff_tag;
 
 BOOST_AUTO_TEST_SUITE( gil_io_tiff_tests )
 

--- a/numeric/test/numeric.cpp
+++ b/numeric/test/numeric.cpp
@@ -39,8 +39,9 @@ namespace boost { namespace gil {
 template <typename T> struct mapping_traits;
 
 template < class F, class I >
-struct mapping_traits< TestMapFn<F,I> > {
-    typedef typename TestMapFn<F,I>::result_type result_type;
+struct mapping_traits<TestMapFn<F, I>>
+{
+    using result_type = typename TestMapFn<F, I>::result_type;
 };
 
 template <class F, class I>

--- a/test/channel.cpp
+++ b/test/channel.cpp
@@ -42,8 +42,8 @@ auto c32f_max = channel_traits<float32_t>::max_value();
 
 template <typename ChannelTestCore>
 struct do_test : public ChannelTestCore {
-    typedef typename ChannelTestCore::channel_t channel_t;
-    typedef typename channel_traits<channel_t>::value_type channel_value_t;
+    using channel_t = typename ChannelTestCore::channel_t;
+    using channel_value_t = typename channel_traits<channel_t>::value_type;
 
     do_test() : ChannelTestCore() {
         error_if(this->_min_v != channel_traits<channel_t>::min_value());
@@ -158,23 +158,34 @@ struct do_test : public ChannelTestCore {
 template <typename ChannelValue>
 class value_core {
 protected:
-    typedef ChannelValue channel_t;
-    channel_t _min_v, _max_v;
+    using channel_t = ChannelValue;
+    channel_t _min_v;
+    channel_t _max_v;
 
-    value_core() : _min_v(channel_traits<ChannelValue>::min_value()), _max_v(channel_traits<ChannelValue>::max_value()) {
+    value_core()
+        : _min_v(channel_traits<ChannelValue>::min_value())
+        , _max_v(channel_traits<ChannelValue>::max_value())
+    {
         boost::function_requires<ChannelValueConcept<ChannelValue> >();
     }
 };
 
 // For channel references we need to have separate channel values
 template <typename ChannelRef>
-class reference_core : public value_core<typename channel_traits<ChannelRef>::value_type> {
-    typedef value_core<typename channel_traits<ChannelRef>::value_type> parent_t;
-protected:
-    typedef ChannelRef channel_t;
-    channel_t _min_v, _max_v;
+class reference_core : public value_core<typename channel_traits<ChannelRef>::value_type>
+{
+    using parent_t = value_core<typename channel_traits<ChannelRef>::value_type>;
 
-    reference_core() : parent_t(), _min_v(parent_t::_min_v), _max_v(parent_t::_max_v) {
+protected:
+    using channel_t = ChannelRef;
+    channel_t _min_v;
+    channel_t _max_v;
+
+    reference_core()
+        : parent_t()
+        , _min_v(parent_t::_min_v)
+        , _max_v(parent_t::_max_v)
+    {
         boost::function_requires<ChannelConcept<ChannelRef> >();
     }
 };
@@ -183,8 +194,8 @@ protected:
 template <typename ChannelSubbyteRef, typename ChannelMutableRef = ChannelSubbyteRef>
 class packed_reference_core {
 protected:
-    typedef ChannelSubbyteRef channel_t;
-    typedef typename channel_t::integer_t integer_t;
+    using channel_t = ChannelSubbyteRef;
+    using integer_t = typename channel_t::integer_t;
     channel_t _min_v, _max_v;
 
     integer_t _min_buf, _max_buf;
@@ -201,7 +212,7 @@ protected:
 template <typename ChannelSubbyteRef, typename ChannelMutableRef = ChannelSubbyteRef>
 class packed_dynamic_reference_core {
 protected:
-    typedef ChannelSubbyteRef channel_t;
+    using channel_t = ChannelSubbyteRef;
     channel_t _min_v, _max_v;
 
     typename channel_t::integer_t _min_buf, _max_buf;
@@ -280,11 +291,11 @@ struct channel_archetype {
     template <typename Scalar> channel_archetype operator*=(Scalar) { return *this; }
     template <typename Scalar> channel_archetype operator/=(Scalar) { return *this; }
 
-    typedef channel_value_archetype         value_type;
-    typedef channel_archetype               reference;
-    typedef const channel_archetype         const_reference;
-    typedef channel_value_archetype*        pointer;
-    typedef const channel_value_archetype*  const_pointer;
+    using value_type = channel_value_archetype;
+    using reference = channel_archetype;
+    using const_reference = channel_archetype const;
+    using pointer = channel_value_archetype *;
+    using const_pointer = channel_value_archetype const*;
     BOOST_STATIC_CONSTANT(bool, is_mutable=true);
 
     static value_type min_value();
@@ -303,10 +314,11 @@ channel_value_archetype channel_archetype::min_value() { return channel_value_ar
 channel_value_archetype channel_archetype::max_value() { return channel_value_archetype(); }
 
 
-void test_packed_channel_reference() {
-    typedef packed_channel_reference<std::uint16_t, 0,5,true> channel16_0_5_reference_t;
-    typedef packed_channel_reference<std::uint16_t, 5,6,true> channel16_5_6_reference_t;
-    typedef packed_channel_reference<std::uint16_t, 11,5,true> channel16_11_5_reference_t;
+void test_packed_channel_reference()
+{
+    using channel16_0_5_reference_t = packed_channel_reference<std::uint16_t, 0, 5, true>;
+    using channel16_5_6_reference_t = packed_channel_reference<std::uint16_t, 5, 6, true>;
+    using channel16_11_5_reference_t = packed_channel_reference<std::uint16_t, 11, 5, true>;
 
     std::uint16_t data=0;
     channel16_0_5_reference_t   channel1(&data);
@@ -323,9 +335,10 @@ void test_packed_channel_reference() {
     test_packed_channel_reference<channel16_11_5_reference_t>();
 }
 
-void test_packed_dynamic_channel_reference() {
-    typedef packed_dynamic_channel_reference<std::uint16_t,5,true> channel16_5_reference_t;
-    typedef packed_dynamic_channel_reference<std::uint16_t,6,true> channel16_6_reference_t;
+void test_packed_dynamic_channel_reference()
+{
+    using channel16_5_reference_t = packed_dynamic_channel_reference<std::uint16_t, 5, true>;
+    using channel16_6_reference_t = packed_dynamic_channel_reference<std::uint16_t, 6, true>;
 
     std::uint16_t data=0;
     channel16_5_reference_t  channel1(&data,0);

--- a/test/image.cpp
+++ b/test/image.cpp
@@ -76,8 +76,8 @@ struct my_color_converter_impl<C1,gray_t> {
 struct my_color_converter {
     template <typename SrcP,typename DstP>
     void operator()(const SrcP& src,DstP& dst) const {
-        typedef typename color_space_type<SrcP>::type src_cs_t;
-        typedef typename color_space_type<DstP>::type dst_cs_t;
+        using src_cs_t = typename color_space_type<SrcP>::type;
+        using dst_cs_t = typename color_space_type<DstP>::type;
         my_color_converter_impl<src_cs_t,dst_cs_t>()(src,dst);
     }
 };
@@ -86,12 +86,12 @@ struct my_color_converter {
 template <typename P>   // Models PixelValueConcept
 struct mandelbrot_fn {
     using point_t = boost::gil::point_t;
-    typedef mandelbrot_fn        const_t;
-    typedef P                    value_type;
-    typedef value_type           reference;
-    typedef value_type           const_reference;
-    typedef point_t              argument_type;
-    typedef reference            result_type;
+    using const_t = mandelbrot_fn<P>;
+    using value_type = P;
+    using reference = value_type;
+    using const_reference = value_type;
+    using argument_type = point_t;
+    using result_type = reference;
     BOOST_STATIC_CONSTANT(bool, is_mutable=false);
 
     value_type                    _in_color,_out_color;
@@ -186,7 +186,7 @@ private:
 // testing image iterators, clone, fill, locators, color convert
 template <typename Img>
 void image_test::basic_test(const string& prefix) {
-    typedef typename Img::view_t View;
+    using View = typename Img::view_t;
 
     // make a 20x20 image
     Img img(typename View::point_t(20,20));
@@ -274,11 +274,12 @@ void image_test::homogeneous_view_transformations_test(const View& img_view, con
     check_view(nth_channel_view(img_view,0),prefix+"0th_n_channel");
 }
 
-void image_test::virtual_view_test() {
-    typedef mandelbrot_fn<rgb8_pixel_t> deref_t;
-    typedef deref_t::point_t            point_t;
-    typedef virtual_2d_locator<deref_t,false> locator_t;
-    typedef image_view<locator_t> my_virt_view_t;
+void image_test::virtual_view_test()
+{
+    using deref_t = mandelbrot_fn<rgb8_pixel_t>;
+    using point_t = deref_t::point_t;
+    using locator_t = virtual_2d_locator<deref_t, false>;
+    using my_virt_view_t = image_view<locator_t>;
 
     boost::function_requires<PixelLocatorConcept<locator_t> >();
     gil_function_requires<StepIteratorConcept<locator_t::x_iterator> >();
@@ -296,9 +297,10 @@ void image_test::virtual_view_test() {
 }
 
 // Test alignment and packed images
-void image_test::packed_image_test() {
-    typedef bit_aligned_image3_type<1,3,1, bgr_layout_t>::type bgr131_image_t;
-    typedef bgr131_image_t::value_type bgr131_pixel_t;
+void image_test::packed_image_test()
+{
+    using bgr131_image_t = bit_aligned_image3_type<1,3,1, bgr_layout_t>::type;
+    using bgr131_pixel_t = bgr131_image_t::value_type;
     bgr131_pixel_t fill_val(1,3,1);
 
     bgr131_image_t bgr131_img(3,10);
@@ -313,9 +315,19 @@ void image_test::packed_image_test() {
     error_if(bgr131_img!=bgr131a_img || bgr131a_img!=bgr131b_img);
 }
 
-void image_test::dynamic_image_test() {
-    typedef any_image<mpl::vector<gray8_image_t, bgr8_image_t, argb8_image_t,
-                                  rgb8_image_t, rgb8_planar_image_t> > any_image_t;
+void image_test::dynamic_image_test()
+{
+    using any_image_t = any_image
+        <
+            mpl::vector
+            <
+                gray8_image_t,
+                bgr8_image_t,
+                argb8_image_t,
+                rgb8_image_t,
+                rgb8_planar_image_t
+            >
+        >;
     rgb8_planar_image_t img(sample_view.dimensions());
     copy_pixels(sample_view, view(img));
     any_image_t any_img=any_image_t(img);
@@ -351,8 +363,14 @@ void image_test::run() {
     image_all_test<rgb8_planar_image_t>("planarrgb8_");
     image_all_test<gray8_image_t>("gray8_");
 
-    typedef const bit_aligned_pixel_reference<boost::uint8_t, mpl::vector3_c<int,1,2,1>, bgr_layout_t, true>  bgr121_ref_t;
-    typedef image<bgr121_ref_t,false> bgr121_image_t;
+    using bgr121_ref_t = bit_aligned_pixel_reference
+        <
+            boost::uint8_t,
+            mpl::vector3_c<int, 1, 2, 1>,
+            bgr_layout_t,
+            true
+        > const;
+    using bgr121_image_t = image<bgr121_ref_t, false>;
     image_all_test<bgr121_image_t>("bgr121_");
 
     // TODO: Remove?
@@ -372,9 +390,10 @@ void image_test::run() {
 ///
 ////////////////////////////////////////////////////
 
-class checksum_image_mgr : public image_test {
+class checksum_image_mgr : public image_test
+{
 protected:
-    typedef map<string,boost::crc_32_type::value_type> crc_map_t;
+    using crc_map_t = map<string, boost::crc_32_type::value_type>;
     crc_map_t _crc_map;
 };
 
@@ -518,13 +537,13 @@ void static_checks() {
     }
 }
 
-typedef checksum_image_test     image_test_t;
-typedef checksum_image_generate image_generate_t;
+using image_test_t = checksum_image_test;
+using image_generate_t = checksum_image_generate;
 
 #ifdef BOOST_GIL_GENERATE_REFERENCE_DATA
-typedef image_generate_t        image_mgr_t;
+using image_mgr_t = image_generate_t;
 #else
-typedef image_test_t            image_mgr_t;
+using image_mgr_t = image_test_t;
 #endif
 
 void test_image(const char* ref_checksum) {

--- a/test/performance.cpp
+++ b/test/performance.cpp
@@ -46,9 +46,9 @@ double measure_time(Op op, std::size_t num_loops) {
 std::size_t width=1000, height=400;
 
 // macros for standard GIL views
-#define RGB_VIEW(T) image_view<memory_based_2d_locator<memory_based_step_iterator<pixel<T,rgb_layout_t>*> > >
-#define BGR_VIEW(T) image_view<memory_based_2d_locator<memory_based_step_iterator<pixel<T,bgr_layout_t>*> > >
-#define RGB_PLANAR_VIEW(T) image_view<memory_based_2d_locator<memory_based_step_iterator<planar_pixel_iterator<T*,rgb_t> > > >
+#define RGB_VIEW(T) image_view<memory_based_2d_locator<memory_based_step_iterator<pixel<T,rgb_layout_t>*>>>
+#define BGR_VIEW(T) image_view<memory_based_2d_locator<memory_based_step_iterator<pixel<T,bgr_layout_t>*>>>
+#define RGB_PLANAR_VIEW(T) image_view<memory_based_2d_locator<memory_based_step_iterator<planar_pixel_iterator<T*,rgb_t>>>>
 
 template <typename View, typename P>
 struct fill_gil_t {
@@ -59,8 +59,9 @@ struct fill_gil_t {
 };
 template <typename View, typename P> struct fill_nongil_t;
 template <typename T, typename P>
-struct fill_nongil_t<RGB_VIEW(T), P> {
-    typedef RGB_VIEW(T) View;
+struct fill_nongil_t<RGB_VIEW(T), P>
+{
+    using View = RGB_VIEW(T);
     View _v;
     P _p;
     fill_nongil_t(const View& v_in,const P& p_in) : _v(v_in), _p(p_in) {}
@@ -76,9 +77,10 @@ struct fill_nongil_t<RGB_VIEW(T), P> {
     }
 };
 template <typename T1, typename T2>
-struct fill_nongil_t<RGB_VIEW(T1), pixel<T2,bgr_layout_t> > {
-    typedef RGB_VIEW(T1) View;
-    typedef pixel<T2,bgr_layout_t> P;
+struct fill_nongil_t<RGB_VIEW(T1), pixel<T2,bgr_layout_t>>
+{
+    using View = RGB_VIEW(T1);
+    using P = pixel<T2, bgr_layout_t>;
     View _v;
     P _p;
     fill_nongil_t(const View& v_in,const P& p_in) : _v(v_in), _p(p_in) {}
@@ -94,9 +96,10 @@ struct fill_nongil_t<RGB_VIEW(T1), pixel<T2,bgr_layout_t> > {
     }
 };
 template <typename T1, typename T2>
-struct fill_nongil_t<RGB_PLANAR_VIEW(T1), pixel<T2,rgb_layout_t> > {
-    typedef RGB_PLANAR_VIEW(T1) View;
-    typedef pixel<T2,rgb_layout_t> P;
+struct fill_nongil_t<RGB_PLANAR_VIEW(T1), pixel<T2,rgb_layout_t>>
+{
+    using View =  RGB_PLANAR_VIEW(T1);
+    using P = pixel<T2, rgb_layout_t>;
     View _v;
     P _p;
     fill_nongil_t(const View& v_in,const P& p_in) : _v(v_in), _p(p_in) {}
@@ -113,9 +116,10 @@ struct fill_nongil_t<RGB_PLANAR_VIEW(T1), pixel<T2,rgb_layout_t> > {
 };
 
 template <typename T1, typename T2>
-struct fill_nongil_t<RGB_PLANAR_VIEW(T1), pixel<T2,bgr_layout_t> > {
-    typedef RGB_PLANAR_VIEW(T1) View;
-    typedef pixel<T2,bgr_layout_t> P;
+struct fill_nongil_t<RGB_PLANAR_VIEW(T1), pixel<T2,bgr_layout_t>>
+{
+    using View = RGB_PLANAR_VIEW(T1);
+    using P = pixel<T2,bgr_layout_t>;
     View _v;
     P _p;
     fill_nongil_t(const View& v_in,const P& p_in) : _v(v_in), _p(p_in) {}
@@ -152,9 +156,10 @@ struct for_each_gil_t {
 };
 template <typename View, typename F> struct for_each_nongil_t;
 template <typename T, typename T2>
-struct for_each_nongil_t<RGB_VIEW(T), rgb_fr_t<T2> > {
-    typedef RGB_VIEW(T) View;
-    typedef rgb_fr_t<T2> F;
+struct for_each_nongil_t<RGB_VIEW(T), rgb_fr_t<T2>>
+{
+    using View = RGB_VIEW(T);
+    using F = rgb_fr_t<T2>;
     View _v;
     F _f;
     for_each_nongil_t(const View& v_in,const F& f_in) : _v(v_in), _f(f_in) {}
@@ -170,9 +175,10 @@ struct for_each_nongil_t<RGB_VIEW(T), rgb_fr_t<T2> > {
     }
 };
 template <typename T1, typename T2>
-struct for_each_nongil_t<RGB_PLANAR_VIEW(T1), rgb_fr_t<T2> > {
-    typedef RGB_PLANAR_VIEW(T1) View;
-    typedef rgb_fr_t<T2> F;
+struct for_each_nongil_t<RGB_PLANAR_VIEW(T1), rgb_fr_t<T2>>
+{
+    using View = RGB_PLANAR_VIEW(T1);
+    using F = rgb_fr_t<T2>;
     View _v;
     F _f;
     for_each_nongil_t(const View& v_in,const F& f_in) : _v(v_in), _f(f_in) {}
@@ -207,9 +213,10 @@ struct copy_gil_t {
 };
 template <typename View1, typename View2> struct copy_nongil_t;
 template <typename T1, typename T2>
-struct copy_nongil_t<RGB_VIEW(T1),RGB_VIEW(T2)> {
-    typedef RGB_VIEW(T1) View1;
-    typedef RGB_VIEW(T2) View2;
+struct copy_nongil_t<RGB_VIEW(T1),RGB_VIEW(T2)>
+{
+    using View1 = RGB_VIEW(T1);
+    using View2 = RGB_VIEW(T2);
     View1 _v1;
     View2 _v2;
     copy_nongil_t(const View1& v1_in,const View2& v2_in) : _v1(v1_in), _v2(v2_in) {}
@@ -221,9 +228,10 @@ struct copy_nongil_t<RGB_VIEW(T1),RGB_VIEW(T2)> {
     }
 };
 template <typename T1, typename T2>
-struct copy_nongil_t<RGB_VIEW(T1),BGR_VIEW(T2)> {
-    typedef RGB_VIEW(T1) View1;
-    typedef BGR_VIEW(T2) View2;
+struct copy_nongil_t<RGB_VIEW(T1),BGR_VIEW(T2)>
+{
+    using View1 = RGB_VIEW(T1);
+    using View2 = BGR_VIEW(T2);
     View1 _v1;
     View2 _v2;
     copy_nongil_t(const View1& v1_in,const View2& v2_in) : _v1(v1_in), _v2(v2_in) {}
@@ -240,9 +248,10 @@ struct copy_nongil_t<RGB_VIEW(T1),BGR_VIEW(T2)> {
     }
 };
 template <typename T1, typename T2>
-struct copy_nongil_t<RGB_PLANAR_VIEW(T1),RGB_PLANAR_VIEW(T2)> {
-    typedef RGB_PLANAR_VIEW(T1) View1;
-    typedef RGB_PLANAR_VIEW(T2) View2;
+struct copy_nongil_t<RGB_PLANAR_VIEW(T1),RGB_PLANAR_VIEW(T2)>
+{
+    using View1 = RGB_PLANAR_VIEW(T1);
+    using View2 = RGB_PLANAR_VIEW(T2);
     View1 _v1;
     View2 _v2;
     copy_nongil_t(const View1& v1_in,const View2& v2_in) : _v1(v1_in), _v2(v2_in) {}
@@ -260,9 +269,10 @@ struct copy_nongil_t<RGB_PLANAR_VIEW(T1),RGB_PLANAR_VIEW(T2)> {
     }
 };
 template <typename T1, typename T2>
-struct copy_nongil_t<RGB_VIEW(T1),RGB_PLANAR_VIEW(T2)> {
-    typedef RGB_VIEW(T1) View1;
-    typedef RGB_PLANAR_VIEW(T2) View2;
+struct copy_nongil_t<RGB_VIEW(T1),RGB_PLANAR_VIEW(T2)>
+{
+    using View1 = RGB_VIEW(T1);
+    using View2 = RGB_PLANAR_VIEW(T2);
     View1 _v1;
     View2 _v2;
     copy_nongil_t(const View1& v1_in,const View2& v2_in) : _v1(v1_in), _v2(v2_in) {}
@@ -281,9 +291,10 @@ struct copy_nongil_t<RGB_VIEW(T1),RGB_PLANAR_VIEW(T2)> {
     }
 };
 template <typename T1, typename T2>
-struct copy_nongil_t<RGB_PLANAR_VIEW(T1),RGB_VIEW(T2)> {
-    typedef RGB_PLANAR_VIEW(T1) View1;
-    typedef RGB_VIEW(T2) View2;
+struct copy_nongil_t<RGB_PLANAR_VIEW(T1),RGB_VIEW(T2)>
+{
+    using View1 = RGB_PLANAR_VIEW(T1);
+    using View2 = RGB_VIEW(T2);
     View1 _v1;
     View2 _v2;
     copy_nongil_t(const View1& v1_in,const View2& v2_in) : _v1(v1_in), _v2(v2_in) {}
@@ -328,9 +339,10 @@ struct transform_gil_t {
 };
 template <typename View1, typename View2, typename F> struct transform_nongil_t;
 template <typename T1, typename T2, typename F>
-struct transform_nongil_t<RGB_VIEW(T1),RGB_VIEW(T2),F> {
-    typedef RGB_VIEW(T1) View1;
-    typedef RGB_VIEW(T2) View2;
+struct transform_nongil_t<RGB_VIEW(T1),RGB_VIEW(T2),F>
+{
+    using View1 = RGB_VIEW(T1);
+    using View2 = RGB_VIEW(T2);
     View1 _v1;
     View2 _v2;
     F _f;
@@ -348,9 +360,10 @@ struct transform_nongil_t<RGB_VIEW(T1),RGB_VIEW(T2),F> {
     }
 };
 template <typename T1, typename T2, typename F>
-struct transform_nongil_t<RGB_PLANAR_VIEW(T1),RGB_PLANAR_VIEW(T2),F> {
-    typedef RGB_PLANAR_VIEW(T1) View1;
-    typedef RGB_PLANAR_VIEW(T2) View2;
+struct transform_nongil_t<RGB_PLANAR_VIEW(T1),RGB_PLANAR_VIEW(T2),F>
+{
+    using View1 = RGB_PLANAR_VIEW(T1);
+    using View2 = RGB_PLANAR_VIEW(T2);
     View1 _v1;
     View2 _v2;
     F _f;
@@ -371,9 +384,10 @@ struct transform_nongil_t<RGB_PLANAR_VIEW(T1),RGB_PLANAR_VIEW(T2),F> {
     }
 };
 template <typename T1, typename T2, typename F>
-struct transform_nongil_t<RGB_VIEW(T1),RGB_PLANAR_VIEW(T2),F> {
-    typedef RGB_VIEW(T1) View1;
-    typedef RGB_PLANAR_VIEW(T2) View2;
+struct transform_nongil_t<RGB_VIEW(T1),RGB_PLANAR_VIEW(T2),F>
+{
+    using View1 = RGB_VIEW(T1);
+    using View2 = RGB_PLANAR_VIEW(T2);
     View1 _v1;
     View2 _v2;
     F _f;
@@ -393,9 +407,10 @@ struct transform_nongil_t<RGB_VIEW(T1),RGB_PLANAR_VIEW(T2),F> {
     }
 };
 template <typename T1, typename T2, typename F>
-struct transform_nongil_t<RGB_PLANAR_VIEW(T1),RGB_VIEW(T2),F> {
-    typedef RGB_PLANAR_VIEW(T1) View1;
-    typedef RGB_VIEW(T2) View2;
+struct transform_nongil_t<RGB_PLANAR_VIEW(T1),RGB_VIEW(T2),F>
+{
+    using View1 = RGB_PLANAR_VIEW(T1);
+    using View2 = RGB_VIEW(T2);
     View1 _v1;
     View2 _v2;
     F _f;

--- a/test/pixel_iterator.cpp
+++ b/test/pixel_iterator.cpp
@@ -34,8 +34,14 @@ void test_pixel_iterator()
 
     boost::function_requires<MutablePixelLocatorConcept<memory_based_2d_locator<rgb8_step_ptr_t> > >();
 
-    typedef const bit_aligned_pixel_reference<std::uint8_t, boost::mpl::vector3_c<int,1,2,1>, bgr_layout_t, true>  bgr121_ref_t;
-    typedef bit_aligned_pixel_iterator<bgr121_ref_t> bgr121_ptr_t;
+    using bgr121_ref_t = bit_aligned_pixel_reference
+        <
+            std::uint8_t,
+            boost::mpl::vector3_c<int,1,2,1>,
+            bgr_layout_t,
+            true
+        > const;
+    using bgr121_ptr_t = bit_aligned_pixel_iterator<bgr121_ref_t>;
 
     boost::function_requires<MutablePixelIteratorConcept<bgr121_ptr_t> >();
     boost::function_requires<PixelBasedConcept<bgr121_ptr_t> >();
@@ -53,24 +59,24 @@ void test_pixel_iterator()
     BOOST_STATIC_ASSERT(iterator_is_step< cmyk16_planar_step_ptr_t >::value);
     BOOST_STATIC_ASSERT(!iterator_is_step< cmyk16_planar_ptr_t >::value);
 
-    typedef color_convert_deref_fn<rgb8c_ref_t, gray8_pixel_t> ccv_rgb_g_fn;
-    typedef color_convert_deref_fn<gray8c_ref_t, rgb8_pixel_t> ccv_g_rgb_fn;
+    using ccv_rgb_g_fn = color_convert_deref_fn<rgb8c_ref_t, gray8_pixel_t>;
+    using ccv_g_rgb_fn = color_convert_deref_fn<gray8c_ref_t, rgb8_pixel_t>;
     gil_function_requires<PixelDereferenceAdaptorConcept<ccv_rgb_g_fn> >();
     gil_function_requires<PixelDereferenceAdaptorConcept<deref_compose<ccv_rgb_g_fn,ccv_g_rgb_fn> > >();
 
-    typedef dereference_iterator_adaptor<rgb8_ptr_t, ccv_rgb_g_fn> rgb2gray_ptr;
+    using rgb2gray_ptr = dereference_iterator_adaptor<rgb8_ptr_t, ccv_rgb_g_fn>;
     BOOST_STATIC_ASSERT(!iterator_is_step< rgb2gray_ptr >::value);
 
-    typedef dynamic_x_step_type<rgb2gray_ptr>::type rgb2gray_step_ptr;
+    using rgb2gray_step_ptr = dynamic_x_step_type<rgb2gray_ptr>::type;
     BOOST_STATIC_ASSERT(( boost::is_same< rgb2gray_step_ptr, dereference_iterator_adaptor<rgb8_step_ptr_t, ccv_rgb_g_fn> >::value));
 
     make_step_iterator(rgb2gray_ptr(),2);
 
-    typedef dereference_iterator_adaptor<rgb8_step_ptr_t, ccv_rgb_g_fn> rgb2gray_step_ptr1;
+    using rgb2gray_step_ptr1 = dereference_iterator_adaptor<rgb8_step_ptr_t, ccv_rgb_g_fn>;
     BOOST_STATIC_ASSERT(iterator_is_step< rgb2gray_step_ptr1 >::value);
     BOOST_STATIC_ASSERT(( boost::is_same< rgb2gray_step_ptr1, dynamic_x_step_type<rgb2gray_step_ptr1>::type >::value));
 
-    typedef memory_based_step_iterator<dereference_iterator_adaptor<rgb8_ptr_t, ccv_rgb_g_fn> > rgb2gray_step_ptr2;
+    using rgb2gray_step_ptr2 = memory_based_step_iterator<dereference_iterator_adaptor<rgb8_ptr_t, ccv_rgb_g_fn>>;
     BOOST_STATIC_ASSERT(iterator_is_step< rgb2gray_step_ptr2 >::value);
     BOOST_STATIC_ASSERT(( boost::is_same< rgb2gray_step_ptr2, dynamic_x_step_type<rgb2gray_step_ptr2>::type >::value));
     make_step_iterator(rgb2gray_step_ptr2(),2);
@@ -78,13 +84,19 @@ void test_pixel_iterator()
 // bit_aligned iterators test
 
     // Mutable reference to a BGR232 pixel
-    typedef const bit_aligned_pixel_reference<std::uint8_t, boost::mpl::vector3_c<unsigned,2,3,2>, bgr_layout_t, true>  bgr232_ref_t;
+    using bgr232_ref_t = bit_aligned_pixel_reference
+        <
+            std::uint8_t,
+            boost::mpl::vector3_c<unsigned, 2, 3, 2>,
+            bgr_layout_t,
+            true
+        > const;
 
     // A mutable iterator over BGR232 pixels
-    typedef bit_aligned_pixel_iterator<bgr232_ref_t> bgr232_ptr_t;
+    using bgr232_ptr_t = bit_aligned_pixel_iterator<bgr232_ref_t>;
 
     // BGR232 pixel value. It is a packed_pixel of size 1 byte. (The last bit is unused)
-    typedef std::iterator_traits<bgr232_ptr_t>::value_type bgr232_pixel_t;
+    using bgr232_pixel_t = std::iterator_traits<bgr232_ptr_t>::value_type;
     BOOST_STATIC_ASSERT((sizeof(bgr232_pixel_t)==1));
 
     bgr232_pixel_t red(0,0,3); // = 0RRGGGBB, = 01100000
@@ -98,13 +110,13 @@ void test_pixel_iterator()
     }
 
 	// test cross byte pixel values - meaning when a pixel value is stretched over two bytes
-	typedef bit_aligned_image1_type< 3, gray_layout_t >::type gray3_image_t;
-    typedef gray3_image_t image_t;
+	using gray3_image_t = bit_aligned_image1_type<3, gray_layout_t>::type;
+    using image_t = gray3_image_t;
 
-    typedef image_t::view_t view_t;
-    typedef view_t::reference ref_t;
+    using view_t = image_t::view_t;
+    using ref_t = view_t::reference;
 
-    typedef bit_aligned_pixel_iterator< ref_t > iterator_t;
+    using iterator_t = bit_aligned_pixel_iterator<ref_t>;
 
 	std::vector< unsigned char > buf( 4 );
 	// bit pattern is: 1011 0110  0110 1101  1101 1011
@@ -238,7 +250,7 @@ void test_pixel_iterator() {
     ++pix_img_it_c;
     pix_img_it_c+=10;
     //  *pix_img_it_c=rgb8_pixel_t(1,2,3);        // error: assigning though const iterator
-    typedef iterator_from_2d<rgb8_loc_t>::difference_type dif_t;
+    using dif_t = iterator_from_2d<rgb8_loc_t>::difference_type;
     dif_t dt=0;
     std::ptrdiff_t tdt=dt; ignore_unused_variable_warning(tdt);
 
@@ -273,10 +285,10 @@ void test_pixel_iterator() {
     // planar vs interleaved
 
 // Pixel POINTERS
-//  typedef const iterator_traits<rgb8_ptr_t>::pointer  RGB8ConstPtr;
-    typedef const rgb8_ptr_t  RGB8ConstPtr;
-    typedef const rgb8_planar_ptr_t  RGB8ConstPlanarPtr;
-//  typedef const iterator_traits<rgb8_planar_ptr_t>::pointer RGB8ConstPlanarPtr;
+//  using RGB8ConstPtr = iterator_traits<rgb8_ptr_t>::pointer const;
+    using RGB8ConstPtr = rgb8_ptr_t const;
+    using RGB8ConstPlanarPtr = rgb8_planar_ptr_t const;
+//  using RGB8ConstPlanarPtr = iterator_traits<rgb8_planar_ptr_t>::pointer const;
 
 // constructing from values, references and other pointers
     RGB8ConstPtr rgb8_const_ptr=NULL; ignore_unused_variable_warning(rgb8_const_ptr);

--- a/test/promote_integral.cpp
+++ b/test/promote_integral.cpp
@@ -136,10 +136,10 @@ struct test_promote_integral
     template <typename Type, typename ExpectedPromotedType>
     static inline void apply(std::string const& case_id)
     {
-        typedef typename bg::promote_integral
+        using promoted_integral_type = typename bg::promote_integral
             <
                 Type, PromoteUnsignedToUnsigned
-            >::type promoted_integral_type;
+            >::type;
 
         bool const same_types = std::is_same
             <
@@ -205,7 +205,7 @@ struct test_promotion
                   << " -> signed ***" << std::endl;
 #endif
 
-        typedef test_promote_integral<PromoteUnsignedToUnsigned> tester;
+        using tester = test_promote_integral<PromoteUnsignedToUnsigned>;
 
         case_id += (PromoteUnsignedToUnsigned ? "-t" : "-f");
 
@@ -254,7 +254,7 @@ struct test_promotion<T, true, false>
 #endif
         case_id += "-t";
 
-        typedef test_promote_integral<true> tester;
+        using tester = test_promote_integral<true>;
 
         std::size_t min_size = 2 * bit_size<T>();
 
@@ -343,8 +343,8 @@ BOOST_AUTO_TEST_CASE( test_long_long )
 
 BOOST_AUTO_TEST_CASE( test_floating_point )
 {
-    typedef test_promote_integral<true> tester1;
-    typedef test_promote_integral<false> tester2;
+    using tester1 = test_promote_integral<true>;
+    using tester2 = test_promote_integral<false>;
 
     // for floating-point types we do not do any promotion
     tester1::apply<float, float>("fp-f");

--- a/test/recreate_image.cpp
+++ b/test/recreate_image.cpp
@@ -60,7 +60,7 @@ template< typename View
 std::size_t total_allocated_size_in_bytes( const typename View::point_t& dimensions )
 {
 
-    typedef typename View::x_iterator x_iterator;
+    using x_iterator = typename View::x_iterator;
 
     // when value_type is a non-pixel, like int or float, num_channels< ... > doesn't work.
     const std::size_t _channels_in_image = mpl::eval_if< is_pixel< typename View::value_type >

--- a/toolbox/test/channel_type.cpp
+++ b/toolbox/test/channel_type.cpp
@@ -24,8 +24,8 @@ BOOST_AUTO_TEST_CASE( channel_type_test )
         is_same<float32_t, channel_type<rgba32f_pixel_t>::type>::value));
 
     // channel_type for bit_aligned images doesn't work with standard gil.
-    typedef bit_aligned_image4_type<4, 4, 4, 4, rgb_layout_t>::type image_t;
-    typedef channel_type< image_t::view_t::reference >::type channel_t;
+    using image_t = bit_aligned_image4_type<4, 4, 4, 4, rgb_layout_t>::type;
+    using channel_t = channel_type<image_t::view_t::reference>::type;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/toolbox/test/channel_view.cpp
+++ b/toolbox/test/channel_view.cpp
@@ -18,14 +18,14 @@ BOOST_AUTO_TEST_SUITE( toolbox_tests )
 
 BOOST_AUTO_TEST_CASE( channel_view_test )
 {
-    typedef rgb8_image_t image_t;
+    using image_t = rgb8_image_t;
 
     image_t img( 100, 100 );
 
-    typedef kth_channel_view_type< 0, rgb8_view_t::const_t >::type view_t;
+    using view_t = kth_channel_view_type<0, rgb8_view_t::const_t>::type;
     view_t red = kth_channel_view<0>( const_view( img ));
 
-    typedef channel_view_type< red_t, rgb8_view_t::const_t >::type channel_view_t;
+    using channel_view_t = channel_view_type<red_t, rgb8_view_t::const_t>::type;
     channel_view_t red_ = channel_view< red_t >( const_view( img ));
 
     BOOST_STATIC_ASSERT(( is_same< kth_channel_view_type< 0, const rgb8_view_t>::type

--- a/toolbox/test/get_num_bits.cpp
+++ b/toolbox/test/get_num_bits.cpp
@@ -19,15 +19,15 @@ BOOST_AUTO_TEST_SUITE( toolbox_tests )
 
 BOOST_AUTO_TEST_CASE( get_num_bits_test )
 {
-    typedef bit_aligned_image4_type<4, 4, 4, 4, rgb_layout_t>::type image_t;
+    using image_t = bit_aligned_image4_type<4, 4, 4, 4, rgb_layout_t>::type;
 
-    typedef channel_type< image_t::view_t::reference >::type channel_t;
+    using channel_t = channel_type<image_t::view_t::reference>::type;
     BOOST_STATIC_ASSERT( get_num_bits< channel_t >::value == 4 );
 
-    typedef channel_type< image_t::const_view_t::reference >::type const_channel_t;
+    using const_channel_t = channel_type<image_t::const_view_t::reference>::type;
     BOOST_STATIC_ASSERT( get_num_bits< const_channel_t >::value == 4 );
 
-    typedef packed_channel_value< 23 > bits_t;
+    using bits_t = packed_channel_value<23>;
     BOOST_STATIC_ASSERT( get_num_bits< bits_t >::value == 23 );
     BOOST_STATIC_ASSERT( get_num_bits< const bits_t >::value == 23 );
 

--- a/toolbox/test/get_pixel_type.cpp
+++ b/toolbox/test/get_pixel_type.cpp
@@ -19,7 +19,7 @@ BOOST_AUTO_TEST_SUITE( toolbox_tests )
 BOOST_AUTO_TEST_CASE( get_pixel_type_test )
 {
     {
-        typedef bit_aligned_image3_type< 4, 15, 4, rgb_layout_t >::type image_t;
+        using image_t = bit_aligned_image3_type<4, 15, 4, rgb_layout_t>::type;
         BOOST_STATIC_ASSERT(( is_same< get_pixel_type< image_t::view_t >::type
                                      , image_t::view_t::reference
                                      >::value
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_CASE( get_pixel_type_test )
     }
 
     {
-        typedef rgb8_image_t image_t;
+        using image_t = rgb8_image_t;
         BOOST_STATIC_ASSERT(( is_same< get_pixel_type< image_t::view_t >::type
                                      , image_t::view_t::value_type
                                      >::value

--- a/toolbox/test/indexed_image_test.cpp
+++ b/toolbox/test/indexed_image_test.cpp
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_CASE( index_image_test )
     }
 
     {
-        typedef indexed_image< gray8_pixel_t, rgb8_pixel_t > image_t;
+        using image_t = indexed_image<gray8_pixel_t, rgb8_pixel_t>;
 
         image_t img( 640, 480, 256 );
 
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE( index_image_test )
     }
 
     {
-        typedef indexed_image< gray8_pixel_t, rgb8_pixel_t > image_t;
+        using image_t = indexed_image<gray8_pixel_t, rgb8_pixel_t>;
         image_t img( 640, 480, 256 );
 
 #if __cplusplus >= 201103L
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE( index_image_test )
     }
 
     {
-        typedef indexed_image< uint8_t, rgb8_pixel_t > image_t;
+        using image_t = indexed_image<uint8_t, rgb8_pixel_t>;
         image_t img( 640, 480, 256 );
 
         for( image_t::y_coord_t y = 0; y < view( img ).height(); ++y )
@@ -166,8 +166,8 @@ BOOST_AUTO_TEST_CASE(index_image_view_test)
     palette[2] = rgb8_pixel_t(70, 80, 90);
 
     // create image views from raw memory
-    typedef gray8_image_t::view_t::locator indices_loc_t;
-    typedef rgb8_image_t::view_t::locator palette_loc_t;
+    using indices_loc_t = gray8_image_t::view_t::locator;
+    using palette_loc_t = rgb8_image_t::view_t::locator;
 
 
     auto indices_view = interleaved_view(width, height

--- a/toolbox/test/is_bit_aligned.cpp
+++ b/toolbox/test/is_bit_aligned.cpp
@@ -18,7 +18,7 @@ BOOST_AUTO_TEST_SUITE( toolbox_tests )
 
 BOOST_AUTO_TEST_CASE( is_bit_aligned_test )
 {
-    typedef bit_aligned_image1_type< 4, gray_layout_t>::type image_t;
+    using image_t = bit_aligned_image1_type< 4, gray_layout_t>::type;
     BOOST_STATIC_ASSERT(( is_bit_aligned< image_t::view_t::value_type >::value ));
 }
 

--- a/toolbox/test/is_homogeneous.cpp
+++ b/toolbox/test/is_homogeneous.cpp
@@ -21,7 +21,7 @@ BOOST_AUTO_TEST_CASE( is_homogeneous_test )
 
     BOOST_STATIC_ASSERT(( is_homogeneous< cmyk16c_planar_ref_t >::value ));
 
-    typedef bit_aligned_image1_type< 4, gray_layout_t>::type image_t;
+    using image_t = bit_aligned_image1_type< 4, gray_layout_t>::type;
     BOOST_STATIC_ASSERT(( is_homogeneous< image_t::view_t::reference >::value ));
 }
 

--- a/toolbox/test/pixel_bit_size.cpp
+++ b/toolbox/test/pixel_bit_size.cpp
@@ -17,7 +17,10 @@ BOOST_AUTO_TEST_SUITE( toolbox_tests )
 
 BOOST_AUTO_TEST_CASE( pixel_bit_size_test )
 {
-    typedef bit_aligned_image5_type< 16, 16, 16, 8, 8, devicen_layout_t< 5 > >::type image_t;
+    using image_t = bit_aligned_image5_type
+        <
+            16, 16, 16, 8, 8, devicen_layout_t<5>
+        >::type;
     BOOST_STATIC_ASSERT(( pixel_bit_size<image_t::view_t::reference>::value == 64 ));
 }
 

--- a/toolbox/test/rgb_to_luminance.cpp
+++ b/toolbox/test/rgb_to_luminance.cpp
@@ -17,8 +17,8 @@ using namespace gil;
 struct double_zero { static double apply() { return 0.0; } };
 struct double_one  { static double apply() { return 1.0; } };
 
-typedef pixel< double, gray_layout_t > gray64f_pixel_t;
-typedef pixel< double, rgb_layout_t  > rgb64f_pixel_t;
+using gray64f_pixel_t = pixel<double, gray_layout_t>;
+using rgb64f_pixel_t = pixel<double, rgb_layout_t >;
 
 BOOST_AUTO_TEST_SUITE( toolbox_tests )
 

--- a/toolbox/test/subchroma_image.cpp
+++ b/toolbox/test/subchroma_image.cpp
@@ -44,8 +44,8 @@ BOOST_AUTO_TEST_CASE( subchroma_image_test )
     }
 
     {
-        typedef rgb8_pixel_t pixel_t;
-        typedef subchroma_image< pixel_t > image_t;
+        using pixel_t = rgb8_pixel_t;
+        using image_t = subchroma_image<pixel_t>;
 
         image_t img( 640, 480 );
 
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE( subchroma_image_test )
     }
 
     {
-        typedef rgb8_pixel_t pixel_t;
+        using pixel_t = rgb8_pixel_t;
 
         subchroma_image< pixel_t, mpl::vector_c< int, 4, 4, 4 > > a( 640, 480 ); BOOST_STATIC_ASSERT(( a.ss_X == 1 && a.ss_Y == 1 ));
         subchroma_image< pixel_t, mpl::vector_c< int, 4, 4, 0 > > b( 640, 480 ); BOOST_STATIC_ASSERT(( b.ss_X == 1 && b.ss_Y == 2 ));
@@ -74,9 +74,9 @@ BOOST_AUTO_TEST_CASE( subchroma_image_test )
     }
 
     {
-        typedef ycbcr_601_8_pixel_t pixel_t;
-        typedef mpl::vector_c< int, 4, 2, 2 > factors_t;
-        typedef subchroma_image< pixel_t, factors_t > image_t;
+        using pixel_t = ycbcr_601_8_pixel_t;
+        using factors_t = mpl::vector_c<int, 4, 2, 2>;
+        using image_t = subchroma_image<pixel_t, factors_t>;
 
         std::size_t y_width     = 640;
         std::size_t y_height    = 480;


### PR DESCRIPTION
Run clang-tidy 7.0 with `-checks='-*,modernize-use-using' -fix` against TU-s of all tests.

Manually refactor numerous `typedef`-s
- where missed by modernize-use-using check, not uncommon
- in code snippets in comments

Outcome is that searching for lower-case whole word `typedef`
in sources of all the tests should return no matches.

### References

-    #192
-   #193
-    #195
-    #196
-    #197
-    #198

### Tasklist

- [ ] Review
- [ ] Adjust for comments
- [x] All CI builds and checks have passed
