### PR TITLE
Add configuration for CI builds with Azure Pipelines

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,23 +1,55 @@
-# C/C++ with GCC
-# Build your C/C++ project with GCC using make.
-# Add steps that publish test results, save build artifacts, deploy, and more:
-# https://docs.microsoft.com/azure/devops/pipelines/apps/c-cpp/gcc
+# Azure Pipelines for Boost.GIL
+#
+# Copyright 2018-2019 Mateusz Loskot <mateusz at loskot dot net>
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
+#
+variables:
+  configuration: release
 
 trigger:
-- master
-- develop
+  - master
+  - develop
+  - azure-pipelines
 
-pool:
-  vmImage: 'Ubuntu-16.04'
+jobs:
+  - job: 'ubuntu1604_gcc54_cmake312'
+    pool:
+      vmImage: 'ubuntu-16.04'
+    steps:
+      - script: which g++ && g++ --version
+        displayName: 'Check GCC'
+      - template: .ci/azure-pipelines/steps-check-cmake.yml
+      - script: |
+          sudo apt-get install libjpeg-dev libpng16-dev libtiff5-dev libraw-dev
+        displayName: 'Install dependencies'
+      - template: .ci/azure-pipelines/steps-install-boost.yml
+      - template: .ci/azure-pipelines/steps-cmake-build-and-test.yml
 
-steps:
-  - script: echo "Install dependencies"
-    displayName: 'TOOD: install'
-  - script: echo "git clone"
-    displayName: 'TOOD: git clone'
-  - script: echo "git submodule"
-    displayName: 'TOOD: git submodule'
-  - script: echo "bootstrap"
-    displayName: 'TOOD: bootstrap'
-  - script: echo "b2 headers"
-    displayName: 'TOOD: b2 headers'
+  - job: 'win2016_vs2017_cmake312'
+    pool:
+      vmImage: 'vs2017-win2016'
+    steps:
+      - template: .ci/azure-pipelines/steps-check-cmake.yml
+      - template: .ci/azure-pipelines/steps-install-conan.yml
+      - template: .ci/azure-pipelines/steps-install-boost.yml
+      - template: .ci/azure-pipelines/steps-cmake-build-and-test.yml
+        parameters:
+          use_conan: 'yes'
+
+  - job: 'macos1013_xcode91_cmake313'
+    pool:
+      vmImage: 'macOS-10.13'
+    steps:
+      - script: which clang++ && clang++ --version
+        displayName: 'Check clang'
+      - template: .ci/azure-pipelines/steps-check-cmake.yml
+      - template: .ci/azure-pipelines/steps-install-conan.yml
+        parameters:
+          python: python3
+      - template: .ci/azure-pipelines/steps-install-boost.yml
+        parameters:
+          toolset: darwin
+      - template: .ci/azure-pipelines/steps-cmake-build-and-test.yml
+        parameters:
+          use_conan: 'yes'

--- a/.ci/azure-pipelines/steps-check-cmake.yml
+++ b/.ci/azure-pipelines/steps-check-cmake.yml
@@ -1,0 +1,9 @@
+# Azure Pipelines for Boost.GIL
+#
+# Copyright 2018-2019 Mateusz Loskot <mateusz at loskot dot net>
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
+#
+steps:
+  - script: cmake --version
+    displayName: 'Check CMake'

--- a/.ci/azure-pipelines/steps-cmake-build-and-test.yml
+++ b/.ci/azure-pipelines/steps-cmake-build-and-test.yml
@@ -1,0 +1,25 @@
+# Azure Pipelines for Boost.GIL
+#
+# Copyright 2018-2019 Mateusz Loskot <mateusz at loskot dot net>
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
+#
+parameters:
+  # defaults, if not specified
+  configuration: 'Release'
+  get_findboost: 'no'
+  enable_ext_io: 'no'
+  enable_ext_numeric: 'yes'
+  enable_ext_toolbox: 'yes'
+  use_conan: 'no'
+
+steps:
+  - script: |
+      cmake -H. -B_build -DCMAKE_BUILD_TYPE=${{ parameters.configuration }} -DCMAKE_VERBOSE_MAKEFILE=ON -DGIL_DOWNLOAD_FINDBOOST=${{ parameters.get_findboost }} -DGIL_USE_CONAN=ON -DGIL_ENABLE_EXT_IO=${{ parameters.enable_ext_io }} -DGIL_ENABLE_EXT_NUMERIC=${{ parameters.enable_ext_numeric }} -DGIL_ENABLE_EXT_TOOLBOX=${{ parameters.enable_ext_toolbox }}
+    displayName: 'Run CMake to configure build'
+
+  - script: cmake --build _build --config ${{ parameters.configuration }} -j 4
+    displayName: 'Run CMake to build'
+
+  - script: cd _build && ctest --build-config ${{ parameters.configuration }} -VV --output-on-failure
+    displayName: 'Run CTest to test'

--- a/.ci/azure-pipelines/steps-install-boost.yml
+++ b/.ci/azure-pipelines/steps-install-boost.yml
@@ -1,0 +1,30 @@
+# Azure Pipelines for Boost.GIL
+#
+# Copyright 2018-2019 Mateusz Loskot <mateusz at loskot dot net>
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
+#
+parameters:
+  # defaults, if not specified
+  variant: 'release'
+  toolset: 'gcc'
+
+steps:
+  - bash: |
+      curl -L https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.gz -o boost.tar.gz
+      tar -xf boost.tar.gz
+    displayName: 'Download Boost'
+
+  - script: |
+      cd boost_*
+      ./bootstrap.sh
+      sudo ./b2 -j4 variant=${{ parameters.variant }} toolset=${{ parameters.toolset }} --with-filesystem --with-test install
+    displayName: 'Install Boost on Unix'
+    condition: ne(variables['Agent.OS'], 'Windows_NT')
+
+  - script: |
+      cd boost_*
+      call .\bootstrap.bat
+      .\b2 -j4 variant=${{ parameters.variant }} --with-filesystem --with-test install
+    displayName: 'Install Boost on Windows'
+    condition: eq(variables['Agent.OS'], 'Windows_NT')

--- a/.ci/azure-pipelines/steps-install-conan.yml
+++ b/.ci/azure-pipelines/steps-install-conan.yml
@@ -1,0 +1,15 @@
+# Azure Pipelines for Boost.GIL
+#
+# Copyright 2018-2019 Mateusz Loskot <mateusz at loskot dot net>
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
+#
+parameters:
+  python: 'python' # default, if not specified
+
+steps:
+  - script: |
+      ${{ parameters.python }} --version
+      ${{ parameters.python }} -m pip install --upgrade conan
+      conan --version
+    displayName: 'Install Conan'


### PR DESCRIPTION
Configuration summary:
  - Linux (GCC 5.4), Windows (VS2017), Mac OS (clang 4.0)
  - Boost 1.68 built with variant=release
  - Boost.GIL built and tested using CMake w/ CMAKE_BUILD_TYPE=Release
  - Basic setup of GIL IO extension dependencies is in place,
    using .deb packages or Conan.
  - Build without GIL IO extension tests due to issues in CMake
    configuration, not related to Azure Pipelines.

### References

- Closes #188

### Tasklist

- [x] Azure Pipelines builds and checks have passed (Travis and AppVeyor skipped)
