### PR TITLE
Build core tests with BOOST_GIL_USE_CONCEPT_CHECK defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,8 @@ target_compile_definitions(gil_compile_options
     $<$<CXX_COMPILER_ID:MSVC>:_SCL_SECURE_NO_DEPRECATE>
     $<$<CXX_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS>
     $<$<CXX_COMPILER_ID:MSVC>:NOMINMAX>
-    $<$<CXX_COMPILER_ID:MSVC>:BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE>)
+    $<$<CXX_COMPILER_ID:MSVC>:BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE>
+    BOOST_GIL_USE_CONCEPT_CHECK)
 
 #-----------------------------------------------------------------------------
 # Dependency target

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,8 +87,7 @@ target_compile_definitions(gil_compile_options
     $<$<CXX_COMPILER_ID:MSVC>:_SCL_SECURE_NO_DEPRECATE>
     $<$<CXX_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS>
     $<$<CXX_COMPILER_ID:MSVC>:NOMINMAX>
-    $<$<CXX_COMPILER_ID:MSVC>:BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE>
-    BOOST_GIL_USE_CONCEPT_CHECK)
+    $<$<CXX_COMPILER_ID:MSVC>:BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE>)
 
 #-----------------------------------------------------------------------------
 # Dependency target

--- a/Jamfile
+++ b/Jamfile
@@ -12,7 +12,6 @@
 project boost-gil
     :
     requirements
-        <define>BOOST_GIL_USE_CONCEPT_CHECK
         # MSVC: Since VS2017, default is -std:c++14, so no explicit switch is required.
         <toolset>msvc:<asynch-exceptions>on
         <toolset>msvc:<cxxflags>/W4

--- a/Jamfile
+++ b/Jamfile
@@ -12,6 +12,7 @@
 project boost-gil
     :
     requirements
+        <define>BOOST_GIL_USE_CONCEPT_CHECK
         # MSVC: Since VS2017, default is -std:c++14, so no explicit switch is required.
         <toolset>msvc:<asynch-exceptions>on
         <toolset>msvc:<cxxflags>/W4

--- a/include/boost/gil/color_base_algorithm.hpp
+++ b/include/boost/gil/color_base_algorithm.hpp
@@ -241,11 +241,12 @@ template <int N>
 struct element_recursion
 {
 
-#if defined(BOOST_GCC)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Wfloat-equal"
 #endif
+
     template <typename P1,typename P2>
     static bool static_equal(const P1& p1, const P2& p2)
     {
@@ -273,7 +274,8 @@ struct element_recursion
         element_recursion<N-1>::static_generate(dst,op);
         semantic_at_c<N-1>(dst)=op();
     }
-#if defined(BOOST_GCC)
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/concepts/basic.hpp
+++ b/include/boost/gil/concepts/basic.hpp
@@ -13,7 +13,12 @@
 #include <type_traits>
 #include <utility> // std::swap
 
-#if BOOST_GCC >= 40700
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedefs"
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
@@ -175,7 +180,11 @@ struct SameType
 
 }} // namespace boost::gil
 
-#if BOOST_GCC >= 40700
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic pop
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/concepts/channel.hpp
+++ b/include/boost/gil/concepts/channel.hpp
@@ -16,7 +16,12 @@
 
 #include <utility> // std::swap
 
-#if BOOST_GCC >= 40700
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedefs"
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
@@ -198,7 +203,11 @@ struct ChannelConvertibleConcept
 
 }} // namespace boost::gil
 
-#if BOOST_GCC >= 40700
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic pop
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/concepts/color.hpp
+++ b/include/boost/gil/concepts/color.hpp
@@ -12,7 +12,12 @@
 
 #include <boost/type_traits.hpp>
 
-#if BOOST_GCC >= 40700
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedefs"
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
@@ -84,7 +89,11 @@ struct ChannelMappingConcept
 
 }} // namespace boost::gil
 
-#if BOOST_GCC >= 40700
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic pop
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/concepts/color_base.hpp
+++ b/include/boost/gil/concepts/color_base.hpp
@@ -15,7 +15,12 @@
 
 #include <boost/type_traits.hpp>
 
-#if BOOST_GCC >= 40700
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedefs"
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
@@ -309,7 +314,11 @@ struct ColorBasesCompatibleConcept
 
 }} // namespace boost::gil
 
-#if BOOST_GCC >= 40700
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic pop
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/concepts/concept_check.hpp
+++ b/include/boost/gil/concepts/concept_check.hpp
@@ -12,7 +12,9 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wfloat-equal"
 #pragma clang diagnostic ignored "-Wuninitialized"
-#elif BOOST_GCC >= 40700
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfloat-equal"
 #pragma GCC diagnostic ignored "-Wuninitialized"
@@ -22,7 +24,9 @@
 
 #if defined(BOOST_CLANG)
 #pragma clang diagnostic pop
-#elif defined(BOOST_GCC)
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/concepts/concept_check.hpp
+++ b/include/boost/gil/concepts/concept_check.hpp
@@ -8,7 +8,23 @@
 #ifndef BOOST_GIL_CONCEPTS_CONCEPTS_CHECK_HPP
 #define BOOST_GIL_CONCEPTS_CONCEPTS_CHECK_HPP
 
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wfloat-equal"
+#pragma clang diagnostic ignored "-Wuninitialized"
+#elif BOOST_GCC >= 40700
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#pragma GCC diagnostic ignored "-Wuninitialized"
+#endif
+
 #include <boost/concept_check.hpp>
+
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic pop
+#elif defined(BOOST_GCC)
+#pragma GCC diagnostic pop
+#endif
 
 // TODO: Document BOOST_GIL_USE_CONCEPT_CHECK here
 

--- a/include/boost/gil/concepts/image.hpp
+++ b/include/boost/gil/concepts/image.hpp
@@ -16,7 +16,12 @@
 
 #include <boost/mpl/size.hpp>
 
-#if BOOST_GCC >= 40700
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedefs"
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
@@ -151,7 +156,11 @@ struct ImageConcept
 
 }} // namespace boost::gil
 
-#if BOOST_GCC >= 40700
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic pop
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/concepts/image_view.hpp
+++ b/include/boost/gil/concepts/image_view.hpp
@@ -21,7 +21,12 @@
 #include <cstddef>
 #include <iterator>
 
-#if BOOST_GCC >= 40700
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedefs"
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
@@ -538,7 +543,11 @@ struct ViewsCompatibleConcept
 
 }} // namespace boost::gil
 
-#if BOOST_GCC >= 40700
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic pop
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/concepts/pixel.hpp
+++ b/include/boost/gil/concepts/pixel.hpp
@@ -23,7 +23,12 @@
 
 #include <cstddef>
 
-#if BOOST_GCC >= 40700
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedefs"
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
@@ -289,7 +294,11 @@ struct PixelConvertibleConcept
 
 }} // namespace boost::gil
 
-#if BOOST_GCC >= 40700
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic pop
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/concepts/pixel_based.hpp
+++ b/include/boost/gil/concepts/pixel_based.hpp
@@ -16,7 +16,12 @@
 
 #include <cstddef>
 
-#if BOOST_GCC >= 40700
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedefs"
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
@@ -87,7 +92,11 @@ struct HomogeneousPixelBasedConcept
 
 }} // namespace boost::gil
 
-#if BOOST_GCC >= 40700
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic pop
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/concepts/pixel_dereference.hpp
+++ b/include/boost/gil/concepts/pixel_dereference.hpp
@@ -19,7 +19,12 @@
 
 #include <cstddef>
 
-#if BOOST_GCC >= 40700
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedefs"
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
@@ -98,7 +103,11 @@ struct PixelDereferenceAdaptorArchetype
 
 }} // namespace boost::gil
 
-#if BOOST_GCC >= 40700
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic pop
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/concepts/pixel_iterator.hpp
+++ b/include/boost/gil/concepts/pixel_iterator.hpp
@@ -21,7 +21,12 @@
 #include <cstddef>
 #include <iterator>
 
-#if BOOST_GCC >= 40700
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedefs"
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
@@ -381,7 +386,11 @@ struct MutableIteratorAdaptorConcept
 
 }} // namespace boost::gil
 
-#if BOOST_GCC >= 40700
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic pop
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/concepts/pixel_locator.hpp
+++ b/include/boost/gil/concepts/pixel_locator.hpp
@@ -19,7 +19,12 @@
 #include <cstddef>
 #include <iterator>
 
-#if BOOST_GCC >= 40700
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedefs"
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
@@ -391,7 +396,11 @@ struct MutablePixelLocatorConcept
 
 }} // namespace boost::gil
 
-#if BOOST_GCC >= 40700
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic pop
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/concepts/point.hpp
+++ b/include/boost/gil/concepts/point.hpp
@@ -13,7 +13,12 @@
 
 #include <cstddef>
 
-#if BOOST_GCC >= 40700
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedefs"
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
@@ -108,7 +113,11 @@ struct Point2DConcept
 
 }} // namespace boost::gil
 
-#if BOOST_GCC >= 40700
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic pop
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/io/path_spec.hpp
+++ b/include/boost/gil/io/path_spec.hpp
@@ -13,7 +13,9 @@
 #if defined(BOOST_CLANG)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wshorten-64-to-32"
-#elif defined(BOOST_GCC)
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #endif
@@ -23,7 +25,9 @@
 
 #if defined(BOOST_CLANG)
 #pragma clang diagnostic pop
-#elif defined(BOOST_GCC)
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic pop
 #endif
 #endif // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT

--- a/io/test/paths.hpp
+++ b/io/test/paths.hpp
@@ -12,7 +12,9 @@
 #if defined(BOOST_CLANG)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wshorten-64-to-32"
-#elif defined(BOOST_GCC)
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #endif
@@ -22,7 +24,9 @@
 
 #if defined(BOOST_CLANG)
 #pragma clang diagnostic pop
-#elif defined(BOOST_GCC)
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic pop
 #endif
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,7 @@ foreach(_name
       gil_compile_options
       gil_include_directories
       gil_dependencies)
+  target_compile_definitions(${_target} PRIVATE BOOST_GIL_USE_CONCEPT_CHECK)
   add_test(test.core.${_name} ${_target})
 
   unset(_target)

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -18,6 +18,7 @@ project
   : requirements
     <include>$(BOOST_ROOT)
     <include>.
+    <define>BOOST_GIL_USE_CONCEPT_CHECK
   ;
 
 run promote_integral.cpp /boost/test//boost_unit_test_framework : : : <link>shared:<define>BOOST_TEST_DYN_LINK=1 ;

--- a/test/algorithm/std_fill.cpp
+++ b/test/algorithm/std_fill.cpp
@@ -6,7 +6,7 @@
 // http://www.boost.org/LICENSE_1_0.txt
 //
 #ifdef BOOST_GIL_USE_CONCEPT_CHECK
-// FIXME: Range as pixel does not seem to fulfil pixel concepts due to no specializations required:
+// FIXME: Range as pixel does not seem to fulfill pixel concepts due to no specializations required:
 //        pixel.hpp(50) : error C2039 : 'type' : is not a member of 'boost::gil::color_space_type<P>
 #undef BOOST_GIL_USE_CONCEPT_CHECK
 #endif

--- a/test/algorithm/std_fill.cpp
+++ b/test/algorithm/std_fill.cpp
@@ -5,6 +5,11 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
+#ifdef BOOST_GIL_USE_CONCEPT_CHECK
+// FIXME: Range as pixel does not seem to fulfil pixel concepts due to no specializations required:
+//        pixel.hpp(50) : error C2039 : 'type' : is not a member of 'boost::gil::color_space_type<P>
+#undef BOOST_GIL_USE_CONCEPT_CHECK
+#endif
 #include <boost/gil/algorithm.hpp>
 #include <boost/gil/image.hpp>
 #include <boost/gil/image_view.hpp>

--- a/test/gil_test_common.hpp
+++ b/test/gil_test_common.hpp
@@ -11,10 +11,13 @@
 #if defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable:4702) // unreachable code
-#elif defined(__clang__) && defined(__has_warning)
+#endif
+
+#if defined(BOOST_CLANG)
 #pragma clang diagnostic push
-#elif defined(__GNUC__) && \
-    !(defined(__INTEL_COMPILER) || defined(__ICL) || defined(__ICC) || defined(__ECC))
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Wfloat-equal"
@@ -25,10 +28,13 @@
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
-#elif defined(__clang__) && defined(__has_warning)
+#endif
+
+#if defined(BOOST_CLANG)
 #pragma clang diagnostic pop
-#elif defined(__GNUC__) && \
-    !(defined(__INTEL_COMPILER) || defined(__ICL) || defined(__ICC) || defined(__ECC))
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
when building tests with both, Boost.Build and CMake.

Disable concepts check for tests where range (e.g. `std::array`)
used as image pixel - not fully specialised as acceptable pixel type.

Tests of extensions will require more work (e.g. numeric test does not compile).

### References

Closes #228

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed
