### PR TITLE
Tidy up uses of Boost.Filesystem in IO

### DIFF
--- a/include/boost/gil/io/path_spec.hpp
+++ b/include/boost/gil/io/path_spec.hpp
@@ -9,8 +9,17 @@
 #define BOOST_GIL_IO_PATH_SPEC_HPP
 
 #ifdef BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
+#if defined(BOOST_GCC)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion" // conversion to 'std::atomic<int>::__integral_type {aka int}' from 'long int' may alter its value
+#endif
+
 #define BOOST_FILESYSTEM_VERSION 3
 #include <boost/filesystem/path.hpp>
+
+#if defined(BOOST_GCC)
+#pragma GCC diagnostic pop
+#endif
 #endif // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 
 #include <boost/mpl/bool.hpp> // for complete types of true_ and false_

--- a/include/boost/gil/io/path_spec.hpp
+++ b/include/boost/gil/io/path_spec.hpp
@@ -9,15 +9,21 @@
 #define BOOST_GIL_IO_PATH_SPEC_HPP
 
 #ifdef BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
-#if defined(BOOST_GCC)
+// Disable warning: conversion to 'std::atomic<int>::__integral_type {aka int}' from 'long int' may alter its value
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"
+#elif defined(BOOST_GCC)
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wconversion" // conversion to 'std::atomic<int>::__integral_type {aka int}' from 'long int' may alter its value
+#pragma GCC diagnostic ignored "-Wconversion"
 #endif
 
 #define BOOST_FILESYSTEM_VERSION 3
 #include <boost/filesystem/path.hpp>
 
-#if defined(BOOST_GCC)
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic pop
+#elif defined(BOOST_GCC)
 #pragma GCC diagnostic pop
 #endif
 #endif // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT

--- a/io/test/all_formats_test.cpp
+++ b/io/test/all_formats_test.cpp
@@ -14,7 +14,6 @@
 #include <boost/gil/extension/io/tiff.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/filesystem.hpp>
 
 #include "paths.hpp"
 

--- a/io/test/bmp_test.cpp
+++ b/io/test/bmp_test.cpp
@@ -11,7 +11,6 @@
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/bmp.hpp>
 
-#include <boost/filesystem/convenience.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <fstream>

--- a/io/test/jpeg_test.cpp
+++ b/io/test/jpeg_test.cpp
@@ -14,7 +14,6 @@
 #include <boost/gil/extension/io/jpeg.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/filesystem/path.hpp>
 
 #include <fstream>
 
@@ -24,7 +23,6 @@
 
 using namespace boost;
 using namespace gil;
-using namespace filesystem;
 
 using tag_t = jpeg_tag;
 
@@ -77,11 +75,12 @@ BOOST_AUTO_TEST_CASE( read_image_info_test )
     }
 
     {
-        using backend_t = get_reader_backend<path, tag_t>::type;
+        using backend_t = get_reader_backend<boost::filesystem::path, tag_t>::type;
 
-        backend_t backend = boost::gil::read_image_info( path( jpeg_filename )
-                                                       , tag_t()
-                                                       );
+        backend_t backend =
+            boost::gil::read_image_info(
+                 boost::filesystem::path(jpeg_filename),
+                 tag_t());
 
         BOOST_CHECK_EQUAL( backend._info._width , 1000u );
         BOOST_CHECK_EQUAL( backend._info._height,  600u );

--- a/io/test/make.cpp
+++ b/io/test/make.cpp
@@ -11,7 +11,6 @@
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/bmp.hpp>
 
-#include <boost/filesystem/convenience.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <fstream>

--- a/io/test/paths.hpp
+++ b/io/test/paths.hpp
@@ -8,13 +8,20 @@
 #ifndef BOOST_GIL_IO_TEST_PATHS_HPP
 #define BOOST_GIL_IO_TEST_PATHS_HPP
 
+#if defined(BOOST_GCC)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion" // conversion to 'std::atomic<int>::__integral_type {aka int}' from 'long int' may alter its value
+#endif
+
+#define BOOST_FILESYSTEM_VERSION 3
 #include <boost/filesystem.hpp>
 
-namespace fs = boost::filesystem;
+#if defined(BOOST_GCC)
+#pragma GCC diagnostic pop
+#endif
 
 // `base` holds the path to ../.., i.e. the directory containing `test_images`
-static const std::string base =
-  (fs::absolute(fs::path(__FILE__)).parent_path().parent_path().string()) + "/";
+static const std::string base = (boost::filesystem::absolute(boost::filesystem::path(__FILE__)).parent_path().parent_path().string()) + "/";
 
 static const std::string bmp_in  = base + "test_images/bmp/";
 static const std::string bmp_out = base + "output/bmp/";

--- a/io/test/paths.hpp
+++ b/io/test/paths.hpp
@@ -8,15 +8,21 @@
 #ifndef BOOST_GIL_IO_TEST_PATHS_HPP
 #define BOOST_GIL_IO_TEST_PATHS_HPP
 
-#if defined(BOOST_GCC)
+// Disable warning: conversion to 'std::atomic<int>::__integral_type {aka int}' from 'long int' may alter its value
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"
+#elif defined(BOOST_GCC)
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wconversion" // conversion to 'std::atomic<int>::__integral_type {aka int}' from 'long int' may alter its value
+#pragma GCC diagnostic ignored "-Wconversion"
 #endif
 
 #define BOOST_FILESYSTEM_VERSION 3
 #include <boost/filesystem.hpp>
 
-#if defined(BOOST_GCC)
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic pop
+#elif defined(BOOST_GCC)
 #pragma GCC diagnostic pop
 #endif
 

--- a/io/test/png_file_format_test.cpp
+++ b/io/test/png_file_format_test.cpp
@@ -12,7 +12,6 @@
 
 #include <boost/gil/extension/io/png.hpp>
 
-#include <boost/filesystem/convenience.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "paths.hpp"

--- a/io/test/png_read_test.cpp
+++ b/io/test/png_read_test.cpp
@@ -12,7 +12,6 @@
 
 #include <boost/gil/extension/io/png.hpp>
 
-#include <boost/filesystem/convenience.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <cstdint>

--- a/io/test/png_write_test.cpp
+++ b/io/test/png_write_test.cpp
@@ -12,7 +12,6 @@
 
 #include <boost/gil/extension/io/png.hpp>
 
-#include <boost/filesystem/convenience.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <cstdint>
@@ -26,7 +25,6 @@ using namespace std;
 using namespace boost;
 using namespace gil;
 using namespace boost::gil::detail;
-namespace fs = boost::filesystem;
 
 using tag_t = png_tag;
 

--- a/io/test/raw_test.cpp
+++ b/io/test/raw_test.cpp
@@ -12,7 +12,6 @@
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/raw.hpp>
 
-#include <boost/filesystem/convenience.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <fstream>

--- a/io/test/targa_test.cpp
+++ b/io/test/targa_test.cpp
@@ -11,7 +11,6 @@
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/targa.hpp>
 
-#include <boost/filesystem/convenience.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <fstream>

--- a/io/test/tiff_test.cpp
+++ b/io/test/tiff_test.cpp
@@ -11,7 +11,6 @@
 
 #include <boost/gil/extension/io/tiff.hpp>
 
-#include <boost/filesystem/convenience.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <fstream>


### PR DESCRIPTION
Remove unused `#include`-s and leave `io/test/paths.hpp` as sole
place of `#include <boost/filesystem.hpp>` for IO tests.

Silence annoying `-Wconversion` or `-Wshorten-64-to-32` warning
from Boost.SmartPtr via Boost.Filesystem:

```
  conversion to 'std::atomic<int>::__integral_type {aka int}'
    from 'long int' may alter its value
```

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed


------

This should disable numerous instances of the warning below thrown during compilation of IO tests

```
In file included from ../../boost/smart_ptr/detail/atomic_count.hpp:77:0,
                 from ../../boost/smart_ptr/intrusive_ref_counter.hpp:19,
                 from ../../boost/filesystem/operations.hpp:32,
                 from ../../boost/filesystem/convenience.hpp:22,
                 from io/test/bmp_test.cpp:14:
../../boost/smart_ptr/detail/atomic_count_std_atomic.hpp: In constructor ‘boost::detail::atomic_count::atomic_count(long int)’:
../../boost/smart_ptr/detail/atomic_count_std_atomic.hpp:29:48: warning: conversion to ‘std::atomic<int>::__integral_type {aka int}’ from ‘long int’ may alter its value [-Wconversion]
     explicit atomic_count( long v ): value_( v )
                                                ^
```