### PR TITLE
Replace assert() macro with BOOST_ASSERT() macro

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -81,6 +81,7 @@ before_build:
   ## Direct
   - git submodule --quiet update --init libs/algorithm
   - git submodule --quiet update --init libs/array
+  - git submodule --quiet update --init libs/assert
   - git submodule --quiet update --init libs/bind
   - git submodule --quiet update --init libs/concept_check
   - git submodule --quiet update --init libs/config
@@ -91,15 +92,12 @@ before_build:
   - git submodule --quiet update --init libs/integer
   - git submodule --quiet update --init libs/iterator
   - git submodule --quiet update --init libs/lambda
-  - git submodule --quiet update --init libs/lexical_cast
   - git submodule --quiet update --init libs/mpl
   - git submodule --quiet update --init libs/numeric/conversion
   - git submodule --quiet update --init libs/preprocessor
-  - git submodule --quiet update --init libs/smart_ptr
   - git submodule --quiet update --init libs/test
   - git submodule --quiet update --init libs/type_traits
   ## Transitive
-  - git submodule --quiet update --init libs/assert
   - git submodule --quiet update --init libs/atomic
   - git submodule --quiet update --init libs/chrono
   - git submodule --quiet update --init libs/container
@@ -120,6 +118,7 @@ before_build:
   - git submodule --quiet update --init libs/rational
   - git submodule --quiet update --init libs/regex
   - git submodule --quiet update --init libs/static_assert
+  - git submodule --quiet update --init libs/smart_ptr
   - git submodule --quiet update --init libs/system
   - git submodule --quiet update --init libs/throw_exception
   - git submodule --quiet update --init libs/timer

--- a/.travis.yml
+++ b/.travis.yml
@@ -199,6 +199,8 @@ install:
   - git submodule --quiet update --init libs/headers
   ## Direct
   - git submodule --quiet update --init libs/algorithm
+  - git submodule --quiet update --init libs/assert
+  - git submodule --quiet update --init libs/array
   - git submodule --quiet update --init libs/bind
   - git submodule --quiet update --init libs/concept_check
   - git submodule --quiet update --init libs/config
@@ -215,8 +217,6 @@ install:
   - git submodule --quiet update --init libs/test
   - git submodule --quiet update --init libs/type_traits
   ## Transitive
-  - git submodule --quiet update --init libs/assert
-  - git submodule --quiet update --init libs/array
   - git submodule --quiet update --init libs/atomic
   - git submodule --quiet update --init libs/chrono
   - git submodule --quiet update --init libs/container

--- a/include/boost/gil/algorithm.hpp
+++ b/include/boost/gil/algorithm.hpp
@@ -14,13 +14,13 @@
 #include <boost/gil/image_view.hpp>
 #include <boost/gil/image_view_factory.hpp>
 
+#include <boost/assert.hpp>
 #include <boost/config.hpp>
-#include <boost/utility/enable_if.hpp>
 #include <boost/mpl/and.hpp>
 #include <boost/mpl/or.hpp>
+#include <boost/utility/enable_if.hpp>
 
 #include <algorithm>
-#include <cassert>
 #include <cstddef>
 #include <cstring>
 #include <iterator>
@@ -267,8 +267,9 @@ namespace boost { namespace gil {
 /// \ingroup ImageViewSTLAlgorithmsCopyPixels
 /// \brief std::copy for image views
 template <typename View1, typename View2> BOOST_FORCEINLINE
-void copy_pixels(const View1& src, const View2& dst) {
-    assert(src.dimensions()==dst.dimensions());
+void copy_pixels(const View1& src, const View2& dst)
+{
+    BOOST_ASSERT(src.dimensions() == dst.dimensions());
     detail::copy_with_2d_iterators(src.begin(),src.end(),dst.begin());
 }
 
@@ -704,7 +705,7 @@ void uninitialized_copy_aux(It1 first1, It1 last1,
 template <typename View1, typename View2>
 void uninitialized_copy_pixels(const View1& view1, const View2& view2) {
     using is_planar = mpl::bool_<is_planar<View1>::value && is_planar<View2>::value>;
-    assert(view1.dimensions()==view2.dimensions());
+    BOOST_ASSERT(view1.dimensions() == view2.dimensions());
     if (view1.is_1d_traversable() && view2.is_1d_traversable())
         detail::uninitialized_copy_aux(view1.begin().x(), view1.end().x(),
                                        view2.begin().x(),
@@ -935,7 +936,7 @@ namespace boost { namespace gil {
 /// \brief std::equal for image views
 template <typename View1, typename View2> BOOST_FORCEINLINE
 bool equal_pixels(const View1& v1, const View2& v2) {
-    assert(v1.dimensions()==v2.dimensions());
+    BOOST_ASSERT(v1.dimensions() == v2.dimensions());
     return std::equal(v1.begin(),v1.end(),v2.begin()); // std::equal has overloads with GIL iterators for optimal performance
 }
 
@@ -953,7 +954,7 @@ bool equal_pixels(const View1& v1, const View2& v2) {
 /// \brief std::transform for image views
 template <typename View1, typename View2, typename F> BOOST_FORCEINLINE
 F transform_pixels(const View1& src,const View2& dst, F fun) {
-    assert(src.dimensions()==dst.dimensions());
+    BOOST_ASSERT(src.dimensions() == dst.dimensions());
     for (std::ptrdiff_t y=0; y<src.height(); ++y) {
         typename View1::x_iterator srcIt=src.row_begin(y);
         typename View2::x_iterator dstIt=dst.row_begin(y);
@@ -985,7 +986,7 @@ F transform_pixels(const View1& src1, const View2& src2,const View3& dst, F fun)
 /// \brief Like transform_pixels but passes to the function object pixel locators instead of pixel references
 template <typename View1, typename View2, typename F> BOOST_FORCEINLINE
 F transform_pixel_positions(const View1& src,const View2& dst, F fun) {
-    assert(src.dimensions()==dst.dimensions());
+    BOOST_ASSERT(src.dimensions() == dst.dimensions());
     typename View1::xy_locator loc=src.xy_at(0,0);
     for (std::ptrdiff_t y=0; y<src.height(); ++y) {
         typename View2::x_iterator dstIt=dst.row_begin(y);
@@ -1000,8 +1001,8 @@ F transform_pixel_positions(const View1& src,const View2& dst, F fun) {
 /// \brief transform_pixel_positions with two sources
 template <typename View1, typename View2, typename View3, typename F> BOOST_FORCEINLINE
 F transform_pixel_positions(const View1& src1,const View2& src2,const View3& dst, F fun) {
-    assert(src1.dimensions()==dst.dimensions());
-    assert(src2.dimensions()==dst.dimensions());
+    BOOST_ASSERT(src1.dimensions() == dst.dimensions());
+    BOOST_ASSERT(src2.dimensions() == dst.dimensions());
     typename View1::xy_locator loc1=src1.xy_at(0,0);
     typename View2::xy_locator loc2=src2.xy_at(0,0);
     for (std::ptrdiff_t y=0; y<src1.height(); ++y) {

--- a/include/boost/gil/bit_aligned_pixel_reference.hpp
+++ b/include/boost/gil/bit_aligned_pixel_reference.hpp
@@ -11,6 +11,7 @@
 #include <boost/gil/pixel.hpp>
 #include <boost/gil/channel.hpp>
 
+#include <boost/assert.hpp>
 #include <boost/config.hpp>
 #include <boost/mpl/accumulate.hpp>
 #include <boost/mpl/at.hpp>
@@ -45,7 +46,12 @@ private:
 
 public:
     bit_range() : _current_byte(nullptr), _bit_offset(0) {}
-    bit_range(byte_t* current_byte, int bit_offset) : _current_byte(current_byte), _bit_offset(bit_offset) { assert(bit_offset>=0 && bit_offset<8); }
+    bit_range(byte_t* current_byte, int bit_offset)
+        : _current_byte(current_byte)
+        , _bit_offset(bit_offset)
+    {
+        BOOST_ASSERT(bit_offset >= 0 && bit_offset < 8);
+    }
 
     bit_range(const bit_range& br) : _current_byte(br._current_byte), _bit_offset(br._bit_offset) {}
     template <bool M> bit_range(const bit_range<RangeSize,M>& br) : _current_byte(br._current_byte), _bit_offset(br._bit_offset) {}
@@ -76,34 +82,32 @@ public:
     int     bit_offset()   const { return _bit_offset; }
 };
 
-
 /// \defgroup ColorBaseModelNonAlignedPixel bit_aligned_pixel_reference
 /// \ingroup ColorBaseModel
 /// \brief A heterogeneous color base representing pixel that may not be byte aligned, i.e. it may correspond to a bit range that does not start/end at a byte boundary. Models ColorBaseConcept.
-
-/**
-\defgroup PixelModelNonAlignedPixel bit_aligned_pixel_reference
-\ingroup PixelModel
-\brief A heterogeneous pixel reference used to represent non-byte-aligned pixels. Models PixelConcept
-
-Example:
-\code
-unsigned char data=0;
-
-// A mutable reference to a 6-bit BGR pixel in "123" format (1 bit for red, 2 bits for green, 3 bits for blue)
-using rgb123_ref_t = bit_aligned_pixel_reference<unsigned char, mpl::vector3_c<int,1,2,3>, rgb_layout_t, true> const;
-
-// create the pixel reference at bit offset 2
-// (i.e. red = [2], green = [3,4], blue = [5,6,7] bits)
-rgb123_ref_t ref(&data, 2);
-get_color(ref, red_t()) = 1;
-assert(data == 0x04);
-get_color(ref, green_t()) = 3;
-assert(data == 0x1C);
-get_color(ref, blue_t()) = 7;
-assert(data == 0xFC);
-\endcode
-*/
+///
+/// \defgroup PixelModelNonAlignedPixel bit_aligned_pixel_reference
+/// \ingroup PixelModel
+/// \brief A heterogeneous pixel reference used to represent non-byte-aligned pixels. Models PixelConcept
+///
+/// Example:
+/// \code
+/// unsigned char data=0;
+///
+/// // A mutable reference to a 6-bit BGR pixel in "123" format (1 bit for red, 2 bits for green, 3 bits for blue)
+/// using rgb123_ref_t = bit_aligned_pixel_reference<unsigned char, mpl::vector3_c<int,1,2,3>, rgb_layout_t, true> const;
+///
+/// // create the pixel reference at bit offset 2
+/// // (i.e. red = [2], green = [3,4], blue = [5,6,7] bits)
+/// rgb123_ref_t ref(&data, 2);
+/// get_color(ref, red_t()) = 1;
+/// assert(data == 0x04);
+/// get_color(ref, green_t()) = 3;
+/// assert(data == 0x1C);
+/// get_color(ref, blue_t()) = 7;
+/// assert(data == 0xFC);
+/// \endcode
+///
 /// \ingroup ColorBaseModelNonAlignedPixel PixelModelNonAlignedPixel PixelBasedModel
 /// \brief Heterogeneous pixel reference corresponding to non-byte-aligned bit range. Models ColorBaseConcept, PixelConcept, PixelBasedConcept
 template <typename BitField,

--- a/include/boost/gil/channel_algorithm.hpp
+++ b/include/boost/gil/channel_algorithm.hpp
@@ -64,31 +64,30 @@ struct unsigned_integral_num_bits<packed_channel_value<K> >
 
 } // namespace detail
 
-/**
-\defgroup ChannelConvertAlgorithm channel_convert
-\brief Converting from one channel type to another
-\ingroup ChannelAlgorithm
+/// \defgroup ChannelConvertAlgorithm channel_convert
+/// \brief Converting from one channel type to another
+/// \ingroup ChannelAlgorithm
+///
+/// Conversion is done as a simple linear mapping of one channel range to the other,
+/// such that the minimum/maximum value of the source maps to the minimum/maximum value of the destination.
+/// One implication of this is that the value 0 of signed channels may not be preserved!
+///
+/// When creating new channel models, it is often a good idea to provide specializations for the channel conversion algorithms, for
+/// example, for performance optimizations. If the new model is an integral type that can be signed, it is easier to define the conversion
+/// only for the unsigned type (\p channel_converter_unsigned) and provide specializations of \p detail::channel_convert_to_unsigned
+/// and \p detail::channel_convert_from_unsigned to convert between the signed and unsigned type.
+///
+/// Example:
+/// \code
+/// // float32_t is a floating point channel with range [0.0f ... 1.0f]
+/// float32_t src_channel = channel_traits<float32_t>::max_value();
+/// assert(src_channel == 1);
+///
+/// // uint8_t is 8-bit unsigned integral channel (aliased from unsigned char)
+/// uint8_t dst_channel = channel_convert<uint8_t>(src_channel);
+/// assert(dst_channel == 255);     // max value goes to max value
+/// \endcode
 
-Conversion is done as a simple linear mapping of one channel range to the other,
-such that the minimum/maximum value of the source maps to the minimum/maximum value of the destination.
-One implication of this is that the value 0 of signed channels may not be preserved!
-
-When creating new channel models, it is often a good idea to provide specializations for the channel conversion algorithms, for
-example, for performance optimizations. If the new model is an integral type that can be signed, it is easier to define the conversion
-only for the unsigned type (\p channel_converter_unsigned) and provide specializations of \p detail::channel_convert_to_unsigned
-and \p detail::channel_convert_from_unsigned to convert between the signed and unsigned type.
-
-Example:
-\code
-// float32_t is a floating point channel with range [0.0f ... 1.0f]
-float32_t src_channel = channel_traits<float32_t>::max_value();
-assert(src_channel == 1);
-
-// uint8_t is 8-bit unsigned integral channel (aliased from unsigned char)
-uint8_t dst_channel = channel_convert<uint8_t>(src_channel);
-assert(dst_channel == 255);     // max value goes to max value
-\endcode
-*/
 
 /**
 \defgroup ChannelConvertUnsignedAlgorithm channel_converter_unsigned
@@ -419,19 +418,17 @@ namespace detail {
     inline uint32_t div32768(uint32_t in) { return (in+16384)>>15; }
 }
 
-/**
-\defgroup ChannelMultiplyAlgorithm channel_multiply
-\ingroup ChannelAlgorithm
-\brief Multiplying unsigned channel values of the same type. Performs scaled multiplication result = a * b / max_value
-
-Example:
-\code
-uint8_t x=128;
-uint8_t y=128;
-uint8_t mul = channel_multiply(x,y);
-assert(mul == 64);    // 64 = 128 * 128 / 255
-\endcode
-*/
+/// \defgroup ChannelMultiplyAlgorithm channel_multiply
+/// \ingroup ChannelAlgorithm
+/// \brief Multiplying unsigned channel values of the same type. Performs scaled multiplication result = a * b / max_value
+///
+/// Example:
+/// \code
+/// uint8_t x=128;
+/// uint8_t y=128;
+/// uint8_t mul = channel_multiply(x,y);
+/// assert(mul == 64);    // 64 = 128 * 128 / 255
+/// \endcode
 /// @{
 
 /// \brief This is the default implementation. Performance specializatons are provided
@@ -490,19 +487,17 @@ inline typename channel_traits<Channel>::value_type channel_multiply(Channel a, 
 }
 /// @}
 
-/**
-\defgroup ChannelInvertAlgorithm channel_invert
-\ingroup ChannelAlgorithm
-\brief Returns the inverse of a channel. result = max_value - x + min_value
-
-Example:
-\code
-// uint8_t == uint8_t == unsigned char
-uint8_t x=255;
-uint8_t inv = channel_invert(x);
-assert(inv == 0);
-\endcode
-*/
+/// \defgroup ChannelInvertAlgorithm channel_invert
+/// \ingroup ChannelAlgorithm
+/// \brief Returns the inverse of a channel. result = max_value - x + min_value
+///
+/// Example:
+/// \code
+/// // uint8_t == uint8_t == unsigned char
+/// uint8_t x=255;
+/// uint8_t inv = channel_invert(x);
+/// assert(inv == 0);
+/// \endcode
 
 /// \brief Default implementation. Provide overloads for performance
 /// \ingroup ChannelInvertAlgorithm channel_invert

--- a/include/boost/gil/color_base.hpp
+++ b/include/boost/gil/color_base.hpp
@@ -11,14 +11,13 @@
 #include <boost/gil/utilities.hpp>
 #include <boost/gil/concepts.hpp>
 
+#include <boost/assert.hpp>
 #include <boost/config.hpp>
 #include <boost/mpl/range_c.hpp>
 #include <boost/mpl/size.hpp>
 #include <boost/mpl/vector_c.hpp>
 #include <boost/type_traits.hpp>
 #include <boost/utility/enable_if.hpp>
-
-#include <cassert>
 
 namespace boost { namespace gil {
 
@@ -334,29 +333,30 @@ public:
 
 template <typename Element, typename Layout, int K>
 typename element_reference_type<homogeneous_color_base<Element,Layout,K> >::type
-dynamic_at_c(homogeneous_color_base<Element,Layout,K>& cb, std::size_t i) {
-    assert(i<K);
+dynamic_at_c(homogeneous_color_base<Element,Layout,K>& cb, std::size_t i)
+{
+    BOOST_ASSERT(i < K);
     return (gil_reinterpret_cast<Element*>(&cb))[i];
 }
 
 template <typename Element, typename Layout, int K>
 typename element_const_reference_type<homogeneous_color_base<Element,Layout,K> >::type
 dynamic_at_c(const homogeneous_color_base<Element,Layout,K>& cb, std::size_t i) {
-    assert(i<K);
+    BOOST_ASSERT(i < K);
     return (gil_reinterpret_cast_c<const Element*>(&cb))[i];
 }
 
 template <typename Element, typename Layout, int K>
 typename element_reference_type<homogeneous_color_base<Element&,Layout,K> >::type
 dynamic_at_c(const homogeneous_color_base<Element&,Layout,K>& cb, std::size_t i) {
-    assert(i<K);
+    BOOST_ASSERT(i < K);
     return cb.at_c_dynamic(i);
 }
 
 template <typename Element, typename Layout, int K>
 typename element_const_reference_type<homogeneous_color_base<const Element&,Layout,K> >::type
 dynamic_at_c(const homogeneous_color_base<const Element&,Layout,K>& cb, std::size_t i) {
-    assert(i<K);
+    BOOST_ASSERT(i < K);
     return cb.at_c_dynamic(i);
 }
 

--- a/include/boost/gil/color_base_algorithm.hpp
+++ b/include/boost/gil/color_base_algorithm.hpp
@@ -446,21 +446,18 @@ struct min_max_recur<1> {
 };
 }  // namespace detail
 
-
-/**
-\defgroup ColorBaseAlgorithmMinMax static_min, static_max
-\ingroup ColorBaseAlgorithm
-\brief Equivalents to std::min_element and std::max_element for homogeneous color bases
-
-Example:
-\code
-rgb8_pixel_t pixel(10,20,30);
-assert(pixel[2] == 30);
-static_max(pixel) = static_min(pixel);
-assert(pixel[2] == 10);
-\endcode
-\{
-*/
+/// \defgroup ColorBaseAlgorithmMinMax static_min, static_max
+/// \ingroup ColorBaseAlgorithm
+/// \brief Equivalents to std::min_element and std::max_element for homogeneous color bases
+///
+/// Example:
+/// \code
+/// rgb8_pixel_t pixel(10,20,30);
+/// assert(pixel[2] == 30);
+/// static_max(pixel) = static_min(pixel);
+/// assert(pixel[2] == 10);
+/// \endcode
+/// \{
 
 template <typename P>
 BOOST_FORCEINLINE
@@ -479,22 +476,20 @@ BOOST_FORCEINLINE
 typename element_reference_type<P>::type       static_min(      P& p) { return detail::min_max_recur<size<P>::value>::min_(p); }
 /// \}
 
-/**
-\defgroup ColorBaseAlgorithmEqual static_equal
-\ingroup ColorBaseAlgorithm
-\brief Equivalent to std::equal. Pairs the elements semantically
-
-Example:
-\code
-rgb8_pixel_t rgb_red(255,0,0);
-bgr8_pixel_t bgr_red(0,0,255);
-assert(rgb_red[0]==255 && bgr_red[0]==0);
-
-assert(static_equal(rgb_red,bgr_red));
-assert(rgb_red==bgr_red);  // operator== invokes static_equal
-\endcode
-\{
-*/
+/// \defgroup ColorBaseAlgorithmEqual static_equal
+/// \ingroup ColorBaseAlgorithm
+/// \brief Equivalent to std::equal. Pairs the elements semantically
+///
+/// Example:
+/// \code
+/// rgb8_pixel_t rgb_red(255,0,0);
+/// bgr8_pixel_t bgr_red(0,0,255);
+/// assert(rgb_red[0]==255 && bgr_red[0]==0);
+///
+/// assert(static_equal(rgb_red,bgr_red));
+/// assert(rgb_red==bgr_red);  // operator== invokes static_equal
+/// \endcode
+/// \{
 
 template <typename P1,typename P2>
 BOOST_FORCEINLINE
@@ -502,22 +497,20 @@ bool static_equal(const P1& p1, const P2& p2) { return detail::element_recursion
 
 /// \}
 
-/**
-\defgroup ColorBaseAlgorithmCopy static_copy
-\ingroup ColorBaseAlgorithm
-\brief Equivalent to std::copy. Pairs the elements semantically
-
-Example:
-\code
-rgb8_pixel_t rgb_red(255,0,0);
-bgr8_pixel_t bgr_red;
-static_copy(rgb_red, bgr_red);  // same as bgr_red = rgb_red
-
-assert(rgb_red[0] == 255 && bgr_red[0] == 0);
-assert(rgb_red == bgr_red);
-\endcode
-\{
-*/
+/// \defgroup ColorBaseAlgorithmCopy static_copy
+/// \ingroup ColorBaseAlgorithm
+/// \brief Equivalent to std::copy. Pairs the elements semantically
+///
+/// Example:
+/// \code
+/// rgb8_pixel_t rgb_red(255,0,0);
+/// bgr8_pixel_t bgr_red;
+/// static_copy(rgb_red, bgr_red);  // same as bgr_red = rgb_red
+///
+/// assert(rgb_red[0] == 255 && bgr_red[0] == 0);
+/// assert(rgb_red == bgr_red);
+/// \endcode
+/// \{
 
 template <typename Src,typename Dst>
 BOOST_FORCEINLINE
@@ -525,77 +518,72 @@ void static_copy(const Src& src, Dst& dst) {  detail::element_recursion<size<Dst
 
 /// \}
 
-/**
-\defgroup ColorBaseAlgorithmFill static_fill
-\ingroup ColorBaseAlgorithm
-\brief Equivalent to std::fill.
+/// \defgroup ColorBaseAlgorithmFill static_fill
+/// \ingroup ColorBaseAlgorithm
+/// \brief Equivalent to std::fill.
+///
+/// Example:
+/// \code
+/// rgb8_pixel_t p;
+/// static_fill(p, 10);
+/// assert(p == rgb8_pixel_t(10,10,10));
+/// \endcode
+/// \{
 
-Example:
-\code
-rgb8_pixel_t p;
-static_fill(p, 10);
-assert(p == rgb8_pixel_t(10,10,10));
-\endcode
-\{
-*/
 template <typename P,typename V>
 BOOST_FORCEINLINE
 void static_fill(P& p, const V& v) {  detail::element_recursion<size<P>::value>::static_fill(p,v); }
 /// \}
 
-/**
-\defgroup ColorBaseAlgorithmGenerate static_generate
-\ingroup ColorBaseAlgorithm
-\brief Equivalent to std::generate.
-
-Example: Set each channel of a pixel to its semantic index. The channels must be assignable from an integer.
-\code
-struct consecutive_fn {
-    int& _current;
-    consecutive_fn(int& start) : _current(start) {}
-    int operator()() { return _current++; }
-};
-rgb8_pixel_t p;
-int start=0;
-static_generate(p, consecutive_fn(start));
-assert(p == rgb8_pixel_t(0,1,2));
-\endcode
-
-\{
-*/
+/// \defgroup ColorBaseAlgorithmGenerate static_generate
+/// \ingroup ColorBaseAlgorithm
+/// \brief Equivalent to std::generate.
+///
+/// Example: Set each channel of a pixel to its semantic index. The channels must be assignable from an integer.
+/// \code
+/// struct consecutive_fn {
+///     int& _current;
+///     consecutive_fn(int& start) : _current(start) {}
+///     int operator()() { return _current++; }
+/// };
+/// rgb8_pixel_t p;
+/// int start=0;
+/// static_generate(p, consecutive_fn(start));
+/// assert(p == rgb8_pixel_t(0,1,2));
+/// \endcode
+///
+/// \{
 
 template <typename P1,typename Op>
 BOOST_FORCEINLINE
 void static_generate(P1& dst,Op op)                      { detail::element_recursion<size<P1>::value>::static_generate(dst,op); }
 /// \}
 
-/**
-\defgroup ColorBaseAlgorithmTransform static_transform
-\ingroup ColorBaseAlgorithm
-\brief Equivalent to std::transform. Pairs the elements semantically
-
-Example: Write a generic function that adds two pixels into a homogeneous result pixel.
-\code
-template <typename Result>
-struct my_plus {
-    template <typename T1, typename T2>
-    Result operator()(T1 f1, T2 f2) const { return f1+f2; }
-};
-
-template <typename Pixel1, typename Pixel2, typename Pixel3>
-void sum_channels(const Pixel1& p1, const Pixel2& p2, Pixel3& result) {
-    using result_channel_t = typename channel_type<Pixel3>::type;
-    static_transform(p1,p2,result,my_plus<result_channel_t>());
-}
-
-rgb8_pixel_t p1(1,2,3);
-bgr8_pixel_t p2(3,2,1);
-rgb8_pixel_t result;
-sum_channels(p1,p2,result);
-assert(result == rgb8_pixel_t(2,4,6));
-\endcode
-\{
-*/
+/// \defgroup ColorBaseAlgorithmTransform static_transform
+/// \ingroup ColorBaseAlgorithm
+/// \brief Equivalent to std::transform. Pairs the elements semantically
+///
+/// Example: Write a generic function that adds two pixels into a homogeneous result pixel.
+/// \code
+/// template <typename Result>
+/// struct my_plus {
+///     template <typename T1, typename T2>
+///     Result operator()(T1 f1, T2 f2) const { return f1+f2; }
+/// };
+///
+/// template <typename Pixel1, typename Pixel2, typename Pixel3>
+/// void sum_channels(const Pixel1& p1, const Pixel2& p2, Pixel3& result) {
+///     using result_channel_t = typename channel_type<Pixel3>::type;
+///     static_transform(p1,p2,result,my_plus<result_channel_t>());
+/// }
+///
+/// rgb8_pixel_t p1(1,2,3);
+/// bgr8_pixel_t p2(3,2,1);
+/// rgb8_pixel_t result;
+/// sum_channels(p1,p2,result);
+/// assert(result == rgb8_pixel_t(2,4,6));
+/// \endcode
+/// \{
 
 //static_transform with one source
 template <typename Src,typename Dst,typename Op>
@@ -619,32 +607,30 @@ BOOST_FORCEINLINE
 Op static_transform(const P2& p2,const P3& p3,Dst& dst,Op op) { return detail::element_recursion<size<Dst>::value>::static_transform(p2,p3,dst,op); }
 /// \}
 
-/**
-\defgroup ColorBaseAlgorithmForEach static_for_each
-\ingroup ColorBaseAlgorithm
-\brief Equivalent to std::for_each. Pairs the elements semantically
-
-Example: Use static_for_each to increment a planar pixel iterator
-\code
-struct increment {
-    template <typename Incrementable>
-    void operator()(Incrementable& x) const { ++x; }
-};
-
-template <typename ColorBase>
-void increment_elements(ColorBase& cb) {
-    static_for_each(cb, increment());
-}
-
-uint8_t red[2], green[2], blue[2];
-rgb8c_planar_ptr_t p1(red,green,blue);
-rgb8c_planar_ptr_t p2=p1;
-increment_elements(p1);
-++p2;
-assert(p1 == p2);
-\endcode
-\{
-*/
+/// \defgroup ColorBaseAlgorithmForEach static_for_each
+/// \ingroup ColorBaseAlgorithm
+/// \brief Equivalent to std::for_each. Pairs the elements semantically
+///
+/// Example: Use static_for_each to increment a planar pixel iterator
+/// \code
+/// struct increment {
+///     template <typename Incrementable>
+///     void operator()(Incrementable& x) const { ++x; }
+/// };
+///
+/// template <typename ColorBase>
+/// void increment_elements(ColorBase& cb) {
+///     static_for_each(cb, increment());
+/// }
+///
+/// uint8_t red[2], green[2], blue[2];
+/// rgb8c_planar_ptr_t p1(red,green,blue);
+/// rgb8c_planar_ptr_t p2=p1;
+/// increment_elements(p1);
+/// ++p2;
+/// assert(p1 == p2);
+/// \endcode
+/// \{
 
 //static_for_each with one source
 template <typename P1,typename Op>

--- a/include/boost/gil/extension/dynamic_image/dynamic_at_c.hpp
+++ b/include/boost/gil/extension/dynamic_image/dynamic_at_c.hpp
@@ -11,7 +11,6 @@
 #include <boost/mpl/at.hpp>
 #include <boost/mpl/size.hpp>
 
-#include <cassert>
 #include <stdexcept>
 
 namespace boost { namespace gil {

--- a/include/boost/gil/extension/dynamic_image/variant.hpp
+++ b/include/boost/gil/extension/dynamic_image/variant.hpp
@@ -23,7 +23,6 @@
 #include <boost/utility/enable_if.hpp>
 
 #include <algorithm>
-#include <cassert>
 #include <cstddef>
 #include <typeinfo>
 

--- a/include/boost/gil/extension/io/bmp/detail/read.hpp
+++ b/include/boost/gil/extension/io/bmp/detail/read.hpp
@@ -20,6 +20,7 @@
 #include <boost/gil/io/row_buffer_helper.hpp>
 #include <boost/gil/io/typedefs.hpp>
 
+#include <boost/assert.hpp>
 #include <boost/mpl/and.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/utility/enable_if.hpp>
@@ -450,9 +451,9 @@ private:
     template< typename View_Dst >
     void read_palette_image_rle( const View_Dst& view )
     {
-        assert(  this->_info._compression == bmp_compression::_rle4
-              || this->_info._compression == bmp_compression::_rle8
-              );
+        BOOST_ASSERT(
+            this->_info._compression == bmp_compression::_rle4 ||
+            this->_info._compression == bmp_compression::_rle8);
 
         this->read_palette();
 

--- a/include/boost/gil/extension/io/png/detail/base.hpp
+++ b/include/boost/gil/extension/io/png/detail/base.hpp
@@ -10,6 +10,8 @@
 
 #include <boost/gil/extension/io/png/tags.hpp>
 
+#include <boost/assert.hpp>
+
 #include <memory>
 
 namespace boost { namespace gil { namespace detail {
@@ -60,7 +62,7 @@ private:
     {
         if( png_ptr )
         {
-            assert( png_ptr->_struct && png_ptr->_info );
+            BOOST_ASSERT(png_ptr->_struct && png_ptr->_info);
 
             png_destroy_read_struct( &png_ptr->_struct
                                    , &png_ptr->_info
@@ -76,7 +78,7 @@ private:
     {
         if( png_ptr )
         {
-            assert( png_ptr->_struct && png_ptr->_info );
+            BOOST_ASSERT(png_ptr->_struct && png_ptr->_info);
 
             png_destroy_write_struct( &png_ptr->_struct
                                     , &png_ptr->_info

--- a/include/boost/gil/extension/io/tiff/detail/read.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/read.hpp
@@ -20,6 +20,8 @@
 #include <boost/gil/io/reader_base.hpp>
 #include <boost/gil/io/row_buffer_helper.hpp>
 
+#include <boost/assert.hpp>
+
 #include <algorithm>
 #include <string>
 #include <vector>
@@ -495,9 +497,9 @@ private:
                    std::ptrdiff_t tile_x1 = img_x1 - x;
                    std::ptrdiff_t tile_y1 = img_y1 - y;
 
-                   assert( tile_x0 >= 0 && tile_y0 >= 0 && tile_x1 >= 0 && tile_y1 >= 0 );
-                   assert( tile_x0 <= img_x1 && tile_y0 <= img_y1 );
-                   assert( tile_x0 < tile_width && tile_y0 < tile_height && tile_x1 < tile_width && tile_y1 < tile_height );
+                   BOOST_ASSERT(tile_x0 >= 0 && tile_y0 >= 0 && tile_x1 >= 0 && tile_y1 >= 0);
+                   BOOST_ASSERT(tile_x0 <= img_x1 && tile_y0 <= img_y1);
+                   BOOST_ASSERT(tile_x0 < tile_width && tile_y0 < tile_height && tile_x1 < tile_width && tile_y1 < tile_height);
 
                    std::ptrdiff_t tile_subimage_view_width  = tile_x1 - tile_x0 + 1;
                    std::ptrdiff_t tile_subimage_view_height = tile_y1 - tile_y0 + 1;
@@ -505,7 +507,7 @@ private:
                    // convert to dst_view coordinates
                    std::ptrdiff_t dst_x0 = img_x0 - subimage_x;
                    std::ptrdiff_t dst_y0 = img_y0 - subimage_y;
-                   assert( dst_x0 >= 0 && dst_y0 >= 0 );
+                   BOOST_ASSERT(dst_x0 >= 0 && dst_y0 >= 0);
 
                    View dst_subimage_view = subimage_view( dst_view
                                                          , (int) dst_x0

--- a/include/boost/gil/extension/numeric/algorithm.hpp
+++ b/include/boost/gil/extension/numeric/algorithm.hpp
@@ -13,8 +13,9 @@
 #include <boost/gil/metafunctions.hpp>
 #include <boost/gil/pixel_iterator.hpp>
 
+#include <boost/assert.hpp>
+
 #include <algorithm>
-#include <cassert>
 #include <iterator>
 #include <numeric>
 
@@ -126,7 +127,7 @@ inline DstIterator correlate_pixels_k(SrcIterator src_begin,SrcIterator src_end,
 /// \brief destination is set to be product of the source and a scalar
 template <typename PixelAccum,typename SrcView,typename Scalar,typename DstView>
 inline void view_multiplies_scalar(const SrcView& src,const Scalar& scalar,const DstView& dst) {
-    assert(src.dimensions()==dst.dimensions());
+    BOOST_ASSERT(src.dimensions() == dst.dimensions());
     using PIXEL_SRC_REF = typename pixel_proxy<typename SrcView::value_type>::type;
     using PIXEL_DST_REF = typename pixel_proxy<typename DstView::value_type>::type;
     int height=src.height();

--- a/include/boost/gil/extension/numeric/convolve.hpp
+++ b/include/boost/gil/extension/numeric/convolve.hpp
@@ -16,8 +16,9 @@
 #include <boost/gil/image_view_factory.hpp>
 #include <boost/gil/metafunctions.hpp>
 
+#include <boost/assert.hpp>
+
 #include <algorithm>
-#include <cassert>
 #include <cstddef>
 #include <functional>
 #include <type_traits>
@@ -43,8 +44,8 @@ template <typename PixelAccum,typename SrcView,typename Kernel,typename DstView,
 void correlate_rows_imp(const SrcView& src, const Kernel& ker, const DstView& dst,
                         convolve_boundary_option option,
                         Correlator correlator) {
-    assert(src.dimensions()==dst.dimensions());
-    assert(ker.size()!=0);
+    BOOST_ASSERT(src.dimensions() == dst.dimensions());
+    BOOST_ASSERT(ker.size() != 0);
 
     using PIXEL_SRC_REF = typename pixel_proxy<typename SrcView::value_type>::type;
     using PIXEL_DST_REF = typename pixel_proxy<typename DstView::value_type>::type;

--- a/include/boost/gil/extension/numeric/kernel.hpp
+++ b/include/boost/gil/extension/numeric/kernel.hpp
@@ -10,9 +10,10 @@
 
 #include <boost/gil/utilities.hpp>
 
+#include <boost/assert.hpp>
+
 #include <algorithm>
 #include <array>
-#include <cassert>
 #include <cstddef>
 #include <memory>
 #include <vector>
@@ -32,19 +33,41 @@ private:
     std::size_t _center;
 public:
     kernel_1d_adaptor() : _center(0) {}
-    explicit kernel_1d_adaptor(std::size_t center_in) : _center(center_in) {assert(_center<this->size());}
-    kernel_1d_adaptor(std::size_t size_in,std::size_t center_in) :
-        Core(size_in), _center(center_in) {assert(_center<this->size());}
-    kernel_1d_adaptor(const kernel_1d_adaptor& k_in) : Core(k_in), _center(k_in._center) {}
+
+    explicit kernel_1d_adaptor(std::size_t center_in)
+        : _center(center_in)
+    {
+        BOOST_ASSERT(_center < this->size());
+    }
+
+    kernel_1d_adaptor(std::size_t size_in, std::size_t center_in)
+        : Core(size_in)
+        , _center(center_in)
+    {
+        BOOST_ASSERT(_center < this->size());
+    }
+
+    kernel_1d_adaptor(kernel_1d_adaptor const& k_in) : Core(k_in), _center(k_in._center) {}
 
     kernel_1d_adaptor& operator=(const kernel_1d_adaptor& k_in) {
         Core::operator=(k_in);
         _center=k_in._center;
         return *this;
     }
-    std::size_t left_size() const {assert(_center<this->size());return _center;}
-    std::size_t right_size() const {assert(_center<this->size());return this->size()-_center-1;}
-          std::size_t& center()       {return _center;}
+
+    std::size_t left_size() const
+    {
+        BOOST_ASSERT(_center < this->size());
+        return _center;
+    }
+
+    std::size_t right_size() const
+    {
+        BOOST_ASSERT(_center < this->size());
+        return this->size() - _center - 1;
+    }
+
+    std::size_t& center()       {return _center;}
     const std::size_t& center() const {return _center;}
 };
 

--- a/include/boost/gil/image_view_factory.hpp
+++ b/include/boost/gil/image_view_factory.hpp
@@ -13,7 +13,8 @@
 #include <boost/gil/metafunctions.hpp>
 #include <boost/gil/point.hpp>
 
-#include <cassert>
+#include <boost/assert.hpp>
+
 #include <cstddef>
 
 /// Methods for creating shallow image views from raw pixel data or from other image views -
@@ -262,8 +263,9 @@ inline View subimage_view(const View& src, int xMin, int yMin, int width, int he
 
 /// \ingroup ImageViewTransformationsSubsampled
 template <typename View>
-inline typename dynamic_xy_step_type<View>::type subsampled_view(const View& src, typename View::coord_t xStep, typename View::coord_t yStep) {
-    assert(xStep>0 && yStep>0);
+inline typename dynamic_xy_step_type<View>::type subsampled_view(const View& src, typename View::coord_t xStep, typename View::coord_t yStep)
+{
+    BOOST_ASSERT(xStep > 0 && yStep > 0);
     using RView = typename dynamic_xy_step_type<View>::type;
     return RView((src.width()+(xStep-1))/xStep,(src.height()+(yStep-1))/yStep,
                                           typename RView::xy_locator(src.xy_at(0,0),xStep,yStep));

--- a/include/boost/gil/io/device.hpp
+++ b/include/boost/gil/io/device.hpp
@@ -10,6 +10,7 @@
 
 #include <boost/gil/io/base.hpp>
 
+#include <boost/assert.hpp>
 #include <boost/core/ignore_unused.hpp>
 #include <boost/utility/enable_if.hpp>
 
@@ -171,12 +172,12 @@ public:
         ///@todo: add compiler symbol to turn error checking on and off.
         if(ferror( get() ))
         {
-            assert( false );
+            BOOST_ASSERT(false);
         }
 
         //libjpeg sometimes reads blocks in 4096 bytes even when the file is smaller than that.
         //assert( num_elements == count );
-        assert( num_elements > 0 );
+        BOOST_ASSERT(num_elements > 0 );
 
         return num_elements;
     }
@@ -230,8 +231,7 @@ public:
                                          , get()
                                          );
 
-        assert( num_elements == count );
-
+        BOOST_ASSERT(num_elements == count);
         return num_elements;
     }
 
@@ -310,7 +310,7 @@ public:
                                          , get()
                                          );
 
-        assert( num_elements == line.size() );
+        BOOST_ASSERT(num_elements == line.size());
         boost::ignore_unused(num_elements);
     }
 

--- a/include/boost/gil/io/reader_base.hpp
+++ b/include/boost/gil/io/reader_base.hpp
@@ -10,6 +10,8 @@
 
 #include <boost/gil/io/base.hpp>
 
+#include <boost/assert.hpp>
+
 namespace boost { namespace gil {
 
 /// Reader Base Class
@@ -54,7 +56,7 @@ public:
     {
         //setup( backend._settings._dim );
 
-        assert( settings._dim.x && settings._dim.y );
+        BOOST_ASSERT(settings._dim.x && settings._dim.y);
 
         img.recreate( settings._dim.x
                     , settings._dim.y

--- a/include/boost/gil/iterator_from_2d.hpp
+++ b/include/boost/gil/iterator_from_2d.hpp
@@ -13,9 +13,8 @@
 #include <boost/gil/pixel_iterator.hpp>
 #include <boost/gil/point.hpp>
 
+#include <boost/assert.hpp>
 #include <boost/iterator/iterator_facade.hpp>
-
-#include <cassert>
 
 namespace boost { namespace gil {
 
@@ -116,9 +115,10 @@ private:
         return (it.y_pos()-_coords.y)*_width + (it.x_pos()-_coords.x);
     }
 
-    bool equal(const iterator_from_2d& it) const {
-        assert(_width==it.width());     // they must belong to the same image
-        return _coords==it._coords && _p==it._p;
+    bool equal(iterator_from_2d const& it) const
+    {
+        BOOST_ASSERT(_width == it.width()); // they must belong to the same image
+        return _coords == it._coords && _p == it._p;
     }
 
     point_t _coords;

--- a/include/boost/gil/locator.hpp
+++ b/include/boost/gil/locator.hpp
@@ -11,7 +11,8 @@
 #include <boost/gil/pixel_iterator.hpp>
 #include <boost/gil/point.hpp>
 
-#include <cassert>
+#include <boost/assert.hpp>
+
 #include <cstddef>
 
 namespace boost { namespace gil {
@@ -287,9 +288,10 @@ public:
     bool                   is_1d_traversable(x_coord_t width)   const { return row_size()-pixel_size()*width==0; }   // is there no gap at the end of each row?
 
     // Returns the vertical distance (it2.y-it1.y) between two x_iterators given the difference of their x positions
-    std::ptrdiff_t y_distance_to(const this_t& p2, x_coord_t xDiff) const {
-        std::ptrdiff_t rowDiff=memunit_distance(x(),p2.x())-pixel_size()*xDiff;
-        assert(( rowDiff % row_size())==0);
+    std::ptrdiff_t y_distance_to(this_t const& p2, x_coord_t xDiff) const
+    {
+        std::ptrdiff_t rowDiff = memunit_distance(x(), p2.x()) - pixel_size() * xDiff;
+        BOOST_ASSERT((rowDiff % row_size()) == 0);
         return rowDiff / row_size();
     }
 

--- a/include/boost/gil/packed_pixel.hpp
+++ b/include/boost/gil/packed_pixel.hpp
@@ -26,23 +26,21 @@ namespace boost { namespace gil {
 /// \ingroup ColorBaseModel
 /// \brief A heterogeneous color base whose elements are reference proxies to channels in a pixel. Models ColorBaseValueConcept. This class is used to model packed pixels, such as 16-bit packed RGB.
 
-/**
-\defgroup PixelModelPackedPixel packed_pixel
-\ingroup PixelModel
-\brief A heterogeneous pixel used to represent packed pixels with non-byte-aligned channels. Models PixelValueConcept
-
-Example:
-\code
-using rgb565_pixel_t = packed_pixel_type<uint16_t, mpl::vector3_c<unsigned,5,6,5>, rgb_layout_t>::type;
-static_assert(sizeof(rgb565_pixel_t) == 2, "");
-
-rgb565_pixel_t r565;
-get_color(r565,red_t())   = 31;
-get_color(r565,green_t()) = 63;
-get_color(r565,blue_t())  = 31;
-assert(r565 == rgb565_pixel_t((uint16_t)0xFFFF));
-\endcode
-*/
+/// \defgroup PixelModelPackedPixel packed_pixel
+/// \ingroup PixelModel
+/// \brief A heterogeneous pixel used to represent packed pixels with non-byte-aligned channels. Models PixelValueConcept
+///
+/// Example:
+/// \code
+/// using rgb565_pixel_t = packed_pixel_type<uint16_t, mpl::vector3_c<unsigned,5,6,5>, rgb_layout_t>::type;
+/// static_assert(sizeof(rgb565_pixel_t) == 2, "");
+///
+/// rgb565_pixel_t r565;
+/// get_color(r565,red_t())   = 31;
+/// get_color(r565,green_t()) = 63;
+/// get_color(r565,blue_t())  = 31;
+/// assert(r565 == rgb565_pixel_t((uint16_t)0xFFFF));
+/// \endcode
 
 /// \ingroup ColorBaseModelPackedPixel PixelModelPackedPixel PixelBasedModel
 /// \brief Heterogeneous pixel value whose channel references can be constructed from the pixel bitfield and their index. Models ColorBaseValueConcept, PixelValueConcept, PixelBasedConcept

--- a/include/boost/gil/pixel_iterator.hpp
+++ b/include/boost/gil/pixel_iterator.hpp
@@ -12,7 +12,6 @@
 #include <boost/gil/utilities.hpp>
 #include <boost/gil/pixel.hpp>
 
-#include <cassert>
 #include <iterator>
 
 namespace boost { namespace gil {

--- a/include/boost/gil/planar_pixel_iterator.hpp
+++ b/include/boost/gil/planar_pixel_iterator.hpp
@@ -13,7 +13,6 @@
 
 #include <boost/iterator/iterator_facade.hpp>
 
-#include <cassert>
 #include <iterator>
 
 namespace boost { namespace gil {

--- a/include/boost/gil/virtual_locator.hpp
+++ b/include/boost/gil/virtual_locator.hpp
@@ -10,6 +10,7 @@
 
 #include <boost/gil/position_iterator.hpp>
 
+#include <boost/assert.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 
 namespace boost { namespace gil {
@@ -45,10 +46,17 @@ public:
     virtual_2d_locator(const point_t& p=point_t(0,0), const point_t& step=point_t(1,1), const deref_fn_t& d=deref_fn_t()) : _p(p,step,d) {}
     template <typename D, bool TR> virtual_2d_locator(const virtual_2d_locator<D,TR>& loc, coord_t y_step)
         : _p(loc.pos(), point_t(loc.step().x,loc.step().y*y_step),     loc.deref_fn()) {}
-    template <typename D, bool TR> virtual_2d_locator(const virtual_2d_locator<D,TR>& loc, coord_t x_step, coord_t y_step, bool transpose=false)
-        : _p(loc.pos(), transpose ?
-                    point_t(loc.step().x*y_step,loc.step().y*x_step) :
-                    point_t(loc.step().x*x_step,loc.step().y*y_step), loc.deref_fn()) { assert(transpose==(IsTransposed!=TR));}
+
+    template <typename D, bool TR>
+    virtual_2d_locator(virtual_2d_locator<D, TR> const& loc, coord_t x_step, coord_t y_step, bool transpose = false)
+        : _p(loc.pos()
+        , transpose ?
+            point_t(loc.step().x * y_step, loc.step().y * x_step) :
+            point_t(loc.step().x * x_step, loc.step().y * y_step)
+        , loc.deref_fn())
+    {
+        BOOST_ASSERT(transpose == (IsTransposed != TR));
+    }
 
     template <typename D, bool TR> virtual_2d_locator(const virtual_2d_locator<D,TR>& pl) : _p(pl._p) {}
     virtual_2d_locator(const virtual_2d_locator& pl) : _p(pl._p) {}

--- a/numeric/test/numeric.cpp
+++ b/numeric/test/numeric.cpp
@@ -13,6 +13,7 @@
 #include <boost/gil/extension/numeric/resample.hpp>
 #include <boost/gil/extension/numeric/sampler.hpp>
 
+#include <boost/assert.hpp>
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
 
@@ -151,27 +152,27 @@ BOOST_AUTO_TEST_CASE(bilinear_sampler_test)
 
     TestMapFn<double,rgb8_image_t::coord_t> mf;
 
-    resample_pixels( const_view(img), view(dimg), mf, bilinear_sampler() );
+    resample_pixels(const_view(img), view(dimg), mf, bilinear_sampler());
 
-    assert( rgb8_pixel_t(128,0,0) == dv(0,0) );
-    assert( rgb8_pixel_t(64,64,0) == dv(0,1) );
-    assert( rgb8_pixel_t(0,64,64) == dv(0,2) );
-    assert( rgb8_pixel_t(0,0,128) == dv(0,3) );
+    BOOST_ASSERT(rgb8_pixel_t(128,0,0) == dv(0,0));
+    BOOST_ASSERT(rgb8_pixel_t(64,64,0) == dv(0,1));
+    BOOST_ASSERT(rgb8_pixel_t(0,64,64) == dv(0,2));
+    BOOST_ASSERT(rgb8_pixel_t(0,0,128) == dv(0,3));
 
-    assert( rgb8_pixel_t(64,64,0) == dv(1,0) );
-    assert( rgb8_pixel_t(64,96,32) == dv(1,1) );
-    assert( rgb8_pixel_t(64,64,64) == dv(1,2) );
-    assert( rgb8_pixel_t(64,0,64) == dv(1,3) );
+    BOOST_ASSERT(rgb8_pixel_t(64,64,0) == dv(1,0));
+    BOOST_ASSERT(rgb8_pixel_t(64,96,32) == dv(1,1));
+    BOOST_ASSERT(rgb8_pixel_t(64,64,64) == dv(1,2));
+    BOOST_ASSERT(rgb8_pixel_t(64,0,64) == dv(1,3));
 
-    assert( rgb8_pixel_t(0,64,64) == dv(2,0) );
-    assert( rgb8_pixel_t(64,64,64) == dv(2,1) );
-    assert( rgb8_pixel_t(96,64,32) == dv(2,2) );
-    assert( rgb8_pixel_t(64,64,0) == dv(2,3) );
+    BOOST_ASSERT(rgb8_pixel_t(0,64,64) == dv(2,0));
+    BOOST_ASSERT(rgb8_pixel_t(64,64,64) == dv(2,1));
+    BOOST_ASSERT(rgb8_pixel_t(96,64,32) == dv(2,2));
+    BOOST_ASSERT(rgb8_pixel_t(64,64,0) == dv(2,3));
 
-    assert( rgb8_pixel_t(0,0,128) == dv(3,0) );
-    assert( rgb8_pixel_t(64,0,64) == dv(3,1) );
-    assert( rgb8_pixel_t(64,64,0) == dv(3,2) );
-    assert( rgb8_pixel_t(0,128,0) == dv(3,3) );
+    BOOST_ASSERT(rgb8_pixel_t(0,0,128) == dv(3,0));
+    BOOST_ASSERT(rgb8_pixel_t(64,0,64) == dv(3,1));
+    BOOST_ASSERT(rgb8_pixel_t(64,64,0) == dv(3,2));
+    BOOST_ASSERT(rgb8_pixel_t(0,128,0) == dv(3,3));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/pixel.cpp
+++ b/test/pixel.cpp
@@ -251,7 +251,7 @@ void test_packed_pixel()
     rgb565_pixel_t r565;//((uint16_t)0);
     rgb8_pixel_t rgb_full(255,255,255);
 
-    // Convert all channels of the unpacked pixel to the packed one & assert the packed one is full
+    // Convert all channels of the unpacked pixel to the packed one & ensure the packed one is full
     get_color(r565,red_t())   = channel_convert<kth_element_type<rgb565_pixel_t, 0>::type>(get_color(rgb_full,red_t()));
     get_color(r565,green_t()) = channel_convert<kth_element_type<rgb565_pixel_t, 1>::type>(get_color(rgb_full,green_t()));
     get_color(r565,blue_t())  = channel_convert<kth_element_type<rgb565_pixel_t, 2>::type>(get_color(rgb_full,blue_t()));

--- a/test/pixel_iterator.cpp
+++ b/test/pixel_iterator.cpp
@@ -7,9 +7,9 @@
 //
 #include <boost/gil.hpp>
 
+#include <boost/assert.hpp>
 #include <boost/mpl/vector.hpp>
 
-#include <cassert>
 #include <exception>
 #include <iostream>
 #include <vector>
@@ -146,14 +146,14 @@ void test_pixel_iterator()
     unsigned char v8 = get_color( p8, gray_color_t() );
 
 	// all values should be 110b ( 6 );
-    assert( v1 == 6 );
-    assert( v2 == 6 );
-    assert( v3 == 6 );
-    assert( v4 == 6 );
-    assert( v5 == 6 );
-    assert( v6 == 6 );
-    assert( v7 == 6 );
-    assert( v8 == 6 );
+    BOOST_ASSERT(v1 == 6);
+    BOOST_ASSERT(v2 == 6);
+    BOOST_ASSERT(v3 == 6);
+    BOOST_ASSERT(v4 == 6);
+    BOOST_ASSERT(v5 == 6);
+    BOOST_ASSERT(v6 == 6);
+    BOOST_ASSERT(v7 == 6);
+    BOOST_ASSERT(v8 == 6);
 }
 
 // TODO: Make better tests. Use some code from below.

--- a/toolbox/test/indexed_image_test.cpp
+++ b/toolbox/test/indexed_image_test.cpp
@@ -8,12 +8,12 @@
 #include <boost/gil.hpp>
 #include <boost/gil/extension/toolbox/image_types/indexed_image.hpp>
 
+#include <boost/assert.hpp>
 #include <boost/test/unit_test.hpp>
 
 using namespace std;
 using namespace boost;
 using namespace gil;
-
 
 BOOST_AUTO_TEST_SUITE( toolbox_tests )
 
@@ -129,13 +129,13 @@ BOOST_AUTO_TEST_CASE(index_image_view_test)
     auto p = ii_view(point_t(0, 0));
     auto q = *ii_view.at(point_t(0, 0));
 
-    assert(get_color(p, red_t()) == 70);
-    assert(get_color(p, green_t()) == 80);
-    assert(get_color(p, blue_t()) == 90);
+    BOOST_ASSERT(get_color(p, red_t()) == 70);
+    BOOST_ASSERT(get_color(p, green_t()) == 80);
+    BOOST_ASSERT(get_color(p, blue_t()) == 90);
 
-    assert(get_color(q, red_t()) == 70);
-    assert(get_color(q, green_t()) == 80);
-    assert(get_color(q, blue_t()) == 90);
+    BOOST_ASSERT(get_color(q, red_t()) == 70);
+    BOOST_ASSERT(get_color(q, green_t()) == 80);
+    BOOST_ASSERT(get_color(q, blue_t()) == 90);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Add `#include <boost/assert.hpp>` where necessary.
Apply minor clean-up near the macro replacements.

### References

Closes #96

### Tasklist

- [ ] Review
- [ ] Adjust for comments
- [ ] All CI builds and checks have passed
