### PR TITLE
Add test for some channel, color and pixel metafunctions

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,6 +31,7 @@ endif()
 
 add_subdirectory(point)
 add_subdirectory(channel)
+add_subdirectory(color)
 add_subdirectory(pixel)
 add_subdirectory(iterator)
 add_subdirectory(locator)

--- a/test/color/CMakeLists.txt
+++ b/test/color/CMakeLists.txt
@@ -7,11 +7,8 @@
 #
 foreach(_name
   concepts
-  is_pixel
-  is_planar
-  num_channels
-  pixels_are_compatible)
-  set(_target test_core_pixel_${_name})
+  color_spaces_are_compatible)
+  set(_target test_core_color_${_name})
 
   add_executable(${_target} "")
   target_sources(${_target} PRIVATE ${_name}.cpp)

--- a/test/color/Jamfile
+++ b/test/color/Jamfile
@@ -14,5 +14,4 @@ project
     ;
 
 compile concepts.cpp ;
-compile dynamic_step.cpp ;
-compile is_planar ;
+compile color_spaces_are_compatible.cpp ;

--- a/test/color/color_spaces_are_compatible.cpp
+++ b/test/color/color_spaces_are_compatible.cpp
@@ -1,0 +1,47 @@
+//
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/gil/color_base.hpp>
+#include <boost/gil/concepts.hpp>
+#include <boost/gil/device_n.hpp>
+#include <boost/gil/gray.hpp>
+#include <boost/gil/rgb.hpp>
+#include <boost/gil/rgba.hpp>
+#include <boost/gil/cmyk.hpp>
+#include <boost/gil/typedefs.hpp>
+
+#include <boost/mp11.hpp>
+
+#include <type_traits>
+
+namespace gil = boost::gil;
+using namespace boost::mp11;
+
+template <typename T>
+using test_self_compatible = gil::color_spaces_are_compatible<T, T>;
+
+int main()
+{
+    using color_spaces = mp_list
+    <
+        gil::devicen_t<2>,
+        gil::devicen_t<3>,
+        gil::devicen_t<4>,
+        gil::devicen_t<5>,
+        gil::gray_t,
+        gil::cmyk_t,
+        gil::rgb_t,
+        gil::rgba_t
+    >;
+
+    static_assert(std::is_same
+        <
+            mp_all_of<color_spaces, test_self_compatible>,
+            std::true_type
+        >::value,
+        "color_spaces_are_compatible should yield true for the same types");
+}

--- a/test/color/concepts.cpp
+++ b/test/color/concepts.cpp
@@ -1,0 +1,46 @@
+//
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#ifndef BOOST_GIL_USE_CONCEPT_CHECK
+#error Compile with BOOST_GIL_USE_CONCEPT_CHECK defined
+#endif
+#include <boost/gil/concepts.hpp>
+#include <boost/gil/device_n.hpp>
+#include <boost/gil/gray.hpp>
+#include <boost/gil/rgb.hpp>
+#include <boost/gil/rgba.hpp>
+#include <boost/gil/cmyk.hpp>
+
+#include <boost/concept_check.hpp>
+
+namespace gil = boost::gil;
+using boost::function_requires;
+
+int main()
+{
+    // TODO: Most constraints() for color concepts are no-op as not implemented.
+    //       Once implemented, this test should help to catch any issues early.
+
+    function_requires<gil::ColorSpaceConcept<gil::devicen_t<2>>>();
+    function_requires<gil::ColorSpaceConcept<gil::devicen_t<3>>>();
+    function_requires<gil::ColorSpaceConcept<gil::devicen_t<4>>>();
+    function_requires<gil::ColorSpaceConcept<gil::devicen_t<5>>>();
+    function_requires<gil::ColorSpaceConcept<gil::gray_t>>();
+    function_requires<gil::ColorSpaceConcept<gil::cmyk_t>>();
+    function_requires<gil::ColorSpaceConcept<gil::rgb_t>>();
+    function_requires<gil::ColorSpaceConcept<gil::rgba_t>>();
+
+    function_requires<gil::ColorSpacesCompatibleConcept<gil::gray_t, gil::gray_t>>();
+    function_requires<gil::ColorSpacesCompatibleConcept<gil::cmyk_t, gil::cmyk_t>>();
+    function_requires<gil::ColorSpacesCompatibleConcept<gil::rgb_t, gil::rgb_t>>();
+    function_requires<gil::ColorSpacesCompatibleConcept<gil::rgba_t, gil::rgba_t>>();
+    function_requires<gil::ColorSpacesCompatibleConcept
+        <
+            gil::devicen_t<2>,
+            gil::devicen_t<2>
+        >>();
+}

--- a/test/iterator/CMakeLists.txt
+++ b/test/iterator/CMakeLists.txt
@@ -7,7 +7,8 @@
 #
 foreach(_name
   concepts
-  dynamic_step)
+  dynamic_step
+  is_planar)
   set(_target test_core_iterator_${_name})
 
   add_executable(${_target} "")

--- a/test/iterator/Jamfile
+++ b/test/iterator/Jamfile
@@ -15,4 +15,4 @@ project
 
 compile concepts.cpp ;
 compile dynamic_step.cpp ;
-compile is_planar ;
+compile is_planar.cpp ;

--- a/test/iterator/is_planar.cpp
+++ b/test/iterator/is_planar.cpp
@@ -1,0 +1,72 @@
+//
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/gil/pixel.hpp>
+#include <boost/gil/planar_pixel_iterator.hpp>
+#include <boost/gil/typedefs.hpp>
+
+#include <boost/mp11.hpp>
+
+namespace gil = boost::gil;
+using namespace boost::mp11;
+
+int main()
+{
+    using iterators = mp_list
+    <
+        gil::planar_pixel_iterator<gil::rgb8_view_t*, gil::rgb_t>,
+        gil::rgb8_planar_ptr_t,
+        gil::rgb8_planar_step_ptr_t,
+        gil::rgb8c_planar_ptr_t,
+        gil::rgb8c_planar_step_ptr_t,
+        gil::rgb16_planar_ptr_t,
+        gil::rgb16c_planar_ptr_t,
+        gil::rgb16s_planar_ptr_t,
+        gil::rgb16sc_planar_ptr_t,
+        gil::rgb32_planar_ptr_t,
+        gil::rgb32c_planar_ptr_t,
+        gil::rgb32f_planar_ptr_t,
+        gil::rgb32fc_planar_ptr_t,
+        gil::rgb32s_planar_ptr_t,
+        gil::rgb32sc_planar_ptr_t,
+        gil::cmyk8_planar_ptr_t,
+        gil::cmyk8c_planar_ptr_t,
+        gil::cmyk8s_planar_ptr_t,
+        gil::cmyk8sc_planar_ptr_t,
+        gil::cmyk16_planar_ptr_t,
+        gil::cmyk16c_planar_ptr_t,
+        gil::cmyk16s_planar_ptr_t,
+        gil::cmyk16sc_planar_ptr_t,
+        gil::cmyk32_planar_ptr_t,
+        gil::cmyk32c_planar_ptr_t,
+        gil::cmyk32f_planar_ptr_t,
+        gil::cmyk32fc_planar_ptr_t,
+        gil::cmyk32s_planar_ptr_t,
+        gil::cmyk32sc_planar_ptr_t,
+        gil::rgba8_planar_ptr_t,
+        gil::rgba8c_planar_ptr_t,
+        gil::rgba8s_planar_ptr_t,
+        gil::rgba8sc_planar_ptr_t,
+        gil::rgba16_planar_ptr_t,
+        gil::rgba16c_planar_ptr_t,
+        gil::rgba16s_planar_ptr_t,
+        gil::rgba16sc_planar_ptr_t,
+        gil::rgba32_planar_ptr_t,
+        gil::rgba32c_planar_ptr_t,
+        gil::rgba32f_planar_ptr_t,
+        gil::rgba32fc_planar_ptr_t,
+        gil::rgba32s_planar_ptr_t,
+        gil::rgba32sc_planar_ptr_t
+    >;
+
+    static_assert(std::is_same
+        <
+            mp_all_of<iterators, gil::is_planar>,
+            std::true_type
+        >::value,
+        "is_planar yields true for non-planar pixel iterator");
+}

--- a/test/pixel/Jamfile
+++ b/test/pixel/Jamfile
@@ -14,4 +14,7 @@ project
     ;
 
 compile concepts.cpp ;
+compile is_pixel.cpp ;
+compile is_planar.cpp ;
+compile num_channels.cpp ;
 compile pixels_are_compatible.cpp ;

--- a/test/pixel/is_pixel.cpp
+++ b/test/pixel/is_pixel.cpp
@@ -1,0 +1,154 @@
+//
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/gil/pixel.hpp>
+#include <boost/gil/concepts/pixel.hpp>
+#include <boost/gil/typedefs.hpp>
+
+#include <boost/mp11.hpp>
+
+namespace gil = boost::gil;
+using namespace boost::mp11;
+
+int main()
+{
+    using pixels = mp_list
+    <
+        gil::gray8_pixel_t,
+        gil::gray8c_pixel_t,
+        gil::gray8s_pixel_t,
+        gil::gray8sc_pixel_t,
+        gil::gray16_pixel_t,
+        gil::gray16c_pixel_t,
+        gil::gray16s_pixel_t,
+        gil::gray16sc_pixel_t,
+        gil::gray16_pixel_t,
+        gil::gray32_pixel_t,
+        gil::gray32c_pixel_t,
+        gil::gray32f_pixel_t,
+        gil::gray32fc_pixel_t,
+        gil::gray32s_pixel_t,
+        gil::gray32sc_pixel_t,
+        gil::bgr8_pixel_t,
+        gil::bgr8c_pixel_t,
+        gil::bgr8s_pixel_t,
+        gil::bgr8sc_pixel_t,
+        gil::bgr16_pixel_t,
+        gil::bgr16c_pixel_t,
+        gil::bgr16s_pixel_t,
+        gil::bgr16sc_pixel_t,
+        gil::bgr32_pixel_t,
+        gil::bgr32c_pixel_t,
+        gil::bgr32f_pixel_t,
+        gil::bgr32fc_pixel_t,
+        gil::bgr32s_pixel_t,
+        gil::bgr32sc_pixel_t,
+        gil::rgb8_pixel_t,
+        gil::rgb8c_pixel_t,
+        gil::rgb8s_pixel_t,
+        gil::rgb8sc_pixel_t,
+        gil::rgb16_pixel_t,
+        gil::rgb16c_pixel_t,
+        gil::rgb16s_pixel_t,
+        gil::rgb16sc_pixel_t,
+        gil::rgb32_pixel_t,
+        gil::rgb32c_pixel_t,
+        gil::rgb32f_pixel_t,
+        gil::rgb32fc_pixel_t,
+        gil::rgb32s_pixel_t,
+        gil::rgb32sc_pixel_t,
+        gil::abgr8_pixel_t,
+        gil::abgr8c_pixel_t,
+        gil::abgr8s_pixel_t,
+        gil::abgr8sc_pixel_t,
+        gil::abgr16_pixel_t,
+        gil::abgr16c_pixel_t,
+        gil::abgr16s_pixel_t,
+        gil::abgr16sc_pixel_t,
+        gil::abgr32_pixel_t,
+        gil::abgr32c_pixel_t,
+        gil::abgr32f_pixel_t,
+        gil::abgr32fc_pixel_t,
+        gil::abgr32s_pixel_t,
+        gil::abgr32sc_pixel_t,
+        gil::bgra8_pixel_t,
+        gil::bgra8c_pixel_t,
+        gil::bgra8s_pixel_t,
+        gil::bgra8sc_pixel_t,
+        gil::bgra16_pixel_t,
+        gil::bgra16c_pixel_t,
+        gil::bgra16s_pixel_t,
+        gil::bgra16sc_pixel_t,
+        gil::bgra32_pixel_t,
+        gil::bgra32c_pixel_t,
+        gil::bgra32f_pixel_t,
+        gil::bgra32fc_pixel_t,
+        gil::bgra32s_pixel_t,
+        gil::bgra32sc_pixel_t,
+        gil::cmyk8_pixel_t,
+        gil::cmyk8c_pixel_t,
+        gil::cmyk8s_pixel_t,
+        gil::cmyk8sc_pixel_t,
+        gil::cmyk16_pixel_t,
+        gil::cmyk16c_pixel_t,
+        gil::cmyk16s_pixel_t,
+        gil::cmyk16sc_pixel_t,
+        gil::cmyk32_pixel_t,
+        gil::cmyk32c_pixel_t,
+        gil::cmyk32f_pixel_t,
+        gil::cmyk32fc_pixel_t,
+        gil::cmyk32s_pixel_t,
+        gil::cmyk32sc_pixel_t,
+        gil::rgba8_pixel_t,
+        gil::rgba8c_pixel_t,
+        gil::rgba8s_pixel_t,
+        gil::rgba8sc_pixel_t,
+        gil::rgba16_pixel_t,
+        gil::rgba16c_pixel_t,
+        gil::rgba16s_pixel_t,
+        gil::rgba16sc_pixel_t,
+        gil::rgba32_pixel_t,
+        gil::rgba32c_pixel_t,
+        gil::rgba32f_pixel_t,
+        gil::rgba32fc_pixel_t,
+        gil::rgba32s_pixel_t,
+        gil::rgba32sc_pixel_t
+    >;
+
+    static_assert(std::is_same
+        <
+            mp_all_of<pixels, gil::is_pixel>,
+            std::true_type
+        >::value,
+        "is_pixel does not yield true for all pixel types");
+
+
+    struct not_a_pixel_type {};
+    using non_pixels = mp_list
+    <
+        not_a_pixel_type,
+        char,
+        short, int, long,
+        double, float,
+        std::size_t,
+        std::true_type, std::false_type
+    >;
+
+    static_assert(std::is_same
+        <
+            mp_all_of<non_pixels, gil::is_pixel>,
+            std::false_type
+        >::value,
+        "is_pixel yields true for non-pixel type");
+
+    static_assert(std::is_same
+        <
+            mp_none_of<non_pixels, gil::is_pixel>,
+            std::true_type
+        >::value,
+        "is_pixel yields true for non-pixel type");
+}

--- a/test/pixel/is_planar.cpp
+++ b/test/pixel/is_planar.cpp
@@ -1,0 +1,137 @@
+//
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/gil/pixel.hpp>
+#include <boost/gil/planar_pixel_iterator.hpp>
+#include <boost/gil/typedefs.hpp>
+
+#include <boost/mp11.hpp>
+
+namespace gil = boost::gil;
+using namespace boost::mp11;
+
+int main()
+{
+    using non_planar_pixels = mp_list
+    <
+        gil::gray8_pixel_t,
+        gil::gray8c_pixel_t,
+        gil::gray8s_pixel_t,
+        gil::gray8sc_pixel_t,
+        gil::gray16_pixel_t,
+        gil::gray16c_pixel_t,
+        gil::gray16s_pixel_t,
+        gil::gray16sc_pixel_t,
+        gil::gray16_pixel_t,
+        gil::gray32_pixel_t,
+        gil::gray32c_pixel_t,
+        gil::gray32f_pixel_t,
+        gil::gray32fc_pixel_t,
+        gil::gray32s_pixel_t,
+        gil::gray32sc_pixel_t,
+        gil::bgr8_pixel_t,
+        gil::bgr8c_pixel_t,
+        gil::bgr8s_pixel_t,
+        gil::bgr8sc_pixel_t,
+        gil::bgr16_pixel_t,
+        gil::bgr16c_pixel_t,
+        gil::bgr16s_pixel_t,
+        gil::bgr16sc_pixel_t,
+        gil::bgr32_pixel_t,
+        gil::bgr32c_pixel_t,
+        gil::bgr32f_pixel_t,
+        gil::bgr32fc_pixel_t,
+        gil::bgr32s_pixel_t,
+        gil::bgr32sc_pixel_t,
+        gil::rgb8_pixel_t,
+        gil::rgb8c_pixel_t,
+        gil::rgb8s_pixel_t,
+        gil::rgb8sc_pixel_t,
+        gil::rgb16_pixel_t,
+        gil::rgb16c_pixel_t,
+        gil::rgb16s_pixel_t,
+        gil::rgb16sc_pixel_t,
+        gil::rgb32_pixel_t,
+        gil::rgb32c_pixel_t,
+        gil::rgb32f_pixel_t,
+        gil::rgb32fc_pixel_t,
+        gil::rgb32s_pixel_t,
+        gil::rgb32sc_pixel_t,
+        gil::abgr8_pixel_t,
+        gil::abgr8c_pixel_t,
+        gil::abgr8s_pixel_t,
+        gil::abgr8sc_pixel_t,
+        gil::abgr16_pixel_t,
+        gil::abgr16c_pixel_t,
+        gil::abgr16s_pixel_t,
+        gil::abgr16sc_pixel_t,
+        gil::abgr32_pixel_t,
+        gil::abgr32c_pixel_t,
+        gil::abgr32f_pixel_t,
+        gil::abgr32fc_pixel_t,
+        gil::abgr32s_pixel_t,
+        gil::abgr32sc_pixel_t,
+        gil::bgra8_pixel_t,
+        gil::bgra8c_pixel_t,
+        gil::bgra8s_pixel_t,
+        gil::bgra8sc_pixel_t,
+        gil::bgra16_pixel_t,
+        gil::bgra16c_pixel_t,
+        gil::bgra16s_pixel_t,
+        gil::bgra16sc_pixel_t,
+        gil::bgra32_pixel_t,
+        gil::bgra32c_pixel_t,
+        gil::bgra32f_pixel_t,
+        gil::bgra32fc_pixel_t,
+        gil::bgra32s_pixel_t,
+        gil::bgra32sc_pixel_t,
+        gil::cmyk8_pixel_t,
+        gil::cmyk8c_pixel_t,
+        gil::cmyk8s_pixel_t,
+        gil::cmyk8sc_pixel_t,
+        gil::cmyk16_pixel_t,
+        gil::cmyk16c_pixel_t,
+        gil::cmyk16s_pixel_t,
+        gil::cmyk16sc_pixel_t,
+        gil::cmyk32_pixel_t,
+        gil::cmyk32c_pixel_t,
+        gil::cmyk32f_pixel_t,
+        gil::cmyk32fc_pixel_t,
+        gil::cmyk32s_pixel_t,
+        gil::cmyk32sc_pixel_t,
+        gil::rgba8_pixel_t,
+        gil::rgba8c_pixel_t,
+        gil::rgba8s_pixel_t,
+        gil::rgba8sc_pixel_t,
+        gil::rgba16_pixel_t,
+        gil::rgba16c_pixel_t,
+        gil::rgba16s_pixel_t,
+        gil::rgba16sc_pixel_t,
+        gil::rgba32_pixel_t,
+        gil::rgba32c_pixel_t,
+        gil::rgba32f_pixel_t,
+        gil::rgba32fc_pixel_t,
+        gil::rgba32s_pixel_t,
+        gil::rgba32sc_pixel_t
+    >;
+
+    static_assert(
+        std::is_same
+        <
+            mp_all_of<non_planar_pixels, gil::is_planar>,
+            std::false_type
+        >::value,
+        "is_planar yields true for non-planar pixel type");
+
+    static_assert(
+        std::is_same
+        <
+            mp_none_of<non_planar_pixels, gil::is_planar>,
+            std::true_type
+        >::value,
+        "is_planar yields true for non-planar pixel type");
+}

--- a/test/pixel/num_channels.cpp
+++ b/test/pixel/num_channels.cpp
@@ -1,0 +1,154 @@
+//
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/gil/pixel.hpp>
+#include <boost/gil/concepts/pixel.hpp>
+#include <boost/gil/typedefs.hpp>
+
+#include <boost/mp11.hpp>
+
+namespace gil = boost::gil;
+using namespace boost::mp11;
+
+template <std::size_t NumChannels>
+struct assert_num_channels
+{
+    template <typename Pixel>
+    void operator()(Pixel&&)
+    {
+        static_assert(
+            gil::num_channels<Pixel>::value == NumChannels,
+            "pixels does not have expected number of channels");
+
+        // TODO: Verify num_channels type with std::is_same
+        // e.g. is std::integral_constant<T, ...>
+    }
+};
+
+template <std::size_t NumChannels, typename... Pixels>
+void test()
+{
+    mp_for_each<Pixels...>(assert_num_channels<NumChannels>());
+}
+
+
+int main()
+{
+    using one = mp_list
+    <
+        gil::gray8_pixel_t,
+        gil::gray8c_pixel_t,
+        gil::gray8s_pixel_t,
+        gil::gray8sc_pixel_t,
+        gil::gray16_pixel_t,
+        gil::gray16c_pixel_t,
+        gil::gray16s_pixel_t,
+        gil::gray16sc_pixel_t,
+        gil::gray16_pixel_t,
+        gil::gray32_pixel_t,
+        gil::gray32c_pixel_t,
+        gil::gray32f_pixel_t,
+        gil::gray32fc_pixel_t,
+        gil::gray32s_pixel_t,
+        gil::gray32sc_pixel_t
+    >;
+    test<1, one>();
+
+    using three = mp_list
+    <
+        gil::bgr8_pixel_t,
+        gil::bgr8c_pixel_t,
+        gil::bgr8s_pixel_t,
+        gil::bgr8sc_pixel_t,
+        gil::bgr16_pixel_t,
+        gil::bgr16c_pixel_t,
+        gil::bgr16s_pixel_t,
+        gil::bgr16sc_pixel_t,
+        gil::bgr32_pixel_t,
+        gil::bgr32c_pixel_t,
+        gil::bgr32f_pixel_t,
+        gil::bgr32fc_pixel_t,
+        gil::bgr32s_pixel_t,
+        gil::bgr32sc_pixel_t,
+        gil::rgb8_pixel_t,
+        gil::rgb8c_pixel_t,
+        gil::rgb8s_pixel_t,
+        gil::rgb8sc_pixel_t,
+        gil::rgb16_pixel_t,
+        gil::rgb16c_pixel_t,
+        gil::rgb16s_pixel_t,
+        gil::rgb16sc_pixel_t,
+        gil::rgb32_pixel_t,
+        gil::rgb32c_pixel_t,
+        gil::rgb32f_pixel_t,
+        gil::rgb32fc_pixel_t,
+        gil::rgb32s_pixel_t,
+        gil::rgb32sc_pixel_t
+    >;
+    test<3, three>();
+
+    using four = mp_list
+    <
+        gil::abgr8_pixel_t,
+        gil::abgr8c_pixel_t,
+        gil::abgr8s_pixel_t,
+        gil::abgr8sc_pixel_t,
+        gil::abgr16_pixel_t,
+        gil::abgr16c_pixel_t,
+        gil::abgr16s_pixel_t,
+        gil::abgr16sc_pixel_t,
+        gil::abgr32_pixel_t,
+        gil::abgr32c_pixel_t,
+        gil::abgr32f_pixel_t,
+        gil::abgr32fc_pixel_t,
+        gil::abgr32s_pixel_t,
+        gil::abgr32sc_pixel_t,
+        gil::bgra8_pixel_t,
+        gil::bgra8c_pixel_t,
+        gil::bgra8s_pixel_t,
+        gil::bgra8sc_pixel_t,
+        gil::bgra16_pixel_t,
+        gil::bgra16c_pixel_t,
+        gil::bgra16s_pixel_t,
+        gil::bgra16sc_pixel_t,
+        gil::bgra32_pixel_t,
+        gil::bgra32c_pixel_t,
+        gil::bgra32f_pixel_t,
+        gil::bgra32fc_pixel_t,
+        gil::bgra32s_pixel_t,
+        gil::bgra32sc_pixel_t,
+        gil::cmyk8_pixel_t,
+        gil::cmyk8c_pixel_t,
+        gil::cmyk8s_pixel_t,
+        gil::cmyk8sc_pixel_t,
+        gil::cmyk16_pixel_t,
+        gil::cmyk16c_pixel_t,
+        gil::cmyk16s_pixel_t,
+        gil::cmyk16sc_pixel_t,
+        gil::cmyk32_pixel_t,
+        gil::cmyk32c_pixel_t,
+        gil::cmyk32f_pixel_t,
+        gil::cmyk32fc_pixel_t,
+        gil::cmyk32s_pixel_t,
+        gil::cmyk32sc_pixel_t,
+        gil::rgba8_pixel_t,
+        gil::rgba8c_pixel_t,
+        gil::rgba8s_pixel_t,
+        gil::rgba8sc_pixel_t,
+        gil::rgba16_pixel_t,
+        gil::rgba16c_pixel_t,
+        gil::rgba16s_pixel_t,
+        gil::rgba16sc_pixel_t,
+        gil::rgba32_pixel_t,
+        gil::rgba32c_pixel_t,
+        gil::rgba32f_pixel_t,
+        gil::rgba32fc_pixel_t,
+        gil::rgba32s_pixel_t,
+        gil::rgba32sc_pixel_t
+    >;
+    test<4, four>();
+}

--- a/test/pixel/pixels_are_compatible.cpp
+++ b/test/pixel/pixels_are_compatible.cpp
@@ -11,6 +11,8 @@
 
 #include <boost/mp11.hpp>
 
+#include <type_traits>
+
 namespace gil = boost::gil;
 using namespace boost::mp11;
 


### PR DESCRIPTION
This adds some more compile-time tests for individual metafunctions.

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed

-----

Note, pure compile-time testing performed by Boost.Build only, while CMake runs the tests.