### PR TITLE
Apply clang-tidy modernize-use-using to all examples

### DIFF
--- a/example/interleaved_ptr.cpp
+++ b/example/interleaved_ptr.cpp
@@ -19,7 +19,7 @@ namespace boost { namespace gil {
     template <typename ColorBase> struct element_reference_type;
 
     template <int K, typename ChannelReference, typename Layout>
-    typename element_reference_type<interleaved_ref<ChannelReference,Layout> >::type
+    typename element_reference_type<interleaved_ref<ChannelReference,Layout>>::type
     at_c(const interleaved_ref<ChannelReference,Layout>& p);
 } }
 
@@ -33,21 +33,21 @@ int main(int argc, char* argv[])
 {
     using namespace boost::gil;
 
-    typedef interleaved_ptr<unsigned char*, rgb_layout_t> rgb8_interleaved_ptr;
-    typedef interleaved_ptr<const unsigned char*, rgb_layout_t> rgb8c_interleaved_ptr;
+    using rgb8_interleaved_ptr = interleaved_ptr<unsigned char*, rgb_layout_t>;
+    using rgb8c_interleaved_ptr = interleaved_ptr<unsigned char const*, rgb_layout_t>;
 
-    boost::function_requires<MutablePixelIteratorConcept<rgb8_interleaved_ptr> >();
-    boost::function_requires<PixelIteratorConcept<rgb8c_interleaved_ptr> >();
-    boost::function_requires<MemoryBasedIteratorConcept<memory_based_step_iterator<rgb8_interleaved_ptr> > >();
+    boost::function_requires<MutablePixelIteratorConcept<rgb8_interleaved_ptr>>();
+    boost::function_requires<PixelIteratorConcept<rgb8c_interleaved_ptr>>();
+    boost::function_requires<MemoryBasedIteratorConcept<memory_based_step_iterator<rgb8_interleaved_ptr>> >();
 
-    boost::function_requires<MutablePixelConcept<rgb8_interleaved_ptr::value_type> >();
-    boost::function_requires<PixelConcept<rgb8c_interleaved_ptr::value_type> >();
+    boost::function_requires<MutablePixelConcept<rgb8_interleaved_ptr::value_type>>();
+    boost::function_requires<PixelConcept<rgb8c_interleaved_ptr::value_type>>();
 
-    typedef type_from_x_iterator<rgb8_interleaved_ptr >::view_t rgb8_interleaved_view_t;
-    typedef type_from_x_iterator<rgb8c_interleaved_ptr>::view_t rgb8c_interleaved_view_t;
+    using rgb8_interleaved_view_t = type_from_x_iterator<rgb8_interleaved_ptr >::view_t;
+    using rgb8c_interleaved_view_t = type_from_x_iterator<rgb8c_interleaved_ptr>::view_t;
 
-    boost::function_requires<MutableImageViewConcept<rgb8_interleaved_view_t> >();
-    boost::function_requires<ImageViewConcept<rgb8c_interleaved_view_t> >();
+    boost::function_requires<MutableImageViewConcept<rgb8_interleaved_view_t>>();
+    boost::function_requires<ImageViewConcept<rgb8c_interleaved_view_t>>();
 
     rgb8_image_t img;
     read_image("test.jpg", img, jpeg_tag{});

--- a/example/interleaved_ptr.hpp
+++ b/example/interleaved_ptr.hpp
@@ -32,17 +32,26 @@ template <typename ChannelPtr,  // Models Channel Iterator (examples: unsigned c
 struct interleaved_ptr : public  boost::iterator_facade<interleaved_ptr<ChannelPtr,Layout>,
                                    pixel<typename std::iterator_traits<ChannelPtr>::value_type,Layout>,
                                    boost::random_access_traversal_tag,
-                                   const interleaved_ref<typename std::iterator_traits<ChannelPtr>::reference,Layout> >
+                                   const interleaved_ref<typename std::iterator_traits<ChannelPtr>::reference,Layout>>
 {
 private:
-    typedef boost::iterator_facade<interleaved_ptr<ChannelPtr,Layout>,
-                                   pixel<typename std::iterator_traits<ChannelPtr>::value_type,Layout>,
-                                   boost::random_access_traversal_tag,
-                                   const interleaved_ref<typename std::iterator_traits<ChannelPtr>::reference,Layout> > parent_t;
-    typedef typename std::iterator_traits<ChannelPtr>::value_type channel_t;
+    using parent_t boost::iterator_facade
+        <
+            interleaved_ptr<ChannelPtr, Layout>,
+            pixel<typename std::iterator_traits<ChannelPtr>::value_type, Layout>,
+            boost::random_access_traversal_tag,
+            interleaved_ref
+            <
+                typename std::iterator_traits<ChannelPtr>::reference,
+                Layout
+            > const
+        >;
+
+    using channel_t = typename std::iterator_traits<ChannelPtr>::value_type;
+
 public:
-    typedef typename parent_t::reference                  reference;
-    typedef typename parent_t::difference_type            difference_type;
+    using reference = typename parent_t::reference;
+    using difference_type = typename parent_t::difference_type;
 
     interleaved_ptr() {}
     interleaved_ptr(const interleaved_ptr& ptr) : _channels(ptr._channels) {}
@@ -92,46 +101,49 @@ private:
 // GIL's planar reference and iterator ("planar_pixel_reference" and "planar_pixel_iterator") which share the class "pixel" as the value_type. The
 // class "pixel" is also the value type for interleaved pixel references. Here we are dealing with channels, not pixels, but the principles still apply.
 template <typename ChannelPtr, typename Layout>
-struct const_iterator_type<interleaved_ptr<ChannelPtr,Layout> > {
+struct const_iterator_type<interleaved_ptr<ChannelPtr,Layout>> {
 private:
-    typedef typename std::iterator_traits<ChannelPtr>::reference channel_ref_t;
-    typedef typename channel_traits<channel_ref_t>::const_pointer channel_const_ptr_t;
+    using channel_ref_t = typename std::iterator_traits<ChannelPtr>::reference;
+    using channel_const_ptr_t = typename channel_traits<channel_ref_t>::const_pointer;
 public:
-    typedef interleaved_ptr<channel_const_ptr_t,Layout> type;
+    using type = interleaved_ptr<channel_const_ptr_t, Layout>;
 };
 
 template <typename ChannelPtr, typename Layout>
-struct iterator_is_mutable<interleaved_ptr<ChannelPtr,Layout> > : public boost::mpl::true_ {};
+struct iterator_is_mutable<interleaved_ptr<ChannelPtr,Layout>> : public boost::mpl::true_ {};
 template <typename Channel, typename Layout>
-struct iterator_is_mutable<interleaved_ptr<const Channel*,Layout> > : public boost::mpl::false_ {};
+struct iterator_is_mutable<interleaved_ptr<const Channel*,Layout>> : public boost::mpl::false_ {};
 
 template <typename ChannelPtr, typename Layout>
-struct is_iterator_adaptor<interleaved_ptr<ChannelPtr,Layout> > : public boost::mpl::false_ {};
+struct is_iterator_adaptor<interleaved_ptr<ChannelPtr,Layout>> : public boost::mpl::false_ {};
 
 /////////////////////////////
 //  PixelBasedConcept
 /////////////////////////////
 
 template <typename ChannelPtr, typename Layout>
-struct color_space_type<interleaved_ptr<ChannelPtr,Layout> > {
-    typedef typename Layout::color_space_t type;
+struct color_space_type<interleaved_ptr<ChannelPtr,Layout>>
+{
+    using type = typename Layout::color_space_t;
 };
 
 template <typename ChannelPtr, typename Layout>
-struct channel_mapping_type<interleaved_ptr<ChannelPtr,Layout> > {
-    typedef typename Layout::channel_mapping_t type;
+struct channel_mapping_type<interleaved_ptr<ChannelPtr,Layout>>
+{
+    using type = typename Layout::channel_mapping_t;
 };
 
 template <typename ChannelPtr, typename Layout>
-struct is_planar<interleaved_ptr<ChannelPtr,Layout> > : public mpl::false_ {};
+struct is_planar<interleaved_ptr<ChannelPtr,Layout>> : public mpl::false_ {};
 
 /////////////////////////////
 //  HomogeneousPixelBasedConcept
 /////////////////////////////
 
 template <typename ChannelPtr, typename Layout>
-struct channel_type<interleaved_ptr<ChannelPtr,Layout> > {
-    typedef typename std::iterator_traits<ChannelPtr>::value_type type;
+struct channel_type<interleaved_ptr<ChannelPtr, Layout>>
+{
+    using type = typename std::iterator_traits<ChannelPtr>::value_type;
 };
 
 /////////////////////////////
@@ -173,8 +185,9 @@ inline typename interleaved_ptr<ChannelPtr,Layout>::reference memunit_advanced_r
 /////////////////////////////
 
 template <typename ChannelPtr, typename Layout>
-struct dynamic_x_step_type<interleaved_ptr<ChannelPtr,Layout> > {
-    typedef memory_based_step_iterator<interleaved_ptr<ChannelPtr,Layout> > type;
+struct dynamic_x_step_type<interleaved_ptr<ChannelPtr, Layout>>
+{
+    using type = memory_based_step_iterator<interleaved_ptr<ChannelPtr, Layout>>;
 };
 } }  // namespace boost::gil
 

--- a/example/interleaved_ref.hpp
+++ b/example/interleaved_ref.hpp
@@ -31,17 +31,20 @@ namespace boost { namespace gil {
 // and their iterator's reference type must be const-qualified.
 // Mutability of the reference proxy is part of its type (in this case, depends on the mutability of ChannelReference)
 
-template <typename ChannelReference, // Models ChannelConcept. A channel reference, unsigned char& or const unsigned char&
-          typename Layout>           // A layout (includes the color space and channel ordering)
-struct interleaved_ref {
+/// \tparam ChannelReference - Models ChannelConcept.
+///         A channel reference, unsigned char& or const unsigned char&
+/// \tparam Layout - A layout (includes the color space and channel ordering)
+template <typename ChannelReference, typename Layout>
+struct interleaved_ref
+{
 private:
-    typedef typename channel_traits<ChannelReference>::value_type      channel_t;
-    typedef typename channel_traits<ChannelReference>::reference       channel_reference_t;
-    typedef typename channel_traits<ChannelReference>::const_reference channel_const_reference_t;
-    typedef typename channel_traits<ChannelReference>::pointer         channel_pointer_t;
+    using channel_t = typename channel_traits<ChannelReference>::value_type;
+    using channel_pointer_t = typename channel_traits<ChannelReference>::pointer;
+    using channel_reference_t = typename channel_traits<ChannelReference>::reference;
+    using channel_const_reference_t = typename channel_traits<ChannelReference>::const_reference;
+
 public:
-// Required by ColorBaseConcept
-    typedef Layout layout_t;
+    using layout_t = Layout; // Required by ColorBaseConcept
 
     // Copy construction from a compatible type. The copy constructor of references is shallow. The channels themselves are not copied.
     interleaved_ref(const interleaved_ref& p) : _channels(p._channels) {}
@@ -57,9 +60,9 @@ public:
     template <typename P> const interleaved_ref& operator=(const P& p) const { check_compatible<P>(); static_copy(p,*this); return *this; }
 
 // Required by PixelConcept
-    typedef pixel<channel_t, layout_t> value_type;
-    typedef interleaved_ref            reference;
-    typedef interleaved_ref<channel_const_reference_t, layout_t> const_reference;
+    using value_type = pixel<channel_t, layout_t>;
+    using reference = interleaved_ref;
+    using const_reference = interleaved_ref<channel_const_reference_t, layout_t>;
     static const bool is_mutable = channel_traits<ChannelReference>::is_mutable;
 
 // Required by HomogeneousPixelConcept
@@ -72,35 +75,37 @@ public:
 private:
     channel_pointer_t _channels;
 
-    template <typename Pixel> static void check_compatible() { gil_function_requires<PixelsCompatibleConcept<Pixel,interleaved_ref> >(); }
+    template <typename Pixel> static void check_compatible() { gil_function_requires<PixelsCompatibleConcept<Pixel,interleaved_ref>>(); }
 };
 
 // Required by ColorBaseConcept
 template <typename ChannelReference, typename Layout, int K>
-struct kth_element_type<interleaved_ref<ChannelReference,Layout>,K> {
-    typedef ChannelReference type;
+struct kth_element_type<interleaved_ref<ChannelReference, Layout>, K>
+{
+    using type = ChannelReference;
 };
 
 template <typename ChannelReference, typename Layout, int K>
-struct kth_element_reference_type<interleaved_ref<ChannelReference,Layout>,K> {
-    typedef ChannelReference type;
+struct kth_element_reference_type<interleaved_ref<ChannelReference, Layout>, K>
+{
+    using type = ChannelReference;
 };
 
 template <typename ChannelReference, typename Layout, int K>
-struct kth_element_const_reference_type<interleaved_ref<ChannelReference,Layout>,K> {
-    typedef ChannelReference type;
-//    typedef typename channel_traits<ChannelReference>::const_reference type;
+struct kth_element_const_reference_type<interleaved_ref<ChannelReference, Layout>, K>
+{
+    using type = ChannelReference;
+    // XXX: using type = typename channel_traits<ChannelReference>::const_reference;
 };
-
 
 // Required by ColorBaseConcept
 template <int K, typename ChannelReference, typename Layout>
-typename element_reference_type<interleaved_ref<ChannelReference,Layout> >::type
+typename element_reference_type<interleaved_ref<ChannelReference,Layout>>::type
 at_c(const interleaved_ref<ChannelReference,Layout>& p) { return p[K]; };
 
 // Required by HomogeneousColorBaseConcept
 template <typename ChannelReference, typename Layout>
-typename element_reference_type<interleaved_ref<ChannelReference,Layout> >::type
+typename element_reference_type<interleaved_ref<ChannelReference,Layout>>::type
 dynamic_at_c(const interleaved_ref<ChannelReference,Layout>& p, std::size_t n) { return p[n]; };
 
 namespace detail {
@@ -120,29 +125,32 @@ void swap(const interleaved_ref<ChannelReference,Layout>& x, const interleaved_r
 
 // Required by PixelConcept
 template <typename ChannelReference, typename Layout>
-struct is_pixel<interleaved_ref<ChannelReference,Layout> > : public boost::mpl::true_ {};
+struct is_pixel<interleaved_ref<ChannelReference,Layout>> : public boost::mpl::true_ {};
 
 
 // Required by PixelBasedConcept
 template <typename ChannelReference, typename Layout>
-struct color_space_type<interleaved_ref<ChannelReference,Layout> > {
-    typedef typename Layout::color_space_t type;
+struct color_space_type<interleaved_ref<ChannelReference, Layout>>
+{
+    using type = typename Layout::color_space_t;
 };
 
 // Required by PixelBasedConcept
 template <typename ChannelReference, typename Layout>
-struct channel_mapping_type<interleaved_ref<ChannelReference,Layout> > {
-    typedef typename Layout::channel_mapping_t type;
+struct channel_mapping_type<interleaved_ref<ChannelReference, Layout>>
+{
+    using type = typename Layout::channel_mapping_t;
 };
 
 // Required by PixelBasedConcept
 template <typename ChannelReference, typename Layout>
-struct is_planar<interleaved_ref<ChannelReference,Layout> > : mpl::false_ {};
+struct is_planar<interleaved_ref<ChannelReference,Layout>> : mpl::false_ {};
 
 // Required by HomogeneousPixelBasedConcept
 template <typename ChannelReference, typename Layout>
-struct channel_type<interleaved_ref<ChannelReference,Layout> > {
-    typedef typename channel_traits<ChannelReference>::value_type type;
+struct channel_type<interleaved_ref<ChannelReference, Layout>>
+{
+    using type = typename channel_traits<ChannelReference>::value_type;
 };
 
 } }  // namespace boost::gil

--- a/example/mandelbrot.cpp
+++ b/example/mandelbrot.cpp
@@ -18,12 +18,12 @@ template <typename P>   // Models PixelValueConcept
 struct mandelbrot_fn
 {
     using point_t = boost::gil::point_t;
-    typedef mandelbrot_fn        const_t;
-    typedef P                    value_type;
-    typedef value_type           reference;
-    typedef value_type           const_reference;
-    typedef point_t              argument_type;
-    typedef reference            result_type;
+    using const_t = mandelbrot_fn;
+    using value_type = P;
+    using reference = value_type;
+    using const_reference = value_type;
+    using argument_type = point_t;
+    using result_type = reference;
     BOOST_STATIC_CONSTANT(bool, is_mutable=false);
 
     value_type                    _in_color,_out_color;
@@ -59,13 +59,13 @@ private:
 
 int main()
 {
-    typedef mandelbrot_fn<rgb8_pixel_t> deref_t;
-    typedef deref_t::point_t            point_t;
-    typedef virtual_2d_locator<deref_t,false> locator_t;
-    typedef image_view<locator_t> my_virt_view_t;
+    using deref_t = mandelbrot_fn<rgb8_pixel_t>;
+    using point_t = deref_t::point_t;
+    using locator_t = virtual_2d_locator<deref_t,false>;
+    using my_virt_view_t = image_view<locator_t>;
 
-    boost::function_requires<PixelLocatorConcept<locator_t> >();
-    gil_function_requires<StepIteratorConcept<locator_t::x_iterator> >();
+    boost::function_requires<PixelLocatorConcept<locator_t>>();
+    gil_function_requires<StepIteratorConcept<locator_t::x_iterator>>();
 
     point_t dims(200,200);
     my_virt_view_t mandel(dims, locator_t(point_t(0,0), point_t(1,1), deref_t(dims, rgb8_pixel_t(255,0,255), rgb8_pixel_t(0,255,0))));

--- a/example/packed_pixel.cpp
+++ b/example/packed_pixel.cpp
@@ -37,7 +37,7 @@ int main() {
     // define a bgr772 image. It is a "packed" image - its channels are not byte-aligned, but its pixels are.
     ////////////////////////////////
 
-    typedef packed_image3_type<uint16_t, 7,7,2, bgr_layout_t>::type bgr772_image_t;
+    using bgr772_image_t = packed_image3_type<uint16_t, 7,7,2, bgr_layout_t>::type;
     bgr772_image_t bgr772_img(img.dimensions());
     copy_and_convert_pixels(const_view(img),view(bgr772_img));
 
@@ -48,7 +48,7 @@ int main() {
     // define a gray1 image (one-bit per pixel). It is a "bit-aligned" image - its pixels are not byte aligned.
     ////////////////////////////////
 
-    typedef bit_aligned_image1_type<1, gray_layout_t>::type gray1_image_t;
+    using gray1_image_t = bit_aligned_image1_type<1, gray_layout_t>::type;
     gray1_image_t gray1_img(img.dimensions());
     copy_and_convert_pixels(const_view(img),view(gray1_img));
 

--- a/example/x_gradient.cpp
+++ b/example/x_gradient.cpp
@@ -20,27 +20,32 @@ struct halfdiff_cast_channels {
 
 
 template <typename SrcView, typename DstView>
-void x_gradient(const SrcView& src, const DstView& dst) {
-    typedef typename channel_type<DstView>::type dst_channel_t;
+void x_gradient(SrcView const& src, DstView const& dst)
+{
+    using dst_channel_t = typename channel_type<DstView>::type;
 
-    for (int y=0; y<src.height(); ++y) {
+    for (int y = 0; y < src.height(); ++y)
+    {
         typename SrcView::x_iterator src_it = src.row_begin(y);
         typename DstView::x_iterator dst_it = dst.row_begin(y);
 
-        for (int x=1; x<src.width()-1; ++x) {
-            static_transform(src_it[x-1], src_it[x+1], dst_it[x],
-                             halfdiff_cast_channels<dst_channel_t>());
+        for (int x = 1; x < src.width() - 1; ++x)
+        {
+            static_transform(src_it[x - 1], src_it[x + 1], dst_it[x],
+                halfdiff_cast_channels<dst_channel_t>());
         }
     }
 }
 
 template <typename SrcView, typename DstView>
-void x_luminosity_gradient(const SrcView& src, const DstView& dst) {
-    typedef pixel<typename channel_type<SrcView>::type, gray_layout_t> gray_pixel_t;
+void x_luminosity_gradient(SrcView const& src, DstView const& dst)
+{
+    using gray_pixel_t = pixel<typename channel_type<SrcView>::type, gray_layout_t>;
     x_gradient(color_converted_view<gray_pixel_t>(src), dst);
 }
 
-int main() {
+int main()
+{
     rgb8_image_t img;
     read_image("test.jpg",img, jpeg_tag{});
 


### PR DESCRIPTION
Run clang-tidy 7.0 with `-checks='-*,modernize-use-using' -fix` against TU-s of examples.

Manually refactor numerous typedef-s where missed by `modernize-use-using` check, not uncommon in code snippets in comments.

Outcome is that searching for lower-case whole word `typedef` in sources of all the tests should return only handful of matches in `boost/gil/extension/dynamic_image/apply_operation_base.hpp`

### References

- #192
- #193
- #195
- #196
- #197
- #198

### Tasklist

- [x] All CI builds and checks have passed

-----

@stefanseefeld Nothing exciting to review though :)