### PR TITLE
Remove uses of Boost.Bind and Boost.Lambda

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -82,7 +82,6 @@ before_build:
   - git submodule --quiet update --init libs/algorithm
   - git submodule --quiet update --init libs/array
   - git submodule --quiet update --init libs/assert
-  - git submodule --quiet update --init libs/bind
   - git submodule --quiet update --init libs/concept_check
   - git submodule --quiet update --init libs/config
   - git submodule --quiet update --init libs/core
@@ -91,7 +90,6 @@ before_build:
   - git submodule --quiet update --init libs/function
   - git submodule --quiet update --init libs/integer
   - git submodule --quiet update --init libs/iterator
-  - git submodule --quiet update --init libs/lambda
   - git submodule --quiet update --init libs/mpl
   - git submodule --quiet update --init libs/numeric/conversion
   - git submodule --quiet update --init libs/preprocessor
@@ -99,6 +97,7 @@ before_build:
   - git submodule --quiet update --init libs/type_traits
   ## Transitive
   - git submodule --quiet update --init libs/atomic
+  - git submodule --quiet update --init libs/bind
   - git submodule --quiet update --init libs/chrono
   - git submodule --quiet update --init libs/container
   - git submodule --quiet update --init libs/container_hash
@@ -109,6 +108,7 @@ before_build:
   - git submodule --quiet update --init libs/fusion
   - git submodule --quiet update --init libs/intrusive
   - git submodule --quiet update --init libs/io
+  - git submodule --quiet update --init libs/lambda
   - git submodule --quiet update --init libs/math
   - git submodule --quiet update --init libs/move
   - git submodule --quiet update --init libs/optional

--- a/.travis.yml
+++ b/.travis.yml
@@ -201,7 +201,6 @@ install:
   - git submodule --quiet update --init libs/algorithm
   - git submodule --quiet update --init libs/assert
   - git submodule --quiet update --init libs/array
-  - git submodule --quiet update --init libs/bind
   - git submodule --quiet update --init libs/concept_check
   - git submodule --quiet update --init libs/config
   - git submodule --quiet update --init libs/core
@@ -210,7 +209,6 @@ install:
   - git submodule --quiet update --init libs/function
   - git submodule --quiet update --init libs/integer
   - git submodule --quiet update --init libs/iterator
-  - git submodule --quiet update --init libs/lambda
   - git submodule --quiet update --init libs/mpl
   - git submodule --quiet update --init libs/numeric/conversion
   - git submodule --quiet update --init libs/preprocessor
@@ -218,6 +216,7 @@ install:
   - git submodule --quiet update --init libs/type_traits
   ## Transitive
   - git submodule --quiet update --init libs/atomic
+  - git submodule --quiet update --init libs/bind
   - git submodule --quiet update --init libs/chrono
   - git submodule --quiet update --init libs/container
   - git submodule --quiet update --init libs/container_hash
@@ -228,6 +227,7 @@ install:
   - git submodule --quiet update --init libs/fusion
   - git submodule --quiet update --init libs/intrusive
   - git submodule --quiet update --init libs/io
+  - git submodule --quiet update --init libs/lambda
   - git submodule --quiet update --init libs/math
   - git submodule --quiet update --init libs/move
   - git submodule --quiet update --init libs/optional

--- a/example/histogram.cpp
+++ b/example/histogram.cpp
@@ -16,10 +16,15 @@
 using namespace boost::gil;
 
 template <typename GrayView, typename R>
-void gray_image_hist(const GrayView& img_view, R& hist) {
-//    for_each_pixel(img_view,++lambda::var(hist)[lambda::_1]);
-    for (typename GrayView::iterator it=img_view.begin(); it!=img_view.end(); ++it)
+void gray_image_hist(GrayView const& img_view, R& hist)
+{
+    for (auto it = img_view.begin(); it != img_view.end(); ++it)
         ++hist[*it];
+
+    // Alternatively, prefer the algorithm with lambda
+    // for_each_pixel(img_view, [&hist](gray8_pixel_t const& pixel) {
+    //     ++hist[pixel];
+    // });
 }
 
 template <typename V, typename R>

--- a/include/boost/gil/extension/dynamic_image/reduce.hpp
+++ b/include/boost/gil/extension/dynamic_image/reduce.hpp
@@ -801,11 +801,11 @@ namespace detail {
     //resize_clobber_image_fnobj
     //image_default_construct_fnobj
     //fill_converted_pixels_fn
-    //bind(gil::detail::copy_pixels_fn(), _1, dst)
-    //bind(gil::detail::copy_pixels_fn(), src,_1)
+    //std::bind(gil::detail::copy_pixels_fn(), std::placeholders::_1, dst)
+    //std::bind(gil::detail::copy_pixels_fn(), src, std::placeholders::_1)
 
-    //bind(detail::copy_and_convert_pixels_fn(), _1, dst)
-    //bind(detail::copy_and_convert_pixels_fn(), src, _1)
+    //std::bind(detail::copy_and_convert_pixels_fn(), std::placeholders::_1, dst)
+    //std::bind(detail::copy_and_convert_pixels_fn(), src, std::placeholders::_1)
     //gil::detail::fill_pixels_fn<Value>(val)
 
     //detail::copy_construct_in_place_fn<base_t>

--- a/include/boost/gil/extension/dynamic_image/variant.hpp
+++ b/include/boost/gil/extension/dynamic_image/variant.hpp
@@ -12,7 +12,6 @@
 
 #include <boost/gil/utilities.hpp>
 
-#include <boost/bind.hpp>
 #include <boost/mpl/at.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/fold.hpp>

--- a/include/boost/gil/extension/numeric/resample.hpp
+++ b/include/boost/gil/extension/numeric/resample.hpp
@@ -11,8 +11,8 @@
 #include <boost/gil/extension/numeric/affine.hpp>
 #include <boost/gil/extension/dynamic_image/dynamic_image_all.hpp>
 
-#include <boost/lambda/bind.hpp>
-#include <boost/lambda/lambda.hpp>
+#include <algorithm>
+#include <functional>
 
 namespace boost { namespace gil {
 
@@ -71,16 +71,25 @@ namespace detail {
 ///        If invoked on incompatible views, throws std::bad_cast()
 /// \ingroup ImageAlgorithms
 template <typename Sampler, typename Types1, typename V2, typename MapFn>
-void resample_pixels(const any_image_view<Types1>& src, const V2& dst, const MapFn& dst_to_src, Sampler sampler=Sampler()) {
-    apply_operation(src,bind(detail::resample_pixels_fn<Sampler,MapFn>(dst_to_src,sampler), _1, dst));
+void resample_pixels(const any_image_view<Types1>& src, const V2& dst, const MapFn& dst_to_src, Sampler sampler=Sampler())
+{
+    apply_operation(src, std::bind(
+        detail::resample_pixels_fn<Sampler, MapFn>(dst_to_src, sampler),
+        std::placeholders::_1,
+        dst));
 }
 
 /// \brief resample_pixels when the destination is run-time specified
 ///        If invoked on incompatible views, throws std::bad_cast()
 /// \ingroup ImageAlgorithms
 template <typename Sampler, typename V1, typename Types2, typename MapFn>
-void resample_pixels(const V1& src, const any_image_view<Types2>& dst, const MapFn& dst_to_src, Sampler sampler=Sampler()) {
-    apply_operation(dst,bind(detail::resample_pixels_fn<Sampler,MapFn>(dst_to_src,sampler), src, _1));
+void resample_pixels(const V1& src, const any_image_view<Types2>& dst, const MapFn& dst_to_src, Sampler sampler=Sampler())
+{
+    using namespace std::placeholders;
+    apply_operation(dst, std::bind(
+        detail::resample_pixels_fn<Sampler, MapFn>(dst_to_src, sampler),
+        src,
+        std::placeholders::_1));
 }
 
 /// \brief resample_pixels when both the source and the destination are run-time specified

--- a/include/boost/gil/io/base.hpp
+++ b/include/boost/gil/io/base.hpp
@@ -17,7 +17,6 @@
 #include <boost/gil/io/error.hpp>
 #include <boost/gil/io/typedefs.hpp>
 
-#include <boost/bind.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 
 #include <istream>

--- a/test/image.cpp
+++ b/test/image.cpp
@@ -14,8 +14,6 @@
 
 #include <boost/core/ignore_unused.hpp>
 #include <boost/crc.hpp>
-#include <boost/lambda/bind.hpp>
-#include <boost/lambda/lambda.hpp>
 #include <boost/mpl/vector.hpp>
 
 #include <ios>
@@ -50,10 +48,15 @@ void error_if(bool condition);
 ////////////////////////////////////////////////////
 
 template <typename GrayView, typename R>
-void gray_image_hist(const GrayView& img_view, R& hist) {
-//    for_each_pixel(img_view,++lambda::var(hist)[lambda::_1]);
-    for (typename GrayView::iterator it=img_view.begin(); it!=img_view.end(); ++it)
+void gray_image_hist(GrayView const& img_view, R& hist)
+{
+    for (auto it = img_view.begin(); it != img_view.end(); ++it)
         ++hist[*it];
+
+    // Alternatively, prefer the algorithm with lambda
+    // for_each_pixel(img_view, [&hist](gray8_pixel_t const& pixel) {
+    //     ++hist[pixel];
+    // });
 }
 
 template <typename V, typename R>

--- a/test/recreate_image.cpp
+++ b/test/recreate_image.cpp
@@ -11,8 +11,7 @@
 #endif
 
 #include <boost/gil/extension/dynamic_image/dynamic_image_all.hpp>
-#include <boost/lambda/bind.hpp>
-#include <boost/lambda/lambda.hpp>
+
 #include <boost/mpl/vector.hpp>
 #include <boost/test/unit_test.hpp>
 


### PR DESCRIPTION
Replace with `std::bind` and C++11 lambda functions.
The two Boost libraries should no longer be a direct dependency of Boost.GIL.

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed
