### PR TITLE
Add <boost/gil/assert.hpp>

### DIFF
--- a/include/boost/gil.hpp
+++ b/include/boost/gil.hpp
@@ -10,6 +10,7 @@
 #define BOOST_GIL_HPP
 
 #include <boost/gil/algorithm.hpp>
+#include <boost/gil/assert.hpp>
 #include <boost/gil/bit_aligned_pixel_iterator.hpp>
 #include <boost/gil/channel_algorithm.hpp>
 #include <boost/gil/color_convert.hpp>

--- a/include/boost/gil/algorithm.hpp
+++ b/include/boost/gil/algorithm.hpp
@@ -9,12 +9,12 @@
 #define BOOST_GIL_ALGORITHM_HPP
 
 #include <boost/gil/bit_aligned_pixel_iterator.hpp>
+#include <boost/gil/assert.hpp>
 #include <boost/gil/color_base_algorithm.hpp>
 #include <boost/gil/concepts.hpp>
 #include <boost/gil/image_view.hpp>
 #include <boost/gil/image_view_factory.hpp>
 
-#include <boost/assert.hpp>
 #include <boost/config.hpp>
 #include <boost/mpl/and.hpp>
 #include <boost/mpl/or.hpp>

--- a/include/boost/gil/assert.hpp
+++ b/include/boost/gil/assert.hpp
@@ -1,0 +1,21 @@
+//
+// Copyright 2019 Mateusz Łoskot
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#ifndef BOOST_GIL_ASSERT_HPP
+#define BOOST_GIL_ASSERT_HPP
+
+// To selectively disable BOOST_ASSERT without affecting the definition of the
+// standard assert define BOOST_DISABLE_ASSERTS when <boost/assert.hpp>
+// is included, regardless of whether NDEBUG is defined.
+// See https://www.boost.org/libs/assert
+
+// TODO: If BOOST_ASSERT is replaced with custom BOOST_GIL_ASSERT,
+//       ensure the new macro respects Boost-wide BOOST_DISABLE_ASSERTS.
+
+#include <boost/assert.hpp>
+
+#endif

--- a/include/boost/gil/bit_aligned_pixel_reference.hpp
+++ b/include/boost/gil/bit_aligned_pixel_reference.hpp
@@ -8,10 +8,10 @@
 #ifndef BOOST_GIL_BIT_ALIGNED_PIXEL_REFERENCE_HPP
 #define BOOST_GIL_BIT_ALIGNED_PIXEL_REFERENCE_HPP
 
+#include <boost/gil/assert.hpp>
 #include <boost/gil/pixel.hpp>
 #include <boost/gil/channel.hpp>
 
-#include <boost/assert.hpp>
 #include <boost/config.hpp>
 #include <boost/mpl/accumulate.hpp>
 #include <boost/mpl/at.hpp>

--- a/include/boost/gil/channel.hpp
+++ b/include/boost/gil/channel.hpp
@@ -8,9 +8,9 @@
 #ifndef BOOST_GIL_CHANNEL_HPP
 #define BOOST_GIL_CHANNEL_HPP
 
+#include <boost/gil/assert.hpp>
 #include <boost/gil/utilities.hpp>
 
-#include <boost/assert.hpp>
 #include <boost/config.hpp>
 #include <boost/config/pragma_message.hpp>
 #include <boost/integer/integer_mask.hpp>

--- a/include/boost/gil/color_base.hpp
+++ b/include/boost/gil/color_base.hpp
@@ -8,10 +8,10 @@
 #ifndef BOOST_GIL_COLOR_BASE_HPP
 #define BOOST_GIL_COLOR_BASE_HPP
 
-#include <boost/gil/utilities.hpp>
+#include <boost/gil/assert.hpp>
 #include <boost/gil/concepts.hpp>
+#include <boost/gil/utilities.hpp>
 
-#include <boost/assert.hpp>
 #include <boost/config.hpp>
 #include <boost/mpl/range_c.hpp>
 #include <boost/mpl/size.hpp>

--- a/include/boost/gil/extension/io/bmp/detail/read.hpp
+++ b/include/boost/gil/extension/io/bmp/detail/read.hpp
@@ -11,6 +11,7 @@
 #include <boost/gil/extension/io/bmp/detail/is_allowed.hpp>
 #include <boost/gil/extension/io/bmp/detail/reader_backend.hpp>
 
+#include <boost/gil/assert.hpp>
 #include <boost/gil/io/base.hpp>
 #include <boost/gil/io/bit_operations.hpp>
 #include <boost/gil/io/conversion_policies.hpp>
@@ -20,7 +21,7 @@
 #include <boost/gil/io/row_buffer_helper.hpp>
 #include <boost/gil/io/typedefs.hpp>
 
-#include <boost/assert.hpp>
+#include <boost/mpl/and.hpp>
 #include <boost/type_traits/is_same.hpp>
 
 #include <type_traits>

--- a/include/boost/gil/extension/io/png/detail/base.hpp
+++ b/include/boost/gil/extension/io/png/detail/base.hpp
@@ -10,7 +10,7 @@
 
 #include <boost/gil/extension/io/png/tags.hpp>
 
-#include <boost/assert.hpp>
+#include <boost/gil/assert.hpp>
 
 #include <memory>
 

--- a/include/boost/gil/extension/io/tiff/detail/read.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/read.hpp
@@ -12,6 +12,7 @@
 #include <boost/gil/extension/io/tiff/detail/is_allowed.hpp>
 #include <boost/gil/extension/io/tiff/detail/reader_backend.hpp>
 
+#include <boost/gil/assert.hpp>
 #include <boost/gil/io/base.hpp>
 #include <boost/gil/io/bit_operations.hpp>
 #include <boost/gil/io/conversion_policies.hpp>
@@ -20,7 +21,6 @@
 #include <boost/gil/io/reader_base.hpp>
 #include <boost/gil/io/row_buffer_helper.hpp>
 
-#include <boost/assert.hpp>
 
 #include <algorithm>
 #include <string>

--- a/include/boost/gil/extension/numeric/algorithm.hpp
+++ b/include/boost/gil/extension/numeric/algorithm.hpp
@@ -10,10 +10,10 @@
 
 #include <boost/gil/extension/numeric/pixel_numeric_operations.hpp>
 
+#include <boost/gil/assert.hpp>
 #include <boost/gil/metafunctions.hpp>
 #include <boost/gil/pixel_iterator.hpp>
 
-#include <boost/assert.hpp>
 
 #include <algorithm>
 #include <iterator>

--- a/include/boost/gil/extension/numeric/convolve.hpp
+++ b/include/boost/gil/extension/numeric/convolve.hpp
@@ -13,10 +13,9 @@
 #include <boost/gil/extension/numeric/pixel_numeric_operations.hpp>
 
 #include <boost/gil/algorithm.hpp>
+#include <boost/gil/assert.hpp>
 #include <boost/gil/image_view_factory.hpp>
 #include <boost/gil/metafunctions.hpp>
-
-#include <boost/assert.hpp>
 
 #include <algorithm>
 #include <cstddef>

--- a/include/boost/gil/extension/numeric/kernel.hpp
+++ b/include/boost/gil/extension/numeric/kernel.hpp
@@ -8,9 +8,8 @@
 #ifndef BOOST_GIL_EXTENSION_NUMERIC_KERNEL_HPP
 #define BOOST_GIL_EXTENSION_NUMERIC_KERNEL_HPP
 
+#include <boost/gil/assert.hpp>
 #include <boost/gil/utilities.hpp>
-
-#include <boost/assert.hpp>
 
 #include <algorithm>
 #include <array>

--- a/include/boost/gil/image_view_factory.hpp
+++ b/include/boost/gil/image_view_factory.hpp
@@ -8,12 +8,11 @@
 #ifndef BOOST_GIL_IMAGE_VIEW_FACTORY_HPP
 #define BOOST_GIL_IMAGE_VIEW_FACTORY_HPP
 
+#include <boost/gil/assert.hpp>
 #include <boost/gil/color_convert.hpp>
 #include <boost/gil/gray.hpp>
 #include <boost/gil/metafunctions.hpp>
 #include <boost/gil/point.hpp>
-
-#include <boost/assert.hpp>
 
 #include <cstddef>
 

--- a/include/boost/gil/io/device.hpp
+++ b/include/boost/gil/io/device.hpp
@@ -8,9 +8,9 @@
 #ifndef BOOST_GIL_IO_DEVICE_HPP
 #define BOOST_GIL_IO_DEVICE_HPP
 
+#include <boost/gil/assert.hpp>
 #include <boost/gil/io/base.hpp>
 
-#include <boost/assert.hpp>
 #include <boost/core/ignore_unused.hpp>
 
 #include <cstdio>

--- a/include/boost/gil/io/reader_base.hpp
+++ b/include/boost/gil/io/reader_base.hpp
@@ -8,9 +8,8 @@
 #ifndef BOOST_GIL_IO_READER_BASE_HPP
 #define BOOST_GIL_IO_READER_BASE_HPP
 
+#include <boost/gil/assert.hpp>
 #include <boost/gil/io/base.hpp>
-
-#include <boost/assert.hpp>
 
 namespace boost { namespace gil {
 

--- a/include/boost/gil/iterator_from_2d.hpp
+++ b/include/boost/gil/iterator_from_2d.hpp
@@ -8,12 +8,12 @@
 #ifndef BOOST_GIL_ITERATOR_FROM_2D_HPP
 #define BOOST_GIL_ITERATOR_FROM_2D_HPP
 
+#include <boost/gil/assert.hpp>
 #include <boost/gil/concepts.hpp>
 #include <boost/gil/locator.hpp>
 #include <boost/gil/pixel_iterator.hpp>
 #include <boost/gil/point.hpp>
 
-#include <boost/assert.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 
 namespace boost { namespace gil {

--- a/include/boost/gil/locator.hpp
+++ b/include/boost/gil/locator.hpp
@@ -8,10 +8,9 @@
 #ifndef BOOST_GIL_LOCATOR_HPP
 #define BOOST_GIL_LOCATOR_HPP
 
+#include <boost/gil/assert.hpp>
 #include <boost/gil/pixel_iterator.hpp>
 #include <boost/gil/point.hpp>
-
-#include <boost/assert.hpp>
 
 #include <cstddef>
 

--- a/include/boost/gil/virtual_locator.hpp
+++ b/include/boost/gil/virtual_locator.hpp
@@ -8,9 +8,9 @@
 #ifndef BOOST_GIL_VIRTUAL_LOCATOR_HPP
 #define BOOST_GIL_VIRTUAL_LOCATOR_HPP
 
+#include <boost/gil/assert.hpp>
 #include <boost/gil/position_iterator.hpp>
 
-#include <boost/assert.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 
 namespace boost { namespace gil {

--- a/numeric/test/numeric.cpp
+++ b/numeric/test/numeric.cpp
@@ -7,13 +7,13 @@
 
 /// \brief Unit test for Numeric extension
 
+#include <boost/gil/assert.hpp>
 #include <boost/gil/image.hpp>
 #include <boost/gil/typedefs.hpp>
 
 #include <boost/gil/extension/numeric/resample.hpp>
 #include <boost/gil/extension/numeric/sampler.hpp>
 
-#include <boost/assert.hpp>
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
 

--- a/test/pixel_iterator.cpp
+++ b/test/pixel_iterator.cpp
@@ -7,7 +7,6 @@
 //
 #include <boost/gil.hpp>
 
-#include <boost/assert.hpp>
 #include <boost/mpl/vector.hpp>
 
 #include <exception>

--- a/toolbox/test/indexed_image_test.cpp
+++ b/toolbox/test/indexed_image_test.cpp
@@ -8,7 +8,6 @@
 #include <boost/gil.hpp>
 #include <boost/gil/extension/toolbox/image_types/indexed_image.hpp>
 
-#include <boost/assert.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <cstdint>


### PR DESCRIPTION
Add proxy header as single place of `<boost/assert.hpp>` include.
In future, it should simplify replacing `BOOST_ASSERT` with
custom `BOOST_GIL_ASSERT`.

### References

Refines #96, #208 following discussion in https://github.com/boostorg/gil/pull/208#issuecomment-453695771 with @stefanseefeld 

### Tasklist

- [ ] Review
- [ ] Adjust for comments
- [x] All CI builds and checks have passed
