### PR TITLE
Add C++14 builds using GCC 8 and VS2017 to Azure Pipelines

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -13,7 +13,7 @@ trigger:
   - azure-pipelines
 
 jobs:
-  - job: 'ubuntu1604_gcc54_cmake312'
+  - job: 'ubuntu1604_gcc5_cxx11_cmake'
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
@@ -26,7 +26,23 @@ jobs:
       - template: .ci/azure-pipelines/steps-install-boost.yml
       - template: .ci/azure-pipelines/steps-cmake-build-and-test.yml
 
-  - job: 'win2016_vs2017_cmake312'
+  - job: 'ubuntu1604_gcc8_cxx14_cmake'
+    pool:
+      vmImage: 'ubuntu-16.04'
+    steps:
+      - template: .ci/azure-pipelines/steps-install-gcc.yml
+      - script: which g++ && g++ --version
+        displayName: 'Check GCC'
+      - template: .ci/azure-pipelines/steps-check-cmake.yml
+      - script: |
+          sudo apt-get install libjpeg-dev libpng16-dev libtiff5-dev libraw-dev
+        displayName: 'Install dependencies'
+      - template: .ci/azure-pipelines/steps-install-boost.yml
+      - template: .ci/azure-pipelines/steps-cmake-build-and-test.yml
+        parameters:
+          cxxver: '14'
+
+  - job: 'win2016_vs2017_cxx14_cmake'
     pool:
       vmImage: 'vs2017-win2016'
     steps:
@@ -37,7 +53,19 @@ jobs:
         parameters:
           use_conan: 'yes'
 
-  - job: 'macos1013_xcode91_cmake313'
+  - job: 'win2016_vs2017_cxx17_cmake'
+    pool:
+      vmImage: 'vs2017-win2016'
+    steps:
+      - template: .ci/azure-pipelines/steps-check-cmake.yml
+      - template: .ci/azure-pipelines/steps-install-conan.yml
+      - template: .ci/azure-pipelines/steps-install-boost.yml
+      - template: .ci/azure-pipelines/steps-cmake-build-and-test.yml
+        parameters:
+          use_conan: 'yes'
+          cxxver: '17'
+
+  - job: 'macos1013_xcode91_cmake'
     pool:
       vmImage: 'macOS-10.13'
     steps:

--- a/.ci/azure-pipelines/steps-cmake-build-and-test.yml
+++ b/.ci/azure-pipelines/steps-cmake-build-and-test.yml
@@ -7,6 +7,7 @@
 parameters:
   # defaults, if not specified
   configuration: 'Release'
+  cxxver: '11'
   get_findboost: 'no'
   enable_ext_io: 'no'
   enable_ext_numeric: 'yes'
@@ -15,7 +16,7 @@ parameters:
 
 steps:
   - script: |
-      cmake -H. -B_build -DCMAKE_BUILD_TYPE=${{ parameters.configuration }} -DCMAKE_VERBOSE_MAKEFILE=ON -DGIL_DOWNLOAD_FINDBOOST=${{ parameters.get_findboost }} -DGIL_USE_CONAN=ON -DGIL_ENABLE_EXT_IO=${{ parameters.enable_ext_io }} -DGIL_ENABLE_EXT_NUMERIC=${{ parameters.enable_ext_numeric }} -DGIL_ENABLE_EXT_TOOLBOX=${{ parameters.enable_ext_toolbox }}
+      cmake -H. -B_build -DCMAKE_BUILD_TYPE=${{ parameters.configuration }} -DCMAKE_CXX_STANDARD=${{ parameters.cxxver }} -DCMAKE_VERBOSE_MAKEFILE=ON -DGIL_DOWNLOAD_FINDBOOST=${{ parameters.get_findboost }} -DGIL_USE_CONAN=ON -DGIL_ENABLE_EXT_IO=${{ parameters.enable_ext_io }} -DGIL_ENABLE_EXT_NUMERIC=${{ parameters.enable_ext_numeric }} -DGIL_ENABLE_EXT_TOOLBOX=${{ parameters.enable_ext_toolbox }}
     displayName: 'Run CMake to configure build'
 
   - script: cmake --build _build --config ${{ parameters.configuration }} -j 4

--- a/.ci/azure-pipelines/steps-install-gcc.yml
+++ b/.ci/azure-pipelines/steps-install-gcc.yml
@@ -1,0 +1,17 @@
+# Azure Pipelines for Boost.GIL
+#
+# Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
+#
+parameters:
+  # defaults, if not specified
+  major_version: 8
+
+steps:
+  - bash: |
+      sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+      sudo apt-get update
+      sudo apt-get install g++-${{ parameters.major_version }}
+      sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ parameters.major_version }} 90
+      sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ parameters.major_version }} 90

--- a/.ci/azure-pipelines/steps-install-gcc.yml
+++ b/.ci/azure-pipelines/steps-install-gcc.yml
@@ -11,7 +11,7 @@ parameters:
 steps:
   - bash: |
       sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-      sudo apt-get update
+      sudo apt-get update -qq
       sudo apt-get install g++-${{ parameters.major_version }}
       sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ parameters.major_version }} 90
       sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ parameters.major_version }} 90


### PR DESCRIPTION
We need build jobs compiling GIL in C++14 mode to start verifying #231 and similar enhancements specific to C++ version.

Tidy up build jobs naming to include C++ version.

### Tasklist

- [x] Azure Pipelines builds and checks have passed

-----

Requested by @sdebionne in https://github.com/boostorg/gil/pull/227#issuecomment-460552577 while prototyping the variant improvements finally submitted in #231