### PR TITLE
Include all public headers in gil.hpp

### DIFF
--- a/include/boost/gil.hpp
+++ b/include/boost/gil.hpp
@@ -11,22 +11,38 @@
 
 #include <boost/gil/algorithm.hpp>
 #include <boost/gil/bit_aligned_pixel_iterator.hpp>
+#include <boost/gil/bit_aligned_pixel_reference.hpp>
+#include <boost/gil/channel.hpp>
 #include <boost/gil/channel_algorithm.hpp>
+#include <boost/gil/cmyk.hpp>
+#include <boost/gil/color_base.hpp>
+#include <boost/gil/color_base_algorithm.hpp>
 #include <boost/gil/color_convert.hpp>
+#include <boost/gil/concepts.hpp>
+#include <boost/gil/deprecated.hpp>
 #include <boost/gil/device_n.hpp>
+#include <boost/gil/gray.hpp>
 #include <boost/gil/image.hpp>
+#include <boost/gil/image_view.hpp>
 #include <boost/gil/image_view_factory.hpp>
 #include <boost/gil/iterator_from_2d.hpp>
+#include <boost/gil/locator.hpp>
 #include <boost/gil/metafunctions.hpp>
 #include <boost/gil/packed_pixel.hpp>
 #include <boost/gil/pixel.hpp>
+#include <boost/gil/pixel_iterator.hpp>
 #include <boost/gil/pixel_iterator_adaptor.hpp>
-#include <boost/gil/planar_pixel_reference.hpp>
 #include <boost/gil/planar_pixel_iterator.hpp>
+#include <boost/gil/planar_pixel_reference.hpp>
 #include <boost/gil/point.hpp>
+#include <boost/gil/position_iterator.hpp>
+#include <boost/gil/premultiply.hpp>
+#include <boost/gil/rgb.hpp>
+#include <boost/gil/rgba.hpp>
 #include <boost/gil/step_iterator.hpp>
 #include <boost/gil/typedefs.hpp>
-#include <boost/gil/virtual_locator.hpp>
+#include <boost/gil/utilities.hpp>
 #include <boost/gil/version.hpp>
+#include <boost/gil/virtual_locator.hpp>
 
 #endif


### PR DESCRIPTION
AFAIU, intention of `gil.hpp` is to include all headers.