### PR TITLE
Fix GCC -Wunused-local-typedefs warning in toolbox tests

### DIFF
--- a/toolbox/test/channel_type.cpp
+++ b/toolbox/test/channel_type.cpp
@@ -6,25 +6,36 @@
 // http://www.boost.org/LICENSE_1_0.txt
 //
 #include <boost/gil/extension/toolbox/metafunctions/channel_type.hpp>
+#include <boost/gil/extension/toolbox/metafunctions/is_bit_aligned.hpp>
+
+#include <boost/gil/channel.hpp> // boost::is_integral<packed_dynamic_channel_reference<...>>
 
 #include <boost/test/unit_test.hpp>
 #include <boost/type_traits/is_same.hpp>
 
-using namespace boost;
-using namespace gil;
+namespace bg = boost::gil;
 
-BOOST_AUTO_TEST_SUITE( toolbox_tests )
+BOOST_AUTO_TEST_SUITE(toolbox_tests)
 
-BOOST_AUTO_TEST_CASE( channel_type_test )
+BOOST_AUTO_TEST_CASE(channel_type_test)
 {
-    static_assert(is_same<unsigned char, channel_type<rgb8_pixel_t>::type>::value, "");
+    static_assert(boost::is_same
+        <
+            unsigned char,
+            bg::channel_type<bg::rgb8_pixel_t>::type
+        >::value, "");
 
     // float32_t is a scoped_channel_value object
-    static_assert(is_same<float32_t, channel_type<rgba32f_pixel_t>::type>::value, "");
+    static_assert(boost::is_same
+        <
+            bg::float32_t,
+            bg::channel_type<bg::rgba32f_pixel_t>::type
+        >::value, "");
 
     // channel_type for bit_aligned images doesn't work with standard gil.
-    using image_t = bit_aligned_image4_type<4, 4, 4, 4, rgb_layout_t>::type;
-    using channel_t = channel_type<image_t::view_t::reference>::type;
+    using image_t = bg::bit_aligned_image4_type<4, 4, 4, 4, bg::rgb_layout_t>::type;
+    using channel_t = bg::channel_type<image_t::view_t::reference>::type;
+    static_assert(boost::is_integral<channel_t>::value, "");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/toolbox/test/indexed_image_test.cpp
+++ b/toolbox/test/indexed_image_test.cpp
@@ -110,10 +110,6 @@ BOOST_AUTO_TEST_CASE(index_image_view_test)
     palette[2] = rgb8_pixel_t(70, 80, 90);
 
     // create image views from raw memory
-    using indices_loc_t = gray8_image_t::view_t::locator;
-    using palette_loc_t = rgb8_image_t::view_t::locator;
-
-
     auto indices_view = interleaved_view(width, height
         , (gray8_image_t::view_t::x_iterator) indices.data()
         , width // row size in bytes


### PR DESCRIPTION
Fixes at least three warnings issued by in the toolbox tests:

```
  warning: typedef (...) locally defined
    but not used [-Wunused-local-typedefs]
```

### Environment

- Compiler version: GCC 5.5
- Build settings: `<toolset>gcc:<cxxflags>"-std=c++11"`

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed

-------

```
toolbox/test/channel_type.cpp: In member function ‘void toolbox_tests::channel_type_test::test_method()’:
toolbox/test/channel_type.cpp:27:69: warning: typedef ‘using channel_t = boost::lazy_enable_if_c<true, boost::gil::gen_chan_ref<unsigned int, boost::mpl::vector4_c<unsigned int, 4u, 4u, 4u, 4u>, boost::gil::layout<boost::mpl::vector3<boost::gil::red_t, boost::gil::green_t, boost::gil::blue_t> >, true> >::type’ locally defined but not used [-Wunused-local-typedefs]
     using channel_t = channel_type<image_t::view_t::reference>::type;
                                                                     ^
```

```
toolbox/test/indexed_image_test.cpp: In member function ‘void toolbox_tests::index_image_view_test::test_method()’:
toolbox/test/indexed_image_test.cpp:113:57: warning: typedef ‘using indices_loc_t = using locator = class boost::gil::memory_based_2d_locator<boost::gil::memory_based_step_iterator<boost::gil::pixel<unsigned char, boost::gil::layout<boost::mpl::vector1<boost::gil::gray_color_t> > >*> >’ locally defined but not used [-Wunused-local-typedefs]
     using indices_loc_t = gray8_image_t::view_t::locator;
                                                         ^
```
```
toolbox/test/indexed_image_test.cpp:114:56: warning: typedef ‘using palette_loc_t = using locator = class boost::gil::memory_based_2d_locator<boost::gil::memory_based_step_iterator<boost::gil::pixel<unsigned char, boost::gil::layout<boost::mpl::vector3<boost::gil::red_t, boost::gil::green_t, boost::gil::blue_t> > >*> >’ locally defined but not used [-Wunused-local-typedefs]
     using palette_loc_t = rgb8_image_t::view_t::locator;
                                                        ^
```