### PR TITLE
Fix GCC -Wunused-but-set-variable warning in toolbox tests

### DIFF
--- a/toolbox/test/channel_view.cpp
+++ b/toolbox/test/channel_view.cpp
@@ -11,28 +11,32 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/type_traits/is_same.hpp>
 
-using namespace boost;
-using namespace gil;
+namespace bg = boost::gil;
 
-BOOST_AUTO_TEST_SUITE( toolbox_tests )
+BOOST_AUTO_TEST_SUITE(toolbox_tests)
 
-BOOST_AUTO_TEST_CASE( channel_view_test )
+BOOST_AUTO_TEST_CASE(channel_view_test)
 {
-    using image_t = rgb8_image_t;
+    using image_t = bg::rgb8_image_t;
+    image_t img(100, 100);
 
-    image_t img( 100, 100 );
+    using kth_channel_view_t
+        = bg::kth_channel_view_type<0, bg::rgb8_view_t::const_t>::type;
+    using channel_view_t
+        = bg::channel_view_type<bg::red_t, bg::rgb8_view_t::const_t>::type;
 
-    using view_t = kth_channel_view_type<0, rgb8_view_t::const_t>::type;
-    view_t red = kth_channel_view<0>( const_view( img ));
-
-    using channel_view_t = channel_view_type<red_t, rgb8_view_t::const_t>::type;
-    channel_view_t red_ = channel_view< red_t >( const_view( img ));
-
-    static_assert(is_same
+    static_assert(boost::is_same
         <
-            kth_channel_view_type<0, rgb8_view_t const>::type,
-            channel_view_type<red_t, rgb8_view_t const>::type
-        >::value, "");
+            kth_channel_view_t,
+            channel_view_t
+        >::value,
+        "");
+
+    kth_channel_view_t const kth0 = bg::kth_channel_view<0>(bg::const_view(img));
+    BOOST_TEST(kth0.num_channels() == 1);
+
+    channel_view_t const red = bg::channel_view<bg::red_t>(bg::const_view(img));
+    BOOST_TEST(red.num_channels() == 1);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Fixes at least eight warnings issued by in the toolbox tests:
  `warning: variable (...) set but not used [-Wunused-but-set-variable]`

Add new or improve existing `BOOST_TEST` checks.

### Environment

All relevant information like:

- Compiler version: GCC 5.5
- Build settings: `<toolset>gcc:<cxxflags>"-std=c++11"`

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed

------

```
toolbox/test/channel_view.cpp: In member function ‘void toolbox_tests::channel_view_test::test_method()’:
toolbox/test/channel_view.cpp:26:12: warning: variable ‘red’ set but not used [-Wunused-but-set-variable]
     view_t red = kth_channel_view<0>( const_view( img ));
            ^
toolbox/test/channel_view.cpp:29:20: warning: variable ‘red_’ set but not used [-Wunused-but-set-variable]
     channel_view_t red_ = channel_view< red_t >( const_view( img ));
                    ^
```

```
toolbox/test/indexed_image_test.cpp: In member function ‘void toolbox_tests::index_image_test::test_method()’:
toolbox/test/indexed_image_test.cpp:26:22: warning: variable ‘p’ set but not used [-Wunused-but-set-variable]
         rgb8_pixel_t p = *view( img ).xy_at( 10, 10 );
                      ^
toolbox/test/indexed_image_test.cpp:49:23: warning: variable ‘color’ set but not used [-Wunused-but-set-variable]
         rgb8_pixel_t  color = *img.get_palette_view().xy_at( index, 0 );
                       ^
toolbox/test/indexed_image_test.cpp:51:22: warning: variable ‘p’ set but not used [-Wunused-but-set-variable]
         rgb8_pixel_t p = *view( img ).xy_at( 10, 1 );
                      ^
toolbox/test/indexed_image_test.cpp:73:22: warning: variable ‘color’ set but not used [-Wunused-but-set-variable]
         rgb8_pixel_t color = *img.get_palette_view().xy_at( index, 0 );
                      ^
toolbox/test/indexed_image_test.cpp:75:22: warning: variable ‘p’ set but not used [-Wunused-but-set-variable]
         rgb8_pixel_t p = *view( img ).xy_at( 10, 1 );
                      ^
toolbox/test/indexed_image_test.cpp:88:30: warning: variable ‘p’ set but not used [-Wunused-but-set-variable]
                 rgb8_pixel_t p = *it;
                              ^
```

