### PR TITLE
Fix examples to make them compile again

### DIFF
--- a/example/interleaved_ptr.cpp
+++ b/example/interleaved_ptr.cpp
@@ -23,13 +23,13 @@ namespace boost { namespace gil {
     at_c(const interleaved_ref<ChannelReference,Layout>& p);
 } }
 
-#include <boost/gil/extension/io/jpeg_dynamic_io.hpp>
+#include <boost/gil/extension/io/jpeg.hpp>
 
 #include <iostream>
 
 #include "interleaved_ptr.hpp"
 
-int main(int argc, unsigned char* argv[])
+int main(int argc, char* argv[])
 {
     using namespace boost::gil;
 
@@ -50,7 +50,7 @@ int main(int argc, unsigned char* argv[])
     boost::function_requires<ImageViewConcept<rgb8c_interleaved_view_t> >();
 
     rgb8_image_t img;
-    jpeg_read_image("test.jpg", img);
+    read_image("test.jpg", img, jpeg_tag{});
 
     // Get a raw pointer to the RGB buffer
     unsigned char* raw_ptr=&view(img)[0][0];
@@ -60,7 +60,7 @@ int main(int argc, unsigned char* argv[])
                                                       view(img).pixels().row_size());
 
     // Apply view transformations and algorithms on it
-    jpeg_write_view("out-interleaved_ptr.jpg",nth_channel_view(flipped_up_down_view(src_view),1));
+    write_view("out-interleaved_ptr.jpg",nth_channel_view(flipped_up_down_view(src_view),1), jpeg_tag{});
 
     return 0;
 }

--- a/example/mandelbrot.cpp
+++ b/example/mandelbrot.cpp
@@ -7,7 +7,7 @@
 //
 #include <boost/gil/image.hpp>
 #include <boost/gil/typedefs.hpp>
-#include <boost/gil/extension/io/jpeg_io.hpp>
+#include <boost/gil/extension/io/jpeg.hpp>
 
 // Example for convolve_rows() and convolve_cols() in the numeric extension
 
@@ -57,7 +57,8 @@ private:
     }
 };
 
-int main() {
+int main()
+{
     typedef mandelbrot_fn<rgb8_pixel_t> deref_t;
     typedef deref_t::point_t            point_t;
     typedef virtual_2d_locator<deref_t,false> locator_t;
@@ -68,7 +69,7 @@ int main() {
 
     point_t dims(200,200);
     my_virt_view_t mandel(dims, locator_t(point_t(0,0), point_t(1,1), deref_t(dims, rgb8_pixel_t(255,0,255), rgb8_pixel_t(0,255,0))));
-    jpeg_write_view("out-mandelbrot.jpg",mandel);
+    write_view("out-mandelbrot.jpg",mandel, jpeg_tag{});
 
     return 0;
 }

--- a/example/packed_pixel.cpp
+++ b/example/packed_pixel.cpp
@@ -5,7 +5,7 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
-#include <boost/gil/extension/io/jpeg_io.hpp>
+#include <boost/gil/extension/io/jpeg.hpp>
 
 #include <algorithm>
 
@@ -31,7 +31,7 @@ using namespace boost::gil;
 
 int main() {
     bgr8_image_t img;
-    jpeg_read_image("test.jpg",img);
+    read_image("test.jpg",img, jpeg_tag{});
 
     ////////////////////////////////
     // define a bgr772 image. It is a "packed" image - its channels are not byte-aligned, but its pixels are.
@@ -42,7 +42,7 @@ int main() {
     copy_and_convert_pixels(const_view(img),view(bgr772_img));
 
     // Save the result. JPEG I/O does not support the packed pixel format, so convert it back to 8-bit RGB
-    jpeg_write_view("out-packed_pixel_bgr772.jpg",color_converted_view<bgr8_pixel_t>(transposed_view(const_view(bgr772_img))));
+    write_view("out-packed_pixel_bgr772.jpg",color_converted_view<bgr8_pixel_t>(transposed_view(const_view(bgr772_img))), jpeg_tag{});
 
     ////////////////////////////////
     // define a gray1 image (one-bit per pixel). It is a "bit-aligned" image - its pixels are not byte aligned.
@@ -53,7 +53,7 @@ int main() {
     copy_and_convert_pixels(const_view(img),view(gray1_img));
 
     // Save the result. JPEG I/O does not support the packed pixel format, so convert it back to 8-bit RGB
-    jpeg_write_view("out-packed_pixel_gray1.jpg",color_converted_view<gray8_pixel_t>(transposed_view(const_view(gray1_img))));
+    write_view("out-packed_pixel_gray1.jpg",color_converted_view<gray8_pixel_t>(transposed_view(const_view(gray1_img))), jpeg_tag{});
 
     return 0;
 }

--- a/example/x_gradient.cpp
+++ b/example/x_gradient.cpp
@@ -5,7 +5,7 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
-#include <boost/gil/extension/io/jpeg_dynamic_io.hpp>
+#include <boost/gil/extension/io/jpeg.hpp>
 
 // Example to demonstrate a way to compute gradients along x-axis
 
@@ -42,13 +42,13 @@ void x_luminosity_gradient(const SrcView& src, const DstView& dst) {
 
 int main() {
     rgb8_image_t img;
-    jpeg_read_image("test.jpg",img);
+    read_image("test.jpg",img, jpeg_tag{});
 
     gray8s_image_t img_out(img.dimensions());
     fill_pixels(view(img_out),int8_t(0));
 
     x_luminosity_gradient(const_view(img), view(img_out));
-    jpeg_write_view("out-x_gradient.jpg",color_converted_view<gray8_pixel_t>(const_view(img_out)));
+    write_view("out-x_gradient.jpg",color_converted_view<gray8_pixel_t>(const_view(img_out)), jpeg_tag{});
 
     return 0;
 }


### PR DESCRIPTION
Following release of the new IO in Boost 1.68, the examples stopped compiling.

Fixes #40

### Tasklist

- [x] Review
- [x] Adjust for comments
- ~[ ] All CI builds and checks have passed~ Currently, CI-s do not build examples
