### PR TITLE
Remove Boost.Bind from io

### DIFF
--- a/include/boost/gil/extension/io/bmp/detail/read.hpp
+++ b/include/boost/gil/extension/io/bmp/detail/read.hpp
@@ -24,6 +24,7 @@
 #include <boost/type_traits/is_same.hpp>
 #include <boost/utility/enable_if.hpp>
 
+#include <type_traits>
 #include <vector>
 
 namespace boost { namespace gil {
@@ -129,11 +130,11 @@ public:
             {
                 this->_scanline_length = ( this->_info._width * num_channels< rgba8_view_t >::value + 3 ) & ~3;
 
-                read_palette_image< gray1_image_t::view_t
-                                  , detail::mirror_bits< byte_vector_t
-                                                       , mpl::true_
-                                                       >
-                                  > ( dst_view );
+                read_palette_image
+                    <
+                        gray1_image_t::view_t,
+                        detail::mirror_bits<byte_vector_t, std::true_type>
+                    >(dst_view);
                 break;
             }
 
@@ -155,11 +156,11 @@ public:
                     {
                         this->_scanline_length = ( this->_info._width * num_channels< rgba8_view_t >::value + 3 ) & ~3;
 
-                        read_palette_image< gray4_image_t::view_t
-                                          , detail::swap_half_bytes< byte_vector_t
-                                                                   , mpl::true_
-                                                                   >
-                                          > ( dst_view );
+                        read_palette_image
+                            <
+                                gray4_image_t::view_t,
+                                detail::swap_half_bytes<byte_vector_t, std::true_type>
+                            >(dst_view);
                         break;
                     }
 

--- a/include/boost/gil/extension/io/bmp/detail/scanline_read.hpp
+++ b/include/boost/gil/extension/io/bmp/detail/scanline_read.hpp
@@ -22,6 +22,7 @@
 
 #include <boost/function.hpp>
 
+#include <type_traits>
 #include <vector>
 
 namespace boost { namespace gil {
@@ -401,11 +402,11 @@ private:
     // the row pitch must be multiple of 4 bytes
     int _pitch;
 
-    std::vector< byte_t > _buffer;
-    detail::mirror_bits    < std::vector< byte_t >, mpl::true_ > _mirror_bits;
-    detail::swap_half_bytes< std::vector< byte_t >, mpl::true_ > _swap_half_bytes;
+    std::vector<byte_t> _buffer;
+    detail::mirror_bits <std::vector<byte_t>, std::true_type> _mirror_bits;
+    detail::swap_half_bytes<std::vector<byte_t>, std::true_type> _swap_half_bytes;
 
-    boost::function< void ( this_t*, byte_t* ) > _read_function;
+    boost::function<void(this_t*, byte_t*)> _read_function;
 };
 
 } // namespace gil

--- a/include/boost/gil/extension/io/pnm/detail/read.hpp
+++ b/include/boost/gil/extension/io/pnm/detail/read.hpp
@@ -22,8 +22,7 @@
 #include <boost/gil/io/row_buffer_helper.hpp>
 #include <boost/gil/io/typedefs.hpp>
 
-#include <boost/bind.hpp>
-
+#include <type_traits>
 #include <vector>
 
 namespace boost { namespace gil {
@@ -311,13 +310,17 @@ private:
 
         // For bit_aligned images we need to negate all bytes in the row_buffer
         // to make sure that 0 is black and 255 is white.
-        detail::negate_bits< typename rh_t::buffer_t
-                           , is_bit_aligned_t
-                           > neg;
+        detail::negate_bits
+            <
+                typename rh_t::buffer_t,
+                std::integral_constant<bool, is_bit_aligned_t::value> // TODO: Simplify after MPL removal
+            > neg;
 
-        detail::swap_half_bytes< typename rh_t::buffer_t
-                               , is_bit_aligned_t
-                               > swhb;
+        detail::swap_half_bytes
+            <
+                typename rh_t::buffer_t,
+                std::integral_constant<bool, is_bit_aligned_t::value> // TODO: Simplify after MPL removal
+            > swhb;
 
         //Skip scanlines if necessary.
         for( y_t y = 0; y < this->_settings._top_left.y; ++y )

--- a/include/boost/gil/extension/io/pnm/detail/scanline_read.hpp
+++ b/include/boost/gil/extension/io/pnm/detail/scanline_read.hpp
@@ -21,9 +21,9 @@
 #include <boost/gil/io/scanline_read_iterator.hpp>
 #include <boost/gil/io/typedefs.hpp>
 
-#include <boost/bind.hpp>
 #include <boost/function.hpp>
 
+#include <type_traits>
 #include <vector>
 
 namespace boost { namespace gil {
@@ -233,11 +233,11 @@ private:
 
     // For bit_aligned images we need to negate all bytes in the row_buffer
     // to make sure that 0 is black and 255 is white.
-    detail::negate_bits    < std::vector< byte_t >, mpl::true_ > _negate_bits;
-    detail::swap_half_bytes< std::vector< byte_t >, mpl::true_ > _swap_half_bytes;
+    detail::negate_bits<std::vector<byte_t>, std::true_type> _negate_bits;
+    detail::swap_half_bytes<std::vector<byte_t>, std::true_type> _swap_half_bytes;
 
-    boost::function< void ( this_t*, byte_t* ) > _read_function;
-    boost::function< void ( this_t* )          > _skip_function;
+    boost::function<void(this_t*, byte_t*)> _read_function;
+    boost::function<void(this_t*)> _skip_function;
 };
 
 

--- a/include/boost/gil/extension/io/pnm/detail/write.hpp
+++ b/include/boost/gil/extension/io/pnm/detail/write.hpp
@@ -141,28 +141,16 @@ private:
         using x_it_t = typename View::x_iterator;
         x_it_t row_it = x_it_t( &( *row.begin() ));
 
-        detail::negate_bits< byte_vector_t
-                           , mpl::true_
-                           > neg;
-
-        detail::mirror_bits< byte_vector_t
-                           , mpl::true_
-                           > mirror;
-
-
-        for( typename View::y_coord_t y = 0; y < src.height(); ++y )
+        detail::negate_bits<byte_vector_t, std::true_type> negate;
+        detail::mirror_bits<byte_vector_t, std::true_type> mirror;
+        for (typename View::y_coord_t y = 0; y < src.height(); ++y)
         {
-            std::copy( src.row_begin( y )
-                     , src.row_end( y )
-                     , row_it
-                     );
+            std::copy(src.row_begin(y), src.row_end(y), row_it);
 
-            mirror( row );
-            neg   ( row );
+            mirror(row);
+            negate(row);
 
-            this->_io_dev.write( &row.front()
-                               , pitch / 8
-                               );
+            this->_io_dev.write(&row.front(), pitch / 8);
         }
     }
 

--- a/include/boost/gil/extension/io/tiff/detail/scanline_read.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/scanline_read.hpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 // taken from jpegxx - https://bitbucket.org/edd/jpegxx/src/ea2492a1a4a6/src/ijg_headers.hpp
@@ -437,11 +438,9 @@ private:
 
 private:
 
-    std::vector< byte_t > _buffer;
-
-    detail::mirror_bits< std::vector< byte_t >, mpl::true_ > _mirror_bites;
-
-    boost::function< void ( this_t*, byte_t*, int ) > _read_function;
+    std::vector< byte_t> _buffer;
+    detail::mirror_bits<std::vector<byte_t>, std::true_type> _mirror_bites;
+    boost::function<void(this_t*, byte_t*, int)> _read_function;
 };
 
 } // namespace gil

--- a/include/boost/gil/io/bit_operations.hpp
+++ b/include/boost/gil/io/bit_operations.hpp
@@ -10,71 +10,50 @@
 
 #include <boost/gil/io/typedefs.hpp>
 
-#include <boost/bind.hpp>
-#include <boost/mpl/bool.hpp>
-
-#include <cstddef>
 #include <array>
+#include <cstddef>
+#include <type_traits>
 
 namespace boost { namespace gil { namespace detail {
 
 // 1110 1100 -> 0011 0111
-template< typename Buffer
-        , typename IsBitAligned
-        >
+template <typename Buffer, typename IsBitAligned>
 struct mirror_bits
 {
-   mirror_bits( bool ) {}
+    mirror_bits(bool) {};
 
-   void operator() ( Buffer& ) {}
-
-
-    void operator() ( byte_t* , std::size_t )
-    {
-    }
+    void operator()(Buffer&) {}
+    void operator()(byte_t*, std::size_t){}
 };
-
 
 // The functor will generate a lookup table since the
 // mirror operation is quite costly.
-template< typename Buffer >
-struct mirror_bits< Buffer
-                  , mpl::true_
-                  >
+template <typename Buffer>
+struct mirror_bits<Buffer, std::true_type>
 {
-   mirror_bits( bool apply_operation = true )
-   : _apply_operation( apply_operation )
-   {
-        if( _apply_operation == true )
+    mirror_bits(bool apply_operation = true)
+        : apply_operation_(apply_operation)
+    {
+        if(apply_operation_)
         {
             byte_t i = 0;
             do
             {
-                _lookup[i] = mirror( i );
+                lookup_[i] = mirror(i);
             }
-            while( i++ != 255 );
+            while (i++ != 255);
         }
    }
 
-   void operator() ( Buffer& buf )
-   {
-        if( _apply_operation == true )
-        {
-            for_each( buf.begin()
-                    , buf.end()
-                    , boost::bind( &mirror_bits< Buffer
-                                               , mpl::true_
-                                               >::lookup
-                                 , *this
-                                 , ::_1
-                                 )
-                    );
-        }
-   }
-
-    void operator() ( byte_t* dst, std::size_t size )
+    void operator()(Buffer& buffer)
     {
-        for( std::size_t i = 0; i < size; ++i )
+        if (apply_operation_)
+            for_each(buffer.begin(), buffer.end(), [this](byte_t& c) { lookup(c); });
+    }
+
+    void operator()(byte_t *dst, std::size_t size)
+    {
+        for (std::size_t i = 0; i < size; ++i)
         {
             lookup(*dst);
             ++dst;
@@ -83,55 +62,48 @@ struct mirror_bits< Buffer
 
 private:
 
-    void lookup( byte_t& c )
+    void lookup(byte_t& c)
     {
-        c = _lookup[ c ];
+        c = lookup_[c];
     }
 
-    static byte_t mirror( byte_t c )
+    static byte_t mirror(byte_t c)
     {
         byte_t result = 0;
-        for( int i = 0; i < 8; ++i )
+        for (int i = 0; i < 8; ++i)
         {
             result = result << 1;
-            result |= ( c & 1 );
+            result |= (c & 1);
             c = c >> 1;
         }
 
         return result;
     }
 
-private:
+    std::array<byte_t, 256> lookup_;
+    bool apply_operation_;
 
-    bool _apply_operation;
-
-    std::array< byte_t, 256 > _lookup;
 };
-
 
 // 0011 1111 -> 1100 0000
-template< typename Buffer
-        , typename IsBitAligned
-        >
+template <typename Buffer, typename IsBitAligned>
 struct negate_bits
 {
-    void operator() ( Buffer& ) {}
+    void operator()(Buffer&) {};
 };
 
-template< typename Buffer >
-struct negate_bits< Buffer, mpl::true_ >
+template <typename Buffer>
+struct negate_bits<Buffer, std::true_type>
 {
-    void operator() ( Buffer& buf )
+    void operator()(Buffer& buffer)
     {
-        for_each( buf.begin()
-                , buf.end()
-                , negate_bits< Buffer, mpl::true_ >::negate
-                );
+        for_each(buffer.begin(), buffer.end(),
+            negate_bits<Buffer, std::true_type>::negate);
     }
 
-    void operator() ( byte_t* dst, std::size_t size )
+    void operator()(byte_t* dst, std::size_t size)
     {
-        for( std::size_t i = 0; i < size; ++i )
+        for (std::size_t i = 0; i < size; ++i)
         {
             negate(*dst);
             ++dst;
@@ -140,72 +112,61 @@ struct negate_bits< Buffer, mpl::true_ >
 
 private:
 
-    static void negate( byte_t& b )
+    static void negate(byte_t& b)
     {
         b = ~b;
     }
 };
 
-
 // 11101100 -> 11001110
-template< typename Buffer
-        , typename IsBitAligned
-        >
+template <typename Buffer, typename IsBitAligned>
 struct swap_half_bytes
 {
-    void operator() ( Buffer& ) {}
+    void operator()(Buffer&) {};
 };
 
-template< typename Buffer >
-struct swap_half_bytes< Buffer
-                      , mpl::true_
-                      >
+template <typename Buffer>
+struct swap_half_bytes<Buffer, std::true_type>
 {
-    void operator() ( Buffer& buf )
+    void operator()(Buffer& buffer)
     {
-        for_each( buf.begin()
-                , buf.end()
-                , swap_half_bytes< Buffer, mpl::true_ >::swap
-                );
+        for_each(buffer.begin(), buffer.end(),
+            swap_half_bytes<Buffer, std::true_type>::swap);
     }
 
-    void operator() ( byte_t* dst, std::size_t size )
+    void operator()(byte_t* dst, std::size_t size)
     {
-        for( std::size_t i = 0; i < size; ++i )
+        for (std::size_t i = 0; i < size; ++i)
         {
             swap(*dst);
             ++dst;
         }
     }
 
-
 private:
 
-    static void swap( byte_t& c )
+    static void swap(byte_t& c)
     {
-        c = (( c << 4 ) & 0xF0 ) | (( c >> 4 ) & 0x0F );
+        c = ((c << 4) & 0xF0) | ((c >> 4) & 0x0F);
     }
 };
 
-template< typename Buffer >
+template <typename Buffer>
 struct do_nothing
 {
-   do_nothing() {}
+   do_nothing() = default;
 
-   void operator() ( Buffer& ) {}
+   void operator()(Buffer&) {}
 };
 
 /// Count consecutive zeros on the right
-template< typename T >
-inline
-unsigned int trailing_zeros( T x )
-throw()
+template <typename T>
+inline unsigned int trailing_zeros(T x) noexcept
 {
     unsigned int n = 0;
 
     x = ~x & (x - 1);
-
-    while( x )
+    while (x)
     {
         n = n + 1;
         x = x >> 1;
@@ -215,14 +176,13 @@ throw()
 }
 
 /// Counts ones in a bit-set
-template< typename T >
+template <typename T>
 inline
-unsigned int count_ones( T x )
-throw()
+unsigned int count_ones(T x) noexcept
 {
     unsigned int n = 0;
 
-    while( x )
+    while (x)
     {
         // clear the least significant bit set
         x &= x - 1;
@@ -232,9 +192,6 @@ throw()
     return n;
 }
 
-
-} // namespace detail
-} // namespace gil
-} // namespace boost
+}}} // namespace boost::gil::detail
 
 #endif


### PR DESCRIPTION
Replace Boost.MPL boolean constants with C++11 equivalents.
Replace `throw()` with `noexcept`.
Replace empty constructor body with `default`.
Rename private class members to avoid leading underscore (too easy to confuse as reserved identifier).
Tidy up with compact formatting.

### References

- #202

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed
