### PR TITLE
[azp] Update Python pip

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -5,6 +5,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
 #
 variables:
+  #system.debug: true
   configuration: release
 
 trigger:
@@ -46,6 +47,12 @@ jobs:
     pool:
       vmImage: 'vs2017-win2016'
     steps:
+      - task: UsePythonVersion@0
+        displayName: 'Setup Python'
+        inputs:
+          versionSpec: '3.6'
+          addToPath: true
+          architecture: 'x64'
       - template: .ci/azure-pipelines/steps-check-cmake.yml
       - template: .ci/azure-pipelines/steps-install-conan.yml
       - template: .ci/azure-pipelines/steps-install-boost.yml
@@ -57,6 +64,12 @@ jobs:
     pool:
       vmImage: 'vs2017-win2016'
     steps:
+      - task: UsePythonVersion@0
+        displayName: 'Setup Python'
+        inputs:
+          versionSpec: '3.6'
+          addToPath: true
+          architecture: 'x64'
       - template: .ci/azure-pipelines/steps-check-cmake.yml
       - template: .ci/azure-pipelines/steps-install-conan.yml
       - template: .ci/azure-pipelines/steps-install-boost.yml

--- a/.ci/azure-pipelines/steps-install-conan.yml
+++ b/.ci/azure-pipelines/steps-install-conan.yml
@@ -10,6 +10,7 @@ parameters:
 steps:
   - script: |
       ${{ parameters.python }} --version
+      ${{ parameters.python }} -m pip install --upgrade pip
       ${{ parameters.python }} -m pip install --upgrade conan
       conan --version
     displayName: 'Install Conan'


### PR DESCRIPTION
### Problem

Attempt to solve recent build failures on Azure Pipelines as reported here, then pip update suggested as a solution:
https://developercommunity.visualstudio.com/content/problem/469073/azp-script-is-installed-in-chostedtoolcachewindows.html

### Solution

Workaround for the problem was suggested in follow-up to the linked report. Adding this task to Windows jobs in `.azure-pipelines.yml` seems to solve the problem:

```
- task: UsePythonVersion@0
    displayName: 'Setup Python'
    inputs:
      versionSpec: '3.6' 
      addToPath: true
      architecture: 'x64'
```

### Tasklist

- [x] All CI builds and checks have passed
