### PR TITLE
Remove Boost.Bind from extension/dynamic_image

### DIFF
--- a/include/boost/gil/extension/dynamic_image/algorithm.hpp
+++ b/include/boost/gil/extension/dynamic_image/algorithm.hpp
@@ -12,7 +12,7 @@
 
 #include <boost/gil/algorithm.hpp>
 
-#include <boost/bind.hpp>
+#include <functional>
 
 ////////////////////////////////////////////////////////////////////////////////////////
 /// \file
@@ -26,145 +26,209 @@
 namespace boost { namespace gil {
 
 namespace detail {
-    struct equal_pixels_fn : public binary_operation_obj<equal_pixels_fn,bool> {
-        template <typename V1, typename V2>
-        BOOST_FORCEINLINE bool apply_compatible(const V1& v1, const V2& v2) const {
-            return equal_pixels(v1,v2);
-        }
-    };
+
+struct equal_pixels_fn : binary_operation_obj<equal_pixels_fn, bool>
+{
+    template <typename V1, typename V2>
+    BOOST_FORCEINLINE
+    bool apply_compatible(V1 const& v1, V2 const& v2) const
+    {
+        return equal_pixels(v1, v2);
+    }
+};
+
 } // namespace detail
 
 /// \ingroup ImageViewSTLAlgorithmsEqualPixels
-template <typename Types1,  // Model MPL Random Access Container of models of ImageViewConcept
-          typename View2>   // Model MutableImageViewConcept
-bool equal_pixels(const any_image_view<Types1>& src, const View2& dst) {
-    return apply_operation(src,boost::bind(detail::equal_pixels_fn(), _1, dst));
+/// \tparam Types Model MPL Random Access Container of models of ImageViewConcept
+/// \tparam View Model MutableImageViewConcept
+template <typename Types, typename View>
+bool equal_pixels(any_image_view<Types> const& src, View const& dst)
+{
+    return apply_operation(
+        src,
+        std::bind(detail::equal_pixels_fn(), std::placeholders::_1, dst));
 }
 
 /// \ingroup ImageViewSTLAlgorithmsEqualPixels
-template <typename View1,   // Model ImageViewConcept
-          typename Types2>  // Model MPL Random Access Container of models of MutableImageViewConcept
-bool equal_pixels(const View1& src, const any_image_view<Types2>& dst) {
-    return apply_operation(dst,boost::bind(detail::equal_pixels_fn(), src, _1));
+/// \tparam View Model ImageViewConcept
+/// \tparam Types Model MPL Random Access Container of models of MutableImageViewConcept
+template <typename View, typename Types>
+bool equal_pixels(View const& src, any_image_view<Types> const& dst)
+{
+    return apply_operation(
+        dst,
+        std::bind(detail::equal_pixels_fn(), src, std::placeholders::_1));
 }
 
 /// \ingroup ImageViewSTLAlgorithmsEqualPixels
-template <typename Types1,  // Model MPL Random Access Container of models of ImageViewConcept
-          typename Types2>  // Model MPL Random Access Container of models of MutableImageViewConcept
-bool equal_pixels(const any_image_view<Types1>& src, const any_image_view<Types2>& dst) {
-    return apply_operation(src,dst,detail::equal_pixels_fn());
+/// \tparam Types1 Model MPL Random Access Container of models of ImageViewConcept
+/// \tparam Types2 Model MPL Random Access Container of models of MutableImageViewConcept
+template <typename Types1, typename Types2>
+bool equal_pixels(any_image_view<Types1> const& src, any_image_view<Types2> const& dst)
+{
+    return apply_operation(src, dst, detail::equal_pixels_fn());
 }
 
 namespace detail {
-    struct copy_pixels_fn : public binary_operation_obj<copy_pixels_fn> {
-        template <typename View1, typename View2>
-        BOOST_FORCEINLINE void apply_compatible(const View1& src, const View2& dst) const {
-            copy_pixels(src,dst);
-        }
-    };
+
+struct copy_pixels_fn : public binary_operation_obj<copy_pixels_fn>
+{
+    template <typename View1, typename View2>
+    BOOST_FORCEINLINE
+    void apply_compatible(View1 const& src, View2 const& dst) const
+    {
+        copy_pixels(src,dst);
+    }
+};
+
+} // namespace detail
+
+/// \ingroup ImageViewSTLAlgorithmsCopyPixels
+/// \tparam Types Model MPL Random Access Container of models of ImageViewConcept
+/// \tparam View Model MutableImageViewConcept
+template <typename Types, typename View>
+void copy_pixels(any_image_view<Types> const& src, View const& dst)
+{
+    apply_operation(src, std::bind(detail::copy_pixels_fn(), std::placeholders::_1, dst));
 }
 
 /// \ingroup ImageViewSTLAlgorithmsCopyPixels
-template <typename Types1,  // Model MPL Random Access Container of models of ImageViewConcept
-          typename View2>   // Model MutableImageViewConcept
-void copy_pixels(const any_image_view<Types1>& src, const View2& dst) {
-    apply_operation(src,boost::bind(detail::copy_pixels_fn(), _1, dst));
+/// \tparam Types Model MPL Random Access Container of models of MutableImageViewConcept
+/// \tparam View Model ImageViewConcept
+template <typename Types, typename View>
+void copy_pixels(View const& src, any_image_view<Types> const& dst)
+{
+    apply_operation(dst, std::bind(detail::copy_pixels_fn(), src, std::placeholders::_1));
 }
 
 /// \ingroup ImageViewSTLAlgorithmsCopyPixels
-template <typename View1,   // Model ImageViewConcept
-          typename Types2>  // Model MPL Random Access Container of models of MutableImageViewConcept
-void copy_pixels(const View1& src, const any_image_view<Types2>& dst) {
-    apply_operation(dst,boost::bind(detail::copy_pixels_fn(), src, _1));
+/// \tparam Types1 Model MPL Random Access Container of models of ImageViewConcept
+/// \tparam Types2 Model MPL Random Access Container of models of MutableImageViewConcept
+template <typename Types1, typename Types2>
+void copy_pixels(any_image_view<Types1> const& src, any_image_view<Types2> const& dst)
+{
+    apply_operation(src, dst, detail::copy_pixels_fn());
 }
-
-/// \ingroup ImageViewSTLAlgorithmsCopyPixels
-template <typename Types1,  // Model MPL Random Access Container of models of ImageViewConcept
-          typename Types2>  // Model MPL Random Access Container of models of MutableImageViewConcept
-void copy_pixels(const any_image_view<Types1>& src, const any_image_view<Types2>& dst) {
-    apply_operation(src,dst,detail::copy_pixels_fn());
-}
-
-
 
 //forward declaration for default_color_converter (see full definition in color_convert.hpp)
 struct default_color_converter;
 
 /// \ingroup ImageViewSTLAlgorithmsCopyAndConvertPixels
-template <typename Types1,  // Model MPL Random Access Container of models of ImageViewConcept
-          typename View2,   // Model MutableImageViewConcept
-          typename CC>      // Model ColorConverterConcept
-void copy_and_convert_pixels(const any_image_view<Types1>& src, const View2& dst, CC cc) {
-    apply_operation(src,boost::bind(detail::copy_and_convert_pixels_fn<CC>(cc), _1, dst));
+/// \tparam Types Model MPL Random Access Container of models of ImageViewConcept
+/// \tparam View Model MutableImageViewConcept
+/// \tparam CC Model ColorConverterConcept
+template <typename Types, typename View, typename CC>
+void copy_and_convert_pixels(any_image_view<Types> const& src, View const& dst, CC cc)
+{
+    using cc_fn = detail::copy_and_convert_pixels_fn<CC>;
+    apply_operation(src, std::bind(cc_fn{cc}, std::placeholders::_1, dst));
 }
 
 /// \ingroup ImageViewSTLAlgorithmsCopyAndConvertPixels
-template <typename Types1,  // Model MPL Random Access Container of models of ImageViewConcept
-          typename View2>   // Model MutableImageViewConcept
-void copy_and_convert_pixels(const any_image_view<Types1>& src, const View2& dst) {
-    apply_operation(src,boost::bind(detail::copy_and_convert_pixels_fn<default_color_converter>(), _1, dst));
+/// \tparam Types Model MPL Random Access Container of models of ImageViewConcept
+/// \tparam View Model MutableImageViewConcept
+template <typename Types, typename View>
+void copy_and_convert_pixels(any_image_view<Types> const& src, View const& dst)
+{
+    using cc_fn = detail::copy_and_convert_pixels_fn<default_color_converter>;
+    apply_operation(src, std::bind(cc_fn{}, std::placeholders::_1, dst));
 }
 
 /// \ingroup ImageViewSTLAlgorithmsCopyAndConvertPixels
-template <typename View1,   // Model ImageViewConcept
-          typename Types2,  // Model MPL Random Access Container of models of MutableImageViewConcept
-          typename CC>      // Model ColorConverterConcept
-void copy_and_convert_pixels(const View1& src, const any_image_view<Types2>& dst, CC cc) {
-    apply_operation(dst,boost::bind(detail::copy_and_convert_pixels_fn<CC>(cc), src, _1));
+/// \tparam View Model ImageViewConcept
+/// \tparam Types Model MPL Random Access Container of models of MutableImageViewConcept
+/// \tparam CC Model ColorConverterConcept
+template <typename View, typename Types, typename CC>
+void copy_and_convert_pixels(View const& src, any_image_view<Types> const& dst, CC cc)
+{
+    using cc_fn = detail::copy_and_convert_pixels_fn<CC>;
+    apply_operation(dst, std::bind(cc_fn{cc}, src, std::placeholders::_1));
 }
 
 /// \ingroup ImageViewSTLAlgorithmsCopyAndConvertPixels
-template <typename View1,   // Model ImageViewConcept
-          typename Types2>  // Model MPL Random Access Container of models of MutableImageViewConcept
-void copy_and_convert_pixels(const View1& src, const any_image_view<Types2>& dst) {
-    apply_operation(dst,boost::bind(detail::copy_and_convert_pixels_fn<default_color_converter>(), src, _1));
+/// \tparam View Model ImageViewConcept
+/// \tparam Type Model MPL Random Access Container of models of MutableImageViewConcept
+template <typename View, typename Types>
+void copy_and_convert_pixels(View const& src, any_image_view<Types> const& dst)
+{
+    using cc_fn = detail::copy_and_convert_pixels_fn<default_color_converter>;
+    apply_operation(dst, std::bind(cc_fn{}, src, std::placeholders::_1));
 }
 
 /// \ingroup ImageViewSTLAlgorithmsCopyAndConvertPixels
-template <typename Types1,  // Model MPL Random Access Container of models of ImageViewConcept
-          typename Types2,  // Model MPL Random Access Container of models of MutableImageViewConcept
-          typename CC>      // Model ColorConverterConcept
-void copy_and_convert_pixels(const any_image_view<Types1>& src, const any_image_view<Types2>& dst, CC cc) {
-    apply_operation(src,dst,detail::copy_and_convert_pixels_fn<CC>(cc));
+/// \tparam Types1 Model MPL Random Access Container of models of ImageViewConcept
+/// \tparam Types2 Model MPL Random Access Container of models of MutableImageViewConcept
+/// \tparam CC Model ColorConverterConcept
+template <typename Types1, typename Types2, typename CC>
+void copy_and_convert_pixels(
+    any_image_view<Types1> const& src,
+    any_image_view<Types2> const& dst, CC cc)
+{
+    apply_operation(src, dst, detail::copy_and_convert_pixels_fn<CC>(cc));
 }
 
 /// \ingroup ImageViewSTLAlgorithmsCopyAndConvertPixels
-template <typename Types1,  // Model MPL Random Access Container of models of ImageViewConcept
-          typename Types2>  // Model MPL Random Access Container of models of MutableImageViewConcept
-void copy_and_convert_pixels(const any_image_view<Types1>& src, const any_image_view<Types2>& dst) {
-    apply_operation(src,dst,detail::copy_and_convert_pixels_fn<default_color_converter>());
+/// \tparam Types1 Model MPL Random Access Container of models of ImageViewConcept
+/// \tparam Types2 Model MPL Random Access Container of models of MutableImageViewConcept
+template <typename Types1, typename Types2>
+void copy_and_convert_pixels(
+    any_image_view<Types1> const& src,
+    any_image_view<Types2> const& dst)
+{
+    apply_operation(src, dst,
+        detail::copy_and_convert_pixels_fn<default_color_converter>());
 }
 
 namespace detail {
-template <bool COMPATIBLE> struct fill_pixels_fn1 {
-    template <typename V, typename Value> static void apply(const V& src, const Value& val) { fill_pixels(src,val); }
+
+template <bool IsCompatible>
+struct fill_pixels_fn1
+{
+    template <typename V, typename Value>
+    static void apply(V const &src, Value const &val) { fill_pixels(src, val); }
 };
 
 // copy_pixels invoked on incompatible images
-template <> struct fill_pixels_fn1<false> {
-    template <typename V, typename Value> static void apply(const V&, const Value&) { throw std::bad_cast();}
+template <>
+struct fill_pixels_fn1<false>
+{
+    template <typename V, typename Value>
+    static void apply(V const &, Value const &) { throw std::bad_cast();}
 };
 
 template <typename Value>
-struct fill_pixels_fn {
-    fill_pixels_fn(const Value& val) : _val(val) {}
+struct fill_pixels_fn
+{
+    fill_pixels_fn(Value const& val) : val_(val) {}
 
     using result_type = void;
-    template <typename V> result_type operator()(const V& img_view) const {
-        fill_pixels_fn1<pixels_are_compatible<typename V::value_type, Value>::value>::apply(img_view,_val);
+    template <typename V>
+    result_type operator()(V const& view) const
+    {
+        fill_pixels_fn1
+        <
+            pixels_are_compatible
+            <
+                typename V::value_type,
+                Value
+            >::value
+        >::apply(view, val_);
     }
-    Value _val;
+
+    Value val_;
 };
-}
+
+} // namespace detail
 
 /// \ingroup ImageViewSTLAlgorithmsFillPixels
 /// \brief fill_pixels for any image view. The pixel to fill with must be compatible with the current view
-template <typename Types, // Model MPL Random Access Container of models of MutableImageViewConcept
-          typename Value>
-void fill_pixels(const any_image_view<Types>& img_view, const Value& val) {
-    apply_operation(img_view,detail::fill_pixels_fn<Value>(val));
+/// \tparam Types Model MPL Random Access Container of models of MutableImageViewConcept
+template <typename Types, typename Value>
+void fill_pixels(any_image_view<Types> const& view, Value const& val)
+{
+    apply_operation(view, detail::fill_pixels_fn<Value>(val));
 }
-
 
 }}  // namespace boost::gil
 

--- a/include/boost/gil/extension/dynamic_image/apply_operation.hpp
+++ b/include/boost/gil/extension/dynamic_image/apply_operation.hpp
@@ -27,23 +27,36 @@ namespace boost { namespace gil {
 
 /// \ingroup Variant
 /// \brief Invokes a generic mutable operation (represented as a unary function object) on a variant
-template <typename Types, typename UnaryOp> BOOST_FORCEINLINE
-typename UnaryOp::result_type apply_operation(variant<Types>& arg, UnaryOp op) {
+template <typename Types, typename UnaryOp>
+BOOST_FORCEINLINE
+auto apply_operation(variant<Types>& arg, UnaryOp op)
+    -> typename UnaryOp::result_type
+{
     return apply_operation_base<Types>(arg._bits, arg._index ,op);
 }
 
 /// \ingroup Variant
 /// \brief Invokes a generic constant operation (represented as a unary function object) on a variant
-template <typename Types, typename UnaryOp> BOOST_FORCEINLINE
-typename UnaryOp::result_type apply_operation(const variant<Types>& arg, UnaryOp op) {
+template <typename Types, typename UnaryOp>
+BOOST_FORCEINLINE
+auto apply_operation(variant<Types> const& arg, UnaryOp op)
+    -> typename UnaryOp::result_type
+{
     return apply_operation_basec<Types>(arg._bits, arg._index ,op);
 }
 
 /// \ingroup Variant
 /// \brief Invokes a generic constant operation (represented as a binary function object) on two variants
-template <typename Types1, typename Types2, typename BinaryOp> BOOST_FORCEINLINE
-typename BinaryOp::result_type apply_operation(const variant<Types1>& arg1, const variant<Types2>& arg2, BinaryOp op) {
-    return apply_operation_base<Types1,Types2>(arg1._bits, arg1._index, arg2._bits, arg2._index, op);
+template <typename Types1, typename Types2, typename BinaryOp>
+BOOST_FORCEINLINE
+auto apply_operation(
+    variant<Types1> const& arg1,
+    variant<Types2> const& arg2,
+    BinaryOp op)
+    -> typename BinaryOp::result_type
+{
+    return apply_operation_base<Types1, Types2>(
+        arg1._bits, arg1._index, arg2._bits, arg2._index, op);
 }
 
 }}  // namespace boost::gil


### PR DESCRIPTION
Replace `boost::bind` with `std::bind` from C++11.
Move template parameter comments to Doxygen `\tparam`-s, so they are captured as proper documentation.
Tidy up code formatting.

### References

- #203

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed
