### PR TITLE
Add tests for dynamic_{x,y}_step_type specializations

### DIFF
--- a/test/image_view/CMakeLists.txt
+++ b/test/image_view/CMakeLists.txt
@@ -9,6 +9,7 @@ foreach(_name
   collection
   concepts
   derived_view_type
+  dynamic_step
   is_planar
   view_is_basic
   view_is_mutable

--- a/test/image_view/Jamfile
+++ b/test/image_view/Jamfile
@@ -15,6 +15,7 @@ project
 
 compile concepts.cpp ;
 compile derived_view_type.cpp ;
+compile dynamic_step.cpp ;
 compile is_planar.cpp ;
 compile view_is_basic.cpp ;
 compile view_is_mutable.cpp ;

--- a/test/image_view/dynamic_step.cpp
+++ b/test/image_view/dynamic_step.cpp
@@ -1,0 +1,133 @@
+//
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/gil/dynamic_step.hpp>
+#include <boost/gil/image_view.hpp>
+#include <boost/gil/typedefs.hpp>
+
+namespace gil = boost::gil;
+
+template <typename View>
+void test()
+{
+    static_assert(
+        gil::view_is_basic
+        <
+            typename gil::dynamic_x_step_type<View>::type
+        >::value, "view does not model HasDynamicXStepTypeConcept");
+
+    static_assert(
+        gil::view_is_basic
+        <
+            typename gil::dynamic_y_step_type<View>::type
+        >::value, "view does not model HasDynamicYStepTypeConcept");
+}
+
+int main()
+{
+    test<gil::gray8_view_t>();
+    test<gil::gray8_step_view_t>();
+    test<gil::gray8c_view_t>();
+    test<gil::gray8c_step_view_t>();
+    test<gil::gray16_view_t>();
+    test<gil::gray16_step_view_t>();
+    test<gil::gray16c_view_t>();
+    test<gil::gray16c_step_view_t>();
+    test<gil::gray32_view_t>();
+    test<gil::gray32_step_view_t>();
+    test<gil::gray32c_view_t>();
+    test<gil::gray32c_step_view_t>();
+    test<gil::gray32f_view_t>();
+    test<gil::gray32f_step_view_t>();
+
+    test<gil::abgr8_view_t>();
+    test<gil::abgr8_step_view_t>();
+    test<gil::abgr16_view_t>();
+    test<gil::abgr16_step_view_t>();
+    test<gil::abgr32_view_t>();
+    test<gil::abgr32_step_view_t>();
+    test<gil::abgr32f_view_t>();
+    test<gil::abgr32f_step_view_t>();
+
+    test<gil::argb8_view_t>();
+    test<gil::argb8_step_view_t>();
+    test<gil::argb16_view_t>();
+    test<gil::argb16_step_view_t>();
+    test<gil::argb32_view_t>();
+    test<gil::argb32_step_view_t>();
+    test<gil::argb32f_view_t>();
+    test<gil::argb32f_step_view_t>();
+
+    test<gil::bgr8_view_t>();
+    test<gil::bgr8_step_view_t>();
+    test<gil::bgr16_view_t>();
+    test<gil::bgr16_step_view_t>();
+    test<gil::bgr32_view_t>();
+    test<gil::bgr32_step_view_t>();
+    test<gil::bgr32f_view_t>();
+    test<gil::bgr32f_step_view_t>();
+
+    test<gil::bgra8_view_t>();
+    test<gil::bgra8_step_view_t>();
+    test<gil::bgra16_view_t>();
+    test<gil::bgra16_step_view_t>();
+    test<gil::bgra32_view_t>();
+    test<gil::bgra32_step_view_t>();
+    test<gil::bgra32f_view_t>();
+    test<gil::bgra32f_step_view_t>();
+
+    test<gil::rgb8_view_t>();
+    test<gil::rgb8_step_view_t>();
+    test<gil::rgb8_planar_view_t>();
+    test<gil::rgb8_planar_step_view_t>();
+    test<gil::rgb16_view_t>();
+    test<gil::rgb16_step_view_t>();
+    test<gil::rgb16_planar_view_t>();
+    test<gil::rgb16_planar_step_view_t>();
+    test<gil::rgb32_view_t>();
+    test<gil::rgb32_step_view_t>();
+    test<gil::rgb32_planar_view_t>();
+    test<gil::rgb32_planar_step_view_t>();
+    test<gil::rgb32f_view_t>();
+    test<gil::rgb32f_step_view_t>();
+    test<gil::rgb32f_planar_view_t>();
+    test<gil::rgb32f_planar_step_view_t>();
+
+    test<gil::rgba8_view_t>();
+    test<gil::rgba8_step_view_t>();
+    test<gil::rgba8_planar_view_t>();
+    test<gil::rgba8_planar_step_view_t>();
+    test<gil::rgba16_view_t>();
+    test<gil::rgba16_step_view_t>();
+    test<gil::rgba16_planar_view_t>();
+    test<gil::rgba16_planar_step_view_t>();
+    test<gil::rgba32_view_t>();
+    test<gil::rgba32_step_view_t>();
+    test<gil::rgba32_planar_view_t>();
+    test<gil::rgba32_planar_step_view_t>();
+    test<gil::rgba32f_view_t>();
+    test<gil::rgba32f_step_view_t>();
+    test<gil::rgba32f_planar_view_t>();
+    test<gil::rgba32f_planar_step_view_t>();
+
+    test<gil::cmyk8_view_t>();
+    test<gil::cmyk8_step_view_t>();
+    test<gil::cmyk8_planar_view_t>();
+    test<gil::cmyk8_planar_step_view_t>();
+    test<gil::cmyk16_view_t>();
+    test<gil::cmyk16_step_view_t>();
+    test<gil::cmyk16_planar_view_t>();
+    test<gil::cmyk16_planar_step_view_t>();
+    test<gil::cmyk32_view_t>();
+    test<gil::cmyk32_step_view_t>();
+    test<gil::cmyk32_planar_view_t>();
+    test<gil::cmyk32_planar_step_view_t>();
+    test<gil::cmyk32f_view_t>();
+    test<gil::cmyk32f_step_view_t>();
+    test<gil::cmyk32f_planar_view_t>();
+    test<gil::cmyk32f_planar_step_view_t>();
+}

--- a/test/iterator/CMakeLists.txt
+++ b/test/iterator/CMakeLists.txt
@@ -6,7 +6,8 @@
 # http://www.boost.org/LICENSE_1_0.txt)
 #
 foreach(_name
-  concepts)
+  concepts
+  dynamic_step)
   set(_target test_core_iterator_${_name})
 
   add_executable(${_target} "")

--- a/test/iterator/Jamfile
+++ b/test/iterator/Jamfile
@@ -14,3 +14,4 @@ project
     ;
 
 compile concepts.cpp ;
+compile dynamic_step.cpp ;

--- a/test/iterator/dynamic_step.cpp
+++ b/test/iterator/dynamic_step.cpp
@@ -1,0 +1,160 @@
+//
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/gil/dynamic_step.hpp>
+#include <boost/gil/color_base.hpp> // kth_element_type
+#include <boost/gil/pixel.hpp> // kth_element_type
+#include <boost/gil/pixel_iterator.hpp>
+#include <boost/gil/pixel_iterator_adaptor.hpp>
+#include <boost/gil/planar_pixel_iterator.hpp> // kth_element_type
+#include <boost/gil/planar_pixel_reference.hpp> // kth_element_type
+#include <boost/gil/step_iterator.hpp>
+#include <boost/gil/typedefs.hpp>
+
+#include <type_traits>
+
+namespace gil = boost::gil;
+
+// NOTE: Iterator does not model HasDynamicYStepTypeConcept
+// TODO: Add compile-fail tests to verify that.
+
+template <typename Iterator>
+void test_non_step()
+{
+    static_assert(std::is_same
+        <
+            gil::memory_based_step_iterator<Iterator>,
+            typename gil::dynamic_x_step_type<Iterator>::type
+        >::value, "iterator does not model HasDynamicXStepTypeConcept");
+
+    static_assert(!std::is_same
+        <
+            Iterator,
+            typename gil::dynamic_x_step_type<Iterator>::type
+        >::value, "dynamic_x_step_type yields X step iterator, not X iterator");
+}
+
+template <typename Iterator>
+void test_step()
+{
+    static_assert(std::is_same
+        <
+            Iterator,
+            typename gil::dynamic_x_step_type<Iterator>::type
+        >::value, "iterator does not model HasDynamicXStepTypeConcept");
+
+    static_assert(!std::is_same
+        <
+            typename Iterator::x_iterator,
+            typename gil::dynamic_x_step_type<gil::gray8_step_ptr_t>::type
+        >::value, "dynamic_x_step_type yields X step iterator, not X iterator");
+}
+
+int main()
+{
+    test_non_step<gil::gray8_ptr_t>();
+    test_non_step<gil::gray8c_ptr_t>();
+    test_non_step<gil::gray16_ptr_t>();
+    test_non_step<gil::gray16c_ptr_t>();
+    test_non_step<gil::gray32_ptr_t>();
+    test_non_step<gil::gray32c_ptr_t>();
+    test_non_step<gil::gray32f_ptr_t>();
+    test_step<gil::gray8_step_ptr_t>();
+    test_step<gil::gray8c_step_ptr_t>();
+    test_step<gil::gray16_step_ptr_t>();
+    test_step<gil::gray16c_step_ptr_t>();
+    test_step<gil::gray32_step_ptr_t>();
+    test_step<gil::gray32c_step_ptr_t>();
+    test_step<gil::gray32f_step_ptr_t>();
+
+    test_non_step<gil::abgr8_ptr_t>();
+    test_non_step<gil::abgr16_ptr_t>();
+    test_non_step<gil::abgr32_ptr_t>();
+    test_non_step<gil::abgr32f_ptr_t>();
+    test_step<gil::abgr8_step_ptr_t>();
+    test_step<gil::abgr16_step_ptr_t>();
+    test_step<gil::abgr32_step_ptr_t>();
+    test_step<gil::abgr32f_step_ptr_t>();
+
+    test_non_step<gil::argb8_ptr_t>();
+    test_non_step<gil::argb16_ptr_t>();
+    test_non_step<gil::argb32_ptr_t>();
+    test_non_step<gil::argb32f_ptr_t>();
+    test_step<gil::argb8_step_ptr_t>();
+    test_step<gil::argb16_step_ptr_t>();
+    test_step<gil::argb32_step_ptr_t>();
+    test_step<gil::argb32f_step_ptr_t>();
+
+    test_non_step<gil::bgr8_ptr_t>();
+    test_non_step<gil::bgr16_ptr_t>();
+    test_non_step<gil::bgr32_ptr_t>();
+    test_non_step<gil::bgr32f_ptr_t>();
+    test_step<gil::bgr8_step_ptr_t>();
+    test_step<gil::bgr16_step_ptr_t>();
+    test_step<gil::bgr32_step_ptr_t>();
+    test_step<gil::bgr32f_step_ptr_t>();
+
+    test_non_step<gil::bgra8_ptr_t>();
+    test_non_step<gil::bgra16_ptr_t>();
+    test_non_step<gil::bgra32_ptr_t>();
+    test_non_step<gil::bgra32f_ptr_t>();
+    test_step<gil::bgra8_step_ptr_t>();
+    test_step<gil::bgra16_step_ptr_t>();
+    test_step<gil::bgra32_step_ptr_t>();
+    test_step<gil::bgra32f_step_ptr_t>();
+
+    test_non_step<gil::rgb8_ptr_t>();
+    test_non_step<gil::rgb8_planar_ptr_t>();
+    test_non_step<gil::rgb16_ptr_t>();
+    test_non_step<gil::rgb16_planar_ptr_t>();
+    test_non_step<gil::rgb32_ptr_t>();
+    test_non_step<gil::rgb32_planar_ptr_t>();
+    test_non_step<gil::rgb32f_ptr_t>();
+    test_non_step<gil::rgb32f_planar_ptr_t>();
+    test_step<gil::rgb8_step_ptr_t>();
+    test_step<gil::rgb8_planar_step_ptr_t>();
+    test_step<gil::rgb16_step_ptr_t>();
+    test_step<gil::rgb16_planar_step_ptr_t>();
+    test_step<gil::rgb32_step_ptr_t>();
+    test_step<gil::rgb32_planar_step_ptr_t>();
+    test_step<gil::rgb32f_step_ptr_t>();
+    test_step<gil::rgb32f_planar_step_ptr_t>();
+
+    test_non_step<gil::rgba8_ptr_t>();
+    test_non_step<gil::rgba8_planar_ptr_t>();
+    test_non_step<gil::rgba16_ptr_t>();
+    test_non_step<gil::rgba16_planar_ptr_t>();
+    test_non_step<gil::rgba32_ptr_t>();
+    test_non_step<gil::rgba32_planar_ptr_t>();
+    test_non_step<gil::rgba32f_ptr_t>();
+    test_non_step<gil::rgba32f_planar_ptr_t>();
+    test_step<gil::rgba8_step_ptr_t>();
+    test_step<gil::rgba8_planar_step_ptr_t>();
+    test_step<gil::rgba16_step_ptr_t>();
+    test_step<gil::rgba16_planar_step_ptr_t>();
+    test_step<gil::rgba32_step_ptr_t>();
+    test_step<gil::rgba32_planar_step_ptr_t>();
+    test_step<gil::rgba32f_step_ptr_t>();
+    test_step<gil::rgba32f_planar_step_ptr_t>();
+
+    test_non_step<gil::cmyk8_ptr_t>();
+    test_non_step<gil::cmyk8_planar_ptr_t>();
+    test_non_step<gil::cmyk16_ptr_t>();
+    test_non_step<gil::cmyk16_planar_ptr_t>();
+    test_non_step<gil::cmyk32_ptr_t>();
+    test_non_step<gil::cmyk32_planar_ptr_t>();
+    test_non_step<gil::cmyk32f_ptr_t>();
+    test_non_step<gil::cmyk32f_planar_ptr_t>();
+    test_step<gil::cmyk8_step_ptr_t>();
+    test_step<gil::cmyk8_planar_step_ptr_t>();
+    test_step<gil::cmyk16_step_ptr_t>();
+    test_step<gil::cmyk16_planar_step_ptr_t>();
+    test_step<gil::cmyk32_step_ptr_t>();
+    test_step<gil::cmyk32_planar_step_ptr_t>();
+    test_step<gil::cmyk32f_step_ptr_t>();
+    test_step<gil::cmyk32f_planar_step_ptr_t>();
+}

--- a/test/locator/CMakeLists.txt
+++ b/test/locator/CMakeLists.txt
@@ -6,7 +6,8 @@
 # http://www.boost.org/LICENSE_1_0.txt)
 #
 foreach(_name
-  concepts)
+  concepts
+  dynamic_step)
   set(_target test_core_locator_${_name})
 
   add_executable(${_target} "")

--- a/test/locator/Jamfile
+++ b/test/locator/Jamfile
@@ -14,3 +14,4 @@ project
     ;
 
 compile concepts.cpp ;
+compile dynamic_step.cpp ;

--- a/test/locator/dynamic_step.cpp
+++ b/test/locator/dynamic_step.cpp
@@ -1,0 +1,92 @@
+//
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/gil/dynamic_step.hpp>
+#include <boost/gil/color_base.hpp> // kth_element_type
+#include <boost/gil/pixel.hpp> // kth_element_type
+#include <boost/gil/locator.hpp>
+#include <boost/gil/pixel_iterator.hpp>
+#include <boost/gil/typedefs.hpp>
+
+#include <type_traits>
+
+namespace gil = boost::gil;
+
+template <typename Locator>
+void test_locator_from_iterator()
+{
+    // The `memory_based_2d_locator` for X-step is calculated based on adapted iterator
+    // Only verify `type` member is available (i.e. specialization defined).
+    static_assert(std::is_class
+        <
+            typename gil::dynamic_x_step_type<Locator>::type
+        >::value, "");
+
+    static_assert(std::is_same
+        <
+            Locator,
+            typename gil::dynamic_y_step_type<Locator>::type
+        >::value, "locator does not model HasDynamicYStepTypeConcept");
+}
+
+int main()
+{
+    test_locator_from_iterator<gil::gray8_loc_t>();
+    test_locator_from_iterator<gil::gray8c_loc_t>();
+    test_locator_from_iterator<gil::gray16_loc_t>();
+    test_locator_from_iterator<gil::gray16c_loc_t>();
+    test_locator_from_iterator<gil::gray32_loc_t>();
+    test_locator_from_iterator<gil::gray32c_loc_t>();
+    test_locator_from_iterator<gil::gray32f_loc_t>();
+
+    test_locator_from_iterator<gil::abgr8_loc_t>();
+    test_locator_from_iterator<gil::abgr16_loc_t>();
+    test_locator_from_iterator<gil::abgr32_loc_t>();
+    test_locator_from_iterator<gil::abgr32f_loc_t>();
+
+    test_locator_from_iterator<gil::argb8_loc_t>();
+    test_locator_from_iterator<gil::argb16_loc_t>();
+    test_locator_from_iterator<gil::argb32_loc_t>();
+    test_locator_from_iterator<gil::argb32f_loc_t>();
+
+    test_locator_from_iterator<gil::bgr8_loc_t>();
+    test_locator_from_iterator<gil::bgr16_loc_t>();
+    test_locator_from_iterator<gil::bgr32_loc_t>();
+    test_locator_from_iterator<gil::bgr32f_loc_t>();
+
+    test_locator_from_iterator<gil::bgra8_loc_t>();
+    test_locator_from_iterator<gil::bgra16_loc_t>();
+    test_locator_from_iterator<gil::bgra32_loc_t>();
+    test_locator_from_iterator<gil::bgra32f_loc_t>();
+
+    test_locator_from_iterator<gil::rgb8_loc_t>();
+    test_locator_from_iterator<gil::rgb8_planar_loc_t>();
+    test_locator_from_iterator<gil::rgb16_loc_t>();
+    test_locator_from_iterator<gil::rgb16_planar_loc_t>();
+    test_locator_from_iterator<gil::rgb32_loc_t>();
+    test_locator_from_iterator<gil::rgb32_planar_loc_t>();
+    test_locator_from_iterator<gil::rgb32f_loc_t>();
+    test_locator_from_iterator<gil::rgb32f_planar_loc_t>();
+
+    test_locator_from_iterator<gil::rgba8_loc_t>();
+    test_locator_from_iterator<gil::rgba8_planar_loc_t>();
+    test_locator_from_iterator<gil::rgba16_loc_t>();
+    test_locator_from_iterator<gil::rgba16_planar_loc_t>();
+    test_locator_from_iterator<gil::rgba32_loc_t>();
+    test_locator_from_iterator<gil::rgba32_planar_loc_t>();
+    test_locator_from_iterator<gil::rgba32f_loc_t>();
+    test_locator_from_iterator<gil::rgba32f_planar_loc_t>();
+
+    test_locator_from_iterator<gil::cmyk8_loc_t>();
+    test_locator_from_iterator<gil::cmyk8_planar_loc_t>();
+    test_locator_from_iterator<gil::cmyk16_loc_t>();
+    test_locator_from_iterator<gil::cmyk16_planar_loc_t>();
+    test_locator_from_iterator<gil::cmyk32_loc_t>();
+    test_locator_from_iterator<gil::cmyk32_planar_loc_t>();
+    test_locator_from_iterator<gil::cmyk32f_loc_t>();
+    test_locator_from_iterator<gil::cmyk32f_planar_loc_t>();
+}


### PR DESCRIPTION
Basic verification expected specializations of `dynamic_x_step_type`
and `dynamic_y_step_type` are in place.

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed
