### PR TITLE
Replace some uses of boost::is_same with std::is_same

### DIFF
--- a/include/boost/gil/bit_aligned_pixel_reference.hpp
+++ b/include/boost/gil/bit_aligned_pixel_reference.hpp
@@ -22,6 +22,7 @@
 #include <boost/mpl/vector.hpp>
 
 #include <functional>
+#include <type_traits>
 
 namespace boost { namespace gil {
 
@@ -177,7 +178,7 @@ private:
 private:
     static void check_gray()
     {
-        static_assert(is_same<typename Layout::color_space_t, gray_t>::value, "");
+        static_assert(std::is_same<typename Layout::color_space_t, gray_t>::value, "");
     }
 
     template <typename Channel> void assign(const Channel& chan, mpl::false_) const { check_gray(); gil::at_c<0>(*this)=chan; }

--- a/include/boost/gil/color_base_algorithm.hpp
+++ b/include/boost/gil/color_base_algorithm.hpp
@@ -215,7 +215,7 @@ typename color_element_const_reference_type<ColorBase,Color>::type get_color(con
 Example:
 \code
 using element_t = element_type<rgb8c_planar_ptr_t>::type;
-static_assert(boost::is_same<element_t, const uint8_t*>::value, "");
+static_assert(std::is_same<element_t, const uint8_t*>::value, "");
 \endcode
 */
 /// \brief Specifies the element type of a homogeneous color base

--- a/include/boost/gil/concepts/basic.hpp
+++ b/include/boost/gil/concepts/basic.hpp
@@ -10,6 +10,7 @@
 
 #include <boost/gil/concepts/concept_check.hpp>
 
+#include <type_traits>
 #include <utility> // std::swap
 
 #if BOOST_GCC >= 40700
@@ -168,7 +169,7 @@ struct SameType
 {
     void constraints()
     {
-        static_assert(boost::is_same<T, U>::value_core, "");
+        static_assert(std::is_same<T, U>::value, "");
     }
 };
 

--- a/include/boost/gil/extension/toolbox/color_spaces/ycbcr.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/ycbcr.hpp
@@ -19,6 +19,7 @@
 #include <boost/mpl/vector_c.hpp>
 
 #include <cstdint>
+#include <type_traits>
 
 namespace boost{ namespace gil {
 
@@ -102,11 +103,11 @@ struct default_color_converter_impl<ycbcr_601__t, rgb_t>
 	void operator()( const SRCP& src, DSTP& dst ) const
 	{
         using dst_channel_t = typename channel_type<DSTP>::type;
-        convert( src, dst
-               , typename boost::is_same< typename mpl::int_< sizeof( dst_channel_t ) >::type
-                                        , typename mpl::int_<1>::type
-                                        >::type()
-               );
+        convert(src, dst, typename std::is_same
+            <
+                typename mpl::int_<sizeof(dst_channel_t)>::type,
+                typename mpl::int_<1>::type
+            >::type());
 	}
 
 private:

--- a/io/test/make.cpp
+++ b/io/test/make.cpp
@@ -15,6 +15,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <fstream>
+#include <type_traits>
 
 #include "paths.hpp"
 
@@ -30,7 +31,7 @@ BOOST_AUTO_TEST_SUITE( gil_io_tests )
 BOOST_AUTO_TEST_CASE( make_reader_backend_test )
 {
     {
-        static_assert(boost::is_same<gil::detail::is_supported_path_spec<char*>::type, mpl::true_>::value, "");
+        static_assert(std::is_same<gil::detail::is_supported_path_spec<char*>::type, mpl::true_>::value, "");
 
         get_reader_backend< const char*, bmp_tag >::type backend_char   = make_reader_backend( bmp_filename.c_str(), bmp_tag() );
         get_reader_backend< std::string, bmp_tag >::type backend_string = make_reader_backend( bmp_filename, bmp_tag() );
@@ -133,7 +134,7 @@ BOOST_AUTO_TEST_CASE( make_writer_test )
     {
         using writer_t = get_writer<char const*, bmp_tag>::type;
 
-        static_assert(boost::is_same<gil::detail::is_writer<writer_t>::type, boost::mpl::true_>::value, "");
+        static_assert(std::is_same<gil::detail::is_writer<writer_t>::type, boost::mpl::true_>::value, "");
     }
 
     {

--- a/test/image.cpp
+++ b/test/image.cpp
@@ -22,6 +22,7 @@
 #include <map>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 using namespace boost::gil;
@@ -522,9 +523,27 @@ void static_checks() {
     static_assert(!view_is_mutable<cmyk8c_planar_step_view_t>::value, "");
     static_assert(view_is_mutable<rgb8_planar_view_t>::value, "");
 
-    static_assert(boost::is_same<derived_view_type<cmyk8c_planar_step_view_t>::type, cmyk8c_planar_step_view_t>::value, "");
-    static_assert(boost::is_same<derived_view_type<cmyk8c_planar_step_view_t, std::uint16_t, rgb_layout_t>::type,  rgb16c_planar_step_view_t>::value, "");
-    static_assert(boost::is_same<derived_view_type<cmyk8c_planar_step_view_t, use_default, rgb_layout_t, mpl::false_, use_default, mpl::false_>::type,  rgb8c_step_view_t>::value, "");
+    static_assert(std::is_same
+        <
+            derived_view_type<cmyk8c_planar_step_view_t>::type,
+            cmyk8c_planar_step_view_t
+        >::value, "");
+    static_assert(std::is_same
+        <
+            derived_view_type
+            <
+                cmyk8c_planar_step_view_t, std::uint16_t, rgb_layout_t
+            >::type,
+            rgb16c_planar_step_view_t
+        >::value, "");
+    static_assert(std::is_same
+        <
+            derived_view_type
+            <
+                cmyk8c_planar_step_view_t, use_default, rgb_layout_t, mpl::false_, use_default, mpl::false_
+            >::type,
+            rgb8c_step_view_t
+        >::value, "");
 
     // test view get raw data (mostly compile-time test)
     {

--- a/test/pixel.cpp
+++ b/test/pixel.cpp
@@ -106,10 +106,11 @@ struct do_basic_test : public C1, public C2
         // Test swap if both are mutable and if their value type is the same
         // (We know the second one is mutable)
         using p1_ref = typename boost::add_reference<typename C1::type>::type;
-        test_swap(
-            boost::mpl::bool_<
+        test_swap(boost::mpl::bool_
+            <
                 pixel_reference_is_mutable<p1_ref>::value &&
-                boost::is_same<pixel1_value_t,pixel2_value_t>::value> ());
+                std::is_same<pixel1_value_t,pixel2_value_t>::value
+            >());
     }
 
     void test_swap(boost::mpl::false_) {}

--- a/test/pixel_iterator.cpp
+++ b/test/pixel_iterator.cpp
@@ -12,6 +12,7 @@
 
 #include <exception>
 #include <iostream>
+#include <type_traits>
 #include <vector>
 
 using namespace boost::gil;
@@ -49,10 +50,10 @@ void test_pixel_iterator()
     boost::function_requires<HasDynamicXStepTypeConcept<bgr121_ptr_t> >();
 
 // TEST dynamic_step_t
-    static_assert(boost::is_same<cmyk16_step_ptr_t, dynamic_x_step_type<cmyk16_step_ptr_t>::type>::value, "");
-    static_assert(boost::is_same<cmyk16_planar_step_ptr_t, dynamic_x_step_type<cmyk16_planar_ptr_t>::type>::value, "");
+    static_assert(std::is_same<cmyk16_step_ptr_t, dynamic_x_step_type<cmyk16_step_ptr_t>::type>::value, "");
+    static_assert(std::is_same<cmyk16_planar_step_ptr_t, dynamic_x_step_type<cmyk16_planar_ptr_t>::type>::value, "");
 
-    static_assert(boost::is_same<iterator_type<uint8_t,gray_layout_t,false,false,false>::type,gray8c_ptr_t>::value, "");
+    static_assert(std::is_same<iterator_type<uint8_t,gray_layout_t,false,false,false>::type,gray8c_ptr_t>::value, "");
 
 // TEST iterator_is_step
     static_assert(iterator_is_step<cmyk16_step_ptr_t>::value, "");
@@ -68,17 +69,17 @@ void test_pixel_iterator()
     static_assert(!iterator_is_step<rgb2gray_ptr>::value, "");
 
     using rgb2gray_step_ptr = dynamic_x_step_type<rgb2gray_ptr>::type;
-    static_assert(boost::is_same<rgb2gray_step_ptr, dereference_iterator_adaptor<rgb8_step_ptr_t, ccv_rgb_g_fn>>::value, "");
+    static_assert(std::is_same<rgb2gray_step_ptr, dereference_iterator_adaptor<rgb8_step_ptr_t, ccv_rgb_g_fn>>::value, "");
 
     make_step_iterator(rgb2gray_ptr(),2);
 
     using rgb2gray_step_ptr1 = dereference_iterator_adaptor<rgb8_step_ptr_t, ccv_rgb_g_fn>;
     static_assert(iterator_is_step<rgb2gray_step_ptr1>::value, "");
-    static_assert(boost::is_same<rgb2gray_step_ptr1, dynamic_x_step_type<rgb2gray_step_ptr1>::type>::value, "");
+    static_assert(std::is_same<rgb2gray_step_ptr1, dynamic_x_step_type<rgb2gray_step_ptr1>::type>::value, "");
 
     using rgb2gray_step_ptr2 = memory_based_step_iterator<dereference_iterator_adaptor<rgb8_ptr_t, ccv_rgb_g_fn>>;
     static_assert(iterator_is_step<rgb2gray_step_ptr2 >::value, "");
-    static_assert(boost::is_same<rgb2gray_step_ptr2, dynamic_x_step_type<rgb2gray_step_ptr2>::type>::value, "");
+    static_assert(std::is_same<rgb2gray_step_ptr2, dynamic_x_step_type<rgb2gray_step_ptr2>::type>::value, "");
     make_step_iterator(rgb2gray_step_ptr2(),2);
 
 // bit_aligned iterators test

--- a/toolbox/test/channel_type.cpp
+++ b/toolbox/test/channel_type.cpp
@@ -11,7 +11,8 @@
 #include <boost/gil/channel.hpp> // boost::is_integral<packed_dynamic_channel_reference<...>>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/type_traits/is_same.hpp>
+
+#include <type_traits>
 
 namespace bg = boost::gil;
 
@@ -19,14 +20,14 @@ BOOST_AUTO_TEST_SUITE(toolbox_tests)
 
 BOOST_AUTO_TEST_CASE(channel_type_test)
 {
-    static_assert(boost::is_same
+    static_assert(std::is_same
         <
             unsigned char,
             bg::channel_type<bg::rgb8_pixel_t>::type
         >::value, "");
 
     // float32_t is a scoped_channel_value object
-    static_assert(boost::is_same
+    static_assert(std::is_same
         <
             bg::float32_t,
             bg::channel_type<bg::rgba32f_pixel_t>::type

--- a/toolbox/test/channel_view.cpp
+++ b/toolbox/test/channel_view.cpp
@@ -9,7 +9,8 @@
 #include <boost/gil/extension/toolbox/metafunctions/channel_view.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/type_traits/is_same.hpp>
+
+#include <type_traits>
 
 namespace bg = boost::gil;
 
@@ -25,7 +26,7 @@ BOOST_AUTO_TEST_CASE(channel_view_test)
     using channel_view_t
         = bg::channel_view_type<bg::red_t, bg::rgb8_view_t::const_t>::type;
 
-    static_assert(boost::is_same
+    static_assert(std::is_same
         <
             kth_channel_view_t,
             channel_view_t


### PR DESCRIPTION
Those are places boost::is_same can be replaced in non-intrusive way.
Remaining are types derived from `boost::is_same`, where the replacing
would affect all their uses - effectively switching from `boost::true_/false_` types
to `std::true_type` and `std::false_type`.
Such change needs to come along with Boost.MPL to MP11 migration.

### Tasklist

- [ ] Review
- [ ] Adjust for comments
- [ ] All CI builds and checks have passed
