### PR TITLE
Remove dependency on Boost.StaticAssert

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -96,7 +96,6 @@ before_build:
   - git submodule --quiet update --init libs/numeric/conversion
   - git submodule --quiet update --init libs/preprocessor
   - git submodule --quiet update --init libs/smart_ptr
-  - git submodule --quiet update --init libs/static_assert
   - git submodule --quiet update --init libs/test
   - git submodule --quiet update --init libs/type_traits
   ## Transitive
@@ -120,6 +119,7 @@ before_build:
   - git submodule --quiet update --init libs/ratio
   - git submodule --quiet update --init libs/rational
   - git submodule --quiet update --init libs/regex
+  - git submodule --quiet update --init libs/static_assert
   - git submodule --quiet update --init libs/system
   - git submodule --quiet update --init libs/throw_exception
   - git submodule --quiet update --init libs/timer

--- a/.travis.yml
+++ b/.travis.yml
@@ -212,7 +212,6 @@ install:
   - git submodule --quiet update --init libs/mpl
   - git submodule --quiet update --init libs/numeric/conversion
   - git submodule --quiet update --init libs/preprocessor
-  - git submodule --quiet update --init libs/static_assert
   - git submodule --quiet update --init libs/test
   - git submodule --quiet update --init libs/type_traits
   ## Transitive
@@ -237,6 +236,7 @@ install:
   - git submodule --quiet update --init libs/ratio
   - git submodule --quiet update --init libs/rational
   - git submodule --quiet update --init libs/regex
+  - git submodule --quiet update --init libs/static_assert
   - git submodule --quiet update --init libs/smart_ptr
   - git submodule --quiet update --init libs/system
   - git submodule --quiet update --init libs/throw_exception

--- a/doc/design_guide.rst
+++ b/doc/design_guide.rst
@@ -808,7 +808,7 @@ provides a model for such packed pixel formats::
   typedef packed_pixel_type<uint16_t, mpl::vector3_c<unsigned,5,6,5>, rgb_layout_t>::type rgb565_pixel_t;
 
   function_requires<PixelValueConcept<rgb565_pixel_t> >();
-  BOOST_STATIC_ASSERT((sizeof(rgb565_pixel_t)==2));
+  static_assert(sizeof(rgb565_pixel_t) == 2, "");
 
   // define a bgr556 pixel
   typedef packed_pixel_type<uint16_t, mpl::vector3_c<unsigned,5,6,5>, bgr_layout_t>::type bgr556_pixel_t;
@@ -838,7 +838,7 @@ pixels and pixel iterators::
 
   // BGR232 pixel value. It is a packed_pixel of size 1 byte. (The last bit is unused)
   typedef std::iterator_traits<bgr232_ptr_t>::value_type bgr232_pixel_t;
-  BOOST_STATIC_ASSERT((sizeof(bgr232_pixel_t)==1));
+  static_assert(sizeof(bgr232_pixel_t) == 1, "");
 
   bgr232_pixel_t red(0,0,3); // = 0RRGGGBB, = 01100000 = 0x60
 
@@ -1959,7 +1959,7 @@ an example::
   #include <boost/gil/extension/dynamic_image/dynamic_image_all.hpp>
   using namespace boost;
 
-  #define ASSERT_SAME(A,B) BOOST_STATIC_ASSERT((is_same< A,B >::value))
+  #define ASSERT_SAME(A,B) static_assert(is_same< A,B >::value, "")
 
   // Define the set of allowed images
   typedef mpl::vector<rgb8_image_t, cmyk16_planar_image_t> my_images_t;
@@ -2380,7 +2380,7 @@ HomogeneousPixelBasedConcept and metafunctions built on top of them::
 These are metafunctions, some of which return integral types which can
 be evaluated like this::
 
-  BOOST_STATIC_ASSERT(is_planar<rgb8_planar_view_t>::value == true);
+  static_assert(is_planar<rgb8_planar_view_t>::value == true, "");
 
 GIL also supports type analysis metafunctions of the form:
 [pixel_reference/iterator/locator/view/image] + "_is_" +
@@ -2537,10 +2537,10 @@ Here is how to use pixels in generic code::
     gil_function_requires<MutableHomogeneousPixelConcept<RGBPixel> >();
 
     typedef typename color_space_type<GrayPixel>::type gray_cs_t;
-    BOOST_STATIC_ASSERT((boost::is_same<gray_cs_t,gray_t>::value));
+    static_assert(boost::is_same<gray_cs_t,gray_t>::value, "");
 
     typedef typename color_space_type<RGBPixel>::type  rgb_cs_t;
-    BOOST_STATIC_ASSERT((boost::is_same<rgb_cs_t,rgb_t>::value));
+    static_assert(boost::is_same<rgb_cs_t,rgb_t>::value, "");
 
     typedef typename channel_type<GrayPixel>::type gray_channel_t;
     typedef typename channel_type<RGBPixel>::type  rgb_channel_t;

--- a/doc/doxygen/design_guide.dox
+++ b/doc/doxygen/design_guide.dox
@@ -886,7 +886,7 @@ channels occupy bits [0..4],[5..9] and [10..15] respectively. GIL provides a mod
 typedef packed_pixel_type<uint16_t, mpl::vector3_c<unsigned,5,6,5>, rgb_layout_t>::type rgb565_pixel_t;
 
 function_requires<PixelValueConcept<rgb565_pixel_t> >();
-BOOST_STATIC_ASSERT((sizeof(rgb565_pixel_t)==2));
+static_assert(sizeof(rgb565_pixel_t) == 2, "");
 
 // define a bgr556 pixel
 typedef packed_pixel_type<uint16_t, mpl::vector3_c<unsigned,5,6,5>, bgr_layout_t>::type bgr556_pixel_t;
@@ -912,7 +912,7 @@ typedef bit_aligned_pixel_iterator<bgr232_ref_t> bgr232_ptr_t;
 
 // BGR232 pixel value. It is a packed_pixel of size 1 byte. (The last bit is unused)
 typedef std::iterator_traits<bgr232_ptr_t>::value_type bgr232_pixel_t;
-BOOST_STATIC_ASSERT((sizeof(bgr232_pixel_t)==1));
+static_assert(sizeof(bgr232_pixel_t) == 1, "");
 
 bgr232_pixel_t red(0,0,3); // = 0RRGGGBB, = 01100000 = 0x60
 
@@ -1965,7 +1965,7 @@ depth. How can we possibly write this using our generic image? What type is the 
 #include <boost/gil/extension/dynamic_image/dynamic_image_all.hpp>
 using namespace boost;
 
-#define ASSERT_SAME(A,B) BOOST_STATIC_ASSERT((is_same< A,B >::value))
+#define ASSERT_SAME(A,B) static_assert(is_same< A,B >::value, "")
 
 // Define the set of allowed images
 typedef mpl::vector<rgb8_image_t, cmyk16_planar_image_t> my_images_t;
@@ -2351,7 +2351,7 @@ template <typename T> struct num_channels { typedef ... type; };
 These are metafunctions, some of which return integral types which can be evaluated like this:
 
 \code
-BOOST_STATIC_ASSERT(is_planar<rgb8_planar_view_t>::value == true);
+static_assert(is_planar<rgb8_planar_view_t>::value == true, "");
 \endcode
 
 \endcode
@@ -2493,10 +2493,10 @@ void gray_to_rgb(const GrayPixel& src, RGBPixel& dst) {
     gil_function_requires<MutableHomogeneousPixelConcept<RGBPixel> >();
 
     typedef typename color_space_type<GrayPixel>::type gray_cs_t;
-    BOOST_STATIC_ASSERT((boost::is_same<gray_cs_t,gray_t>::value));
+    static_assert(boost::is_same<gray_cs_t,gray_t>::value, "");
 
     typedef typename color_space_type<RGBPixel>::type  rgb_cs_t;
-    BOOST_STATIC_ASSERT((boost::is_same<rgb_cs_t,rgb_t>::value));
+    static_assert(boost::is_same<rgb_cs_t,rgb_t>::value, "");
 
     typedef typename channel_type<GrayPixel>::type gray_channel_t;
     typedef typename channel_type<RGBPixel>::type  rgb_channel_t;

--- a/include/boost/gil/bit_aligned_pixel_reference.hpp
+++ b/include/boost/gil/bit_aligned_pixel_reference.hpp
@@ -130,8 +130,10 @@ struct bit_aligned_pixel_reference {
     template <bool IsMutable2> bit_aligned_pixel_reference(const bit_aligned_pixel_reference<BitField,ChannelBitSizes,Layout,IsMutable2>& p) : _bit_range(p._bit_range) {}
 
     // Grayscale references can be constructed from the channel reference
-    explicit bit_aligned_pixel_reference(const typename kth_element_type<bit_aligned_pixel_reference,0>::type channel0) : _bit_range(static_cast<data_ptr_t>(&channel0), channel0.first_bit()) {
-        BOOST_STATIC_ASSERT((num_channels<bit_aligned_pixel_reference>::value==1));
+    explicit bit_aligned_pixel_reference(typename kth_element_type<bit_aligned_pixel_reference,0>::type const channel0)
+        : _bit_range(static_cast<data_ptr_t>(&channel0), channel0.first_bit())
+    {
+        static_assert(num_channels<bit_aligned_pixel_reference>::value == 1, "");
     }
 
     // Construct from another compatible pixel type
@@ -159,7 +161,11 @@ private:
     template <typename Pixel> bool  equal(const Pixel& p, mpl::true_) const { check_compatible<Pixel>(); return static_equal(*this,p); }
 
 private:
-    static void check_gray() {  BOOST_STATIC_ASSERT((is_same<typename Layout::color_space_t, gray_t>::value)); }
+    static void check_gray()
+    {
+        static_assert(is_same<typename Layout::color_space_t, gray_t>::value, "");
+    }
+
     template <typename Channel> void assign(const Channel& chan, mpl::false_) const { check_gray(); gil::at_c<0>(*this)=chan; }
     template <typename Channel> bool equal (const Channel& chan, mpl::false_) const { check_gray(); return gil::at_c<0>(*this)==chan; }
 };

--- a/include/boost/gil/channel.hpp
+++ b/include/boost/gil/channel.hpp
@@ -262,7 +262,7 @@ using bits4 = packed_channel_value<4>;
 assert(channel_traits<bits4>::min_value()==0);
 assert(channel_traits<bits4>::max_value()==15);
 assert(sizeof(bits4)==1);
-BOOST_STATIC_ASSERT((boost::is_integral<bits4>::value));
+static_assert(boost::is_integral<bits4>::value, "");
 \endcode
 */
 

--- a/include/boost/gil/color_base_algorithm.hpp
+++ b/include/boost/gil/color_base_algorithm.hpp
@@ -34,8 +34,8 @@ namespace boost { namespace gil {
 
 Example:
 \code
-BOOST_STATIC_ASSERT((size<rgb8_pixel_t>::value == 3));
-BOOST_STATIC_ASSERT((size<cmyk8_planar_ptr_t>::value == 4));
+static_assert(size<rgb8_pixel_t>::value == 3, "");
+static_assert(size<cmyk8_planar_ptr_t>::value == 4, "");
 \endcode
 */
 
@@ -133,7 +133,7 @@ Example: A function that takes a generic pixel containing a red channel and sets
 template <typename Pixel>
 void set_red_to_max(Pixel& pixel) {
     boost::function_requires<MutablePixelConcept<Pixel> >();
-    BOOST_STATIC_ASSERT((contains_color<Pixel, red_t>::value));
+    static_assert(contains_color<Pixel, red_t>::value, "");
 
     using red_channel_t = typename color_element_type<Pixel, red_t>::type;
     get_color(pixel, red_t()) = channel_traits<red_channel_t>::max_value();
@@ -192,7 +192,7 @@ typename color_element_const_reference_type<ColorBase,Color>::type get_color(con
 Example:
 \code
 using element_t = element_type<rgb8c_planar_ptr_t>::type;
-BOOST_STATIC_ASSERT((boost::is_same<element_t, const uint8_t*>::value));
+static_assert(boost::is_same<element_t, const uint8_t*>::value, "");
 \endcode
 */
 /// \brief Specifies the element type of a homogeneous color base

--- a/include/boost/gil/concepts/basic.hpp
+++ b/include/boost/gil/concepts/basic.hpp
@@ -168,7 +168,7 @@ struct SameType
 {
     void constraints()
     {
-        BOOST_STATIC_ASSERT((boost::is_same<T, U>::value_core));
+        static_assert(boost::is_same<T, U>::value_core, "");
     }
 };
 

--- a/include/boost/gil/concepts/channel.hpp
+++ b/include/boost/gil/concepts/channel.hpp
@@ -140,7 +140,7 @@ struct ChannelValueConcept
 /// Example:
 ///
 /// \code
-/// BOOST_STATIC_ASSERT((channels_are_compatible<uint8_t, const uint8_t&>::value));
+/// static_assert(channels_are_compatible<uint8_t, const uint8_t&>::value, "");
 /// \endcode
 /// \ingroup ChannelAlgorithm
 template <typename T1, typename T2>  // Models GIL Pixel
@@ -167,7 +167,7 @@ struct ChannelsCompatibleConcept
 {
     void constraints()
     {
-        BOOST_STATIC_ASSERT((channels_are_compatible<Channel1, Channel2>::value));
+        static_assert(channels_are_compatible<Channel1, Channel2>::value, "");
     }
 };
 

--- a/include/boost/gil/concepts/color.hpp
+++ b/include/boost/gil/concepts/color.hpp
@@ -57,7 +57,7 @@ struct ColorSpacesCompatibleConcept
 {
     void constraints()
     {
-        BOOST_STATIC_ASSERT((color_spaces_are_compatible<CS1, CS2>::value));
+        static_assert(color_spaces_are_compatible<CS1, CS2>::value, "");
     }
 };
 

--- a/include/boost/gil/concepts/color_base.hpp
+++ b/include/boost/gil/concepts/color_base.hpp
@@ -229,7 +229,7 @@ struct HomogeneousColorBaseConcept
         using T0 = typename kth_element_type<ColorBase, 0>::type;
         using TN = typename kth_element_type<ColorBase, num_elements - 1>::type;
 
-        BOOST_STATIC_ASSERT((is_same<T0, TN>::value));   // better than nothing
+        static_assert(is_same<T0, TN>::value, "");   // better than nothing
 
         using R0 = typename kth_element_const_reference_type<ColorBase, 0>::type;
         R0 r = dynamic_at_c(cb, 0);
@@ -296,11 +296,11 @@ struct ColorBasesCompatibleConcept
 {
     void constraints()
     {
-        BOOST_STATIC_ASSERT((is_same
+        static_assert(is_same
             <
                 typename ColorBase1::layout_t::color_space_t,
                 typename ColorBase2::layout_t::color_space_t
-            >::value));
+            >::value, "");
 
 //        using e1 = typename kth_semantic_element_type<ColorBase1,0>::type;
 //        using e2 = typename kth_semantic_element_type<ColorBase2,0>::type;

--- a/include/boost/gil/concepts/image.hpp
+++ b/include/boost/gil/concepts/image.hpp
@@ -141,10 +141,10 @@ struct ImageConcept
         gil_function_requires<RandomAccess2DImageConcept<Image>>();
         gil_function_requires<MutableImageViewConcept<typename Image::view_t>>();
         using coord_t = typename Image::coord_t;
-        BOOST_STATIC_ASSERT(num_channels<Image>::value == mpl::size<typename color_space_type<Image>::type>::value);
+        static_assert(num_channels<Image>::value == mpl::size<typename color_space_type<Image>::type>::value, "");
 
-        BOOST_STATIC_ASSERT((is_same<coord_t, typename Image::x_coord_t>::value));
-        BOOST_STATIC_ASSERT((is_same<coord_t, typename Image::y_coord_t>::value));
+        static_assert(is_same<coord_t, typename Image::x_coord_t>::value, "");
+        static_assert(is_same<coord_t, typename Image::y_coord_t>::value, "");
     }
     Image image;
 };

--- a/include/boost/gil/concepts/image_view.hpp
+++ b/include/boost/gil/concepts/image_view.hpp
@@ -120,22 +120,22 @@ struct RandomAccessNDImageViewConcept
         gil_function_requires<boost_concepts::RandomAccessTraversalConcept<first_it_type>>();
         gil_function_requires<boost_concepts::RandomAccessTraversalConcept<last_it_type>>();
 
-//        BOOST_STATIC_ASSERT((typename std::iterator_traits<first_it_type>::difference_type, typename point_t::template axis<0>::coord_t>::value));
-//        BOOST_STATIC_ASSERT((typename std::iterator_traits<last_it_type>::difference_type, typename point_t::template axis<N-1>::coord_t>::value));
+//        static_assert(typename std::iterator_traits<first_it_type>::difference_type, typename point_t::template axis<0>::coord_t>::value, "");
+//        static_assert(typename std::iterator_traits<last_it_type>::difference_type, typename point_t::template axis<N-1>::coord_t>::value, "");
 
         // point_t must be an N-dimensional point, each dimension of which must have the same type as difference_type of the corresponding iterator
         gil_function_requires<PointNDConcept<point_t>>();
-        BOOST_STATIC_ASSERT(point_t::num_dimensions==N);
-        BOOST_STATIC_ASSERT((is_same
+        static_assert(point_t::num_dimensions == N, "");
+        static_assert(is_same
             <
                 typename std::iterator_traits<first_it_type>::difference_type,
                 typename point_t::template axis<0>::coord_t
-            >::value));
-        BOOST_STATIC_ASSERT((is_same
+            >::value, "");
+        static_assert(is_same
             <
                 typename std::iterator_traits<last_it_type>::difference_type,
                 typename point_t::template axis<N-1>::coord_t
-            >::value));
+            >::value, "");
 
         point_t p;
         locator lc;
@@ -215,7 +215,7 @@ struct RandomAccess2DImageViewConcept
     void constraints()
     {
         gil_function_requires<RandomAccessNDImageViewConcept<View>>();
-        BOOST_STATIC_ASSERT(View::num_dimensions==2);
+        static_assert(View::num_dimensions == 2, "");
 
         // TODO: This executes the requirements for RandomAccessNDLocatorConcept again. Fix it to improve compile time
         gil_function_requires<RandomAccess2DLocatorConcept<typename View::locator>>();
@@ -373,7 +373,7 @@ struct ImageViewConcept
         // TODO: This executes the requirements for RandomAccess2DLocatorConcept again. Fix it to improve compile time
         gil_function_requires<PixelLocatorConcept<typename View::xy_locator>>();
 
-        BOOST_STATIC_ASSERT((is_same<typename View::x_coord_t, typename View::y_coord_t>::value));
+        static_assert(is_same<typename View::x_coord_t, typename View::y_coord_t>::value, "");
 
         using coord_t = typename View::coord_t; // 1D difference type (same for all dimensions)
         std::size_t num_chan = view.num_channels(); ignore_unused_variable_warning(num_chan);
@@ -532,7 +532,7 @@ struct ViewsCompatibleConcept
 {
     void constraints()
     {
-        BOOST_STATIC_ASSERT((views_are_compatible<V1, V2>::value));
+        static_assert(views_are_compatible<V1, V2>::value, "");
     }
 };
 

--- a/include/boost/gil/concepts/pixel.hpp
+++ b/include/boost/gil/concepts/pixel.hpp
@@ -63,7 +63,7 @@ struct PixelConcept
         gil_function_requires<ColorBaseConcept<P>>();
         gil_function_requires<PixelBasedConcept<P>>();
 
-        BOOST_STATIC_ASSERT((is_pixel<P>::value));
+        static_assert(is_pixel<P>::value, "");
         static const bool is_mutable = P::is_mutable;
         ignore_unused_variable_warning(is_mutable);
 
@@ -99,7 +99,7 @@ struct MutablePixelConcept
     void constraints()
     {
         gil_function_requires<PixelConcept<P>>();
-        BOOST_STATIC_ASSERT(P::is_mutable);
+        static_assert(P::is_mutable, "");
     }
 };
 
@@ -187,7 +187,7 @@ struct HomogeneousPixelValueConcept
     {
         gil_function_requires<HomogeneousPixelConcept<P>>();
         gil_function_requires<Regular<P>>();
-        BOOST_STATIC_ASSERT((is_same<P, typename P::value_type>::value));
+        static_assert(is_same<P, typename P::value_type>::value, "");
     }
 };
 
@@ -258,7 +258,7 @@ struct PixelsCompatibleConcept
 {
     void constraints()
     {
-        BOOST_STATIC_ASSERT((pixels_are_compatible<P1, P2>::value));
+        static_assert(pixels_are_compatible<P1, P2>::value, "");
     }
 };
 

--- a/include/boost/gil/concepts/pixel_iterator.hpp
+++ b/include/boost/gil/concepts/pixel_iterator.hpp
@@ -354,7 +354,7 @@ struct IteratorAdaptorConcept
         using base_t = typename iterator_adaptor_get_base<Iterator>::type;
         gil_function_requires<boost_concepts::ForwardTraversalConcept<base_t>>();
 
-        BOOST_STATIC_ASSERT(is_iterator_adaptor<Iterator>::value);
+        static_assert(is_iterator_adaptor<Iterator>::value, "");
         using rebind_t = typename iterator_adaptor_rebind<Iterator, void*>::type;
 
         base_t base = it.base();

--- a/include/boost/gil/concepts/pixel_locator.hpp
+++ b/include/boost/gil/concepts/pixel_locator.hpp
@@ -133,17 +133,17 @@ struct RandomAccessNDLocatorConcept
         // point_t must be an N-dimensional point, each dimension of which must
         // have the same type as difference_type of the corresponding iterator
         gil_function_requires<PointNDConcept<point_t>>();
-        BOOST_STATIC_ASSERT(point_t::num_dimensions==N);
-        BOOST_STATIC_ASSERT((is_same
+        static_assert(point_t::num_dimensions == N, "");
+        static_assert(is_same
             <
                 typename std::iterator_traits<first_it_type>::difference_type,
                 typename point_t::template axis<0>::coord_t
-            >::value));
-        BOOST_STATIC_ASSERT((is_same
+            >::value, "");
+        static_assert(is_same
             <
                 typename std::iterator_traits<last_it_type>::difference_type,
                 typename point_t::template axis<N-1>::coord_t
-            >::value));
+            >::value, "");
 
         difference_type d;
         loc += d;
@@ -214,7 +214,7 @@ struct RandomAccess2DLocatorConcept
     void constraints()
     {
         gil_function_requires<RandomAccessNDLocatorConcept<Loc>>();
-        BOOST_STATIC_ASSERT(Loc::num_dimensions==2);
+        static_assert(Loc::num_dimensions == 2, "");
 
         using dynamic_x_step_t = typename dynamic_x_step_type<Loc>::type;
         using dynamic_y_step_t = typename dynamic_y_step_type<Loc>::type;
@@ -287,7 +287,7 @@ struct PixelLocatorConcept
         gil_function_requires<PixelIteratorConcept<typename Loc::x_iterator>>();
         gil_function_requires<PixelIteratorConcept<typename Loc::y_iterator>>();
         using coord_t = typename Loc::coord_t;
-        BOOST_STATIC_ASSERT((is_same<typename Loc::x_coord_t, typename Loc::y_coord_t>::value));
+        static_assert(is_same<typename Loc::x_coord_t, typename Loc::y_coord_t>::value, "");
     }
     Loc loc;
 };

--- a/include/boost/gil/concepts/point.hpp
+++ b/include/boost/gil/concepts/point.hpp
@@ -99,7 +99,7 @@ struct Point2DConcept
     void constraints()
     {
         gil_function_requires<PointNDConcept<P>>();
-        BOOST_STATIC_ASSERT(P::num_dimensions == 2);
+        static_assert(P::num_dimensions == 2, "");
         point.x = point.y;
         point[0] = point[1];
     }

--- a/include/boost/gil/extension/io/pnm/detail/write.hpp
+++ b/include/boost/gil/extension/io/pnm/detail/write.hpp
@@ -131,10 +131,7 @@ private:
                    , const mpl::true_&    // bit_aligned
                    )
     {
-        BOOST_STATIC_ASSERT(( is_same< View
-                                     , typename gray1_image_t::view_t
-                                     >::value
-                           ));
+        static_assert(is_same<View, typename gray1_image_t::view_t>::value, "");
 
         byte_vector_t row( pitch / 8 );
 

--- a/include/boost/gil/extension/io/tiff/detail/read.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/read.hpp
@@ -20,8 +20,6 @@
 #include <boost/gil/io/reader_base.hpp>
 #include <boost/gil/io/row_buffer_helper.hpp>
 
-#include <boost/static_assert.hpp>
-
 #include <algorithm>
 #include <string>
 #include <vector>

--- a/include/boost/gil/extension/io/tiff/detail/scanline_read.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/scanline_read.hpp
@@ -21,7 +21,6 @@
 #include <boost/gil/io/scanline_read_iterator.hpp>
 
 #include <boost/function.hpp>
-#include <boost/static_assert.hpp>
 
 #include <algorithm>
 #include <string>

--- a/include/boost/gil/extension/io/tiff/detail/write.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/write.hpp
@@ -17,8 +17,6 @@
 #include <boost/gil/io/device.hpp>
 #include <boost/gil/io/dynamic_io_new.hpp>
 
-#include <boost/static_assert.hpp>
-
 #include <algorithm>
 #include <string>
 #include <vector>

--- a/include/boost/gil/extension/toolbox/image_types/subchroma_image.hpp
+++ b/include/boost/gil/extension/toolbox/image_types/subchroma_image.hpp
@@ -31,23 +31,21 @@ namespace detail {
 template< int J, int A, int B>
 struct scaling_factors
 {
-    BOOST_STATIC_ASSERT(( mpl::equal_to< mpl::int_< J >, mpl::int_< 4 > >::type::value ));
+    static_assert(mpl::equal_to< mpl::int_< J >, mpl::int_< 4 > >::type::value, "");
 
-    BOOST_STATIC_ASSERT(( mpl::or_< mpl::equal_to< mpl::int_<A>, mpl::int_< 4 > >
+    static_assert(mpl::or_<mpl::equal_to< mpl::int_<A>, mpl::int_< 4 > >
                                   , mpl::or_< mpl::equal_to< mpl::int_<A>, mpl::int_< 2 > >
                                             , mpl::equal_to< mpl::int_<A>, mpl::int_< 1 > >
                                             >
-                                  >::type::value
-                       ));
+                                  >::type::value, "");
 
-    BOOST_STATIC_ASSERT(( mpl::or_< mpl::equal_to< mpl::int_<B>, mpl::int_< 4 > >
+    static_assert(mpl::or_< mpl::equal_to< mpl::int_<B>, mpl::int_< 4 > >
                                   , mpl::or_< mpl::equal_to< mpl::int_<B>, mpl::int_< 2 > >
                                             , mpl::or_< mpl::equal_to< mpl::int_<B>, mpl::int_< 1 > >
                                                       , mpl::equal_to< mpl::int_<B>, mpl::int_< 0 > >
                                                       >
                                             >
-                                  >::type::value
-                       ));
+                                  >::type::value, "");
 
     BOOST_STATIC_CONSTANT( int, ss_X = ( mpl::divides< mpl::int_< J >
                                                      , mpl::int_<A>

--- a/include/boost/gil/image_view_factory.hpp
+++ b/include/boost/gil/image_view_factory.hpp
@@ -89,8 +89,8 @@ namespace detail {
 /// \brief Returns C pointer to the the channels of an interleaved homogeneous view.
 template <typename HomogeneousView>
 typename detail::channel_pointer_type<HomogeneousView>::type interleaved_view_get_raw_data(const HomogeneousView& view) {
-    BOOST_STATIC_ASSERT((!is_planar<HomogeneousView>::value && view_is_basic<HomogeneousView>::value));
-    BOOST_STATIC_ASSERT((boost::is_pointer<typename HomogeneousView::x_iterator>::value));
+    static_assert(!is_planar<HomogeneousView>::value && view_is_basic<HomogeneousView>::value, "");
+    static_assert(boost::is_pointer<typename HomogeneousView::x_iterator>::value, "");
 
     return &gil::at_c<0>(view(0,0));
 }
@@ -99,7 +99,7 @@ typename detail::channel_pointer_type<HomogeneousView>::type interleaved_view_ge
 /// \brief Returns C pointer to the the channels of a given color plane of a planar homogeneous view.
 template <typename HomogeneousView>
 typename detail::channel_pointer_type<HomogeneousView>::type planar_view_get_raw_data(const HomogeneousView& view, int plane_index) {
-    BOOST_STATIC_ASSERT((is_planar<HomogeneousView>::value && view_is_basic<HomogeneousView>::value));
+    static_assert(is_planar<HomogeneousView>::value && view_is_basic<HomogeneousView>::value, "");
     return dynamic_at_c(view.row_begin(0),plane_index);
 }
 

--- a/include/boost/gil/packed_pixel.hpp
+++ b/include/boost/gil/packed_pixel.hpp
@@ -34,7 +34,7 @@ namespace boost { namespace gil {
 Example:
 \code
 using rgb565_pixel_t = packed_pixel_type<uint16_t, mpl::vector3_c<unsigned,5,6,5>, rgb_layout_t>::type;
-BOOST_STATIC_ASSERT((sizeof(rgb565_pixel_t)==2));
+static_assert(sizeof(rgb565_pixel_t) == 2, "");
 
 rgb565_pixel_t r565;
 get_color(r565,red_t())   = 31;
@@ -71,21 +71,21 @@ struct packed_pixel
         boost::ignore_unused(d);
     }
     packed_pixel(int chan0, int chan1) : _bitfield(0) {
-        BOOST_STATIC_ASSERT((num_channels<packed_pixel>::value==2));
+        static_assert(num_channels<packed_pixel>::value == 2, "");
         gil::at_c<0>(*this)=chan0; gil::at_c<1>(*this)=chan1;
     }
     packed_pixel(int chan0, int chan1, int chan2) : _bitfield(0) {
-        BOOST_STATIC_ASSERT((num_channels<packed_pixel>::value==3));
+        static_assert(num_channels<packed_pixel>::value == 3, "");
         gil::at_c<0>(*this) = chan0;
         gil::at_c<1>(*this) = chan1;
         gil::at_c<2>(*this) = chan2;
     }
     packed_pixel(int chan0, int chan1, int chan2, int chan3) : _bitfield(0) {
-        BOOST_STATIC_ASSERT((num_channels<packed_pixel>::value==4));
+        static_assert(num_channels<packed_pixel>::value == 4, "");
         gil::at_c<0>(*this)=chan0; gil::at_c<1>(*this)=chan1; gil::at_c<2>(*this)=chan2; gil::at_c<3>(*this)=chan3;
     }
     packed_pixel(int chan0, int chan1, int chan2, int chan3, int chan4) : _bitfield(0) {
-        BOOST_STATIC_ASSERT((num_channels<packed_pixel>::value==5));
+        static_assert(num_channels<packed_pixel>::value == 5, "");
         gil::at_c<0>(*this)=chan0; gil::at_c<1>(*this)=chan1; gil::at_c<2>(*this)=chan2; gil::at_c<3>(*this)=chan3; gil::at_c<4>(*this)=chan4;
     }
 
@@ -102,7 +102,10 @@ private:
     template <typename Pixel> bool  equal(const Pixel& p, mpl::true_) const { check_compatible<Pixel>(); return static_equal(*this,p); }
 
 // Support for assignment/equality comparison of a channel with a grayscale pixel
-    static void check_gray() {  BOOST_STATIC_ASSERT((is_same<typename Layout::color_space_t, gray_t>::value)); }
+    static void check_gray()
+    {
+        static_assert(is_same<typename Layout::color_space_t, gray_t>::value, "");
+    }
     template <typename Channel> void assign(const Channel& chan, mpl::false_)       { check_gray(); gil::at_c<0>(*this)=chan; }
     template <typename Channel> bool equal (const Channel& chan, mpl::false_) const { check_gray(); return gil::at_c<0>(*this)==chan; }
 public:

--- a/include/boost/gil/pixel.hpp
+++ b/include/boost/gil/pixel.hpp
@@ -54,14 +54,14 @@ struct num_channels : public mpl::size<typename color_space_type<PixelBased>::ty
 
 Example:
 \code
-BOOST_STATIC_ASSERT((num_channels<rgb8_view_t>::value==3));
-BOOST_STATIC_ASSERT((num_channels<cmyk16_planar_ptr_t>::value==4));
+static_assert(num_channels<rgb8_view_t>::value == 3, "");
+static_assert(num_channels<cmyk16_planar_ptr_t>::value == 4, "");
 
-BOOST_STATIC_ASSERT((is_planar<rgb16_planar_image_t>::value));
-BOOST_STATIC_ASSERT((is_same<color_space_type<rgb8_planar_ref_t>::type, rgb_t>::value));
-BOOST_STATIC_ASSERT((is_same<channel_mapping_type<cmyk8_pixel_t>::type,
-                             channel_mapping_type<rgba8_pixel_t>::type>::value));
-BOOST_STATIC_ASSERT((is_same<channel_type<bgr8_pixel_t>::type, uint8_t>::value));
+static_assert(is_planar<rgb16_planar_image_t>::value));
+static_assert(is_same<color_space_type<rgb8_planar_ref_t>::type, rgb_t>::value, "");
+static_assert(is_same<channel_mapping_type<cmyk8_pixel_t>::type,
+                             channel_mapping_type<rgba8_pixel_t>::type>::value, "");
+static_assert(is_same<channel_type<bgr8_pixel_t>::type, uint8_t>::value, "");
 \endcode
 */
 
@@ -134,7 +134,10 @@ private:
 // Support for assignment/equality comparison of a channel with a grayscale pixel
 
 private:
-    static void check_gray() {  BOOST_STATIC_ASSERT((is_same<typename Layout::color_space_t, gray_t>::value)); }
+    static void check_gray()
+    {
+        static_assert(is_same<typename Layout::color_space_t, gray_t>::value, "");
+    }
     template <typename Channel> void assign(const Channel& chan, mpl::false_)       { check_gray(); gil::at_c<0>(*this)=chan; }
     template <typename Channel> bool equal (const Channel& chan, mpl::false_) const { check_gray(); return gil::at_c<0>(*this)==chan; }
 public:

--- a/include/boost/gil/utilities.hpp
+++ b/include/boost/gil/utilities.hpp
@@ -15,7 +15,6 @@
 #include <boost/mpl/size.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 #include <boost/iterator/iterator_facade.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/type_traits.hpp>
 
 #include <algorithm>

--- a/io/test/make.cpp
+++ b/io/test/make.cpp
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_SUITE( gil_io_tests )
 BOOST_AUTO_TEST_CASE( make_reader_backend_test )
 {
     {
-        BOOST_STATIC_ASSERT(( boost::is_same< gil::detail::is_supported_path_spec< char* >::type, mpl::true_ >::value ));
+        static_assert(boost::is_same<gil::detail::is_supported_path_spec<char*>::type, mpl::true_>::value, "");
 
         get_reader_backend< const char*, bmp_tag >::type backend_char   = make_reader_backend( bmp_filename.c_str(), bmp_tag() );
         get_reader_backend< std::string, bmp_tag >::type backend_string = make_reader_backend( bmp_filename, bmp_tag() );
@@ -133,7 +133,7 @@ BOOST_AUTO_TEST_CASE( make_writer_test )
     {
         using writer_t = get_writer<char const*, bmp_tag>::type;
 
-        BOOST_STATIC_ASSERT(( boost::is_same< gil::detail::is_writer< writer_t >::type, boost::mpl::true_ >::value ));
+        static_assert(boost::is_same<gil::detail::is_writer<writer_t>::type, boost::mpl::true_>::value, "");
     }
 
     {

--- a/test/image.cpp
+++ b/test/image.cpp
@@ -501,25 +501,25 @@ const string ref_dir=in_dir+"image-ref/";  // reference directory to compare wri
 void static_checks() {
     gil_function_requires<ImageConcept<rgb8_image_t> >();
 
-    BOOST_STATIC_ASSERT(view_is_basic<rgb8_step_view_t>::value);
-    BOOST_STATIC_ASSERT(view_is_basic<cmyk8c_planar_step_view_t>::value);
-    BOOST_STATIC_ASSERT(view_is_basic<rgb8_planar_view_t>::value);
+    static_assert(view_is_basic<rgb8_step_view_t>::value, "");
+    static_assert(view_is_basic<cmyk8c_planar_step_view_t>::value, "");
+    static_assert(view_is_basic<rgb8_planar_view_t>::value, "");
 
-    BOOST_STATIC_ASSERT(view_is_step_in_x<rgb8_step_view_t>::value);
-    BOOST_STATIC_ASSERT(view_is_step_in_x<cmyk8c_planar_step_view_t>::value);
-    BOOST_STATIC_ASSERT(!view_is_step_in_x<rgb8_planar_view_t>::value);
+    static_assert(view_is_step_in_x<rgb8_step_view_t>::value, "");
+    static_assert(view_is_step_in_x<cmyk8c_planar_step_view_t>::value, "");
+    static_assert(!view_is_step_in_x<rgb8_planar_view_t>::value, "");
 
-    BOOST_STATIC_ASSERT(!is_planar<rgb8_step_view_t>::value);
-    BOOST_STATIC_ASSERT(is_planar<cmyk8c_planar_step_view_t>::value);
-    BOOST_STATIC_ASSERT(is_planar<rgb8_planar_view_t>::value);
+    static_assert(!is_planar<rgb8_step_view_t>::value, "");
+    static_assert(is_planar<cmyk8c_planar_step_view_t>::value, "");
+    static_assert(is_planar<rgb8_planar_view_t>::value, "");
 
-    BOOST_STATIC_ASSERT(view_is_mutable<rgb8_step_view_t>::value);
-    BOOST_STATIC_ASSERT(!view_is_mutable<cmyk8c_planar_step_view_t>::value);
-    BOOST_STATIC_ASSERT(view_is_mutable<rgb8_planar_view_t>::value);
+    static_assert(view_is_mutable<rgb8_step_view_t>::value, "");
+    static_assert(!view_is_mutable<cmyk8c_planar_step_view_t>::value, "");
+    static_assert(view_is_mutable<rgb8_planar_view_t>::value, "");
 
-    BOOST_STATIC_ASSERT((boost::is_same<derived_view_type<cmyk8c_planar_step_view_t>::type, cmyk8c_planar_step_view_t>::value));
-    BOOST_STATIC_ASSERT((boost::is_same<derived_view_type<cmyk8c_planar_step_view_t, std::uint16_t, rgb_layout_t>::type,  rgb16c_planar_step_view_t>::value));
-    BOOST_STATIC_ASSERT((boost::is_same<derived_view_type<cmyk8c_planar_step_view_t, use_default, rgb_layout_t, mpl::false_, use_default, mpl::false_>::type,  rgb8c_step_view_t>::value));
+    static_assert(boost::is_same<derived_view_type<cmyk8c_planar_step_view_t>::type, cmyk8c_planar_step_view_t>::value, "");
+    static_assert(boost::is_same<derived_view_type<cmyk8c_planar_step_view_t, std::uint16_t, rgb_layout_t>::type,  rgb16c_planar_step_view_t>::value, "");
+    static_assert(boost::is_same<derived_view_type<cmyk8c_planar_step_view_t, use_default, rgb_layout_t, mpl::false_, use_default, mpl::false_>::type,  rgb8c_step_view_t>::value, "");
 
     // test view get raw data (mostly compile-time test)
     {

--- a/test/pixel.cpp
+++ b/test/pixel.cpp
@@ -241,7 +241,7 @@ void test_packed_pixel()
     using rgb565_pixel_t = packed_pixel_type<uint16_t, mpl::vector3_c<unsigned,5,6,5>, rgb_layout_t>::type;
 
     boost::function_requires<PixelValueConcept<rgb565_pixel_t> >();
-    BOOST_STATIC_ASSERT((sizeof(rgb565_pixel_t)==2));
+    static_assert(sizeof(rgb565_pixel_t) == 2, "");
 
     // define a bgr556 pixel
     using bgr556_pixel_t = packed_pixel_type<uint16_t, mpl::vector3_c<unsigned,5,6,5>, bgr_layout_t>::type;
@@ -273,24 +273,24 @@ void test_packed_pixel()
     do_basic_test<reference_core<bgr121_ref_t,0>, reference_core<rgb121_ref_t,1> >(p121).test_heterogeneous();
     do_basic_test<value_core<rgb121_pixel_t,0>, reference_core<rgb121_ref_t,1> >(p121).test_heterogeneous();
 
-    BOOST_STATIC_ASSERT((pixel_reference_is_proxy<rgb8_planar_ref_t>::value));
-    BOOST_STATIC_ASSERT((pixel_reference_is_proxy<bgr121_ref_t>::value));
+    static_assert(pixel_reference_is_proxy<rgb8_planar_ref_t>::value, "");
+    static_assert(pixel_reference_is_proxy<bgr121_ref_t>::value, "");
 
-    BOOST_STATIC_ASSERT(!(pixel_reference_is_proxy<rgb8_pixel_t>::value));
-    BOOST_STATIC_ASSERT(!(pixel_reference_is_proxy<rgb8_pixel_t&>::value));
-    BOOST_STATIC_ASSERT(!(pixel_reference_is_proxy<const rgb8_pixel_t&>::value));
+    static_assert(!pixel_reference_is_proxy<rgb8_pixel_t>::value, "");
+    static_assert(!pixel_reference_is_proxy<rgb8_pixel_t&>::value, "");
+    static_assert(!pixel_reference_is_proxy<rgb8_pixel_t const&>::value, "");
 
-    BOOST_STATIC_ASSERT( (pixel_reference_is_mutable<      rgb8_pixel_t&>::value));
-    BOOST_STATIC_ASSERT(!(pixel_reference_is_mutable<const rgb8_pixel_t&>::value));
+    static_assert(pixel_reference_is_mutable<rgb8_pixel_t&>::value, "");
+    static_assert(!pixel_reference_is_mutable<rgb8_pixel_t const&>::value, "");
 
-    BOOST_STATIC_ASSERT((pixel_reference_is_mutable<const rgb8_planar_ref_t&>::value));
-    BOOST_STATIC_ASSERT((pixel_reference_is_mutable<      rgb8_planar_ref_t >::value));
+    static_assert(pixel_reference_is_mutable<rgb8_planar_ref_t>::value, "");
+    static_assert(pixel_reference_is_mutable<rgb8_planar_ref_t const&>::value, "");
 
-    BOOST_STATIC_ASSERT(!(pixel_reference_is_mutable<const rgb8c_planar_ref_t&>::value));
-    BOOST_STATIC_ASSERT(!(pixel_reference_is_mutable<      rgb8c_planar_ref_t >::value));
+    static_assert(!pixel_reference_is_mutable<rgb8c_planar_ref_t>::value, "");
+    static_assert(!pixel_reference_is_mutable<rgb8c_planar_ref_t const&>::value, "");
 
-    BOOST_STATIC_ASSERT( (pixel_reference_is_mutable<bgr121_ref_t>::value));
-    BOOST_STATIC_ASSERT(!(pixel_reference_is_mutable<bgr121_ref_t::const_reference>::value));
+    static_assert(pixel_reference_is_mutable<bgr121_ref_t>::value, "");
+    static_assert(!pixel_reference_is_mutable<bgr121_ref_t::const_reference>::value, "");
 
 }
 

--- a/test/pixel_iterator.cpp
+++ b/test/pixel_iterator.cpp
@@ -49,15 +49,15 @@ void test_pixel_iterator()
     boost::function_requires<HasDynamicXStepTypeConcept<bgr121_ptr_t> >();
 
 // TEST dynamic_step_t
-    BOOST_STATIC_ASSERT(( boost::is_same<cmyk16_step_ptr_t,dynamic_x_step_type<cmyk16_step_ptr_t>::type>::value ));
-    BOOST_STATIC_ASSERT(( boost::is_same<cmyk16_planar_step_ptr_t,dynamic_x_step_type<cmyk16_planar_ptr_t>::type>::value ));
+    static_assert(boost::is_same<cmyk16_step_ptr_t, dynamic_x_step_type<cmyk16_step_ptr_t>::type>::value, "");
+    static_assert(boost::is_same<cmyk16_planar_step_ptr_t, dynamic_x_step_type<cmyk16_planar_ptr_t>::type>::value, "");
 
-    BOOST_STATIC_ASSERT(( boost::is_same<iterator_type<uint8_t,gray_layout_t,false,false,false>::type,gray8c_ptr_t>::value ));
+    static_assert(boost::is_same<iterator_type<uint8_t,gray_layout_t,false,false,false>::type,gray8c_ptr_t>::value, "");
 
 // TEST iterator_is_step
-    BOOST_STATIC_ASSERT(iterator_is_step< cmyk16_step_ptr_t >::value);
-    BOOST_STATIC_ASSERT(iterator_is_step< cmyk16_planar_step_ptr_t >::value);
-    BOOST_STATIC_ASSERT(!iterator_is_step< cmyk16_planar_ptr_t >::value);
+    static_assert(iterator_is_step<cmyk16_step_ptr_t>::value, "");
+    static_assert(iterator_is_step<cmyk16_planar_step_ptr_t>::value, "");
+    static_assert(!iterator_is_step<cmyk16_planar_ptr_t>::value, "");
 
     using ccv_rgb_g_fn = color_convert_deref_fn<rgb8c_ref_t, gray8_pixel_t>;
     using ccv_g_rgb_fn = color_convert_deref_fn<gray8c_ref_t, rgb8_pixel_t>;
@@ -65,20 +65,20 @@ void test_pixel_iterator()
     gil_function_requires<PixelDereferenceAdaptorConcept<deref_compose<ccv_rgb_g_fn,ccv_g_rgb_fn> > >();
 
     using rgb2gray_ptr = dereference_iterator_adaptor<rgb8_ptr_t, ccv_rgb_g_fn>;
-    BOOST_STATIC_ASSERT(!iterator_is_step< rgb2gray_ptr >::value);
+    static_assert(!iterator_is_step<rgb2gray_ptr>::value, "");
 
     using rgb2gray_step_ptr = dynamic_x_step_type<rgb2gray_ptr>::type;
-    BOOST_STATIC_ASSERT(( boost::is_same< rgb2gray_step_ptr, dereference_iterator_adaptor<rgb8_step_ptr_t, ccv_rgb_g_fn> >::value));
+    static_assert(boost::is_same<rgb2gray_step_ptr, dereference_iterator_adaptor<rgb8_step_ptr_t, ccv_rgb_g_fn>>::value, "");
 
     make_step_iterator(rgb2gray_ptr(),2);
 
     using rgb2gray_step_ptr1 = dereference_iterator_adaptor<rgb8_step_ptr_t, ccv_rgb_g_fn>;
-    BOOST_STATIC_ASSERT(iterator_is_step< rgb2gray_step_ptr1 >::value);
-    BOOST_STATIC_ASSERT(( boost::is_same< rgb2gray_step_ptr1, dynamic_x_step_type<rgb2gray_step_ptr1>::type >::value));
+    static_assert(iterator_is_step<rgb2gray_step_ptr1>::value, "");
+    static_assert(boost::is_same<rgb2gray_step_ptr1, dynamic_x_step_type<rgb2gray_step_ptr1>::type>::value, "");
 
     using rgb2gray_step_ptr2 = memory_based_step_iterator<dereference_iterator_adaptor<rgb8_ptr_t, ccv_rgb_g_fn>>;
-    BOOST_STATIC_ASSERT(iterator_is_step< rgb2gray_step_ptr2 >::value);
-    BOOST_STATIC_ASSERT(( boost::is_same< rgb2gray_step_ptr2, dynamic_x_step_type<rgb2gray_step_ptr2>::type >::value));
+    static_assert(iterator_is_step<rgb2gray_step_ptr2 >::value, "");
+    static_assert(boost::is_same<rgb2gray_step_ptr2, dynamic_x_step_type<rgb2gray_step_ptr2>::type>::value, "");
     make_step_iterator(rgb2gray_step_ptr2(),2);
 
 // bit_aligned iterators test
@@ -97,7 +97,7 @@ void test_pixel_iterator()
 
     // BGR232 pixel value. It is a packed_pixel of size 1 byte. (The last bit is unused)
     using bgr232_pixel_t = std::iterator_traits<bgr232_ptr_t>::value_type;
-    BOOST_STATIC_ASSERT((sizeof(bgr232_pixel_t)==1));
+    static_assert(sizeof(bgr232_pixel_t) == 1, "");
 
     bgr232_pixel_t red(0,0,3); // = 0RRGGGBB, = 01100000
 

--- a/toolbox/test/channel_type.cpp
+++ b/toolbox/test/channel_type.cpp
@@ -17,11 +17,10 @@ BOOST_AUTO_TEST_SUITE( toolbox_tests )
 
 BOOST_AUTO_TEST_CASE( channel_type_test )
 {
-    BOOST_STATIC_ASSERT(( is_same< unsigned char, channel_type< rgb8_pixel_t >::type >::value ));
+    static_assert(is_same<unsigned char, channel_type<rgb8_pixel_t>::type>::value, "");
 
     // float32_t is a scoped_channel_value object
-    BOOST_STATIC_ASSERT((
-        is_same<float32_t, channel_type<rgba32f_pixel_t>::type>::value));
+    static_assert(is_same<float32_t, channel_type<rgba32f_pixel_t>::type>::value, "");
 
     // channel_type for bit_aligned images doesn't work with standard gil.
     using image_t = bit_aligned_image4_type<4, 4, 4, 4, rgb_layout_t>::type;

--- a/toolbox/test/channel_view.cpp
+++ b/toolbox/test/channel_view.cpp
@@ -28,10 +28,11 @@ BOOST_AUTO_TEST_CASE( channel_view_test )
     using channel_view_t = channel_view_type<red_t, rgb8_view_t::const_t>::type;
     channel_view_t red_ = channel_view< red_t >( const_view( img ));
 
-    BOOST_STATIC_ASSERT(( is_same< kth_channel_view_type< 0, const rgb8_view_t>::type
-                                 , channel_view_type< red_t, const rgb8_view_t>::type
-                                 >::value
-                       ));
+    static_assert(is_same
+        <
+            kth_channel_view_type<0, rgb8_view_t const>::type,
+            channel_view_type<red_t, rgb8_view_t const>::type
+        >::value, "");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/toolbox/test/get_num_bits.cpp
+++ b/toolbox/test/get_num_bits.cpp
@@ -22,20 +22,20 @@ BOOST_AUTO_TEST_CASE( get_num_bits_test )
     using image_t = bit_aligned_image4_type<4, 4, 4, 4, rgb_layout_t>::type;
 
     using channel_t = channel_type<image_t::view_t::reference>::type;
-    BOOST_STATIC_ASSERT( get_num_bits< channel_t >::value == 4 );
+    static_assert(get_num_bits<channel_t>::value == 4, "");
 
     using const_channel_t = channel_type<image_t::const_view_t::reference>::type;
-    BOOST_STATIC_ASSERT( get_num_bits< const_channel_t >::value == 4 );
+    static_assert(get_num_bits<const_channel_t>::value == 4, "");
 
     using bits_t = packed_channel_value<23>;
-    BOOST_STATIC_ASSERT( get_num_bits< bits_t >::value == 23 );
-    BOOST_STATIC_ASSERT( get_num_bits< const bits_t >::value == 23 );
+    static_assert(get_num_bits<bits_t>::value == 23, "");
+    static_assert(get_num_bits<bits_t const>::value == 23, "");
 
-    BOOST_STATIC_ASSERT( get_num_bits< unsigned char >::value == 8 );
-    BOOST_STATIC_ASSERT( get_num_bits< const unsigned char >::value == 8 );
+    static_assert(get_num_bits<unsigned char >::value == 8, "");
+    static_assert(get_num_bits<unsigned char const>::value == 8, "");
 
-    BOOST_STATIC_ASSERT( get_num_bits< channel_type< gray8_image_t::view_t::value_type >::type >::value == 8 );
-    BOOST_STATIC_ASSERT( get_num_bits< channel_type< rgba32_image_t::view_t::value_type >::type >::value == 32 );
+    static_assert(get_num_bits<channel_type<gray8_image_t::view_t::value_type>::type>::value == 8, "");
+    static_assert(get_num_bits<channel_type<rgba32_image_t::view_t::value_type>::type>::value == 32, "");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/toolbox/test/get_pixel_type.cpp
+++ b/toolbox/test/get_pixel_type.cpp
@@ -20,18 +20,20 @@ BOOST_AUTO_TEST_CASE( get_pixel_type_test )
 {
     {
         using image_t = bit_aligned_image3_type<4, 15, 4, rgb_layout_t>::type;
-        BOOST_STATIC_ASSERT(( is_same< get_pixel_type< image_t::view_t >::type
-                                     , image_t::view_t::reference
-                                     >::value
-                           ));
+        static_assert(is_same
+            <
+                get_pixel_type<image_t::view_t>::type,
+                image_t::view_t::reference
+            >::value, "");
     }
 
     {
         using image_t = rgb8_image_t;
-        BOOST_STATIC_ASSERT(( is_same< get_pixel_type< image_t::view_t >::type
-                                     , image_t::view_t::value_type
-                                     >::value
-                           ));
+        static_assert(is_same
+            <
+                get_pixel_type<image_t::view_t>::type,
+                image_t::view_t::value_type
+            >::value, "");
     }
 }
 

--- a/toolbox/test/is_bit_aligned.cpp
+++ b/toolbox/test/is_bit_aligned.cpp
@@ -19,7 +19,7 @@ BOOST_AUTO_TEST_SUITE( toolbox_tests )
 BOOST_AUTO_TEST_CASE( is_bit_aligned_test )
 {
     using image_t = bit_aligned_image1_type< 4, gray_layout_t>::type;
-    BOOST_STATIC_ASSERT(( is_bit_aligned< image_t::view_t::value_type >::value ));
+    static_assert(is_bit_aligned<image_t::view_t::value_type>::value, "");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/toolbox/test/is_homogeneous.cpp
+++ b/toolbox/test/is_homogeneous.cpp
@@ -17,12 +17,12 @@ BOOST_AUTO_TEST_SUITE( toolbox_tests )
 
 BOOST_AUTO_TEST_CASE( is_homogeneous_test )
 {
-    BOOST_STATIC_ASSERT(( is_homogeneous< rgb8_pixel_t >::value ));
+    static_assert(is_homogeneous<rgb8_pixel_t>::value, "");
 
-    BOOST_STATIC_ASSERT(( is_homogeneous< cmyk16c_planar_ref_t >::value ));
+    static_assert(is_homogeneous<cmyk16c_planar_ref_t>::value, "");
 
     using image_t = bit_aligned_image1_type< 4, gray_layout_t>::type;
-    BOOST_STATIC_ASSERT(( is_homogeneous< image_t::view_t::reference >::value ));
+    static_assert(is_homogeneous<image_t::view_t::reference>::value, "");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/toolbox/test/pixel_bit_size.cpp
+++ b/toolbox/test/pixel_bit_size.cpp
@@ -21,7 +21,7 @@ BOOST_AUTO_TEST_CASE( pixel_bit_size_test )
         <
             16, 16, 16, 8, 8, devicen_layout_t<5>
         >::type;
-    BOOST_STATIC_ASSERT(( pixel_bit_size<image_t::view_t::reference>::value == 64 ));
+    static_assert(pixel_bit_size<image_t::view_t::reference>::value == 64, "");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/toolbox/test/subchroma_image.cpp
+++ b/toolbox/test/subchroma_image.cpp
@@ -57,12 +57,18 @@ BOOST_AUTO_TEST_CASE( subchroma_image_test )
     {
         using pixel_t = rgb8_pixel_t;
 
-        subchroma_image< pixel_t, mpl::vector_c< int, 4, 4, 4 > > a( 640, 480 ); BOOST_STATIC_ASSERT(( a.ss_X == 1 && a.ss_Y == 1 ));
-        subchroma_image< pixel_t, mpl::vector_c< int, 4, 4, 0 > > b( 640, 480 ); BOOST_STATIC_ASSERT(( b.ss_X == 1 && b.ss_Y == 2 ));
-        subchroma_image< pixel_t, mpl::vector_c< int, 4, 2, 2 > > c( 640, 480 ); BOOST_STATIC_ASSERT(( c.ss_X == 2 && c.ss_Y == 1 ));
-        subchroma_image< pixel_t, mpl::vector_c< int, 4, 2, 0 > > d( 640, 480 ); BOOST_STATIC_ASSERT(( d.ss_X == 2 && d.ss_Y == 2 ));
-        subchroma_image< pixel_t, mpl::vector_c< int, 4, 1, 1 > > e( 640, 480 ); BOOST_STATIC_ASSERT(( e.ss_X == 4 && e.ss_Y == 1 ));
-        subchroma_image< pixel_t, mpl::vector_c< int, 4, 1, 0 > > f( 640, 480 ); BOOST_STATIC_ASSERT(( f.ss_X == 4 && f.ss_Y == 2 ));
+        subchroma_image<pixel_t, mpl::vector_c<int, 4, 4, 4>> a(640, 480);
+        static_assert(a.ss_X == 1 && a.ss_Y == 1, "");
+        subchroma_image<pixel_t, mpl::vector_c<int, 4, 4, 0>> b(640, 480);
+        static_assert(b.ss_X == 1 && b.ss_Y == 2, "");
+        subchroma_image<pixel_t, mpl::vector_c<int, 4, 2, 2>> c(640, 480);
+        static_assert(c.ss_X == 2 && c.ss_Y == 1, "");
+        subchroma_image<pixel_t, mpl::vector_c<int, 4, 2, 0>> d(640, 480);
+        static_assert(d.ss_X == 2 && d.ss_Y == 2, "");
+        subchroma_image<pixel_t, mpl::vector_c<int, 4, 1, 1>> e(640, 480);
+        static_assert(e.ss_X == 4 && e.ss_Y == 1, "");
+        subchroma_image<pixel_t, mpl::vector_c<int, 4, 1, 0>> f(640, 480);
+        static_assert(f.ss_X == 4 && f.ss_Y == 2, "");
 
         fill_pixels( view( a ), pixel_t( 10, 20, 30 ) );
         fill_pixels( view( b ), pixel_t( 10, 20, 30 ) );


### PR DESCRIPTION
Replaced `BOOST_STATIC_ASSERT` with C++11 binary `static_assert(expr, msg)`, with empty message.

In future, this should make it possible to automatically refactor into C++17 unary `static_assert(expr)`
using `clang-tidy` and its `modernize-unary-static-assert` check.

### References

Closes #106

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed
