### PR TITLE
Update CONTRIBUTING.md with PRs do's and don'ts [ci skip]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ please follow the workflow explained in this document.
   Separate real product/test code changes from larger code formatting/dead code removal changes,
   unless the former are extensive enough to justify such refactoring, then also mention it.
 * **DO** start PR subject with "WIP:" tag if you submit it as "work in progress".
-  A PR should preferable be submitted when it is considered ready for review and subsequent
+  A PR should preferably be submitted when it is considered ready for review and subsequent
   merging by the contributor. Otherwise, clearly indicate it is not yet ready.
   The "WIP:" tag will also help maintainers to label your PR with [status/work-in-progress].
 * **DO** give PRs short-but-descriptive names (e.g. "Add test for algorithm XXX", not "Fix #1234").

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ please follow the workflow explained in this document.
 ## Table of Content
 
 * [Prerequisites](#prerequisites)
+* [Pull Requests](#pull-requests)
 * [Getting started with Git workflow](#getting-started-with-git-workflow)
   * [1. Clone Boost super-project](#1-clone-boost-super-project)
   * [2. Checkout Boost.GIL development branch](#2-checkout-boostgil-development-branch)
@@ -33,6 +34,48 @@ please follow the workflow explained in this document.
   [Boost Getting Started](https://www.boost.org/more/getting_started/index.html)
   chapters, especially if you are going to use
   [Boost.Build](https://boostorg.github.io/build/) for the first time.
+
+## Pull Requests
+
+* **DO** submit all major changes to code via pull requests (PRs) rather than through
+  a direct commit. PRs will be CI-checked first, then reviewed and potentially merged
+  by the repo maintainers after a peer review that includes at least one maintainer.
+  Contributors with commit access may submit trivial patches or changes to the project
+  infrastructure configuration via direct commits (CAUTION!)
+* **DO NOT** mix independent, unrelated changes in one PR.
+  Separate unrelated fixes into separate PRs, especially if they are in different components
+  (e.g. core headers versus extensions).
+  Separate real product/test code changes from larger code formatting/dead code removal changes,
+  unless the former are extensive enough to justify such refactoring, then also mention it.
+* **DO NOT** submit PRs with "work in progress" (WIP). A PR should only be submitted when
+  it is considered ready for review and subsequent merging by the contributor. PRs may
+  receive [status/work-in-progress] label if review reveals the work is incomplete.
+* **DO** give PRs short-but-descriptive names (e.g. "Add test for algorithm XXX", not "Fix #1234").
+* **DO** [refer] to any relevant issues, and include the [keywords] that automatically
+  close issues when the PR is merged.
+* **DO** [mention] any users that should know about and/or review the change.
+* **DO** ensure each commit successfully builds. The entire PR must pass all tests in
+  the Continuous Integration (CI) system before it'll be merged.
+* **DO** address PR feedback in an additional commit(s) rather than amending the existing
+  commits, and only rebase/squash them when necessary. This makes it easier for reviewers
+  to track changes.
+* **DO** assume that the [Squash and Merge] will be used to merge your commit unless you
+  request otherwise in the PR.
+* **DO** NOT fix merge conflicts using a merge commit. Prefer git rebase.
+
+### Merging Pull Requests (for maintainers with write access)
+
+* **DO** use [Squash and Merge] by default for individual contributions unless requested
+  by the PR author. Do so, even if the PR contains only one commit. It creates a simpler
+  history than [Create a Merge Commit].<br />
+  Reasons that PR authors may request the true merge recording a merge commit
+  may include (but are not limited to):
+
+    * The change is easier to understand as a series of focused commits.<br />
+      Each commit in the series must be buildable so as not to break git bisect.
+    * Contributor is using an e-mail address other than the primary GitHub address
+      and wants that preserved in the history.<br />
+      Contributor must be willing to squash the commits manually before acceptance.
 
 ## Getting started with Git workflow
 
@@ -494,3 +537,11 @@ Maintain structure your source code files according to the following guidelines:
     * Indent with **4 spaces** and no tabs.
     * Trim any trailing whitespaces.
 * Do not increases the indentation level within namespace.
+
+
+[status/work-in-progress]: https://github.com/boostorg/gil/labels/status%2Fwork-in-progress
+[refer]: https://help.github.com/articles/autolinked-references-and-urls/
+[keywords]: https://help.github.com/articles/closing-issues-using-keywords/
+[mention]: https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams
+[squash and merge]: https://help.github.com/articles/merging-a-pull-request/
+[create a merge commit]: https://help.github.com/articles/merging-a-pull-request/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,9 +47,10 @@ please follow the workflow explained in this document.
   (e.g. core headers versus extensions).
   Separate real product/test code changes from larger code formatting/dead code removal changes,
   unless the former are extensive enough to justify such refactoring, then also mention it.
-* **DO NOT** submit PRs with "work in progress" (WIP). A PR should only be submitted when
-  it is considered ready for review and subsequent merging by the contributor. PRs may
-  receive [status/work-in-progress] label if review reveals the work is incomplete.
+* **DO** start PR subject with "WIP:" tag if you submit it as "work in progress".
+  A PR should preferable be submitted when it is considered ready for review and subsequent
+  merging by the contributor. Otherwise, clearly indicate it is not yet ready.
+  The "WIP:" tag will also help maintainers to label your PR with [status/work-in-progress].
 * **DO** give PRs short-but-descriptive names (e.g. "Add test for algorithm XXX", not "Fix #1234").
 * **DO** [refer] to any relevant issues, and include the [keywords] that automatically
   close issues when the PR is merged.


### PR DESCRIPTION
This update does not inroduce any major modification to the current
workflow, it adds a more formal description of it.
With minor updates, copied from CoreFX guidelines:
https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/contributing.md

### Tasklist

- [ ] Review
- [ ] Adjust for comments

-----

@stefanseefeld AFAIR, we discussed usefulness of the CoreFx guidelines on Gitter and your recent post, https://lists.boost.org/Archives/boost/2019/01/244851.php, reminded me about this.