### PR TITLE
Add dynamic_step.hpp for base templates declaration

### DIFF
--- a/include/boost/gil/concepts/dynamic_step.hpp
+++ b/include/boost/gil/concepts/dynamic_step.hpp
@@ -1,0 +1,77 @@
+//
+// Copyright 2005-2007 Adobe Systems Incorporated
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#ifndef BOOST_GIL_CONCEPTS_DYNAMIC_STEP_HPP
+#define BOOST_GIL_CONCEPTS_DYNAMIC_STEP_HPP
+
+#include <boost/gil/concepts/fwd.hpp>
+#include <boost/gil/concepts/concept_check.hpp>
+
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedefs"
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
+#endif
+
+namespace boost { namespace gil {
+
+/// \ingroup PixelIteratorConcept
+/// \brief Concept for iterators, locators and views that can define a type just like the given
+///        iterator, locator or view, except it supports runtime specified step along the X navigation.
+///
+/// \code
+/// concept HasDynamicXStepTypeConcept<typename T>
+/// {
+///     typename dynamic_x_step_type<T>;
+///         where Metafunction<dynamic_x_step_type<T> >;
+/// };
+/// \endcode
+template <typename T>
+struct HasDynamicXStepTypeConcept
+{
+    void constraints()
+    {
+        using type = typename dynamic_x_step_type<T>::type;
+        ignore_unused_variable_warning(type{});
+    }
+};
+
+/// \ingroup PixelLocatorConcept
+/// \brief Concept for locators and views that can define a type just like the given locator or view,
+///        except it supports runtime specified step along the Y navigation
+/// \code
+/// concept HasDynamicYStepTypeConcept<typename T>
+/// {
+///     typename dynamic_y_step_type<T>;
+///         where Metafunction<dynamic_y_step_type<T> >;
+/// };
+/// \endcode
+template <typename T>
+struct HasDynamicYStepTypeConcept
+{
+    void constraints()
+    {
+        using type = typename dynamic_y_step_type<T>::type;
+        ignore_unused_variable_warning(type{});
+    }
+};
+
+}} // namespace boost::gil
+
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic pop
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#pragma GCC diagnostic pop
+#endif
+
+#endif

--- a/include/boost/gil/concepts/pixel_iterator.hpp
+++ b/include/boost/gil/concepts/pixel_iterator.hpp
@@ -123,45 +123,6 @@ struct PixelIteratorIsMutableConcept
 
 } // namespace detail
 
-/// \ingroup PixelIteratorConcept
-/// \brief Concept for iterators, locators and views that can define a type just like the given iterator/locator/view, except it supports runtime specified step along the X navigation
-///
-/// \code
-/// concept HasDynamicXStepTypeConcept<typename T>
-/// {
-///     typename dynamic_x_step_type<T>;
-///         where Metafunction<dynamic_x_step_type<T> >;
-/// };
-/// \endcode
-template <typename T>
-struct HasDynamicXStepTypeConcept
-{
-    void constraints()
-    {
-        using type = typename dynamic_x_step_type<T>::type;
-        ignore_unused_variable_warning(type{});
-    }
-};
-
-/// \ingroup PixelLocatorConcept
-/// \brief Concept for locators and views that can define a type just like the given locator or view, except it supports runtime specified step along the Y navigation
-/// \code
-/// concept HasDynamicYStepTypeConcept<typename T>
-/// {
-///     typename dynamic_y_step_type<T>;
-///         where Metafunction<dynamic_y_step_type<T> >;
-/// };
-/// \endcode
-template <typename T>
-struct HasDynamicYStepTypeConcept
-{
-    void constraints()
-    {
-        using type = typename dynamic_y_step_type<T>::type;
-        ignore_unused_variable_warning(type{});
-    }
-};
-
 /// \ingroup PixelLocatorConcept
 /// \brief Concept for locators and views that can define a type just like the given locator or view, except X and Y is swapped
 /// \code

--- a/include/boost/gil/dynamic_step.hpp
+++ b/include/boost/gil/dynamic_step.hpp
@@ -1,0 +1,31 @@
+//
+// Copyright 2005-2007 Adobe Systems Incorporated
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#ifndef BOOST_GIL_DYNAMIC_STEP_HPP
+#define BOOST_GIL_DYNAMIC_STEP_HPP
+
+#include <boost/gil/concepts/dynamic_step.hpp>
+
+namespace boost { namespace gil {
+
+/// Base template for types that model HasDynamicXStepTypeConcept.
+template <typename IteratorOrLocatorOrView>
+struct dynamic_x_step_type;
+
+/// Base template for types that model HasDynamicYStepTypeConcept.
+template <typename LocatorOrView>
+struct dynamic_y_step_type;
+
+/// Base template for types that model both, HasDynamicXStepTypeConcept and HasDynamicYStepTypeConcept.
+///
+/// \todo TODO: Is Locator allowed or practical to occur?
+template <typename View>
+struct dynamic_xy_step_type;
+
+}}  // namespace boost::gil
+
+#endif

--- a/include/boost/gil/extension/dynamic_image/any_image_view.hpp
+++ b/include/boost/gil/extension/dynamic_image/any_image_view.hpp
@@ -8,11 +8,12 @@
 #ifndef BOOST_GIL_EXTENSION_DYNAMIC_IMAGE_ANY_IMAGE_VIEW_HPP
 #define BOOST_GIL_EXTENSION_DYNAMIC_IMAGE_ANY_IMAGE_VIEW_HPP
 
-#include <boost/variant.hpp>
-
+#include <boost/gil/dynamic_step.hpp>
 #include <boost/gil/image.hpp>
 #include <boost/gil/image_view.hpp>
 #include <boost/gil/point.hpp>
+
+#include <boost/variant.hpp>
 
 namespace boost { namespace gil {
 
@@ -20,7 +21,7 @@ namespace detail {
     template <typename View> struct get_const_t { using type = typename View::const_t; };
     template <typename Views> struct views_get_const_t : public mpl::transform<Views, get_const_t<mpl::_1> > {};
 }
-template <typename View> struct dynamic_xy_step_type;
+
 template <typename View> struct dynamic_xy_step_transposed_type;
 
 namespace detail {

--- a/include/boost/gil/extension/dynamic_image/image_view_factory.hpp
+++ b/include/boost/gil/extension/dynamic_image/image_view_factory.hpp
@@ -10,6 +10,7 @@
 
 #include <boost/gil/extension/dynamic_image/any_image_view.hpp>
 
+#include <boost/gil/dynamic_step.hpp>
 #include <boost/gil/image_view_factory.hpp>
 #include <boost/gil/point.hpp>
 

--- a/include/boost/gil/extension/toolbox/image_types/subchroma_image.hpp
+++ b/include/boost/gil/extension/toolbox/image_types/subchroma_image.hpp
@@ -8,6 +8,7 @@
 #ifndef BOOST_GIL_EXTENSION_TOOLBOX_IMAGE_TYPES_SUBCHROMA_IMAGE_HPP
 #define BOOST_GIL_EXTENSION_TOOLBOX_IMAGE_TYPES_SUBCHROMA_IMAGE_HPP
 
+#include <boost/gil/dynamic_step.hpp>
 #include <boost/gil/image.hpp>
 #include <boost/gil/image_view.hpp>
 #include <boost/gil/point.hpp>

--- a/include/boost/gil/image_view.hpp
+++ b/include/boost/gil/image_view.hpp
@@ -8,6 +8,7 @@
 #ifndef BOOST_GIL_IMAGE_VIEW_HPP
 #define BOOST_GIL_IMAGE_VIEW_HPP
 
+#include <boost/gil/dynamic_step.hpp>
 #include <boost/gil/iterator_from_2d.hpp>
 
 #include <cstddef>

--- a/include/boost/gil/image_view_factory.hpp
+++ b/include/boost/gil/image_view_factory.hpp
@@ -9,6 +9,7 @@
 #define BOOST_GIL_IMAGE_VIEW_FACTORY_HPP
 
 #include <boost/gil/color_convert.hpp>
+#include <boost/gil/dynamic_step.hpp>
 #include <boost/gil/gray.hpp>
 #include <boost/gil/metafunctions.hpp>
 #include <boost/gil/point.hpp>
@@ -33,8 +34,6 @@
 namespace boost { namespace gil {
 struct default_color_converter;
 
-template <typename T> struct dynamic_x_step_type;
-template <typename T> struct dynamic_y_step_type;
 template <typename T> struct transposed_type;
 
 /// \brief Returns the type of a view that has a dynamic step along both X and Y

--- a/include/boost/gil/locator.hpp
+++ b/include/boost/gil/locator.hpp
@@ -8,6 +8,7 @@
 #ifndef BOOST_GIL_LOCATOR_HPP
 #define BOOST_GIL_LOCATOR_HPP
 
+#include <boost/gil/dynamic_step.hpp>
 #include <boost/gil/pixel_iterator.hpp>
 #include <boost/gil/point.hpp>
 
@@ -29,8 +30,6 @@ namespace detail {
     // helper class specialized for each axis of pixel_2d_locator
     template <std::size_t D, typename Loc>  class locator_axis;
 }
-template <typename T> struct dynamic_x_step_type;
-template <typename T> struct dynamic_y_step_type;
 
 template <typename T> struct channel_type;
 template <typename T> struct color_space_type;
@@ -38,9 +37,14 @@ template <typename T> struct channel_mapping_type;
 template <typename T> struct is_planar;
 template <typename T> struct num_channels;
 
-// The type of a locator or a view that has X and Y swapped. By default it is the same
-template <typename T>
-struct transposed_type { using type = T; };
+/// Base template for types that model HasTransposedTypeConcept.
+/// The type of a locator or a view that has X and Y swapped.
+/// By default it is the same.
+template <typename LocatorOrView>
+struct transposed_type
+{
+    using type = LocatorOrView;
+};
 
 /// \class pixel_2d_locator_base
 /// \brief base class for models of PixelLocatorConcept

--- a/include/boost/gil/metafunctions.hpp
+++ b/include/boost/gil/metafunctions.hpp
@@ -9,6 +9,7 @@
 #define BOOST_GIL_METAFUNCTIONS_HPP
 
 #include <boost/gil/channel.hpp>
+#include <boost/gil/dynamic_step.hpp>
 #include <boost/gil/concepts.hpp>
 
 #include <boost/mpl/accumulate.hpp>

--- a/include/boost/gil/pixel_iterator.hpp
+++ b/include/boost/gil/pixel_iterator.hpp
@@ -9,6 +9,7 @@
 #define BOOST_GIL_PIXEL_ITERATOR_HPP
 
 #include <boost/gil/concepts.hpp>
+#include <boost/gil/dynamic_step.hpp>
 #include <boost/gil/utilities.hpp>
 #include <boost/gil/pixel.hpp>
 
@@ -19,8 +20,6 @@ namespace boost { namespace gil {
 //forwarded declaration (as this file is included in step_iterator.hpp)
 template <typename Iterator>
 class memory_based_step_iterator;
-
-template <typename Iterator> struct dynamic_x_step_type;
 
 /// \brief metafunction predicate determining whether the given iterator is a plain one or an adaptor over another iterator.
 /// Examples of adaptors are the step iterator and the dereference iterator adaptor.

--- a/include/boost/gil/step_iterator.hpp
+++ b/include/boost/gil/step_iterator.hpp
@@ -8,6 +8,7 @@
 #ifndef BOOST_GIL_STEP_ITERATOR_HPP
 #define BOOST_GIL_STEP_ITERATOR_HPP
 
+#include <boost/gil/dynamic_step.hpp>
 #include <boost/gil/pixel_iterator.hpp>
 #include <boost/gil/pixel_iterator_adaptor.hpp>
 #include <boost/gil/utilities.hpp>

--- a/include/boost/gil/virtual_locator.hpp
+++ b/include/boost/gil/virtual_locator.hpp
@@ -8,6 +8,7 @@
 #ifndef BOOST_GIL_VIRTUAL_LOCATOR_HPP
 #define BOOST_GIL_VIRTUAL_LOCATOR_HPP
 
+#include <boost/gil/dynamic_step.hpp>
 #include <boost/gil/position_iterator.hpp>
 
 #include <boost/assert.hpp>


### PR DESCRIPTION
Replace all scattered around forward declarations of
`dynamic_{x,y,xy}_step_type` with this common header,
where the templates are also documented.

Refine documentation of `transposed_type` - this is kept
in `locator.hpp` as it is not just related to the dynamic step.

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed
