### PR TITLE
Remove uses of Boost.Function

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -78,7 +78,7 @@ before_build:
   - git submodule --quiet update --init tools/boost_install
   - git submodule --quiet update --init tools/boostdep
   - git submodule --quiet update --init libs/headers
-  ## Direct
+  ## Direct (of GIL headers only)
   - git submodule --quiet update --init libs/algorithm
   - git submodule --quiet update --init libs/array
   - git submodule --quiet update --init libs/assert
@@ -87,7 +87,6 @@ before_build:
   - git submodule --quiet update --init libs/core
   - git submodule --quiet update --init libs/crc
   - git submodule --quiet update --init libs/filesystem
-  - git submodule --quiet update --init libs/function
   - git submodule --quiet update --init libs/integer
   - git submodule --quiet update --init libs/iterator
   - git submodule --quiet update --init libs/mpl
@@ -95,7 +94,7 @@ before_build:
   - git submodule --quiet update --init libs/preprocessor
   - git submodule --quiet update --init libs/test
   - git submodule --quiet update --init libs/type_traits
-  ## Transitive
+  ## Transitive (of GIL tests too)
   - git submodule --quiet update --init libs/atomic
   - git submodule --quiet update --init libs/bind
   - git submodule --quiet update --init libs/chrono
@@ -104,6 +103,7 @@ before_build:
   - git submodule --quiet update --init libs/conversion
   - git submodule --quiet update --init libs/detail
   - git submodule --quiet update --init libs/exception
+  - git submodule --quiet update --init libs/function
   - git submodule --quiet update --init libs/function_types
   - git submodule --quiet update --init libs/fusion
   - git submodule --quiet update --init libs/intrusive

--- a/.travis.yml
+++ b/.travis.yml
@@ -197,7 +197,7 @@ install:
   - git submodule --quiet update --init tools/boost_install
   - git submodule --quiet update --init tools/boostdep
   - git submodule --quiet update --init libs/headers
-  ## Direct
+  ## Direct (of GIL headers only)
   - git submodule --quiet update --init libs/algorithm
   - git submodule --quiet update --init libs/assert
   - git submodule --quiet update --init libs/array
@@ -206,7 +206,6 @@ install:
   - git submodule --quiet update --init libs/core
   - git submodule --quiet update --init libs/crc
   - git submodule --quiet update --init libs/filesystem
-  - git submodule --quiet update --init libs/function
   - git submodule --quiet update --init libs/integer
   - git submodule --quiet update --init libs/iterator
   - git submodule --quiet update --init libs/mpl
@@ -214,7 +213,7 @@ install:
   - git submodule --quiet update --init libs/preprocessor
   - git submodule --quiet update --init libs/test
   - git submodule --quiet update --init libs/type_traits
-  ## Transitive
+  ## Transitive (of GIL tests too)
   - git submodule --quiet update --init libs/atomic
   - git submodule --quiet update --init libs/bind
   - git submodule --quiet update --init libs/chrono
@@ -223,6 +222,7 @@ install:
   - git submodule --quiet update --init libs/conversion
   - git submodule --quiet update --init libs/detail
   - git submodule --quiet update --init libs/exception
+  - git submodule --quiet update --init libs/function
   - git submodule --quiet update --init libs/function_types
   - git submodule --quiet update --init libs/fusion
   - git submodule --quiet update --init libs/intrusive

--- a/include/boost/gil/extension/io/bmp/detail/scanline_read.hpp
+++ b/include/boost/gil/extension/io/bmp/detail/scanline_read.hpp
@@ -20,8 +20,7 @@
 #include <boost/gil/io/scanline_read_iterator.hpp>
 #include <boost/gil/io/typedefs.hpp>
 
-#include <boost/function.hpp>
-
+#include <functional>
 #include <type_traits>
 #include <vector>
 
@@ -122,7 +121,7 @@ private:
                 read_palette();
                 _buffer.resize( _pitch );
 
-                _read_function = boost::mem_fn( &this_t::read_1_bit_row );
+                _read_function = std::mem_fn(&this_t::read_1_bit_row);
 
                 break;
             }
@@ -145,7 +144,7 @@ private:
                         read_palette();
                         _buffer.resize( _pitch );
 
-                        _read_function = boost::mem_fn( &this_t::read_4_bits_row );
+                        _read_function = std::mem_fn(&this_t::read_4_bits_row);
 
                         break;
                     }
@@ -176,7 +175,7 @@ private:
                         read_palette();
                         _buffer.resize( _pitch );
 
-                        _read_function = boost::mem_fn( &this_t::read_8_bits_row );
+                        _read_function = std::mem_fn(&this_t::read_8_bits_row);
 
                         break;
                     }
@@ -239,7 +238,7 @@ private:
                 }
 
 
-                _read_function = boost::mem_fn( &this_t::read_15_bits_row );
+                _read_function = std::mem_fn(&this_t::read_15_bits_row);
 
                 break;
             }
@@ -247,7 +246,7 @@ private:
             case 24:
             {
                 this->_scanline_length = ( this->_info._width * num_channels< rgb8_view_t >::value + 3 ) & ~3;
-                _read_function = boost::mem_fn( &this_t::read_row );
+                _read_function = std::mem_fn(&this_t::read_row);
 
                 break;
             }
@@ -255,7 +254,7 @@ private:
             case 32:
             {
                 this->_scanline_length = ( this->_info._width * num_channels< rgba8_view_t >::value + 3 ) & ~3;
-                _read_function = boost::mem_fn( &this_t::read_row );
+                _read_function = std::mem_fn(&this_t::read_row);
 
                 break;
             }
@@ -406,7 +405,7 @@ private:
     detail::mirror_bits <std::vector<byte_t>, std::true_type> _mirror_bits;
     detail::swap_half_bytes<std::vector<byte_t>, std::true_type> _swap_half_bytes;
 
-    boost::function<void(this_t*, byte_t*)> _read_function;
+    std::function<void(this_t*, byte_t*)> _read_function;
 };
 
 } // namespace gil

--- a/include/boost/gil/extension/io/pnm/detail/scanline_read.hpp
+++ b/include/boost/gil/extension/io/pnm/detail/scanline_read.hpp
@@ -21,8 +21,7 @@
 #include <boost/gil/io/scanline_read_iterator.hpp>
 #include <boost/gil/io/typedefs.hpp>
 
-#include <boost/function.hpp>
-
+#include <functional>
 #include <type_traits>
 #include <vector>
 
@@ -86,8 +85,8 @@ private:
             {
                 this->_scanline_length = this->_info._width;
 
-                _read_function = boost::mem_fn( &this_t::read_text_row );
-                _skip_function = boost::mem_fn( &this_t::skip_text_row );
+                _read_function = std::mem_fn(&this_t::read_text_row);
+                _skip_function = std::mem_fn(&this_t::skip_text_row);
 
                 break;
             }
@@ -96,8 +95,8 @@ private:
             {
                 this->_scanline_length = this->_info._width * num_channels< rgb8_view_t >::value;
 
-                _read_function = boost::mem_fn( &this_t::read_text_row );
-                _skip_function = boost::mem_fn( &this_t::skip_text_row );
+                _read_function = std::mem_fn(&this_t::read_text_row);
+                _skip_function = std::mem_fn(&this_t::skip_text_row);
 
                 break;
             }
@@ -108,8 +107,8 @@ private:
                 //gray1_image_t
                 this->_scanline_length = ( this->_info._width + 7 ) >> 3;
 
-                _read_function = boost::mem_fn( &this_t::read_binary_bit_row );
-                _skip_function = boost::mem_fn( &this_t::skip_binary_row     );
+                _read_function = std::mem_fn(&this_t::read_binary_bit_row);
+                _skip_function = std::mem_fn(&this_t::skip_binary_row);
 
                 break;
             }
@@ -119,8 +118,8 @@ private:
                 // gray8_image_t
                 this->_scanline_length = this->_info._width;
 
-                _read_function = boost::mem_fn( &this_t::read_binary_byte_row );
-                _skip_function = boost::mem_fn( &this_t::skip_binary_row      );
+                _read_function = std::mem_fn(&this_t::read_binary_byte_row);
+                _skip_function = std::mem_fn(&this_t::skip_binary_row);
 
                 break;
             }
@@ -130,8 +129,8 @@ private:
                 // rgb8_image_t
                 this->_scanline_length = this->_info._width * num_channels< rgb8_view_t >::value;
 
-                _read_function = boost::mem_fn( &this_t::read_binary_byte_row );
-                _skip_function = boost::mem_fn( &this_t::skip_binary_row      );
+                _read_function = std::mem_fn(&this_t::read_binary_byte_row);
+                _skip_function = std::mem_fn(&this_t::skip_binary_row);
 
                 break;
             }
@@ -236,8 +235,8 @@ private:
     detail::negate_bits<std::vector<byte_t>, std::true_type> _negate_bits;
     detail::swap_half_bytes<std::vector<byte_t>, std::true_type> _swap_half_bytes;
 
-    boost::function<void(this_t*, byte_t*)> _read_function;
-    boost::function<void(this_t*)> _skip_function;
+    std::function<void(this_t*, byte_t*)> _read_function;
+    std::function<void(this_t*)> _skip_function;
 };
 
 

--- a/include/boost/gil/extension/io/tiff/detail/scanline_read.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/scanline_read.hpp
@@ -20,9 +20,8 @@
 #include <boost/gil/io/row_buffer_helper.hpp>
 #include <boost/gil/io/scanline_read_iterator.hpp>
 
-#include <boost/function.hpp>
-
 #include <algorithm>
+#include <functional>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -122,7 +121,7 @@ private:
                                               , sizeof(uint16_t) * num_colors
                                               );
 
-                    _read_function = boost::mem_fn( &this_t::read_1_bit_index_image );
+                    _read_function = std::mem_fn(&this_t::read_1_bit_index_image);
 
                     break;
                 }
@@ -141,7 +140,7 @@ private:
                                               , sizeof(uint16_t) * num_colors
                                               );
 
-                    _read_function = boost::mem_fn( &this_t::read_2_bits_index_image );
+                    _read_function = std::mem_fn(&this_t::read_2_bits_index_image);
 
                     break;
                 }
@@ -159,7 +158,7 @@ private:
                                               , sizeof(uint16_t) * num_colors
                                               );
 
-                    _read_function = boost::mem_fn( &this_t::read_4_bits_index_image );
+                    _read_function = std::mem_fn(&this_t::read_4_bits_index_image);
 
                     break;
                 }
@@ -178,7 +177,7 @@ private:
                                               , sizeof(uint16_t) * num_colors
                                               );
 
-                    _read_function = boost::mem_fn( &this_t::read_8_bits_index_image );
+                    _read_function = std::mem_fn(&this_t::read_8_bits_index_image);
 
                     break;
                 }
@@ -197,7 +196,7 @@ private:
                                               , sizeof(uint16_t) * num_colors
                                               );
 
-                    _read_function = boost::mem_fn( &this_t::read_16_bits_index_image );
+                    _read_function = std::mem_fn(&this_t::read_16_bits_index_image);
 
                     break;
                 }
@@ -216,7 +215,7 @@ private:
                                               , sizeof(uint16_t) * num_colors
                                               );
 
-                    _read_function = boost::mem_fn( &this_t::read_24_bits_index_image );
+                    _read_function = std::mem_fn(&this_t::read_24_bits_index_image);
 
                     break;
                 }
@@ -235,7 +234,7 @@ private:
                                               , sizeof(uint16_t) * num_colors
                                               );
 
-                    _read_function = boost::mem_fn( &this_t::read_32_bits_index_image );
+                    _read_function = std::mem_fn(&this_t::read_32_bits_index_image);
 
                     break;
                 }
@@ -273,7 +272,7 @@ private:
                             case 14:
                             case 16:
                             case 24:
-                            case 32: { _read_function = boost::mem_fn( &this_t::read_row ); break; }
+                            case 32: { _read_function = std::mem_fn(&this_t::read_row); break; }
                             default: { io_error( "Image type is not supported." ); }
                         }
 
@@ -296,7 +295,7 @@ private:
                                     case 14:
                                     case 16:
                                     case 24:
-                                    case 32: { _read_function = boost::mem_fn( &this_t::read_row );  break; }
+                                    case 32: { _read_function = std::mem_fn(&this_t::read_row);  break; }
                                     default: { io_error( "Image type is not supported." ); }
                                 }
 
@@ -315,7 +314,7 @@ private:
                                     case 14:
                                     case 16:
                                     case 24:
-                                    case 32: { _read_function = boost::mem_fn( &this_t::read_row );  break; }
+                                    case 32: { _read_function = std::mem_fn(&this_t::read_row);  break; }
                                     default: { io_error( "Image type is not supported." ); }
                                 }
 
@@ -339,7 +338,7 @@ private:
                             case 14:
                             case 16:
                             case 24:
-                            case 32: { _read_function = boost::mem_fn( &this_t::read_row );  break; }
+                            case 32: { _read_function = std::mem_fn(&this_t::read_row);  break; }
                             default: { io_error( "Image type is not supported." ); }
                         }
 
@@ -439,7 +438,7 @@ private:
 
     std::vector< byte_t> _buffer;
     detail::mirror_bits<std::vector<byte_t>, std::true_type> _mirror_bites;
-    boost::function<void(this_t*, byte_t*, int)> _read_function;
+    std::function<void(this_t*, byte_t*, int)> _read_function;
 };
 
 } // namespace gil


### PR DESCRIPTION
Remove uses of `boost::mem_fn` (missing from Bind.Bind removal in #212).

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed
