### PR TITLE
Fix hard-wired use of Boost.Array static_size member

### DIFF
--- a/example/convolution.cpp
+++ b/example/convolution.cpp
@@ -6,7 +6,7 @@
 // http://www.boost.org/LICENSE_1_0.txt
 #include <boost/gil/image.hpp>
 #include <boost/gil/typedefs.hpp>
-#include <boost/gil/extension/io/jpeg_io.hpp>
+#include <boost/gil/extension/io/jpeg.hpp>
 #include <boost/gil/extension/numeric/kernel.hpp>
 #include <boost/gil/extension/numeric/convolve.hpp>
 
@@ -16,7 +16,7 @@ int main() {
     using namespace boost::gil;
 
     rgb8_image_t img;
-    jpeg_read_image("test.jpg",img);
+    read_image("test.jpg", img, jpeg_tag{});
 
     // Convolve the rows and the columns of the image with a fixed kernel
     rgb8_image_t convolved(img);
@@ -56,16 +56,15 @@ int main() {
     */
 
     kernel_1d_fixed<float,9> kernel(gaussian_1,4);
-
     convolve_rows_fixed<rgb32f_pixel_t>(const_view(convolved),kernel,view(convolved));
     convolve_cols_fixed<rgb32f_pixel_t>(const_view(convolved),kernel,view(convolved));
-    jpeg_write_view("out-convolution.jpg", view(convolved));
+    write_view("out-convolution.jpg", view(convolved), jpeg_tag{});
 
     // This is how to use a resizable kernel
     kernel_1d<float> kernel2(gaussian_1,9,4);
     convolve_rows<rgb32f_pixel_t>(const_view(img),kernel2,view(img));
     convolve_cols<rgb32f_pixel_t>(const_view(img),kernel2,view(img));
-    jpeg_write_view("out-convolution2.jpg", view(img));
+    write_view("out-convolution2.jpg", view(img), jpeg_tag{});
 
     return 0;
 }

--- a/include/boost/gil/extension/numeric/convolve.hpp
+++ b/include/boost/gil/extension/numeric/convolve.hpp
@@ -9,6 +9,7 @@
 #define BOOST_GIL_EXTENSION_NUMERIC_CONVOLVE_HPP
 
 #include <boost/gil/extension/numeric/algorithm.hpp>
+#include <boost/gil/extension/numeric/kernel.hpp>
 #include <boost/gil/extension/numeric/pixel_numeric_operations.hpp>
 
 #include <boost/gil/algorithm.hpp>
@@ -19,6 +20,7 @@
 #include <cassert>
 #include <cstddef>
 #include <functional>
+#include <type_traits>
 #include <vector>
 
 namespace boost { namespace gil {
@@ -168,11 +170,18 @@ void convolve_cols(const SrcView& src, const Kernel& ker, const DstView& dst,
 
 /// \ingroup ImageAlgorithms
 ///correlate a 1D fixed-size kernel along the rows of an image
-template <typename PixelAccum,typename SrcView,typename Kernel,typename DstView>
+template <typename PixelAccum, typename SrcView, typename Kernel, typename DstView>
 BOOST_FORCEINLINE
-void correlate_rows_fixed(const SrcView& src, const Kernel& ker, const DstView& dst,
-                          convolve_boundary_option option=convolve_option_extend_zero) {
-    detail::correlate_rows_imp<PixelAccum>(src,ker,dst,option,detail::correlator_k<Kernel::static_size,PixelAccum>());
+void correlate_rows_fixed(const SrcView& src, const Kernel& kernel, const DstView& dst,
+                          convolve_boundary_option option=convolve_option_extend_zero)
+{
+    using correlator = detail::correlator_k
+        <
+            std::extent<Kernel>::value,
+            PixelAccum
+        >;
+    detail::correlate_rows_imp<PixelAccum>(
+        src, kernel, dst, option, correlator{});
 }
 
 /// \ingroup ImageAlgorithms


### PR DESCRIPTION
Fixes #142

### References

- #40
- #142

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed
