### PR TITLE
Replace boost::enable_if with std::enable_if

### DIFF
--- a/include/boost/gil/color_base.hpp
+++ b/include/boost/gil/color_base.hpp
@@ -17,7 +17,6 @@
 #include <boost/mpl/size.hpp>
 #include <boost/mpl/vector_c.hpp>
 #include <boost/type_traits.hpp>
-#include <boost/utility/enable_if.hpp>
 
 namespace boost { namespace gil {
 
@@ -26,7 +25,14 @@ template <typename P> P* memunit_advanced(const P* p, std::ptrdiff_t diff);
 
 // Forward-declare semantic_at_c
 template <int K, typename ColorBase>
-typename disable_if<is_const<ColorBase>,typename kth_semantic_element_reference_type<ColorBase,K>::type>::type semantic_at_c(ColorBase& p);
+auto semantic_at_c(ColorBase& p)
+    -> typename std::enable_if
+    <
+        !std::is_const<ColorBase>::value,
+        typename kth_semantic_element_reference_type<ColorBase, K>::type
+    >::type;
+
+
 template <int K, typename ColorBase>
 typename kth_semantic_element_const_reference_type<ColorBase,K>::type semantic_at_c(const ColorBase& p);
 

--- a/include/boost/gil/color_base_algorithm.hpp
+++ b/include/boost/gil/color_base_algorithm.hpp
@@ -15,9 +15,9 @@
 #include <boost/mpl/at.hpp>
 #include <boost/mpl/contains.hpp>
 #include <boost/type_traits.hpp>
-#include <boost/utility/enable_if.hpp>
 
 #include <algorithm>
+#include <type_traits>
 
 namespace boost { namespace gil {
 
@@ -119,9 +119,15 @@ template <typename ColorBase, int K> struct kth_semantic_element_const_reference
 
 /// \brief A mutable accessor to the K-th semantic element of a color base
 /// \ingroup ColorBaseAlgorithmSemanticAtC
-template <int K, typename ColorBase> inline
-typename disable_if<is_const<ColorBase>,typename kth_semantic_element_reference_type<ColorBase,K>::type>::type
-semantic_at_c(ColorBase& p) {
+template <int K, typename ColorBase>
+inline
+auto semantic_at_c(ColorBase& p)
+    -> typename std::enable_if
+    <
+        !std::is_const<ColorBase>::value,
+        typename kth_semantic_element_reference_type<ColorBase, K>::type
+    >::type
+{
     return kth_semantic_element_reference_type<ColorBase,K>::get(p);
 }
 

--- a/include/boost/gil/concepts/color_base.hpp
+++ b/include/boost/gil/concepts/color_base.hpp
@@ -14,7 +14,6 @@
 #include <boost/gil/concepts/fwd.hpp>
 
 #include <boost/type_traits.hpp>
-#include <boost/utility/enable_if.hpp>
 
 #if BOOST_GCC >= 40700
 #pragma GCC diagnostic push
@@ -64,9 +63,9 @@ inline auto at_c(bit_aligned_pixel_reference<B, C, L, M> const& p)
 // Forward declarations of semantic_at_c
 template <int K, typename ColorBase>
 auto semantic_at_c(ColorBase& p)
-    -> typename disable_if
+    -> typename std::enable_if
         <
-            is_const<ColorBase>,
+            !std::is_const<ColorBase>::value,
             typename kth_semantic_element_reference_type<ColorBase, K>::type
         >::type;
 

--- a/include/boost/gil/extension/dynamic_image/variant.hpp
+++ b/include/boost/gil/extension/dynamic_image/variant.hpp
@@ -19,7 +19,6 @@
 #include <boost/mpl/size.hpp>
 #include <boost/mpl/sizeof.hpp>
 #include <boost/mpl/transform.hpp>
-#include <boost/utility/enable_if.hpp>
 
 #include <algorithm>
 #include <cstddef>

--- a/include/boost/gil/extension/io/bmp/detail/read.hpp
+++ b/include/boost/gil/extension/io/bmp/detail/read.hpp
@@ -21,9 +21,7 @@
 #include <boost/gil/io/typedefs.hpp>
 
 #include <boost/assert.hpp>
-#include <boost/mpl/and.hpp>
 #include <boost/type_traits/is_same.hpp>
-#include <boost/utility/enable_if.hpp>
 
 #include <type_traits>
 #include <vector>

--- a/include/boost/gil/extension/io/png/detail/write.hpp
+++ b/include/boost/gil/extension/io/png/detail/write.hpp
@@ -19,6 +19,8 @@
 #include <boost/mpl/less.hpp>
 #include <boost/mpl/not.hpp>
 
+#include <type_traits>
+
 namespace boost { namespace gil {
 
 #if BOOST_WORKAROUND(BOOST_MSVC, >= 1400)
@@ -167,25 +169,30 @@ private:
     template< typename Info > struct is_less_than_eight : mpl::less< mpl::int_< Info::_bit_depth >, mpl::int_< 8 > > {};
     template< typename Info > struct is_equal_to_sixteen : mpl::equal_to< mpl::int_< Info::_bit_depth >, mpl::int_< 16 > > {};
 
-    template< typename Info >
-    void set_swap( typename enable_if< is_less_than_eight< Info > >::type* /* ptr */ = 0 )
+    template <typename Info>
+    void set_swap(typename std::enable_if<is_less_than_eight<Info>::type::value>::type* /*ptr*/ = 0)
     {
-        png_set_packswap( this->get_struct() );
+        png_set_packswap(this->get_struct());
     }
 
-    template< typename Info >
-    void set_swap( typename enable_if< is_equal_to_sixteen< Info > >::type* /* ptr */ = nullptr )
+    template <typename Info>
+    void set_swap(typename std::enable_if<is_equal_to_sixteen<Info>::type::value>::type* /*ptr*/ = 0)
     {
-        png_set_swap( this->get_struct() );
+        png_set_swap(this->get_struct());
     }
 
-    template< typename Info >
-    void set_swap( typename enable_if< mpl::and_< mpl::not_< is_less_than_eight< Info > >
-                                                , mpl::not_< is_equal_to_sixteen< Info > >
-                                                >
-                                     >::type* /* ptr */ = nullptr
-                 )
-    {}
+    template <typename Info>
+    void set_swap(
+        typename std::enable_if
+        <
+            mpl::and_
+            <
+                mpl::not_<is_less_than_eight<Info>>,
+                mpl::not_<is_equal_to_sixteen<Info>>
+            >::type::value
+        >::type* /*ptr*/ = nullptr)
+    {
+    }
 };
 
 ///

--- a/include/boost/gil/extension/io/raw/detail/device.hpp
+++ b/include/boost/gil/extension/io/raw/detail/device.hpp
@@ -14,8 +14,6 @@
 #include <boost/gil/io/base.hpp>
 #include <boost/gil/io/device.hpp>
 
-#include <boost/utility/enable_if.hpp>
-
 #include <memory>
 #include <string>
 

--- a/include/boost/gil/extension/io/tiff/detail/device.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/device.hpp
@@ -15,7 +15,6 @@
 #include <boost/gil/io/device.hpp>
 
 #include <boost/mpl/size.hpp>
-#include <boost/utility/enable_if.hpp>
 
 #include <algorithm>
 #include <memory>

--- a/include/boost/gil/extension/io/tiff/detail/is_allowed.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/is_allowed.hpp
@@ -13,53 +13,95 @@
 
 #include <boost/mpl/for_each.hpp>
 
+#include <type_traits>
+
 namespace boost { namespace gil { namespace detail {
 
 using channel_sizes_t = std::vector<tiff_bits_per_sample::type>;
 
-template< typename View, typename Channel, typename Enable = void > struct Format_Type {};
+template <typename View, typename Channel, typename Enable = void>
+struct Format_Type {};
 
 // is_bit_aligned< View >
-template< typename View, typename Channel > struct Format_Type< View
-                                                              , Channel
-                                                              , typename boost::enable_if< typename is_bit_aligned< typename get_pixel_type< View >::type >::type >::type
-                                                              >
+template <typename View, typename Channel>
+struct Format_Type
+<
+    View,
+    Channel,
+    typename std::enable_if
+    <
+        is_bit_aligned
+        <
+            typename get_pixel_type<View>::type
+        >::type::value
+    >::type
+>
 {
     static const int value = SAMPLEFORMAT_UINT;
 };
 
 // is_not_bit_aligned< View > && is_unsigned< Channel >
-template< typename View, typename Channel > struct Format_Type< View
-                                                              , Channel
-                                                              , typename boost::enable_if< mpl::and_< mpl::not_< typename is_bit_aligned< typename get_pixel_type< View >::type >::type >
-                                                                                                    , is_unsigned< Channel >
-                                                                                                    >
-                                                                                         >::type
-                                                              >
+template <typename View, typename Channel>
+struct Format_Type
+<
+    View,
+    Channel,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            mpl::not_
+            <
+                typename is_bit_aligned<typename get_pixel_type<View>::type>::type
+            >,
+            is_unsigned<Channel>
+        >::type::value
+    >::type
+>
 {
     static const int value = SAMPLEFORMAT_UINT;
 };
 
 // is_not_bit_aligned< View > && is_signed< Channel >
-template< typename View, typename Channel > struct Format_Type< View
-                                                              , Channel
-                                                              , typename boost::enable_if< mpl::and_< mpl::not_< typename is_bit_aligned< typename get_pixel_type< View >::type >::type >
-                                                                                                    , is_signed< Channel >
-                                                                                                    >
-                                                                                         >::type
-                                                              >
+template <typename View, typename Channel>
+struct Format_Type
+<
+    View,
+    Channel,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            mpl::not_
+            <
+                typename is_bit_aligned<typename get_pixel_type<View>::type>::type
+            >,
+            is_signed<Channel>
+        >::type::value
+    >::type
+>
 {
     static const int value = SAMPLEFORMAT_INT;
 };
 
 // is_not_bit_aligned< View > && is_floating_point< Channel >
-template< typename View, typename Channel > struct Format_Type< View
-                                                              , Channel
-                                                              , typename boost::enable_if< mpl::and_< mpl::not_< typename is_bit_aligned< typename get_pixel_type< View >::type >::type >
-                                                                                                    , is_floating_point< Channel >
-                                                                                                    >
-                                                                                         >::type
-                                                              >
+template <typename View, typename Channel>
+struct Format_Type
+<
+    View,
+    Channel,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            mpl::not_
+            <
+                typename is_bit_aligned<typename get_pixel_type<View>::type>::type
+            >,
+            is_floating_point<Channel>
+        >::type::value
+    >::type
+>
 {
     static const int value = SAMPLEFORMAT_IEEEFP;
 };

--- a/include/boost/gil/extension/toolbox/image_types/indexed_image.hpp
+++ b/include/boost/gil/extension/toolbox/image_types/indexed_image.hpp
@@ -16,7 +16,6 @@
 
 #include <boost/mpl/if.hpp>
 #include <boost/type_traits/is_integral.hpp>
-#include <boost/utility/enable_if.hpp>
 
 #include <cstddef>
 #include <memory>
@@ -104,37 +103,31 @@ struct indexed_image_deref_fn : indexed_image_deref_fn_base< IndicesLoc
 };
 
 
-template< typename IndicesLoc
-        , typename PaletteLoc
-        >
-struct indexed_image_deref_fn< IndicesLoc
-                             , PaletteLoc
-                             , typename boost::enable_if< boost::is_integral< typename IndicesLoc::value_type > >::type
-                             > : indexed_image_deref_fn_base< IndicesLoc
-                                                            , PaletteLoc
-                                                            >
+template <typename IndicesLoc, typename PaletteLoc>
+struct indexed_image_deref_fn
+<
+    IndicesLoc,
+    PaletteLoc,
+    typename std::enable_if
+    <
+        std::is_integral<typename IndicesLoc::value_type>::value
+    >::type
+> : indexed_image_deref_fn_base<IndicesLoc, PaletteLoc>
 {
-    using base_t = indexed_image_deref_fn_base
-        <
-            IndicesLoc,
-            PaletteLoc
-        >;
+    using base_t = indexed_image_deref_fn_base<IndicesLoc, PaletteLoc>;
 
-    indexed_image_deref_fn()
-    : base_t()
-    {}
+    indexed_image_deref_fn() : base_t() {}
 
-    indexed_image_deref_fn( const typename base_t::indices_locator_t& indices_loc
-                          , const typename base_t::palette_locator_t& palette_loc
-                          )
-    : base_t( indices_loc
-            , palette_loc
-            )
-    {}
-
-    typename base_t::result_type operator()( const point_t& p ) const
+    indexed_image_deref_fn(
+        typename base_t::indices_locator_t const& indices_loc,
+        typename base_t::palette_locator_t const& palette_loc)
+        : base_t(indices_loc, palette_loc)
     {
-        return *this->_palette_loc.xy_at( *this->_indices_loc.xy_at( p ), 0 );
+    }
+
+    typename base_t::result_type operator()(point_t const& p) const
+    {
+        return *this->_palette_loc.xy_at(*this->_indices_loc.xy_at(p), 0);
     }
 };
 

--- a/include/boost/gil/extension/toolbox/metafunctions/channel_type.hpp
+++ b/include/boost/gil/extension/toolbox/metafunctions/channel_type.hpp
@@ -16,7 +16,7 @@
 #include <boost/gil/channel.hpp>
 
 #include <boost/mpl/at.hpp>
-#include <boost/utility/enable_if.hpp>
+#include <boost/utility/enable_if.hpp> // boost::lazy_enable_if
 
 namespace boost{ namespace gil {
 

--- a/include/boost/gil/extension/toolbox/metafunctions/get_num_bits.hpp
+++ b/include/boost/gil/extension/toolbox/metafunctions/get_num_bits.hpp
@@ -14,7 +14,8 @@
 #include <boost/mpl/size_t.hpp>
 #include <boost/type_traits/is_integral.hpp>
 #include <boost/type_traits/is_class.hpp>
-#include <boost/utility/enable_if.hpp>
+
+#include <type_traits>
 
 namespace boost{ namespace gil {
 
@@ -48,14 +49,21 @@ template< int N >
 struct get_num_bits< const packed_channel_value< N > > : mpl::int_< N >
 {};
 
-template< typename T >
-struct get_num_bits< T
-                   , typename enable_if< mpl::and_< is_integral< T >
-                                                  , mpl::not_< is_class< T > >
-                                                  >
-                                       >::type
-                   > : mpl::size_t< sizeof(T) * 8 >
-{};
+template <typename T>
+struct get_num_bits
+<
+    T,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            is_integral<T>,
+            mpl::not_<is_class<T>>
+        >::type::value
+    >::type
+> : mpl::size_t<sizeof(T) * 8>
+{
+};
 
 } // namespace gil
 } // namespace boost

--- a/include/boost/gil/io/conversion_policies.hpp
+++ b/include/boost/gil/io/conversion_policies.hpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <type_traits>
 
 namespace boost{namespace gil{ namespace detail {
 
@@ -21,39 +22,37 @@ struct read_and_no_convert
 public:
     using color_converter_type = void *;
 
-    template< typename InIterator
-            , typename OutIterator
-            >
-    void read( const InIterator& /* begin */
-             , const InIterator& /* end   */
-             , OutIterator       /* out   */
-             , typename disable_if< typename pixels_are_compatible< typename std::iterator_traits<InIterator>::value_type
-                                                                  , typename std::iterator_traits<OutIterator>::value_type
-                                                                  >::type
-                                  >::type* /* ptr */ = nullptr
-             )
+    template <typename InIterator, typename OutIterator>
+    void read(
+        InIterator const& /*begin*/, InIterator const& /*end*/ , OutIterator /*out*/,
+        typename std::enable_if
+        <
+            mpl::not_
+            <
+                pixels_are_compatible
+                <
+                    typename std::iterator_traits<InIterator>::value_type,
+                    typename std::iterator_traits<OutIterator>::value_type
+                >
+            >::type::value
+        >::type* /*dummy*/ = nullptr)
     {
-        io_error( "Data cannot be copied because the pixels are incompatible." );
+        io_error("Data cannot be copied because the pixels are incompatible.");
     }
 
-    template< typename InIterator
-            , typename OutIterator
-            >
-    void read( const InIterator& begin
-             , const InIterator& end
-             , OutIterator       out
-             , typename enable_if< typename pixels_are_compatible< typename std::iterator_traits<InIterator>::value_type
-                                                                 , typename std::iterator_traits<OutIterator>::value_type
-                                                                 >::type
-                                 >::type* /* ptr */ = nullptr
-             )
+    template <typename InIterator, typename OutIterator>
+    void read(InIterator const& begin, InIterator const& end, OutIterator out,
+        typename std::enable_if
+        <
+            pixels_are_compatible
+            <
+                typename std::iterator_traits<InIterator>::value_type,
+                typename std::iterator_traits<OutIterator>::value_type
+            >::type::value
+        >::type* /*dummy*/ = nullptr)
     {
-        std::copy( begin
-                 , end
-                 , out
-                 );
+        std::copy(begin, end, out);
     }
-
 };
 
 template<typename CC>

--- a/include/boost/gil/io/device.hpp
+++ b/include/boost/gil/io/device.hpp
@@ -12,10 +12,10 @@
 
 #include <boost/assert.hpp>
 #include <boost/core/ignore_unused.hpp>
-#include <boost/utility/enable_if.hpp>
 
 #include <cstdio>
 #include <memory>
+#include <type_traits>
 
 namespace boost { namespace gil {
 
@@ -554,16 +554,20 @@ template< typename FormatTag
         >
 struct is_adaptable_input_device : mpl::false_{};
 
-template< typename FormatTag
-        , typename T
-        >
-struct is_adaptable_input_device< FormatTag
-                                , T
-                                , typename enable_if< mpl::or_< is_base_and_derived< std::istream, T >
-                                                              , is_same            < std::istream, T >
-                                                              >
-                                                    >::type
-                                > : mpl::true_
+template <typename FormatTag, typename T>
+struct is_adaptable_input_device
+<
+    FormatTag,
+    T,
+    typename std::enable_if
+    <
+        mpl::or_
+        <
+            is_base_and_derived<std::istream, T>,
+            is_same<std::istream, T>
+        >::type::value
+    >::type
+> : mpl::true_
 {
     using device_type = istream_device<FormatTag>;
 };
@@ -588,19 +592,22 @@ template< typename FormatTag
 struct is_read_device : mpl::false_
 {};
 
-template< typename FormatTag
-        , typename T
-        >
-struct is_read_device< FormatTag
-                     , T
-                     , typename enable_if< mpl::or_< is_input_device< FormatTag >
-                                                   , is_adaptable_input_device< FormatTag
-                                                                              , T
-                                                                              >
-                                                   >
-                                         >::type
-                     > : mpl::true_
-{};
+template <typename FormatTag, typename T>
+struct is_read_device
+<
+    FormatTag,
+    T,
+    typename std::enable_if
+    <
+        mpl::or_
+        <
+            is_input_device<FormatTag>,
+            is_adaptable_input_device<FormatTag, T>
+        >::type::value
+    >::type
+> : mpl::true_
+{
+};
 
 
 /**
@@ -618,15 +625,20 @@ template< typename FormatTag
         >
 struct is_adaptable_output_device : mpl::false_ {};
 
-template< typename FormatTag
-        , typename T
-        > struct is_adaptable_output_device< FormatTag
-                                           , T
-                                           , typename enable_if< mpl::or_< is_base_and_derived< std::ostream, T >
-                                                                         , is_same            < std::ostream, T >
-                                                                         >
-                                           >::type
-        > : mpl::true_
+template <typename FormatTag, typename T>
+struct is_adaptable_output_device
+<
+    FormatTag,
+    T,
+    typename std::enable_if
+    <
+        mpl::or_
+        <
+            is_base_and_derived<std::ostream, T>,
+            is_same<std::ostream, T>
+        >::type::value
+    >::type
+> : mpl::true_
 {
     using device_type = ostream_device<FormatTag>;
 };
@@ -648,19 +660,22 @@ template< typename FormatTag
 struct is_write_device : mpl::false_
 {};
 
-template< typename FormatTag
-        , typename T
-        >
-struct is_write_device< FormatTag
-                      , T
-                      , typename enable_if< mpl::or_< is_output_device< FormatTag >
-                                                    , is_adaptable_output_device< FormatTag
-                                                                                , T
-                                                                                >
-                                                    >
-                                          >::type
-                      > : mpl::true_
-{};
+template <typename FormatTag, typename T>
+struct is_write_device
+<
+    FormatTag,
+    T,
+    typename std::enable_if
+    <
+        mpl::or_
+        <
+            is_output_device<FormatTag>,
+            is_adaptable_output_device<FormatTag, T>
+        >::type::value
+    >::type
+> : mpl::true_
+{
+};
 
 } // namespace detail
 

--- a/include/boost/gil/io/get_read_device.hpp
+++ b/include/boost/gil/io/get_read_device.hpp
@@ -12,7 +12,8 @@
 #include <boost/gil/io/path_spec.hpp>
 
 #include <boost/mpl/and.hpp>
-#include <boost/utility/enable_if.hpp>
+
+#include <type_traits>
 
 namespace boost { namespace gil {
 
@@ -23,18 +24,20 @@ template< typename T
 struct get_read_device
 {};
 
-template< typename Device
-        , typename FormatTag
-        >
-struct get_read_device< Device
-                      , FormatTag
-                      , typename enable_if< mpl::and_< detail::is_adaptable_input_device< FormatTag
-                                                                                        , Device
-                                                                                        >
-                                                     , is_format_tag< FormatTag >
-                                                     >
-                                          >::type
-                 >
+template <typename Device, typename FormatTag>
+struct get_read_device
+<
+    Device,
+    FormatTag,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_adaptable_input_device<FormatTag, Device>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type
+>
 {
     using type = typename detail::is_adaptable_input_device
         <
@@ -43,16 +46,20 @@ struct get_read_device< Device
         >::device_type;
 };
 
-template< typename String
-        , typename FormatTag
-        >
-struct get_read_device< String
-                      , FormatTag
-                      , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
-                                                     , is_format_tag< FormatTag >
-                                                     >
-                                          >::type
-                      >
+template <typename String, typename FormatTag>
+struct get_read_device
+<
+    String,
+    FormatTag,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_supported_path_spec<String>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type
+>
 {
     using type = detail::file_stream_device<FormatTag>;
 };

--- a/include/boost/gil/io/get_reader.hpp
+++ b/include/boost/gil/io/get_reader.hpp
@@ -10,141 +10,152 @@
 
 #include <boost/gil/io/get_read_device.hpp>
 
+#include <boost/mpl/and.hpp>
+
+#include <type_traits>
+
 namespace boost { namespace gil {
 
 /// \brief Helper metafunction to generate image reader type.
-template< typename T
-        , typename FormatTag
-        , typename ConversionPolicy
-        , class Enable = void
-        >
-struct get_reader
-{};
+template
+<
+    typename T,
+    typename FormatTag,
+    typename ConversionPolicy,
+    class Enable = void
+>
+struct get_reader {};
 
-template< typename String
-        , typename FormatTag
-        , typename ConversionPolicy
-        >
-struct get_reader< String
-                 , FormatTag
-                 , ConversionPolicy
-                 , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
-                                                , is_format_tag< FormatTag >
-                                                >
-                                     >::type
-                 >
+template <typename String, typename FormatTag, typename ConversionPolicy>
+struct get_reader
+<
+    String,
+    FormatTag,
+    ConversionPolicy,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_supported_path_spec<String>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type
+>
 {
     using device_t = typename get_read_device<String, FormatTag>::type;
     using type = reader<device_t, FormatTag, ConversionPolicy>;
 };
 
-template< typename Device
-        , typename FormatTag
-        , typename ConversionPolicy
-        >
-struct get_reader< Device
-                 , FormatTag
-                 , ConversionPolicy
-                 , typename enable_if< mpl::and_< detail::is_adaptable_input_device< FormatTag
-                                                                                   , Device
-                                                                                   >
-                                                , is_format_tag< FormatTag >
-                                                >
-                                     >::type
-                 >
+template <typename Device, typename FormatTag, typename ConversionPolicy>
+struct get_reader
+<
+    Device,
+    FormatTag,
+    ConversionPolicy,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_adaptable_input_device<FormatTag, Device>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type
+>
 {
     using device_t = typename get_read_device<Device, FormatTag>::type;
     using type = reader<device_t, FormatTag, ConversionPolicy>;
 };
-
 
 /// \brief Helper metafunction to generate dynamic image reader type.
-template< typename T
-        , typename FormatTag
-        , class Enable = void
-        >
+template <typename T, typename FormatTag, class Enable = void>
 struct get_dynamic_image_reader
-{};
+{
+};
 
-template< typename String
-        , typename FormatTag
-        >
-struct get_dynamic_image_reader< String
-                               , FormatTag
-                               , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
-                                                              , is_format_tag< FormatTag >
-                                                              >
-                                                   >::type
-                               >
+template <typename String, typename FormatTag>
+struct get_dynamic_image_reader
+<
+    String,
+    FormatTag,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_supported_path_spec<String>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type
+>
 {
     using device_t = typename get_read_device<String, FormatTag>::type;
     using type = dynamic_image_reader<device_t, FormatTag>;
 };
 
-template< typename Device
-        , typename FormatTag
-        >
-struct get_dynamic_image_reader< Device
-                               , FormatTag
-                               , typename enable_if< mpl::and_< detail::is_adaptable_input_device< FormatTag
-                                                                                                 , Device
-                                                                                                 >
-                                                              , is_format_tag< FormatTag >
-                                                              >
-                                                   >::type
-                               >
+template <typename Device, typename FormatTag>
+struct get_dynamic_image_reader
+<
+    Device,
+    FormatTag,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_adaptable_input_device<FormatTag, Device>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type
+>
 {
     using device_t = typename get_read_device<Device, FormatTag>::type;
     using type = dynamic_image_reader<device_t, FormatTag>;
 };
 
-
-/////////////////////////////////////////////////////////////
-
 /// \brief Helper metafunction to generate image backend type.
-template< typename T
-        , typename FormatTag
-        , class Enable = void
-        >
+template <typename T, typename FormatTag, class Enable = void>
 struct get_reader_backend
-{};
+{
+};
 
-template< typename String
-        , typename FormatTag
-        >
-struct get_reader_backend< String
-                         , FormatTag
-                         , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
-                                                        , is_format_tag< FormatTag >
-                                                        >
-                                             >::type
-                         >
+template <typename String, typename FormatTag>
+struct get_reader_backend
+<
+    String,
+    FormatTag,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_supported_path_spec<String>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type
+>
 {
     using device_t = typename get_read_device<String, FormatTag>::type;
     using type = reader_backend<device_t, FormatTag>;
 };
 
-template< typename Device
-        , typename FormatTag
-        >
-struct get_reader_backend< Device
-                         , FormatTag
-                         , typename enable_if< mpl::and_< detail::is_adaptable_input_device< FormatTag
-                                                                                           , Device
-                                                                                           >
-                                                        , is_format_tag< FormatTag >
-                                                        >
-                                             >::type
-                         >
+template <typename Device, typename FormatTag>
+struct get_reader_backend
+<
+    Device,
+    FormatTag,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_adaptable_input_device<FormatTag, Device>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type
+>
 {
     using device_t = typename get_read_device<Device, FormatTag>::type;
     using type = reader_backend<device_t, FormatTag>;
 };
 
 /// \brief Helper metafunction to generate image scanline_reader type.
-template< typename T
-        , typename FormatTag
-        >
+template <typename T, typename FormatTag>
 struct get_scanline_reader
 {
     using device_t = typename get_read_device<T, FormatTag>::type;

--- a/include/boost/gil/io/get_write_device.hpp
+++ b/include/boost/gil/io/get_write_device.hpp
@@ -12,54 +12,51 @@
 #include <boost/gil/io/path_spec.hpp>
 
 #include <boost/mpl/and.hpp>
-#include <boost/utility/enable_if.hpp>
+
+#include <type_traits>
 
 namespace boost { namespace gil {
 
-template< typename T
-        , typename FormatTag
-        , class Enable = void
-        >
+template <typename T, typename FormatTag, class Enable = void>
+struct get_write_device {};
+
+template <typename Device, typename FormatTag>
 struct get_write_device
-{};
-
-
-template< typename Device
-        , typename FormatTag
-        >
-struct get_write_device< Device
-                       , FormatTag
-                       , typename enable_if< mpl::and_< detail::is_adaptable_output_device< FormatTag
-                                                                                          , Device
-                                                                                          >
-                                                      , is_format_tag< FormatTag >
-                                                      >
-                                           >::type
-                       >
-{
-    using type = typename detail::is_adaptable_output_device
+<
+    Device,
+    FormatTag,
+    typename std::enable_if
+    <
+        mpl::and_
         <
-            FormatTag,
-            Device
-        >::device_type;
+            detail::is_adaptable_output_device<FormatTag, Device>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type
+>
+{
+    using type =
+        typename detail::is_adaptable_output_device<FormatTag, Device>::device_type;
 };
 
-
-template< typename String
-        , typename FormatTag
-        >
-struct get_write_device< String
-                       , FormatTag
-                       , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
-                                                      , is_format_tag< FormatTag >
-                                                      >
-                                           >::type
-                       >
+template <typename String, typename FormatTag>
+struct get_write_device
+<
+    String,
+    FormatTag,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_supported_path_spec<String>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type
+>
 {
     using type = detail::file_stream_device<FormatTag>;
 };
 
-} // namespace gil
-} // namespace boost
+}} // namespace boost::gil
 
 #endif

--- a/include/boost/gil/io/get_writer.hpp
+++ b/include/boost/gil/io/get_writer.hpp
@@ -10,91 +10,97 @@
 
 #include <boost/gil/io/get_write_device.hpp>
 
+#include <boost/mpl/and.hpp>
+
+#include <type_traits>
+
 namespace boost { namespace gil {
 
 /// \brief Helper metafunction to generate writer type.
-template< typename T
-        , typename FormatTag
-        , class Enable = void
-        >
+template <typename T, typename FormatTag, class Enable = void>
+struct get_writer {};
+
+
+template <typename String, typename FormatTag>
 struct get_writer
-{};
-
-
-template< typename String
-        , typename FormatTag
-        >
-struct get_writer< String
-                 , FormatTag
-                 , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
-                                                , is_format_tag< FormatTag >
-                                                >
-                                     >::type
-                 >
+<
+    String,
+    FormatTag,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_supported_path_spec<String>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type
+>
 {
     using device_t = typename get_write_device<String, FormatTag>::type;
     using type = writer<device_t, FormatTag>;
 };
 
-template< typename Device
-        , typename FormatTag
-        >
-struct get_writer< Device
-                 , FormatTag
-                 , typename enable_if< mpl::and_< detail::is_adaptable_output_device< FormatTag
-                                                                                    , Device
-                                                                                    >
-                                                , is_format_tag< FormatTag >
-                                                >
-                                     >::type
-                 >
+template <typename Device, typename FormatTag>
+struct get_writer
+<
+    Device,
+    FormatTag,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_adaptable_output_device<FormatTag, Device>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type
+>
 {
     using device_t = typename get_write_device<Device, FormatTag>::type;
     using type = writer<device_t, FormatTag>;
 };
-
 
 /// \brief Helper metafunction to generate dynamic image writer type.
-template< typename T
-        , typename FormatTag
-        , class Enable = void
-        >
-struct get_dynamic_image_writer
-{};
+template <typename T, typename FormatTag, class Enable = void>
+struct get_dynamic_image_writer {};
 
-template< typename String
-        , typename FormatTag
-        >
-struct get_dynamic_image_writer< String
-                               , FormatTag
-                               , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
-                                                              , is_format_tag< FormatTag >
-                                                              >
-                                                   >::type
-                               >
+template <typename String, typename FormatTag>
+struct get_dynamic_image_writer
+<
+    String,
+    FormatTag,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_supported_path_spec<String>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type
+>
 {
     using device_t = typename get_write_device<String, FormatTag>::type;
     using type = dynamic_image_writer<device_t, FormatTag>;
 };
 
-template< typename Device
-        , typename FormatTag
-        >
-struct get_dynamic_image_writer< Device
-                               , FormatTag
-                               , typename enable_if< mpl::and_< detail::is_write_device< FormatTag
-                                                                                       , Device
-                                                                                       >
-                                                              , is_format_tag< FormatTag >
-                                                              >
-                                                   >::type
-                               >
+template <typename Device, typename FormatTag>
+struct get_dynamic_image_writer
+<
+    Device,
+    FormatTag,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_write_device<FormatTag, Device>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type
+>
 {
     using device_t = typename get_write_device<Device, FormatTag>::type;
     using type = dynamic_image_writer<device_t, FormatTag>;
 };
 
-} // namespace gil
-} // namespace boost
+}} // namespace boost::gil
 
 #endif

--- a/include/boost/gil/io/make_backend.hpp
+++ b/include/boost/gil/io/make_backend.hpp
@@ -11,136 +11,114 @@
 
 #include <boost/gil/io/get_reader.hpp>
 
-#include <boost/utility/enable_if.hpp>
+#include <boost/mpl/and.hpp>
+
+#include <type_traits>
 
 namespace boost { namespace gil {
 
-template< typename String
-        , typename FormatTag
-        >
+template <typename String, typename FormatTag>
 inline
-typename get_reader_backend< String
-                           , FormatTag
-                           >::type
-make_reader_backend( const String&                           file_name
-                   , const image_read_settings< FormatTag >& settings
-                   , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
-                                                  , is_format_tag< FormatTag >
-                                                           >
-                                       >::type* /* ptr */ = nullptr
-                   )
+auto make_reader_backend(
+    String const& file_name, image_read_settings<FormatTag> const& settings,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_supported_path_spec<String>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+    -> typename get_reader_backend<String, FormatTag>::type
 {
     using device_t = typename get_read_device<String, FormatTag>::type;
 
-    device_t device( detail::convert_to_native_string( file_name )
-                   , typename detail::file_stream_device< FormatTag >::read_tag()
-                   );
+    device_t device(
+        detail::convert_to_native_string(file_name),
+        typename detail::file_stream_device<FormatTag>::read_tag());
 
-    return reader_backend< device_t, FormatTag >( device, settings );
+    return reader_backend<device_t, FormatTag>(device, settings);
 }
 
-template< typename FormatTag >
+template <typename FormatTag>
 inline
-typename get_reader_backend< std::wstring
-                           , FormatTag
-                           >::type
-make_reader_backend( const std::wstring&                     file_name
-                   , const image_read_settings< FormatTag >& settings
-                   )
+auto make_reader_backend(
+    std::wstring const& file_name, image_read_settings<FormatTag> const& settings)
+    -> typename get_reader_backend<std::wstring, FormatTag>::type
 {
+    char const* str = detail::convert_to_native_string(file_name);
+
     using device_t = typename get_read_device<std::wstring, FormatTag>::type;
+    device_t device(str, typename detail::file_stream_device<FormatTag>::read_tag());
 
-    const char* str = detail::convert_to_native_string( file_name );
+    delete[] str;  // TODO: RAII
 
-    device_t device( str
-                   , typename detail::file_stream_device< FormatTag >::read_tag()
-                   );
-
-    delete[] str; // TODO: RAII
-
-    return reader_backend< device_t, FormatTag >( device, settings );
+    return reader_backend<device_t, FormatTag>(device, settings);
 }
 
 #ifdef BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
-template< typename FormatTag >
+template <typename FormatTag>
 inline
-typename get_reader_backend< std::wstring
-                           , FormatTag
-                           >::type
-make_reader_backend( const filesystem::path&                 path
-                   , const image_read_settings< FormatTag >& settings
-                   )
+auto make_reader_backend(
+    filesystem::path const& path,
+    image_read_settings<FormatTag> const& settings)
+    -> typename get_reader_backend<std::wstring, FormatTag>::type
 {
-    return make_reader_backend( path.wstring()
-                              , settings
-                              );
+    return make_reader_backend(path.wstring(), settings);
 }
-#endif // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
+#endif  // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 
-template< typename Device
-        , typename FormatTag
-        >
+template <typename Device, typename FormatTag>
 inline
-typename get_reader_backend< Device
-                           , FormatTag
-                           >::type
-make_reader_backend( Device&                                 io_dev
-                   , const image_read_settings< FormatTag >& settings
-                   , typename enable_if< mpl::and_< detail::is_adaptable_input_device< FormatTag
-                                                                                     , Device
-                                                                                     >
-                                                  , is_format_tag< FormatTag >
-                                                  >
-                                       >::type* /* ptr */ = nullptr
-                   )
+auto make_reader_backend(Device& io_dev, image_read_settings<FormatTag> const& settings,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_adaptable_input_device<FormatTag, Device>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+    -> typename get_reader_backend<Device, FormatTag>::type
 {
-    using device_t = typename get_read_device< Device, FormatTag>::type;
-    device_t device( io_dev );
+    using device_t = typename get_read_device<Device, FormatTag>::type;
+    device_t device(io_dev);
 
-    return reader_backend< device_t, FormatTag >( device, settings );
+    return reader_backend<device_t, FormatTag>(device, settings);
 }
 
-
-
-template< typename String
-        , typename FormatTag
-        >
+template <typename String, typename FormatTag>
 inline
-typename get_reader_backend< String
-                           , FormatTag
-                           >::type
-make_reader_backend( const String&    file_name
-                   , const FormatTag&
-                   , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
-                                                  , is_format_tag< FormatTag >
-                                                           >
-                                       >::type* /* ptr */ = 0
-                   )
+auto make_reader_backend(String const& file_name, FormatTag const&,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_supported_path_spec<String>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+    -> typename get_reader_backend<String, FormatTag>::type
 {
-    return make_reader_backend( file_name, image_read_settings< FormatTag >() );
+    return make_reader_backend(file_name, image_read_settings<FormatTag>());
 }
 
-template< typename Device
-        , typename FormatTag
-        >
+template <typename Device, typename FormatTag>
 inline
-typename get_reader_backend< Device
-                           , FormatTag
-                           >::type
-make_reader_backend( Device&          io_dev
-                   , const FormatTag&
-                   , typename enable_if< mpl::and_< detail::is_adaptable_input_device< FormatTag
-                                                                                     , Device
-                                                                                     >
-                                                  , is_format_tag< FormatTag >
-                                                  >
-                                       >::type* /* ptr */ = 0
-                   )
+auto make_reader_backend(Device& io_dev, FormatTag const&,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_adaptable_input_device<FormatTag, Device>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+    -> typename get_reader_backend<Device, FormatTag>::type
 {
-    return make_reader_backend( io_dev, image_read_settings< FormatTag >() );
+    return make_reader_backend(io_dev, image_read_settings<FormatTag>());
 }
 
-} // namespace gil
-} // namespace boost
+}} // namespace boost::gil
 
 #endif

--- a/include/boost/gil/io/make_dynamic_image_reader.hpp
+++ b/include/boost/gil/io/make_dynamic_image_reader.hpp
@@ -10,183 +10,132 @@
 
 #include <boost/gil/io/get_reader.hpp>
 
-#include <boost/utility/enable_if.hpp>
+#include <boost/mpl/and.hpp>
+
+#include <type_traits>
 
 namespace boost { namespace gil {
 
-template< typename String
-        , typename FormatTag
-        >
+template <typename String, typename FormatTag>
 inline
-typename get_dynamic_image_reader< String
-                                 , FormatTag
-                                 >::type
-make_dynamic_image_reader( const String&    file_name
-                         , const image_read_settings< FormatTag >& settings
-                         , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
-                                                        , is_format_tag< FormatTag >
-                                                                 >
-                                             >::type* /* ptr */ = nullptr
-                         )
+auto make_dynamic_image_reader(
+    String const& file_name, image_read_settings<FormatTag> const& settings,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_supported_path_spec<String>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+    -> typename get_dynamic_image_reader<String, FormatTag>::type
 {
-    typename get_read_device< String
-                   , FormatTag
-                   >::type device( detail::convert_to_native_string( file_name )
-                                 , typename detail::file_stream_device< FormatTag >::read_tag()
-                                 );
+    using device_t = typename get_read_device<String, FormatTag>::type;
+    device_t device(
+        detail::convert_to_native_string(file_name),
+        typename detail::file_stream_device<FormatTag>::read_tag());
 
-    return typename get_dynamic_image_reader< String
-                                            , FormatTag
-                                            >::type( device
-                                                   , settings
-                                                   );
+    return typename get_dynamic_image_reader<String, FormatTag>::type(device, settings);
 }
 
-template< typename FormatTag >
+template <typename FormatTag>
 inline
-typename get_dynamic_image_reader< std::wstring
-                                 , FormatTag
-                                 >::type
-make_dynamic_image_reader( const std::wstring& file_name
-                         , const image_read_settings< FormatTag >& settings
-                         )
+auto make_dynamic_image_reader(
+    std::wstring const& file_name, image_read_settings<FormatTag> const& settings)
+    -> typename get_dynamic_image_reader<std::wstring, FormatTag>::type
 {
-    const char* str = detail::convert_to_native_string( file_name );
+    char const* str = detail::convert_to_native_string(file_name);
 
-    typename get_read_device< std::wstring
-                   , FormatTag
-                   >::type device( str
-                                 , typename detail::file_stream_device< FormatTag >::read_tag()
-                                 );
+    using device_t = typename get_read_device<std::wstring, FormatTag>::type;
+    device_t device(str, typename detail::file_stream_device<FormatTag>::read_tag());
 
-    delete[] str;
+    delete[] str; // TODO: RAII
 
-    return typename get_dynamic_image_reader< std::wstring
-                                            , FormatTag
-                                            >::type( device
-                                                   , settings
-                                                   );
+    return
+        typename get_dynamic_image_reader<std::wstring, FormatTag>::type(device, settings);
 }
 
 #ifdef BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
-template< typename FormatTag >
+template <typename FormatTag>
 inline
-typename get_dynamic_image_reader< std::wstring
-                                 , FormatTag
-                                 >::type
-make_dynamic_image_reader( const filesystem::path&                 path
-                         , const image_read_settings< FormatTag >& settings
-                         )
+auto make_dynamic_image_reader(
+    filesystem::path const& path, image_read_settings<FormatTag> const& settings)
+    -> typename get_dynamic_image_reader<std::wstring, FormatTag>::type
 {
-    return make_dynamic_image_reader( path.wstring()
-                                    , settings
-                                    );
+    return make_dynamic_image_reader(path.wstring(), settings);
 }
-#endif // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
+#endif  // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 
-template< typename Device
-        , typename FormatTag
-        >
+template <typename Device, typename FormatTag>
 inline
-typename get_dynamic_image_reader< Device
-                                 , FormatTag
-                                 >::type
-make_dynamic_image_reader( Device&          file
-                         , const image_read_settings< FormatTag >& settings
-                         , typename enable_if< mpl::and_< detail::is_adaptable_input_device< FormatTag
-                                                                                           , Device
-                                                                                           >
-                                                        , is_format_tag< FormatTag >
-                                                        >
-                                             >::type* /* ptr */ = 0
-                         )
+auto make_dynamic_image_reader(
+    Device& file, image_read_settings<FormatTag> const& settings,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_adaptable_input_device<FormatTag, Device>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+    -> typename get_dynamic_image_reader<Device, FormatTag>::type
 {
-    typename get_read_device< Device
-                   , FormatTag
-                   >::type device( file );
-
-    return typename get_dynamic_image_reader< Device
-                                            , FormatTag
-                                            >::type( device
-                                                   , settings
-                                                   );
+    typename get_read_device<Device, FormatTag>::type device(file);
+    return typename get_dynamic_image_reader<Device, FormatTag>::type(device, settings);
 }
 
 // without image_read_settings
 
-template< typename String
-        , typename FormatTag
-        >
+template <typename String, typename FormatTag>
 inline
-typename get_dynamic_image_reader< String
-                                 , FormatTag
-                                 >::type
-make_dynamic_image_reader( const String&    file_name
-                         , const FormatTag&
-                         , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
-                                                        , is_format_tag< FormatTag >
-                                                                 >
-                                             >::type* /* ptr */ = nullptr
-                         )
+auto make_dynamic_image_reader(String const& file_name, FormatTag const&,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_supported_path_spec<String>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+    -> typename get_dynamic_image_reader<String, FormatTag>::type
 {
-    return make_dynamic_image_reader( file_name
-                                    , image_read_settings< FormatTag >()
-                                    );
+    return make_dynamic_image_reader(file_name, image_read_settings<FormatTag>());
 }
 
-template< typename FormatTag >
+template <typename FormatTag>
 inline
-typename get_dynamic_image_reader< std::wstring
-                                 , FormatTag
-                                 >::type
-make_dynamic_image_reader( const std::wstring& file_name
-                         , const FormatTag&
-                         )
+auto make_dynamic_image_reader(std::wstring const& file_name, FormatTag const&)
+    -> typename get_dynamic_image_reader<std::wstring, FormatTag>::type
 {
-    return make_dynamic_image_reader( file_name
-                                    , image_read_settings< FormatTag >()
-                                    );
+    return make_dynamic_image_reader(file_name, image_read_settings<FormatTag>());
 }
 
 #ifdef BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
-template< typename FormatTag >
+template <typename FormatTag>
 inline
-typename get_dynamic_image_reader< std::wstring
-                                 , FormatTag
-                                 >::type
-make_dynamic_image_reader( const filesystem::path& path
-                         , const FormatTag&
-                         )
+auto make_dynamic_image_reader(filesystem::path const& path, FormatTag const&)
+    -> typename get_dynamic_image_reader<std::wstring, FormatTag>::type
 {
-    return make_dynamic_image_reader( path.wstring()
-                                    , image_read_settings< FormatTag >()
-                                    );
+    return make_dynamic_image_reader(path.wstring(), image_read_settings<FormatTag>());
 }
-#endif // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
+#endif  // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 
-template< typename Device
-        , typename FormatTag
-        >
+template <typename Device, typename FormatTag>
 inline
-typename get_dynamic_image_reader< Device
-                                 , FormatTag
-                                 >::type
-make_dynamic_image_reader( Device&          file
-                         , const FormatTag&
-                         , typename enable_if< mpl::and_< detail::is_adaptable_input_device< FormatTag
-                                                                                           , Device
-                                                                                           >
-                                                        , is_format_tag< FormatTag >
-                                                        >
-                                             >::type* /* ptr */ = 0
-                         )
+auto make_dynamic_image_reader(Device& file, FormatTag const&,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_adaptable_input_device<FormatTag, Device>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+    ->  typename get_dynamic_image_reader<Device, FormatTag>::type
 {
-    return make_dynamic_image_reader( file
-                                    , image_read_settings< FormatTag >()
-                                    );
+    return make_dynamic_image_reader(file, image_read_settings<FormatTag>());
 }
 
-} // namespace gil
-} // namespace boost
+}} // namespace boost::gil
 
 #endif

--- a/include/boost/gil/io/make_dynamic_image_writer.hpp
+++ b/include/boost/gil/io/make_dynamic_image_writer.hpp
@@ -10,36 +10,32 @@
 
 #include <boost/gil/io/get_writer.hpp>
 
-#include <boost/utility/enable_if.hpp>
+#include <boost/mpl/and.hpp>
+
+#include <type_traits>
 
 namespace boost { namespace gil {
 
-template< typename String
-        , typename FormatTag
-        >
+template <typename String, typename FormatTag>
 inline
-typename get_dynamic_image_writer< String
-                                 , FormatTag
-                                 >::type
-make_dynamic_image_writer( const String&                        file_name
-                         , const image_write_info< FormatTag >& info
-                         , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
-                                                        , is_format_tag< FormatTag >
-                                                        >
-                                             >::type* /* ptr */ = nullptr
-                         )
+auto make_dynamic_image_writer(
+    String const& file_name, image_write_info<FormatTag> const& info,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_supported_path_spec<String>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+    -> typename get_dynamic_image_writer<String, FormatTag>::type
 {
-    typename get_write_device< String
-                    , FormatTag
-                    >::type device( detail::convert_to_native_string( file_name )
-                                  , typename detail::file_stream_device< FormatTag >::write_tag()
-                                  );
+    using deveice_t = typename get_write_device<String, FormatTag>::type;
+    deveice_t device(
+        detail::convert_to_native_string(file_name),
+        typename detail::file_stream_device<FormatTag>::write_tag());
 
-    return typename get_dynamic_image_writer< String
-                                            , FormatTag
-                                            >::type( device
-                                                   , info
-                                                   );
+    return typename get_dynamic_image_writer<String, FormatTag>::type(device, info);
 }
 
 template< typename FormatTag >
@@ -59,7 +55,7 @@ make_dynamic_image_writer( const std::wstring&                  file_name
                                   , typename detail::file_stream_device< FormatTag >::write_tag()
                                   );
 
-    delete[] str;
+    delete[] str; // TODO: RAII
 
     return typename get_dynamic_image_writer< std::wstring
                                             , FormatTag
@@ -84,54 +80,39 @@ make_dynamic_image_writer( const filesystem::path&              path
 }
 #endif // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 
-
-template< typename Device
-        , typename FormatTag
-        >
+template <typename Device, typename FormatTag>
 inline
-typename get_dynamic_image_writer< Device
-                                 , FormatTag
-                                 >::type
-make_dynamic_image_writer( Device&                              file
-                         , const image_write_info< FormatTag >& info
-                         , typename enable_if< mpl::and_< typename detail::is_adaptable_output_device< FormatTag, Device >::type
-                                                        , is_format_tag< FormatTag >
-                                                        >
-                                             >::type* /* ptr */ = 0
-                         )
+auto make_dynamic_image_writer(Device& file, image_write_info<FormatTag> const& info,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            typename detail::is_adaptable_output_device<FormatTag, Device>::type,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+    -> typename get_dynamic_image_writer<Device, FormatTag>::type
 {
-    typename get_write_device< Device
-                    , FormatTag
-                    >::type device( file );
-
-    return typename get_dynamic_image_writer< Device
-                                            , FormatTag
-                                            >::type( device
-                                                   , info
-                                                   );
+    typename get_write_device<Device, FormatTag>::type device(file);
+    return typename get_dynamic_image_writer<Device, FormatTag>::type(device, info);
 }
-
 
 // no image_write_info
 
-template< typename String
-        , typename FormatTag
-        >
+template <typename String, typename FormatTag>
 inline
-typename get_dynamic_image_writer< String
-                                 , FormatTag
-                                 >::type
-make_dynamic_image_writer( const String&    file_name
-                         , const FormatTag&
-                         , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
-                                                        , is_format_tag< FormatTag >
-                                                        >
-                                             >::type* /* ptr */ = nullptr
-                         )
+auto make_dynamic_image_writer(String const& file_name, FormatTag const&,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_supported_path_spec<String>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+    -> typename get_dynamic_image_writer<String, FormatTag>::type
 {
-    return make_dynamic_image_writer( file_name
-                                    , image_write_info< FormatTag >()
-                                    );
+    return make_dynamic_image_writer(file_name, image_write_info<FormatTag>());
 }
 
 template< typename FormatTag >
@@ -165,27 +146,22 @@ make_dynamic_image_writer( const filesystem::path& path
 #endif // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 
 
-template< typename Device
-        , typename FormatTag
-        >
+template <typename Device, typename FormatTag>
 inline
-typename get_dynamic_image_writer< Device
-                                 , FormatTag
-                                 >::type
-make_dynamic_image_writer( Device&          file
-                         , const FormatTag&
-                         , typename enable_if< mpl::and_< typename detail::is_adaptable_output_device< FormatTag, Device >::type
-                                                        , is_format_tag< FormatTag >
-                                                        >
-                                             >::type* /* ptr */ = 0
-                         )
+auto make_dynamic_image_writer(Device& file, FormatTag const&,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            typename detail::is_adaptable_output_device<FormatTag, Device>::type,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+    -> typename get_dynamic_image_writer<Device, FormatTag>::type
 {
-    return make_dynamic_image_writer( file
-                                    , image_write_info< FormatTag >()
-                                    );
+    return make_dynamic_image_writer(file, image_write_info<FormatTag>());
 }
 
-} // namespace gil
-} // namespace boost
+}} // namespace boost::gil
 
 #endif

--- a/include/boost/gil/io/make_reader.hpp
+++ b/include/boost/gil/io/make_reader.hpp
@@ -10,40 +10,34 @@
 
 #include <boost/gil/io/get_reader.hpp>
 
-#include <boost/utility/enable_if.hpp>
+#include <boost/mpl/and.hpp>
+
+#include <type_traits>
 
 namespace boost { namespace gil {
 
-template< typename String
-        , typename FormatTag
-        , typename ConversionPolicy
-        >
+template <typename String, typename FormatTag, typename ConversionPolicy>
 inline
-typename get_reader< String
-                   , FormatTag
-                   , ConversionPolicy
-                   >::type
-make_reader( const String&    file_name
-           , const image_read_settings< FormatTag >& settings
-           , const ConversionPolicy&
-           , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
-                                          , is_format_tag< FormatTag >
-                                                   >
-                               >::type* /* ptr */ = nullptr
-           )
+auto make_reader(
+    String const&file_name,
+    image_read_settings<FormatTag> const& settings,
+    ConversionPolicy const&,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_supported_path_spec<String>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+    -> typename get_reader<String, FormatTag, ConversionPolicy>::type
 {
-    typename get_read_device< String
-                            , FormatTag
-                            >::type device( detail::convert_to_native_string( file_name )
-                                          , typename detail::file_stream_device< FormatTag >::read_tag()
-                                          );
+    typename get_read_device<String, FormatTag>::type device(
+    detail::convert_to_native_string(file_name),
+    typename detail::file_stream_device<FormatTag>::read_tag());
 
-    return typename get_reader< String
-                              , FormatTag
-                              , ConversionPolicy
-                              >::type( device
-                                     , settings
-                                     );
+    return
+    typename get_reader<String, FormatTag, ConversionPolicy>::type(device, settings);
 }
 
 template< typename FormatTag
@@ -98,62 +92,47 @@ make_reader( const filesystem::path&                 path
 }
 #endif // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 
-template< typename Device
-        , typename FormatTag
-        , typename ConversionPolicy
-        >
+template <typename Device, typename FormatTag, typename ConversionPolicy>
 inline
-typename get_reader< Device
-                   , FormatTag
-                   , ConversionPolicy
-                   >::type
-make_reader( Device&                                 file
-           , const image_read_settings< FormatTag >& settings
-           , const ConversionPolicy&
-           , typename enable_if< mpl::and_< detail::is_adaptable_input_device< FormatTag
-                                                                             , Device
-                                                                             >
-                                          , is_format_tag< FormatTag >
-                                          >
-                               >::type* /* ptr */ = nullptr
-           )
+auto make_reader(
+    Device& file,
+    image_read_settings<FormatTag> const& settings,
+    ConversionPolicy const&,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_adaptable_input_device<FormatTag, Device>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+    -> typename get_reader<Device, FormatTag, ConversionPolicy>::type
 {
-    typename get_read_device< Device
-                            , FormatTag
-                            >::type device( file );
+    typename get_read_device<Device, FormatTag>::type device(file);
 
-    return typename get_reader< Device
-                              , FormatTag
-                              , ConversionPolicy
-                              >::type( device
-                                     , settings
-                                     );
+    return
+        typename get_reader<Device, FormatTag, ConversionPolicy>::type(device, settings);
 }
 
 // no image_read_settings
 
-template< typename String
-        , typename FormatTag
-        , typename ConversionPolicy
-        >
+template <typename String, typename FormatTag, typename ConversionPolicy>
 inline
-typename get_reader< String
-                   , FormatTag
-                   , ConversionPolicy
-                   >::type
-make_reader( const String&    file_name
-           , const FormatTag&
-           , const ConversionPolicy& cc
-           , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
-                                          , is_format_tag< FormatTag >
-                                                   >
-                               >::type* /* ptr */ = nullptr
-           )
+auto make_reader(
+    String const&file_name,
+    FormatTag const&,
+    ConversionPolicy const& cc,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_supported_path_spec<String>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+    ->  typename get_reader<String, FormatTag, ConversionPolicy>::type
 {
-    return make_reader( file_name
-                      , image_read_settings< FormatTag >()
-                      , cc
-                      );
+    return make_reader(file_name, image_read_settings<FormatTag>(), cc);
 }
 
 template< typename FormatTag
@@ -196,33 +175,25 @@ make_reader( const filesystem::path& path
 }
 #endif // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 
-template< typename Device
-        , typename FormatTag
-        , typename ConversionPolicy
-        >
+template <typename Device, typename FormatTag, typename ConversionPolicy>
 inline
-typename get_reader< Device
-                   , FormatTag
-                   , ConversionPolicy
-                   >::type
-make_reader( Device&                 file
-           , const FormatTag&
-           , const ConversionPolicy& cc
-           , typename enable_if< mpl::and_< detail::is_adaptable_input_device< FormatTag
-                                                                             , Device
-                                                                             >
-                                          , is_format_tag< FormatTag >
-                                          >
-                               >::type* /* ptr */ = nullptr
-           )
+auto make_reader(
+    Device& file,
+    FormatTag const&,
+    ConversionPolicy const& cc,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_adaptable_input_device<FormatTag, Device>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+    -> typename get_reader<Device, FormatTag, ConversionPolicy>::type
 {
-    return make_reader( file
-                      , image_read_settings< FormatTag >()
-                      , cc
-                      );
+    return make_reader(file, image_read_settings<FormatTag>(), cc);
 }
 
-} // namespace gil
-} // namespace boost
+}} // namespace boost::gil
 
 #endif

--- a/include/boost/gil/io/make_scanline_reader.hpp
+++ b/include/boost/gil/io/make_scanline_reader.hpp
@@ -10,36 +10,32 @@
 
 #include <boost/gil/io/get_reader.hpp>
 
-#include <boost/utility/enable_if.hpp>
+#include <boost/mpl/and.hpp>
+
+#include <type_traits>
 
 namespace boost { namespace gil {
 
-template< typename String
-        , typename FormatTag
-        >
+template <typename String, typename FormatTag>
 inline
-typename get_scanline_reader< String
-                            , FormatTag
-                            >::type
-make_scanline_reader( const String&    file_name
-                    , const FormatTag&
-                    , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
-                                                   , is_format_tag< FormatTag >
-                                                   >
-                                        >::type* /* ptr */ = nullptr
-           )
+auto make_scanline_reader(String const& file_name, FormatTag const&,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_supported_path_spec<String>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+    -> typename get_scanline_reader<String, FormatTag>::type
 {
-    typename get_read_device< String
-                            , FormatTag
-                            >::type device( detail::convert_to_native_string( file_name )
-                                          , typename detail::file_stream_device< FormatTag >::read_tag()
-                                          );
+    using device_t = typename get_read_device<String, FormatTag>::type;
+    device_t device(
+        detail::convert_to_native_string(file_name),
+        typename detail::file_stream_device<FormatTag>::read_tag());
 
-    return typename get_scanline_reader< String
-                                       , FormatTag
-                                       >::type( device
-                                              , image_read_settings<FormatTag>()
-                                              );
+    return typename get_scanline_reader<String, FormatTag>::type(
+        device, image_read_settings<FormatTag>());
 }
 
 template< typename FormatTag >
@@ -48,7 +44,7 @@ typename get_scanline_reader< std::wstring
                             , FormatTag
                             >::type
 make_scanline_reader( const std::wstring& file_name
-                    , const FormatTag&
+                    , FormatTag const&
                     )
 {
     const char* str = detail::convert_to_native_string( file_name );
@@ -75,7 +71,7 @@ typename get_scanline_reader< std::wstring
                             , FormatTag
                             >::type
 make_scanline_reader( const filesystem::path& path
-                    , const FormatTag&
+                    , FormatTag const&
                     )
 {
     return make_scanline_reader( path.wstring()
@@ -84,27 +80,22 @@ make_scanline_reader( const filesystem::path& path
 }
 #endif // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 
-template< typename Device
-        , typename FormatTag
-        >
+template <typename Device, typename FormatTag>
 inline
-typename get_scanline_reader< Device
-                            , FormatTag
-                            >::type
-make_scanline_reader( Device&          io_dev
-                    , const FormatTag&
-                    , typename enable_if< mpl::and_< detail::is_adaptable_input_device< FormatTag
-                                                                                      , Device
-                                                                                      >
-                                                   , is_format_tag< FormatTag >
-                                                   >
-                                        >::type* /* ptr */ = 0
-                    )
+auto make_scanline_reader(Device& io_dev, FormatTag const&,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_adaptable_input_device<FormatTag, Device>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+    -> typename get_scanline_reader<Device, FormatTag>::type
 {
-    return make_scanline_reader( io_dev, image_read_settings< FormatTag >() );
+    return make_scanline_reader(io_dev, image_read_settings<FormatTag>());
 }
 
-} // namespace gil
-} // namespace boost
+}} // namespace boost::gil
 
 #endif

--- a/include/boost/gil/io/make_writer.hpp
+++ b/include/boost/gil/io/make_writer.hpp
@@ -10,36 +10,29 @@
 
 #include <boost/gil/io/get_writer.hpp>
 
-#include <boost/utility/enable_if.hpp>
+#include <boost/mpl/and.hpp>
+
+#include <type_traits>
 
 namespace boost { namespace gil {
 
-template< typename String
-        , typename FormatTag
-        >
+template <typename String, typename FormatTag>
 inline
-typename get_writer< String
-                   , FormatTag
-                   >::type
-make_writer( const String&                        file_name
-           , const image_write_info< FormatTag >& info
-           , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
-                                          , is_format_tag< FormatTag >
-                                          >
-                               >::type* /* ptr */ = nullptr
-           )
+auto make_writer(String const& file_name, image_write_info<FormatTag> const& info,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_supported_path_spec<String>,
+            is_format_tag<FormatTag>
+        >::type::value>::type* /*dummy*/ = nullptr)
+    -> typename get_writer<String, FormatTag>::type
 {
-    typename get_write_device< String
-                    , FormatTag
-                    >::type device( detail::convert_to_native_string( file_name )
-                                  , typename detail::file_stream_device< FormatTag >::write_tag()
-                                  );
+    typename get_write_device<String, FormatTag>::type device(
+    detail::convert_to_native_string(file_name),
+    typename detail::file_stream_device<FormatTag>::write_tag());
 
-    return typename get_writer< String
-                              , FormatTag
-                              >::type( device
-                                     , info
-                                     );
+    return typename get_writer<String, FormatTag>::type(device, info);
 }
 
 template< typename FormatTag >
@@ -84,54 +77,39 @@ make_writer( const filesystem::path&              path
 }
 #endif // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 
-
-template< typename Device
-        , typename FormatTag
-        >
+template <typename Device, typename FormatTag>
 inline
-typename get_writer< Device
-                   , FormatTag
-                   >::type
-make_writer( Device&                              file
-           , const image_write_info< FormatTag >& info
-           , typename enable_if< mpl::and_< typename detail::is_adaptable_output_device< FormatTag, Device >::type
-                                          , is_format_tag< FormatTag >
-                                          >
-                               >::type* /* ptr */ = nullptr
-           )
+auto make_writer(Device& file, image_write_info<FormatTag> const& info,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            typename detail::is_adaptable_output_device<FormatTag, Device>::type,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+    -> typename get_writer<Device, FormatTag>::type
 {
-    typename get_write_device< Device
-                    , FormatTag
-                    >::type device( file );
-
-    return typename get_writer< Device
-                              , FormatTag
-                              >::type( device
-                                     , info
-                                     );
+    typename get_write_device<Device, FormatTag>::type device(file);
+    return typename get_writer<Device, FormatTag>::type(device, info);
 }
-
 
 // no image_write_info
 
-template< typename String
-        , typename FormatTag
-        >
+template <typename String, typename FormatTag>
 inline
-typename get_writer< String
-                   , FormatTag
-                   >::type
-make_writer( const String&    file_name
-           , const FormatTag&
-           , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
-                                          , is_format_tag< FormatTag >
-                                          >
-                               >::type* /* ptr */ = nullptr
-           )
+auto make_writer(String const& file_name, FormatTag const&,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_supported_path_spec<String>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+    -> typename get_writer<String, FormatTag>::type
 {
-    return make_writer( file_name
-                      , image_write_info< FormatTag >()
-                      );
+    return make_writer(file_name, image_write_info<FormatTag>());
 }
 
 template< typename FormatTag >
@@ -164,28 +142,22 @@ make_writer( const filesystem::path& path
 }
 #endif // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 
-
-template< typename Device
-        , typename FormatTag
-        >
+template <typename Device, typename FormatTag>
 inline
-typename get_writer< Device
-                   , FormatTag
-                   >::type
-make_writer( Device&          file
-           , const FormatTag&
-           , typename enable_if< mpl::and_< typename detail::is_adaptable_output_device< FormatTag, Device >::type
-                                          , is_format_tag< FormatTag >
-                                          >
-                               >::type* /* ptr */ = nullptr
-           )
+auto make_writer(Device& file, FormatTag const&,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            typename detail::is_adaptable_output_device<FormatTag, Device>::type,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+    -> typename get_writer<Device, FormatTag>::type
 {
-    return make_writer( file
-                      , image_write_info< FormatTag >()
-                      );
+    return make_writer(file, image_write_info<FormatTag>());
 }
 
-} // namespace gil
-} // namespace boost
+}} // namespace boost::gil
 
 #endif

--- a/include/boost/gil/io/read_image.hpp
+++ b/include/boost/gil/io/read_image.hpp
@@ -18,9 +18,10 @@
 
 #include <boost/mpl/and.hpp>
 #include <boost/type_traits/is_base_and_derived.hpp>
-#include <boost/utility/enable_if.hpp>
 
-namespace boost{ namespace gil {
+#include <type_traits>
+
+namespace boost { namespace gil {
 
 /// \ingroup IO
 
@@ -28,26 +29,25 @@ namespace boost{ namespace gil {
 /// \param reader    An image reader.
 /// \param img       The image in which the data is read into. Must satisfy is_read_supported metafunction.
 /// \throw std::ios_base::failure
-template < typename Reader
-         , typename Image
-         >
+template <typename Reader, typename Image>
 inline
-void read_image( Reader           reader
-               , Image&           img
-               , typename enable_if< mpl::and_< detail::is_reader< Reader >
-                                              , is_format_tag< typename Reader::format_tag_t >
-                                              , is_read_supported< typename get_pixel_type< typename Image::view_t >::type
-                                                                 , typename Reader::format_tag_t
-                                                                 >
-                                              >
-                                   >::type* /* ptr */ = nullptr
-               )
+void read_image(Reader reader, Image& img,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_reader<Reader>,
+            is_format_tag<typename Reader::format_tag_t>,
+            is_read_supported
+            <
+                typename get_pixel_type<typename Image::view_t>::type,
+                typename Reader::format_tag_t
+            >
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
 {
-    reader.init_image( img
-                     , reader._settings
-                     );
-
-    reader.apply( view( img ));
+    reader.init_image(img, reader._settings);
+    reader.apply(view(img));
 }
 
 /// \brief Reads an image without conversion. Image memory is allocated.
@@ -55,40 +55,31 @@ void read_image( Reader           reader
 /// \param img       The image in which the data is read into. Must satisfy is_read_supported metafunction.
 /// \param settings  Specifies read settings depending on the image format.
 /// \throw std::ios_base::failure
-template < typename Device
-         , typename Image
-         , typename FormatTag
-         >
+template <typename Device, typename Image, typename FormatTag>
 inline
-void read_image( Device&                                 file
-               , Image&                                  img
-               , const image_read_settings< FormatTag >& settings
-               , typename enable_if< mpl::and_< detail::is_read_device< FormatTag
-                                                                      , Device
-                                                                      >
-                                              , is_format_tag< FormatTag >
-                                              , is_read_supported< typename get_pixel_type< typename Image::view_t >::type
-                                                                 , FormatTag
-                                                                 >
-                                              >
-                                   >::type* /* ptr */ = 0
-               )
-{
-    using reader_t = typename get_reader
+void read_image(
+    Device& file,
+    Image& img,
+    image_read_settings<FormatTag> const& settings,
+    typename std::enable_if
+    <
+        mpl::and_
         <
-            Device,
-            FormatTag,
-            detail::read_and_no_convert
-        >::type;
+            detail::is_read_device<FormatTag, Device>,
+            is_format_tag<FormatTag>,
+            is_read_supported
+            <
+                typename get_pixel_type<typename Image::view_t>::type,
+                FormatTag
+            >
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+{
+    using reader_t =
+        typename get_reader<Device, FormatTag, detail::read_and_no_convert>::type;
 
-    reader_t reader = make_reader( file
-                                 , settings
-                                 , detail::read_and_no_convert()
-                                 );
-
-    read_image( reader
-              , img
-              );
+    reader_t reader = make_reader(file, settings, detail::read_and_no_convert());
+    read_image(reader, img);
 }
 
 /// \brief Reads an image without conversion. Image memory is allocated.
@@ -96,40 +87,28 @@ void read_image( Device&                                 file
 /// \param img       The image in which the data is read into. Must satisfy is_read_supported metafunction.
 /// \param tag       Defines the image format. Must satisfy is_format_tag metafunction.
 /// \throw std::ios_base::failure
-template < typename Device
-         , typename Image
-         , typename FormatTag
-         >
+template <typename Device, typename Image, typename FormatTag>
 inline
-void read_image( Device&          file
-               , Image&           img
-               , const FormatTag& tag
-               , typename enable_if< mpl::and_< detail::is_read_device< FormatTag
-                                                                      , Device
-                                                                      >
-                                              , is_format_tag< FormatTag >
-                                              , is_read_supported< typename get_pixel_type< typename Image::view_t >::type
-                                                                 , FormatTag
-                                                                 >
-                                              >
-                                   >::type* /* ptr */ = nullptr
-               )
-{
-    using reader_t = typename get_reader
+void read_image(Device& file, Image& img, FormatTag const& tag,
+    typename std::enable_if
+    <
+        mpl::and_
         <
-            Device,
-            FormatTag,
-            detail::read_and_no_convert
-        >::type;
+            detail::is_read_device<FormatTag, Device>,
+            is_format_tag<FormatTag>,
+            is_read_supported
+            <
+                typename get_pixel_type<typename Image::view_t>::type,
+                FormatTag
+            >
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+{
+    using reader_t =
+        typename get_reader<Device, FormatTag, detail::read_and_no_convert>::type;
 
-    reader_t reader = make_reader( file
-                                 , tag
-                                 , detail::read_and_no_convert()
-                                 );
-
-    read_image( reader
-              , img
-              );
+    reader_t reader = make_reader(file, tag, detail::read_and_no_convert());
+    read_image(reader, img);
 }
 
 /// \brief Reads an image without conversion. Image memory is allocated.
@@ -137,38 +116,31 @@ void read_image( Device&          file
 /// \param img       The image in which the data is read into. Must satisfy is_read_supported metafunction.
 /// \param settings  Specifies read settings depending on the image format.
 /// \throw std::ios_base::failure
-template < typename String
-         , typename Image
-         , typename FormatTag
-         >
+template <typename String, typename Image, typename FormatTag>
 inline
-void read_image( const String&                           file_name
-               , Image&                                  img
-               , const image_read_settings< FormatTag >& settings
-               , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
-                                              , is_format_tag< FormatTag >
-                                              , is_read_supported< typename get_pixel_type< typename Image::view_t >::type
-                                                                 , FormatTag
-                                                                 >
-                                              >
-                                   >::type* /* ptr */ = nullptr
-               )
-{
-    using reader_t = typename get_reader
+void read_image(
+    String const& file_name,
+    Image& img,
+    image_read_settings<FormatTag> const& settings,
+    typename std::enable_if
+    <
+        mpl::and_
         <
-            String,
-            FormatTag,
-            detail::read_and_no_convert
-        >::type;
+            detail::is_supported_path_spec<String>,
+            is_format_tag<FormatTag>,
+            is_read_supported
+            <
+                typename get_pixel_type<typename Image::view_t>::type,
+                FormatTag
+            >
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+{
+    using reader_t =
+        typename get_reader<String, FormatTag, detail::read_and_no_convert>::type;
 
-    reader_t reader = make_reader( file_name
-                                 , settings
-                                 , detail::read_and_no_convert()
-                                 );
-
-    read_image( reader
-              , img
-              );
+    reader_t reader = make_reader(file_name, settings, detail::read_and_no_convert());
+    read_image(reader, img);
 }
 
 /// \brief Reads an image without conversion. Image memory is allocated.
@@ -176,55 +148,43 @@ void read_image( const String&                           file_name
 /// \param img       The image in which the data is read into. Must satisfy is_read_supported metafunction.
 /// \param tag       Defines the image format. Must satisfy is_format_tag metafunction.
 /// \throw std::ios_base::failure
-template < typename String
-         , typename Image
-         , typename FormatTag
-         >
+template <typename String, typename Image, typename FormatTag>
 inline
-void read_image( const String&    file_name
-               , Image&           img
-               , const FormatTag& tag
-               , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
-                                              , is_format_tag< FormatTag >
-                                              , is_read_supported< typename get_pixel_type< typename Image::view_t >::type
-                                                                 , FormatTag
-                                                                 >
-                                              >
-                                   >::type* /* ptr */ = nullptr
-               )
-{
-    using reader_t = typename get_reader
+void read_image(String const& file_name, Image& img, FormatTag const& tag,
+    typename std::enable_if
+    <
+        mpl::and_<detail::is_supported_path_spec<String>,
+        is_format_tag<FormatTag>,
+        is_read_supported
         <
-            String,
-            FormatTag,
-            detail::read_and_no_convert
-        >::type;
+            typename get_pixel_type<typename Image::view_t>::type,
+            FormatTag
+        >
+    >::type::value
+>::type* /*dummy*/ = nullptr)
+{
+    using reader_t =
+        typename get_reader<String, FormatTag, detail::read_and_no_convert>::type;
 
-    reader_t reader = make_reader( file_name
-                                 , tag
-                                 , detail::read_and_no_convert()
-                                 );
-
-    read_image( reader
-              , img
-              );
+    reader_t reader = make_reader(file_name, tag, detail::read_and_no_convert());
+    read_image(reader, img);
 }
 
 ///
 
-template < typename Reader
-         , typename Images
-         >
+template <typename Reader, typename Images>
 inline
-void read_image( Reader&              reader
-               , any_image< Images >& images
-               , typename enable_if< mpl::and_< detail::is_dynamic_image_reader< Reader >
-                                              , is_format_tag< typename Reader::format_tag_t >
-                                              >
-                                   >::type* /* ptr */ = nullptr
-               )
+void read_image(Reader& reader, any_image<Images>& images,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_dynamic_image_reader<Reader>,
+            is_format_tag<typename Reader::format_tag_t>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
 {
-    reader.apply( images );
+    reader.apply(images);
 }
 
 /// \brief Reads an image without conversion. Image memory is allocated.
@@ -232,35 +192,25 @@ void read_image( Reader&              reader
 /// \param images    Dynamic image ( mpl::vector ). See boost::gil::dynamic_image extension.
 /// \param settings  Specifies read settings depending on the image format.
 /// \throw std::ios_base::failure
-template < typename Device
-         , typename Images
-         , typename FormatTag
-         >
+template <typename Device, typename Images, typename FormatTag>
 inline
-void read_image( Device&                                 file
-               , any_image< Images >&                    images
-               , const image_read_settings< FormatTag >& settings
-               , typename enable_if< mpl::and_< detail::is_read_device< FormatTag
-                                                                      , Device
-                                                                      >
-                                              , is_format_tag< FormatTag >
-                                              >
-                                   >::type* /* ptr */ = 0
-               )
-{
-    using reader_t = typename get_dynamic_image_reader
+void read_image(
+    Device& file,
+    any_image<Images>& images,
+    image_read_settings<FormatTag> const& settings,
+    typename std::enable_if
+    <
+        mpl::and_
         <
-            Device,
-            FormatTag
-        >::type;
+            detail::is_read_device<FormatTag, Device>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+{
+    using reader_t = typename get_dynamic_image_reader<Device, FormatTag>::type;
 
-    reader_t reader = make_dynamic_image_reader( file
-                                               , settings
-                                               );
-
-    read_image( reader
-              , images
-              );
+    reader_t reader = make_dynamic_image_reader(file, settings);
+    read_image(reader, images);
 }
 
 /// \brief Reads an image without conversion. Image memory is allocated.
@@ -268,35 +218,22 @@ void read_image( Device&                                 file
 /// \param images    Dynamic image ( mpl::vector ). See boost::gil::dynamic_image extension.
 /// \param tag       Defines the image format. Must satisfy is_format_tag metafunction.
 /// \throw std::ios_base::failure
-template < typename Device
-         , typename Images
-         , typename FormatTag
-         >
+template <typename Device, typename Images, typename FormatTag>
 inline
-void read_image( Device&              file
-               , any_image< Images >& images
-               , const FormatTag&     tag
-               , typename enable_if< mpl::and_< detail::is_read_device< FormatTag
-                                                                      , Device
-                                                                      >
-                                              , is_format_tag< FormatTag >
-                                              >
-                                   >::type* /* ptr */ = 0
-               )
-{
-    using reader_t = typename get_dynamic_image_reader
+void read_image(Device& file, any_image<Images>& images, FormatTag const& tag,
+    typename std::enable_if
+    <
+        mpl::and_
         <
-            Device,
-            FormatTag
-        >::type;
+            detail::is_read_device<FormatTag, Device>,
+            is_format_tag<FormatTag>
+        >::type::value
+        >::type* /*dummy*/ = nullptr)
+{
+    using reader_t = typename get_dynamic_image_reader<Device, FormatTag>::type;
 
-    reader_t reader = make_dynamic_image_reader( file
-                                               , tag
-                                               );
-
-    read_image( reader
-              , images
-              );
+    reader_t reader = make_dynamic_image_reader(file, tag);
+    read_image(reader, images);
 }
 
 /// \brief Reads an image without conversion. Image memory is allocated.
@@ -304,33 +241,25 @@ void read_image( Device&              file
 /// \param images    Dynamic image ( mpl::vector ). See boost::gil::dynamic_image extension.
 /// \param settings  Specifies read settings depending on the image format.
 /// \throw std::ios_base::failure
-template < typename String
-         , typename Images
-         , typename FormatTag
-         >
+template <typename String, typename Images, typename FormatTag>
 inline
-void read_image( const String&                           file_name
-               , any_image< Images >&                    images
-               , const image_read_settings< FormatTag >& settings
-               , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
-                                              , is_format_tag< FormatTag >
-                                              >
-                                   >::type* /* ptr */ = 0
-               )
-{
-    using reader_t = typename get_dynamic_image_reader
+void read_image(
+    String const& file_name,
+    any_image<Images>& images,
+    image_read_settings<FormatTag> const& settings,
+    typename std::enable_if
+    <
+        mpl::and_
         <
-            String,
-            FormatTag
-        >::type;
+            detail::is_supported_path_spec<String>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+{
+    using reader_t = typename get_dynamic_image_reader<String, FormatTag>::type;
 
-    reader_t reader = make_dynamic_image_reader( file_name
-                                               , settings
-                                               );
-
-    read_image( reader
-              , images
-              );
+    reader_t reader = make_dynamic_image_reader(file_name, settings);
+    read_image(reader, images);
 }
 
 /// \brief Reads an image without conversion. Image memory is allocated.
@@ -338,34 +267,24 @@ void read_image( const String&                           file_name
 /// \param images    Dynamic image ( mpl::vector ). See boost::gil::dynamic_image extension.
 /// \param tag       Defines the image format. Must satisfy is_format_tag metafunction.
 /// \throw std::ios_base::failure
-template < typename String
-         , typename Images
-         , typename FormatTag
-         >
+template <typename String, typename Images, typename FormatTag>
 inline
-void read_image( const String&        file_name
-               , any_image< Images >& images
-               , const FormatTag&     tag
-               , typename enable_if< mpl::and_< detail::is_supported_path_spec< String >
-                                              , is_format_tag< FormatTag >
-                                              >
-                                   >::type* /* ptr */ = nullptr
-               )
-{
-    using reader_t = typename get_dynamic_image_reader
+void read_image(String const& file_name, any_image<Images>& images, FormatTag const& tag,
+    typename std::enable_if
+    <
+        mpl::and_
         <
-            String,
-            FormatTag
-        >::type;
+            detail::is_supported_path_spec<String>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+{
+    using reader_t = typename get_dynamic_image_reader<String, FormatTag>::type;
 
-    reader_t reader = make_dynamic_image_reader( file_name, tag );
-
-    read_image( reader
-              , images
-              );
+    reader_t reader = make_dynamic_image_reader(file_name, tag);
+    read_image(reader, images);
 }
 
-} // namespace gil
-} // namespace boost
+}}  // namespace boost::gil
 
 #endif

--- a/include/boost/gil/io/read_image_info.hpp
+++ b/include/boost/gil/io/read_image_info.hpp
@@ -15,7 +15,8 @@
 
 #include <boost/mpl/and.hpp>
 #include <boost/type_traits/is_base_and_derived.hpp>
-#include <boost/utility/enable_if.hpp>
+
+#include <type_traits>
 
 namespace boost{ namespace gil {
 
@@ -26,24 +27,20 @@ namespace boost{ namespace gil {
 /// \param settings  Specifies read settings depending on the image format.
 /// \return image_read_info object dependent on the image format.
 /// \throw std::ios_base::failure
-template< typename Device
-        , typename FormatTag
-        >
+template <typename Device, typename FormatTag>
 inline
-typename get_reader_backend< Device
-                           , FormatTag
-                           >::type
-read_image_info( Device&                                 file
-               , const image_read_settings< FormatTag >& settings
-               , typename enable_if< mpl::and_< detail::is_adaptable_input_device< FormatTag
-                                                                                 , Device
-                                                                                 >
-                                              , is_format_tag< FormatTag >
-                                              >
-                                   >::type* /* ptr */ = nullptr
-               )
+auto read_image_info(Device& file, image_read_settings<FormatTag> const& settings,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_adaptable_input_device<FormatTag, Device>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+    -> typename get_reader_backend<Device, FormatTag>::type
 {
-    return make_reader_backend( file, settings );
+    return make_reader_backend(file, settings);
 }
 
 /// \brief Returns the image format backend. Backend is format specific.
@@ -51,26 +48,20 @@ read_image_info( Device&                                 file
 /// \param tag  Defines the image format. Must satisfy is_format_tag metafunction.
 /// \return image_read_info object dependent on the image format.
 /// \throw std::ios_base::failure
-template< typename Device
-        , typename FormatTag
-        >
+template <typename Device, typename FormatTag>
 inline
-typename get_reader_backend< Device
-                           , FormatTag
-                           >::type
-read_image_info( Device&          file
-               , const FormatTag&
-               , typename enable_if< mpl::and_< detail::is_adaptable_input_device< FormatTag
-                                                                                 , Device
-                                                                                 >
-                                              , is_format_tag< FormatTag >
-                                              >
-                                   >::type* /* ptr */ = nullptr
-               )
+auto read_image_info(Device& file, FormatTag const&,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_adaptable_input_device<FormatTag, Device>,
+            is_format_tag<FormatTag>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+    -> typename get_reader_backend<Device, FormatTag>::type
 {
-    return read_image_info( file
-                          , image_read_settings< FormatTag >()
-                          );
+    return read_image_info(file, image_read_settings<FormatTag>());
 }
 
 /// \brief Returns the image format backend. Backend is format specific.
@@ -78,22 +69,21 @@ read_image_info( Device&          file
 /// \param settings  Specifies read settings depending on the image format.
 /// \return image_read_info object dependent on the image format.
 /// \throw std::ios_base::failure
-template< typename String
-        , typename FormatTag
-        >
+template <typename String, typename FormatTag>
 inline
-typename get_reader_backend< String
-                           , FormatTag
-                           >::type
-read_image_info( const String&                           file_name
-               , const image_read_settings< FormatTag >& settings
-               , typename enable_if< mpl::and_< is_format_tag< FormatTag >
-                                              , detail::is_supported_path_spec< String >
-                                              >
-                                   >::type* /* ptr */ = nullptr
-               )
+auto read_image_info(
+    String const& file_name, image_read_settings<FormatTag> const& settings,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            is_format_tag<FormatTag>,
+            detail::is_supported_path_spec<String>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+    -> typename get_reader_backend<String, FormatTag>::type
 {
-    return make_reader_backend( file_name, settings );
+    return make_reader_backend(file_name, settings);
 }
 
 /// \brief Returns the image format backend. Backend is format specific.
@@ -101,27 +91,22 @@ read_image_info( const String&                           file_name
 /// \param tag       Defines the image format. Must satisfy is_format_tag metafunction.
 /// \return image_read_info object dependent on the image format.
 /// \throw std::ios_base::failure
-template< typename String
-        , typename FormatTag
-        >
+template <typename String, typename FormatTag>
 inline
-typename get_reader_backend< String
-                           , FormatTag
-                           >::type
-read_image_info( const String&    file_name
-               , const FormatTag&
-               , typename enable_if< mpl::and_< is_format_tag< FormatTag >
-                                              , detail::is_supported_path_spec< String >
-                                              >
-                                   >::type* /* ptr */ = nullptr
-               )
+auto read_image_info(String const& file_name, FormatTag const&,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            is_format_tag<FormatTag>,
+            detail::is_supported_path_spec<String>
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+    -> typename get_reader_backend<String, FormatTag>::type
 {
-    return read_image_info( file_name
-                          , image_read_settings< FormatTag >()
-                          );
+    return read_image_info(file_name, image_read_settings<FormatTag>());
 }
 
-} // namespace gil
-} // namespace boost
+}} // namespace boost::gil
 
 #endif

--- a/include/boost/gil/io/read_view.hpp
+++ b/include/boost/gil/io/read_view.hpp
@@ -14,11 +14,12 @@
 #include <boost/gil/io/get_reader.hpp>
 #include <boost/gil/io/path_spec.hpp>
 
-#include <boost/type_traits/is_base_and_derived.hpp>
 #include <boost/mpl/and.hpp>
-#include <boost/utility/enable_if.hpp>
+#include <boost/type_traits/is_base_and_derived.hpp>
 
-namespace boost{ namespace gil {
+#include <type_traits>
+
+namespace boost { namespace gil {
 
 /// \ingroup IO
 
@@ -27,28 +28,26 @@ namespace boost{ namespace gil {
 /// \param view      The image view in which the data is read into.
 /// \param settings  Specifies read settings depending on the image format.
 /// \throw std::ios_base::failure
-template < typename Reader
-         , typename View
-         >
+template <typename Reader, typename View>
 inline
-void read_view( Reader                                  reader
-              , const View&                             view
-              , typename enable_if< typename mpl::and_< detail::is_reader< Reader >
-                                                      , typename is_format_tag< typename Reader::format_tag_t >::type
-                                                      , typename is_read_supported< typename get_pixel_type< View >::type
-                                                                                  , typename Reader::format_tag_t
-                                                                                  >::type
-                                                       >::type
-                                  >::type* /* ptr */ = nullptr
-              )
+void read_view(Reader reader, View const& view,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            detail::is_reader<Reader>,
+            typename is_format_tag<typename Reader::format_tag_t>::type,
+            typename is_read_supported
+            <
+                typename get_pixel_type<View>::type,
+                typename Reader::format_tag_t
+            >::type
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
 {
-    reader.check_image_size( view.dimensions() );
-
-    reader.init_view( view
-                    , reader._settings
-                    );
-
-    reader.apply( view );
+    reader.check_image_size(view.dimensions());
+    reader.init_view(view, reader._settings);
+    reader.apply(view);
 }
 
 /// \brief Reads an image view without conversion. No memory is allocated.
@@ -56,40 +55,31 @@ void read_view( Reader                                  reader
 /// \param view      The image view in which the data is read into.
 /// \param settings  Specifies read settings depending on the image format.
 /// \throw std::ios_base::failure
-template < typename Device
-         , typename View
-         , typename FormatTag
-         >
+template <typename Device, typename View, typename FormatTag>
 inline
-void read_view( Device&                                 file
-              , const View&                             view
-              , const image_read_settings< FormatTag >& settings
-              , typename enable_if< typename mpl::and_< detail::is_read_device< FormatTag
-                                                                              , Device
-                                                                              >
-                                                      , typename is_format_tag< FormatTag >::type
-                                                      , typename is_read_supported< typename get_pixel_type< View >::type
-                                                                                  , FormatTag
-                                                                                  >::type
-                                                      >::type
-                                  >::type* /* ptr */ = 0
-              )
-{
-    using reader_t = typename get_reader
+void read_view(
+    Device& file,
+    View const& view,
+    image_read_settings<FormatTag> const& settings,
+    typename std::enable_if
+    <
+        mpl::and_
         <
-            Device,
-            FormatTag,
-            detail::read_and_no_convert
-        >::type;
+            detail::is_read_device<FormatTag, Device>,
+            typename is_format_tag<FormatTag>::type,
+            typename is_read_supported
+            <
+                typename get_pixel_type<View>::type,
+                FormatTag
+            >::type
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+{
+    using reader_t =
+        typename get_reader<Device, FormatTag, detail::read_and_no_convert>::type;
 
-    reader_t reader = make_reader( file
-                                 , settings
-                                 , detail::read_and_no_convert()
-                                 );
-
-    read_view( reader
-             , view
-             );
+    reader_t reader = make_reader(file, settings, detail::read_and_no_convert());
+    read_view(reader, view);
 }
 
 /// \brief Reads an image view without conversion. No memory is allocated.
@@ -97,40 +87,27 @@ void read_view( Device&                                 file
 /// \param view The image view in which the data is read into.
 /// \param tag  Defines the image format. Must satisfy is_format_tag metafunction.
 /// \throw std::ios_base::failure
-template< typename Device
-        , typename View
-        , typename FormatTag
-        >
+template <typename Device, typename View, typename FormatTag>
 inline
-void read_view( Device&          file
-              , const View&      view
-              , const FormatTag& tag
-              , typename enable_if< typename mpl::and_< typename is_format_tag< FormatTag >::type
-                                                      , detail::is_read_device< FormatTag
-                                                                              , Device
-                                                                              >
-                                                      , typename is_read_supported< typename get_pixel_type< View >::type
-                                                                                  , FormatTag
-                                                                                  >::type
-                                                      >::type
-                                  >::type* /* ptr */ = nullptr
-              )
-{
-    using reader_t = typename get_reader
+void read_view(Device& file, View const& view, FormatTag const& tag,
+    typename std::enable_if
+    <
+        mpl::and_
         <
-            Device,
-            FormatTag,
-            detail::read_and_no_convert
-        >::type;
+            typename is_format_tag<FormatTag>::type,
+            detail::is_read_device<FormatTag, Device>,
+            typename is_read_supported
+            <
+                typename get_pixel_type<View>::type,
+                FormatTag
+            >::type
+        >::type::value>::type* /*dummy*/ = nullptr)
+{
+    using reader_t =
+        typename get_reader<Device, FormatTag, detail::read_and_no_convert>::type;
 
-    reader_t reader = make_reader( file
-                                 , tag
-                                 , detail::read_and_no_convert()
-                                 );
-
-    read_view( reader
-             , view
-             );
+    reader_t reader = make_reader(file, tag, detail::read_and_no_convert());
+    read_view(reader, view);
 }
 
 /// \brief Reads an image view without conversion. No memory is allocated.
@@ -138,38 +115,31 @@ void read_view( Device&          file
 /// \param view      The image view in which the data is read into.
 /// \param settings  Specifies read settings depending on the image format.
 /// \throw std::ios_base::failure
-template < typename String
-         , typename View
-         , typename FormatTag
-         >
+template <typename String, typename View, typename FormatTag>
 inline
-void read_view( const String&                           file_name
-              , const View&                             view
-              , const image_read_settings< FormatTag >& settings
-              , typename enable_if< typename mpl::and_< typename detail::is_supported_path_spec< String >::type
-                                                      , typename is_format_tag< FormatTag >::type
-                                                      , typename is_read_supported< typename get_pixel_type< View >::type
-                                                                                  , FormatTag
-                                                                                  >::type
-                                                      >::type
-                                  >::type* /* ptr */ = 0
-              )
-{
-    using reader_t = typename get_reader
+void read_view(
+    String const& file_name,
+    View const& view,
+    image_read_settings<FormatTag> const& settings,
+    typename std::enable_if
+    <
+        mpl::and_
         <
-            String,
-            FormatTag,
-            detail::read_and_no_convert
-        >::type;
+            typename detail::is_supported_path_spec<String>::type,
+            typename is_format_tag<FormatTag>::type,
+            typename is_read_supported
+            <
+                typename get_pixel_type<View>::type,
+                FormatTag
+            >::type
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+{
+    using reader_t =
+        typename get_reader<String, FormatTag, detail::read_and_no_convert>::type;
 
-    reader_t reader = make_reader( file_name
-                                 , settings
-                                 , detail::read_and_no_convert()
-                                 );
-
-    read_view( reader
-             , view
-             );
+    reader_t reader = make_reader(file_name, settings, detail::read_and_no_convert());
+    read_view(reader, view);
 }
 
 /// \brief Reads an image view without conversion. No memory is allocated.
@@ -177,41 +147,30 @@ void read_view( const String&                           file_name
 /// \param view      The image view in which the data is read into.
 /// \param tag       Defines the image format. Must satisfy is_format_tag metafunction.
 /// \throw std::ios_base::failure
-template < typename String
-         , typename View
-         , typename FormatTag
-         >
+template <typename String, typename View, typename FormatTag>
 inline
-void read_view( const String&    file_name
-              , const View&      view
-              , const FormatTag& tag
-              , typename enable_if< typename mpl::and_< typename detail::is_supported_path_spec< String >::type
-                                                      , typename is_format_tag< FormatTag >::type
-                                                      , typename is_read_supported< typename get_pixel_type< View >::type
-                                                                                  , FormatTag
-                                                                                  >::type
-                                                      >::type
-                                  >::type* /* ptr */ = nullptr
-              )
-{
-    using reader_t = typename get_reader
+void read_view(String const& file_name, View const& view, FormatTag const& tag,
+    typename std::enable_if
+    <
+        mpl::and_
         <
-            String,
-            FormatTag,
-            detail::read_and_no_convert
-        >::type;
+            typename detail::is_supported_path_spec<String>::type,
+            typename is_format_tag<FormatTag>::type,
+            typename is_read_supported
+            <
+                typename get_pixel_type<View>::type,
+                FormatTag
+            >::type
+        >::type::value
+    >::type* /*dummy*/ = nullptr)
+{
+    using reader_t =
+        typename get_reader<String, FormatTag, detail::read_and_no_convert>::type;
 
-    reader_t reader = make_reader( file_name
-                                 , tag
-                                 , detail::read_and_no_convert()
-                                 );
-
-    read_view( reader
-             , view
-             );
+    reader_t reader = make_reader(file_name, tag, detail::read_and_no_convert());
+    read_view(reader, view);
 }
 
-} // namespace gil
-} // namespace boost
+}}  // namespace boost::gil
 
 #endif

--- a/include/boost/gil/io/write_view.hpp
+++ b/include/boost/gil/io/write_view.hpp
@@ -16,301 +16,217 @@
 
 #include <boost/mpl/and.hpp>
 #include <boost/type_traits/is_base_and_derived.hpp>
-#include <boost/utility/enable_if.hpp>
 
-////////////////////////////////////////////////////////////////////////////////////////
-/// \file
-/// \brief
-/// \author Christian Henning, Andreas Pokorny, Lubomir Bourdev \n
-///
-/// \date   2007-2012 \n
-///
-////////////////////////////////////////////////////////////////////////////////////////
+#include <type_traits>
 
 namespace boost{ namespace gil {
 
 /// \ingroup IO
-
-template< typename Writer
-        , typename View
-        >
+template<typename Writer, typename View>
 inline
-void write_view( Writer&     writer
-               , const View& view
-               , typename enable_if< typename mpl::and_< typename detail::is_writer< Writer >::type
-                                                       , typename is_format_tag< typename Writer::format_tag_t >::type
-                                                       , typename is_write_supported< typename get_pixel_type< View >::type
-                                                                                    , typename Writer::format_tag_t
-                                                                                    >::type
-                                                       >::type
-                                   >::type* /* ptr */ = nullptr
-               )
+void write_view(Writer& writer, View const& view,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            typename detail::is_writer<Writer>::type,
+            typename is_format_tag<typename Writer::format_tag_t>::type,
+            typename is_write_supported
+            <
+                typename get_pixel_type<View>::type,
+                typename Writer::format_tag_t
+            >::type
+        >::type::value
+    >::type* /* ptr */ = nullptr)
 {
-    writer.apply( view );
-}
-
-template< typename Device
-        , typename View
-        , typename FormatTag
-        >
-inline
-void write_view( Device&          device
-               , const View&      view
-               , const FormatTag& tag
-               , typename enable_if< typename mpl::and_< typename detail::is_write_device< FormatTag
-                                                                                         , Device
-                                                                                         >::type
-                                                       , typename is_format_tag< FormatTag >::type
-                                                       , typename is_write_supported< typename get_pixel_type< View >::type
-                                                                                    , FormatTag
-                                                                                    >::type
-                                                       >::type
-                                   >::type* /* ptr */ = nullptr
-               )
-{
-    using writer_t = typename get_writer<Device, FormatTag>::type;
-
-    writer_t writer = make_writer( device
-                                 , tag
-                                 );
-
-    write_view( writer
-              , view
-              );
-}
-
-template< typename String
-        , typename View
-        , typename FormatTag
-        >
-inline
-void write_view( const String&    file_name
-               , const View&      view
-               , const FormatTag& tag
-               , typename enable_if< typename mpl::and_< typename detail::is_supported_path_spec< String >::type
-                                                       , typename is_format_tag< FormatTag >::type
-                                                       , typename is_write_supported< typename get_pixel_type< View >::type
-                                                                                    , FormatTag
-                                                                                    >::type
-                                                       >::type
-                                   >::type* /* ptr */ = nullptr
-               )
-{
-    using writer_t = typename get_writer<String, FormatTag>::type;
-
-    writer_t writer = make_writer( file_name
-                                 , tag
-                                 );
-
-    write_view( writer
-              , view
-              );
+    writer.apply(view);
 }
 
 /// \ingroup IO
-template< typename Device
-        , typename View
-        , typename FormatTag
-        , typename Log
-        >
+template<typename Device, typename View, typename FormatTag>
 inline
-void write_view( Device&                                 device
-               , const View&                             view
-               , const image_write_info<FormatTag, Log>& info
-               , typename enable_if< typename mpl::and_< typename detail::is_write_device< FormatTag
-                                                                                         , Device
-                                                                                         >::type
-                                                       , typename is_format_tag< FormatTag >::type
-                                                       , typename is_write_supported< typename get_pixel_type< View >::type
-                                                                                    , FormatTag
-                                                                                    >::type
-                                                       >::type
-                                   >::type* /* ptr */ = nullptr
-               )
+void write_view(Device& device, View const& view, FormatTag const& tag,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            typename detail::is_write_device<FormatTag, Device>::type,
+            typename is_format_tag<FormatTag>::type,
+            typename is_write_supported
+            <
+                typename get_pixel_type<View>::type,
+                FormatTag
+            >::type
+        >::type::value
+    >::type* /* ptr */ = nullptr)
 {
     using writer_t = typename get_writer<Device, FormatTag>::type;
-
-    writer_t writer = make_writer( device
-                                 , info
-                                 );
-
-    write_view( writer
-              , view
-              );
+    writer_t writer = make_writer(device, tag);
+    write_view(writer, view);
 }
 
-template< typename String
-        , typename View
-        , typename FormatTag
-        , typename Log
-        >
+/// \ingroup IO
+template<typename String, typename View, typename FormatTag>
 inline
-void write_view( const String&                             file_name
-               , const View&                               view
-               , const image_write_info< FormatTag, Log >& info
-               , typename enable_if< typename mpl::and_< typename detail::is_supported_path_spec< String >::type
-                                                       , typename is_format_tag< FormatTag >::type
-                                                       , typename is_write_supported< typename get_pixel_type< View >::type
-                                                                                    , FormatTag
-                                                                                    >::type
-                                                       >::type
-                                   >::type* /* ptr */ = nullptr
-               )
+void write_view(String const& file_name, View const& view, FormatTag const& tag,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            typename detail::is_supported_path_spec<String>::type,
+            typename is_format_tag<FormatTag>::type,
+            typename is_write_supported
+            <
+                typename get_pixel_type<View>::type,
+                FormatTag
+            >::type
+        >::type::value
+    >::type* /* ptr */ = nullptr)
 {
     using writer_t = typename get_writer<String, FormatTag>::type;
-
-    writer_t writer = make_writer( file_name
-                                 , info
-                                 );
-
-    write_view( writer
-              , view
-              );
+    writer_t writer = make_writer(file_name, tag);
+    write_view(writer, view);
 }
 
+/// \ingroup IO
+template<typename Device, typename View, typename FormatTag, typename Log>
+inline
+void write_view(
+    Device& device, View const& view, image_write_info<FormatTag, Log> const& info,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            typename detail::is_write_device<FormatTag, Device>::type,
+            typename is_format_tag<FormatTag>::type,
+            typename is_write_supported
+            <
+                typename get_pixel_type<View>::type,
+                FormatTag
+            >::type
+        >::type::value
+    >::type* /* ptr */ = nullptr)
+{
+    using writer_t = typename get_writer<Device, FormatTag>::type;
+    writer_t writer = make_writer(device, info);
+    write_view(writer, view);
+}
+
+/// \ingroup IO
+template<typename String, typename View, typename FormatTag, typename Log>
+inline
+void write_view(
+    String const& file_name, View const& view, image_write_info<FormatTag, Log> const& info,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            typename detail::is_supported_path_spec<String>::type,
+            typename is_format_tag<FormatTag>::type,
+            typename is_write_supported
+            <
+                typename get_pixel_type<View>::type,
+                FormatTag
+            >::type
+        >::type::value
+    >::type* /* ptr */ = nullptr)
+{
+    using writer_t = typename get_writer<String, FormatTag>::type;
+    writer_t writer = make_writer(file_name, info);
+    write_view(writer, view);
+}
 
 ////////////////////////////////////// dynamic_image
 
 // without image_write_info
-template< typename Writer
-        , typename Views
-        >
+template <typename Writer, typename Views>
 inline
-void write_view( Writer&                        writer
-               , const any_image_view< Views >& view
-               , typename enable_if< typename mpl::and_< typename detail::is_dynamic_image_writer< Writer >::type
-                                                       , typename is_format_tag< typename Writer::format_tag_t >::type
-                                                       >::type
-                                   >::type* /* ptr */ = nullptr
-               )
+void write_view(Writer& writer, any_image_view<Views> const& view,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            typename detail::is_dynamic_image_writer<Writer>::type,
+            typename is_format_tag<typename Writer::format_tag_t>::type
+        >::type::value
+    >::type * /* ptr */ = nullptr)
 {
-    writer.apply( view );
+    writer.apply(view);
 }
 
 // without image_write_info
-
-template< typename Device
-        , typename Views
-        , typename FormatTag
-        >
+template <typename Device, typename Views, typename FormatTag>
 inline
-void write_view( Device&                        device
-               , const any_image_view< Views >& views
-               , const FormatTag&               tag
-               , typename enable_if< typename mpl::and_< typename detail::is_write_device< FormatTag
-                                                                                         , Device
-                                                                                         >::type
-                                                       , typename is_format_tag< FormatTag >::type
-                                                       >::type
-                                   >::type* /* ptr */ = 0
-               )
+void write_view(
+    Device& device, any_image_view<Views> const& views, FormatTag const& tag,
+    typename std::enable_if
+    <
+        mpl::and_
+        <
+            typename detail::is_write_device<FormatTag, Device>::type,
+            typename is_format_tag<FormatTag>::type
+        >::type::value
+    >::type * /* ptr */ = 0)
 {
     using writer_t = typename get_dynamic_image_writer<Device, FormatTag>::type;
-
-    writer_t writer = make_dynamic_image_writer( device
-                                               , tag
-                                               );
-
-    write_view( writer
-              , views
-              );
+    writer_t writer = make_dynamic_image_writer(device, tag);
+    write_view(writer, views);
 }
 
-template< typename String
-        , typename Views
-        , typename FormatTag
-        >
+template <typename String, typename Views, typename FormatTag>
 inline
-void write_view( const String&                  file_name
-               , const any_image_view< Views >& views
-               , const FormatTag&               tag
-               , typename enable_if< typename mpl::and_< typename detail::is_supported_path_spec< String >::type
-                                                       , typename is_format_tag< FormatTag >::type
-                                                       >::type
-                                   >::type* /* ptr */ = nullptr
-               )
-{
-    using writer_t = typename get_dynamic_image_writer
+void write_view(
+    String const& file_name, any_image_view<Views> const& views, FormatTag const& tag,
+    typename std::enable_if
+    <
+        mpl::and_
         <
-            String,
-            FormatTag
-        >::type;
-
-    writer_t writer = make_dynamic_image_writer( file_name
-                                               , tag
-                                               );
-
-    write_view( writer
-              , views
-              );
+            typename detail::is_supported_path_spec<String>::type,
+            typename is_format_tag<FormatTag>::type
+        >::type::value
+    >::type * /* ptr */ = nullptr)
+{
+    using writer_t = typename get_dynamic_image_writer<String, FormatTag>::type;
+    writer_t writer = make_dynamic_image_writer(file_name, tag);
+    write_view(writer, views);
 }
 
 // with image_write_info
 /// \ingroup IO
-template< typename Device
-        , typename Views
-        , typename FormatTag
-        , typename Log
-        >
+template <typename Device, typename Views, typename FormatTag, typename Log>
 inline
-void write_view( Device&                           device
-               , const any_image_view< Views >&    views
-               , const image_write_info< FormatTag
-                                       , Log
-                                       >&           info
-               , typename enable_if< typename mpl::and_< typename detail::is_write_device< FormatTag
-                                                                                         , Device
-                                                                                         >::type
-                                                       , typename is_format_tag< FormatTag >::type
-                                                       >::type
-                                   >::type* /* ptr */ = 0
-               )
-{
-    using writer_t = typename get_dynamic_image_writer
+void write_view(
+    Device& device, any_image_view<Views> const& views, image_write_info<FormatTag, Log> const& info,
+    typename std::enable_if
+    <
+        mpl::and_
         <
-            Device,
-            FormatTag
-        >::type;
-
-    writer_t writer = make_dynamic_image_writer( device
-                                               , info
-                                               );
-
-    write_view( writer
-              , views
-              );
+            typename detail::is_write_device<FormatTag, Device>::type,
+            typename is_format_tag<FormatTag>::type
+        >::type::value
+    >::type * /* ptr */ = 0)
+{
+    using writer_t = typename get_dynamic_image_writer<Device, FormatTag>::type;
+    writer_t writer = make_dynamic_image_writer(device, info);
+    write_view(writer, views);
 }
 
-template< typename String
-        , typename Views
-        , typename FormatTag
-        , typename Log
-        >
+template <typename String, typename Views, typename FormatTag, typename Log>
 inline
-void write_view( const String&                      file_name
-               , const any_image_view< Views >&     views
-               , const image_write_info< FormatTag
-                                       , Log
-                                       >&           info
-               , typename enable_if< typename mpl::and_< typename detail::is_supported_path_spec< String >::type
-                                                       , typename is_format_tag< FormatTag >::type
-                                                       >::type
-                                   >::type* /* ptr */ = nullptr
-               )
-{
-    using writer_t = typename get_dynamic_image_writer
+void write_view(
+    String const& file_name, any_image_view<Views> const& views, image_write_info<FormatTag, Log> const& info,
+    typename std::enable_if
+    <
+        mpl::and_
         <
-            String,
-            FormatTag
-        >::type;
-
-    writer_t writer = make_dynamic_image_writer( file_name
-                                               , info
-                                               );
-
-    write_view( writer
-              , views
-              );
+            typename detail::is_supported_path_spec<String>::type,
+            typename is_format_tag<FormatTag>::type
+        >::type::value
+    >::type * /* ptr */ = nullptr)
+{
+    using writer_t = typename get_dynamic_image_writer<String, FormatTag>::type;
+    writer_t writer = make_dynamic_image_writer(file_name, info);
+    write_view(writer, views);
 }
 
 }} // namespace boost::gil

--- a/include/boost/gil/packed_pixel.hpp
+++ b/include/boost/gil/packed_pixel.hpp
@@ -11,11 +11,11 @@
 #include <boost/gil/pixel.hpp>
 
 #include <boost/core/ignore_unused.hpp>
-#include <boost/utility/enable_if.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/front.hpp>
 
 #include <functional>
+#include <type_traits>
 
 namespace boost { namespace gil {
 
@@ -65,10 +65,15 @@ struct packed_pixel
 
     // Construct from another compatible pixel type
     packed_pixel(const packed_pixel& p) : _bitfield(p._bitfield) {}
-    template <typename P> packed_pixel(const P& p, typename enable_if_c<is_pixel<P>::value>::type* d=nullptr) {
-        check_compatible<P>(); static_copy(p,*this);
-        boost::ignore_unused(d);
+
+    template <typename P>
+    packed_pixel(P const& p,
+        typename std::enable_if<is_pixel<P>::value>::type* /*dummy*/ = nullptr)
+    {
+        check_compatible<P>();
+        static_copy(p, *this);
     }
+
     packed_pixel(int chan0, int chan1) : _bitfield(0) {
         static_assert(num_channels<packed_pixel>::value == 2, "");
         gil::at_c<0>(*this)=chan0; gil::at_c<1>(*this)=chan1;

--- a/include/boost/gil/pixel.hpp
+++ b/include/boost/gil/pixel.hpp
@@ -19,9 +19,9 @@
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/front.hpp>
 #include <boost/type_traits.hpp>
-#include <boost/utility/enable_if.hpp>
 
 #include <functional>
+#include <type_traits>
 
 namespace boost { namespace gil {
 
@@ -112,9 +112,12 @@ public:
     pixel&                       operator=(const pixel& p)       { static_copy(p,*this); return *this; }
 
     // Construct from another compatible pixel type
-    template <typename Pixel>    pixel(const Pixel& p, typename enable_if_c<is_pixel<Pixel>::value>::type* dummy = nullptr) : parent_t(p) {
+    template <typename Pixel>
+    pixel(Pixel const& p,
+        typename std::enable_if<is_pixel<Pixel>::value>::type* /*dummy*/ = nullptr)
+        : parent_t(p)
+    {
         check_compatible<Pixel>();
-        boost::ignore_unused(dummy);
     }
 
     template <typename P> pixel& operator=(const P& p)           { assign(p, mpl::bool_<is_pixel<P>::value>()); return *this; }


### PR DESCRIPTION
* Replace `boost::disable_if` with `std::enable_if` and negated condition.
* Update `mpl::and_` expressions to yield value convertible to `bool`, instead of type.
* Format `std::enable_if` expressions and nearby code they are nested in.
* Replace complex template-based leading return type of functions with auto and trailing return type for greater readability.
* Replace some Boost type traits with `<type_traits>` features.
* Replace 0 with `nullptr` where modernize-use-nullptr missed (updates #180).
* Notice, `boost::lazy_enable_if` in extension/toolbox has not been replaced, but it seems it could have been - need verification with number of compilers.

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed
