### PR TITLE
Add pixel test fixture with all core pixel types

### DIFF
--- a/test/algorithm/CMakeLists.txt
+++ b/test/algorithm/CMakeLists.txt
@@ -17,7 +17,7 @@ foreach(_name
       gil_compile_options
       gil_include_directories
       gil_dependencies)
-  add_test(test.core.${_name} ${_target})
+  add_test(test.core.algorithm.${_name} ${_target})
 
   unset(_name)
   unset(_target)

--- a/test/channel/CMakeLists.txt
+++ b/test/channel/CMakeLists.txt
@@ -15,7 +15,7 @@ foreach(_name
   concepts
   scoped_channel_value
   test_fixture)
-  set(_target test_core_${_name})
+  set(_target test_core_channel_${_name})
 
   add_executable(${_target} "")
   target_sources(${_target} PRIVATE ${_name}.cpp)
@@ -25,7 +25,7 @@ foreach(_name
       gil_include_directories
       gil_dependencies)
   target_compile_definitions(${_target} PRIVATE BOOST_GIL_USE_CONCEPT_CHECK)
-  add_test(test.core.${_name} ${_target})
+  add_test(test.core.channel.${_name} ${_target})
 
   unset(_name)
   unset(_target)

--- a/test/color/CMakeLists.txt
+++ b/test/color/CMakeLists.txt
@@ -18,7 +18,7 @@ foreach(_name
       gil_include_directories
       gil_dependencies)
   target_compile_definitions(${_target} PRIVATE BOOST_GIL_USE_CONCEPT_CHECK)
-  add_test(test.core.${_name} ${_target})
+  add_test(test.core.color.${_name} ${_target})
 
   unset(_name)
   unset(_target)

--- a/test/image/CMakeLists.txt
+++ b/test/image/CMakeLists.txt
@@ -17,7 +17,7 @@ foreach(_name
       gil_include_directories
       gil_dependencies)
   target_compile_definitions(${_target} PRIVATE BOOST_GIL_USE_CONCEPT_CHECK)
-  add_test(test.core.${_name} ${_target})
+  add_test(test.core.image.${_name} ${_target})
 
   unset(_name)
   unset(_target)

--- a/test/image_view/CMakeLists.txt
+++ b/test/image_view/CMakeLists.txt
@@ -26,7 +26,7 @@ foreach(_name
       gil_include_directories
       gil_dependencies)
   target_compile_definitions(${_target} PRIVATE BOOST_GIL_USE_CONCEPT_CHECK)
-  add_test(test.core.${_name} ${_target})
+  add_test(test.core.image_view.${_name} ${_target})
 
   unset(_name)
   unset(_target)

--- a/test/iterator/CMakeLists.txt
+++ b/test/iterator/CMakeLists.txt
@@ -19,7 +19,7 @@ foreach(_name
       gil_include_directories
       gil_dependencies)
   target_compile_definitions(${_target} PRIVATE BOOST_GIL_USE_CONCEPT_CHECK)
-  add_test(test.core.${_name} ${_target})
+  add_test(test.core.iterator.${_name} ${_target})
 
   unset(_name)
   unset(_target)

--- a/test/locator/CMakeLists.txt
+++ b/test/locator/CMakeLists.txt
@@ -18,7 +18,7 @@ foreach(_name
       gil_include_directories
       gil_dependencies)
   target_compile_definitions(${_target} PRIVATE BOOST_GIL_USE_CONCEPT_CHECK)
-  add_test(test.core.${_name} ${_target})
+  add_test(test.core.locator.${_name} ${_target})
 
   unset(_name)
   unset(_target)

--- a/test/pixel/CMakeLists.txt
+++ b/test/pixel/CMakeLists.txt
@@ -23,7 +23,7 @@ foreach(_name
       gil_include_directories
       gil_dependencies)
   target_compile_definitions(${_target} PRIVATE BOOST_GIL_USE_CONCEPT_CHECK)
-  add_test(test.core.${_name} ${_target})
+  add_test(test.core.pixel.${_name} ${_target})
 
   unset(_name)
   unset(_target)

--- a/test/pixel/CMakeLists.txt
+++ b/test/pixel/CMakeLists.txt
@@ -10,7 +10,9 @@ foreach(_name
   is_pixel
   is_planar
   num_channels
-  pixels_are_compatible)
+  pixel_reference_is_mutable
+  pixels_are_compatible
+  test_fixture)
   set(_target test_core_pixel_${_name})
 
   add_executable(${_target} "")

--- a/test/pixel/Jamfile
+++ b/test/pixel/Jamfile
@@ -17,4 +17,7 @@ compile concepts.cpp ;
 compile is_pixel.cpp ;
 compile is_planar.cpp ;
 compile num_channels.cpp ;
+compile pixel_reference_is_mutable.cpp ;
 compile pixels_are_compatible.cpp ;
+
+run test_fixture.cpp ;

--- a/test/pixel/Jamfile
+++ b/test/pixel/Jamfile
@@ -20,4 +20,4 @@ compile num_channels.cpp ;
 compile pixel_reference_is_mutable.cpp ;
 compile pixels_are_compatible.cpp ;
 
-run test_fixture.cpp ;
+run test_fixture.cpp /boost/test//boost_unit_test_framework : : : <link>shared:<define>BOOST_TEST_DYN_LINK=1 ;

--- a/test/pixel/concepts.cpp
+++ b/test/pixel/concepts.cpp
@@ -11,17 +11,36 @@
 #include <boost/gil.hpp>
 
 #include <boost/concept_check.hpp>
+#include <boost/mp11.hpp>
 #include <boost/mpl/vector_c.hpp>
+
+#include "test_fixture.hpp"
 
 namespace mpl = boost::mpl;
 namespace gil = boost::gil;
 using boost::function_requires;
+using namespace boost::mp11;
+
+template <template<typename> typename Concept>
+struct assert_concept
+{
+    template <typename Pixel>
+    void operator()(Pixel&&)
+    {
+        function_requires<Concept<Pixel>>();
+    }
+};
+
+template <template<typename> typename Concept, typename... Pixels>
+void test_concept()
+{
+    mp_for_each<Pixels...>(assert_concept<Concept>());
+}
 
 int main()
 {
-    function_requires<gil::PixelConcept<gil::gray8_pixel_t>>();
-    function_requires<gil::PixelConcept<gil::rgb8_pixel_t>>();
-    function_requires<gil::PixelConcept<gil::bgr8_pixel_t>>();
+    test_concept<gil::PixelConcept, gil::test::fixture::pixel_typedefs>();
+    test_concept<gil::MutablePixelConcept, gil::test::fixture::pixel_typedefs>();
 
     using rgb565_pixel_t = gil::packed_pixel_type
         <

--- a/test/pixel/is_pixel.cpp
+++ b/test/pixel/is_pixel.cpp
@@ -11,142 +11,46 @@
 
 #include <boost/mp11.hpp>
 
+#include "test_fixture.hpp"
+
 namespace gil = boost::gil;
 using namespace boost::mp11;
 
 int main()
 {
-    using pixels = mp_list
-    <
-        gil::gray8_pixel_t,
-        gil::gray8c_pixel_t,
-        gil::gray8s_pixel_t,
-        gil::gray8sc_pixel_t,
-        gil::gray16_pixel_t,
-        gil::gray16c_pixel_t,
-        gil::gray16s_pixel_t,
-        gil::gray16sc_pixel_t,
-        gil::gray32_pixel_t,
-        gil::gray32c_pixel_t,
-        gil::gray32f_pixel_t,
-        gil::gray32fc_pixel_t,
-        gil::gray32s_pixel_t,
-        gil::gray32sc_pixel_t,
-        gil::bgr8_pixel_t,
-        gil::bgr8c_pixel_t,
-        gil::bgr8s_pixel_t,
-        gil::bgr8sc_pixel_t,
-        gil::bgr16_pixel_t,
-        gil::bgr16c_pixel_t,
-        gil::bgr16s_pixel_t,
-        gil::bgr16sc_pixel_t,
-        gil::bgr32_pixel_t,
-        gil::bgr32c_pixel_t,
-        gil::bgr32f_pixel_t,
-        gil::bgr32fc_pixel_t,
-        gil::bgr32s_pixel_t,
-        gil::bgr32sc_pixel_t,
-        gil::rgb8_pixel_t,
-        gil::rgb8c_pixel_t,
-        gil::rgb8s_pixel_t,
-        gil::rgb8sc_pixel_t,
-        gil::rgb16_pixel_t,
-        gil::rgb16c_pixel_t,
-        gil::rgb16s_pixel_t,
-        gil::rgb16sc_pixel_t,
-        gil::rgb32_pixel_t,
-        gil::rgb32c_pixel_t,
-        gil::rgb32f_pixel_t,
-        gil::rgb32fc_pixel_t,
-        gil::rgb32s_pixel_t,
-        gil::rgb32sc_pixel_t,
-        gil::abgr8_pixel_t,
-        gil::abgr8c_pixel_t,
-        gil::abgr8s_pixel_t,
-        gil::abgr8sc_pixel_t,
-        gil::abgr16_pixel_t,
-        gil::abgr16c_pixel_t,
-        gil::abgr16s_pixel_t,
-        gil::abgr16sc_pixel_t,
-        gil::abgr32_pixel_t,
-        gil::abgr32c_pixel_t,
-        gil::abgr32f_pixel_t,
-        gil::abgr32fc_pixel_t,
-        gil::abgr32s_pixel_t,
-        gil::abgr32sc_pixel_t,
-        gil::bgra8_pixel_t,
-        gil::bgra8c_pixel_t,
-        gil::bgra8s_pixel_t,
-        gil::bgra8sc_pixel_t,
-        gil::bgra16_pixel_t,
-        gil::bgra16c_pixel_t,
-        gil::bgra16s_pixel_t,
-        gil::bgra16sc_pixel_t,
-        gil::bgra32_pixel_t,
-        gil::bgra32c_pixel_t,
-        gil::bgra32f_pixel_t,
-        gil::bgra32fc_pixel_t,
-        gil::bgra32s_pixel_t,
-        gil::bgra32sc_pixel_t,
-        gil::cmyk8_pixel_t,
-        gil::cmyk8c_pixel_t,
-        gil::cmyk8s_pixel_t,
-        gil::cmyk8sc_pixel_t,
-        gil::cmyk16_pixel_t,
-        gil::cmyk16c_pixel_t,
-        gil::cmyk16s_pixel_t,
-        gil::cmyk16sc_pixel_t,
-        gil::cmyk32_pixel_t,
-        gil::cmyk32c_pixel_t,
-        gil::cmyk32f_pixel_t,
-        gil::cmyk32fc_pixel_t,
-        gil::cmyk32s_pixel_t,
-        gil::cmyk32sc_pixel_t,
-        gil::rgba8_pixel_t,
-        gil::rgba8c_pixel_t,
-        gil::rgba8s_pixel_t,
-        gil::rgba8sc_pixel_t,
-        gil::rgba16_pixel_t,
-        gil::rgba16c_pixel_t,
-        gil::rgba16s_pixel_t,
-        gil::rgba16sc_pixel_t,
-        gil::rgba32_pixel_t,
-        gil::rgba32c_pixel_t,
-        gil::rgba32f_pixel_t,
-        gil::rgba32fc_pixel_t,
-        gil::rgba32s_pixel_t,
-        gil::rgba32sc_pixel_t
-    >;
-
     static_assert(std::is_same
         <
-            mp_all_of<pixels, gil::is_pixel>,
+            mp_all_of<gil::test::fixture::pixel_typedefs, gil::is_pixel>,
             std::true_type
         >::value,
-        "is_pixel does not yield true for all pixel types");
-
-
-    struct not_a_pixel_type {};
-    using non_pixels = mp_list
-    <
-        not_a_pixel_type,
-        char,
-        short, int, long,
-        double, float,
-        std::size_t,
-        std::true_type, std::false_type
-    >;
+        "is_pixel does not yield true for all core pixel types");
 
     static_assert(std::is_same
         <
-            mp_all_of<non_pixels, gil::is_pixel>,
+            mp_all_of
+            <
+                mp_transform
+                <
+                    gil::test::fixture::nested_pixel_type,
+                    gil::test::fixture::representative_pixel_types
+                >,
+                gil::is_pixel
+            >,
+            std::true_type
+        >::value,
+        "is_pixel does not yield true for representative pixel types");
+
+
+    static_assert(std::is_same
+        <
+            mp_all_of<gil::test::fixture::non_pixels, gil::is_pixel>,
             std::false_type
         >::value,
         "is_pixel yields true for non-pixel type");
 
     static_assert(std::is_same
         <
-            mp_none_of<non_pixels, gil::is_pixel>,
+            mp_none_of<gil::test::fixture::non_pixels, gil::is_pixel>,
             std::true_type
         >::value,
         "is_pixel yields true for non-pixel type");

--- a/test/pixel/pixel_reference_is_mutable.cpp
+++ b/test/pixel/pixel_reference_is_mutable.cpp
@@ -1,0 +1,40 @@
+//
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+//#include <boost/gil/concepts/pixel.hpp>
+//#include <boost/gil/metafunctions.hpp>
+//#include <boost/gil/pixel.hpp>
+//#include <boost/gil/typedefs.hpp>
+#include <boost/gil.hpp>
+#include <boost/mp11.hpp>
+#include <boost/mp11/mpl.hpp>
+
+#include "test_fixture.hpp"
+
+namespace gil = boost::gil;
+using namespace boost::mp11;
+
+int main()
+{
+    static_assert(mp_all_of
+        <
+            gil::test::fixture::pixel_typedefs,
+            gil::pixel_reference_is_mutable
+        >::value,
+        "pixel_reference_is_mutable should yield true for all core pixel typedefs");
+
+    static_assert(!mp_all_of
+        <
+            mp_transform
+            <
+                gil::test::fixture::nested_type,
+                gil::test::fixture::representative_pixel_types
+            >,
+            gil::pixel_reference_is_mutable
+        >::value,
+        "pixel_reference_is_mutable should yield true for some representative core pixel types");
+}

--- a/test/pixel/test_fixture.cpp
+++ b/test/pixel/test_fixture.cpp
@@ -50,5 +50,5 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(pixel_reference_parameterized_constructor, Pixel, 
     Pixel sample_pixel;
     gil::static_fill(sample_pixel, std::numeric_limits<channel_t>::max());
     fixture::pixel_reference<Pixel&> fix{sample_pixel};
-    //BOOST_TEST(fix.pixel_ == sample_pixel);
+    BOOST_TEST(fix.pixel_ == sample_pixel);
 }

--- a/test/pixel/test_fixture.cpp
+++ b/test/pixel/test_fixture.cpp
@@ -28,12 +28,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(pixel_value_default_constructor, Pixel, fixture::p
 BOOST_AUTO_TEST_CASE_TEMPLATE(pixel_value_parameterized_constructor, Pixel, fixture::pixel_types)
 {
     using channel_t = typename gil::channel_type<Pixel>::type;
-    auto const channel1_max = std::numeric_limits<channel_t>::max();
-    Pixel const pixel{channel1_max};
-    fixture::pixel_value<Pixel> fix{pixel};
+    Pixel sample_pixel;
+    gil::static_fill(sample_pixel, std::numeric_limits<channel_t>::max());
+    fixture::pixel_value<Pixel> fix{sample_pixel};
     // FIXME: Default value of pixel/homogeneous_color_base is undermined
     // Despite initialising first channel, rest of channels remain undetermined.
-    //BOOST_TEST(fix.pixel_ == pixel);
+    BOOST_TEST(fix.pixel_ == sample_pixel);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(pixel_reference_default_constructor, Pixel, fixture::pixel_types)
@@ -47,8 +47,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(pixel_reference_default_constructor, Pixel, fixtur
 BOOST_AUTO_TEST_CASE_TEMPLATE(pixel_reference_parameterized_constructor, Pixel, fixture::pixel_types)
 {
     using channel_t = typename gil::channel_type<Pixel>::type;
-    auto const channel1_max = std::numeric_limits<channel_t>::max();
-    Pixel const pixel{channel1_max};
-    fixture::pixel_reference<Pixel&> fix{pixel};
-    BOOST_TEST(fix.pixel_ == pixel);
+    Pixel sample_pixel;
+    gil::static_fill(sample_pixel, std::numeric_limits<channel_t>::max());
+    fixture::pixel_reference<Pixel&> fix{sample_pixel};
+    BOOST_TEST(fix.pixel_ == sample_pixel);
 }

--- a/test/pixel/test_fixture.cpp
+++ b/test/pixel/test_fixture.cpp
@@ -10,7 +10,7 @@
 #include <limits>
 #include <ostream>
 
-#define BOOST_TEST_MODULE test_channel_test_fixture
+#define BOOST_TEST_MODULE test_pixel_test_fixture
 #include "unit_test.hpp"
 #include "test_fixture.hpp"
 

--- a/test/pixel/test_fixture.cpp
+++ b/test/pixel/test_fixture.cpp
@@ -50,5 +50,5 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(pixel_reference_parameterized_constructor, Pixel, 
     Pixel sample_pixel;
     gil::static_fill(sample_pixel, std::numeric_limits<channel_t>::max());
     fixture::pixel_reference<Pixel&> fix{sample_pixel};
-    BOOST_TEST(fix.pixel_ == sample_pixel);
+    //BOOST_TEST(fix.pixel_ == sample_pixel);
 }

--- a/test/pixel/test_fixture.cpp
+++ b/test/pixel/test_fixture.cpp
@@ -1,0 +1,52 @@
+//
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/gil/channel.hpp>
+
+#include <limits>
+#include <ostream>
+
+#define BOOST_TEST_MODULE test_channel_test_fixture
+#include "unit_test.hpp"
+#include "test_fixture.hpp"
+
+namespace gil = boost::gil;
+namespace fixture = boost::gil::test::fixture;
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(pixel_value_default_constructor, Pixel, fixture::pixel_types)
+{
+    fixture::pixel_value<Pixel> fix;
+    Pixel const default_value{};
+    // FIXME: Default value of pixel/homogeneous_color_base is undermined
+    //BOOST_TEST(fix.pixel_ == default_value);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(pixel_value_parameterized_constructor, Pixel, fixture::pixel_types)
+{
+    using channel_t = gil::channel_type<Pixel>::type;
+    auto const channel1_max = std::numeric_limits<channel_t>::max();
+    Pixel const pixel{channel1_max};
+    fixture::pixel_value<Pixel> fix{pixel};
+    BOOST_TEST(fix.pixel_ == pixel);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(pixel_reference_default_constructor, Pixel, fixture::pixel_types)
+{
+    fixture::pixel_reference<Pixel&> fix;
+    Pixel const default_value{};
+    // FIXME: Default value of pixel/homogeneous_color_base is undermined
+    //BOOST_TEST(fix.pixel_ == Pixel{});
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(pixel_reference_parameterized_constructor, Pixel, fixture::pixel_types)
+{
+    using channel_t = gil::channel_type<Pixel>::type;
+    auto const channel1_max = std::numeric_limits<channel_t>::max();
+    Pixel const pixel{channel1_max};
+    fixture::pixel_reference<Pixel&> fix{pixel};
+    BOOST_TEST(fix.pixel_ == pixel);
+}

--- a/test/pixel/test_fixture.cpp
+++ b/test/pixel/test_fixture.cpp
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(pixel_value_default_constructor, Pixel, fixture::p
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(pixel_value_parameterized_constructor, Pixel, fixture::pixel_types)
 {
-    using channel_t = gil::channel_type<Pixel>::type;
+    using channel_t = typename gil::channel_type<Pixel>::type;
     auto const channel1_max = std::numeric_limits<channel_t>::max();
     Pixel const pixel{channel1_max};
     fixture::pixel_value<Pixel> fix{pixel};
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(pixel_reference_default_constructor, Pixel, fixtur
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(pixel_reference_parameterized_constructor, Pixel, fixture::pixel_types)
 {
-    using channel_t = gil::channel_type<Pixel>::type;
+    using channel_t = typename gil::channel_type<Pixel>::type;
     auto const channel1_max = std::numeric_limits<channel_t>::max();
     Pixel const pixel{channel1_max};
     fixture::pixel_reference<Pixel&> fix{pixel};

--- a/test/pixel/test_fixture.cpp
+++ b/test/pixel/test_fixture.cpp
@@ -5,6 +5,20 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
+#include <boost/config.hpp>
+
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wconversion"
+#pragma clang diagnostic ignored "-Wfloat-equal"
+#pragma clang diagnostic ignored "-Wsign-conversion"
+#elif BOOST_GCC >= 40700
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
+
 #include <boost/gil/channel.hpp>
 
 #include <limits>
@@ -28,11 +42,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(pixel_value_default_constructor, Pixel, fixture::p
 BOOST_AUTO_TEST_CASE_TEMPLATE(pixel_value_parameterized_constructor, Pixel, fixture::pixel_types)
 {
     using channel_t = typename gil::channel_type<Pixel>::type;
+    // Sample channel value, simplified, could be min, max, random
+    channel_t const sample_channel = 2;
     Pixel sample_pixel;
-    gil::static_fill(sample_pixel, std::numeric_limits<channel_t>::max());
+    gil::static_fill(sample_pixel, sample_channel);
     fixture::pixel_value<Pixel> fix{sample_pixel};
-    // FIXME: Default value of pixel/homogeneous_color_base is undermined
-    // Despite initialising first channel, rest of channels remain undetermined.
     BOOST_TEST(fix.pixel_ == sample_pixel);
 }
 
@@ -47,8 +61,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(pixel_reference_default_constructor, Pixel, fixtur
 BOOST_AUTO_TEST_CASE_TEMPLATE(pixel_reference_parameterized_constructor, Pixel, fixture::pixel_types)
 {
     using channel_t = typename gil::channel_type<Pixel>::type;
+    // Sample channel value, simplified, could be min, max, random
+    channel_t const sample_channel = 3;
     Pixel sample_pixel;
-    gil::static_fill(sample_pixel, std::numeric_limits<channel_t>::max());
+    gil::static_fill(sample_pixel, sample_channel);
     fixture::pixel_reference<Pixel&> fix{sample_pixel};
     BOOST_TEST(fix.pixel_ == sample_pixel);
 }

--- a/test/pixel/test_fixture.cpp
+++ b/test/pixel/test_fixture.cpp
@@ -31,7 +31,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(pixel_value_parameterized_constructor, Pixel, fixt
     auto const channel1_max = std::numeric_limits<channel_t>::max();
     Pixel const pixel{channel1_max};
     fixture::pixel_value<Pixel> fix{pixel};
-    BOOST_TEST(fix.pixel_ == pixel);
+    // FIXME: Default value of pixel/homogeneous_color_base is undermined
+    // Despite initialising first channel, rest of channels remain undetermined.
+    //BOOST_TEST(fix.pixel_ == pixel);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(pixel_reference_default_constructor, Pixel, fixture::pixel_types)

--- a/test/pixel/test_fixture.hpp
+++ b/test/pixel/test_fixture.hpp
@@ -1,0 +1,285 @@
+//
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+// Copyright 2005-2007 Adobe Systems Incorporated
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/gil/concepts/pixel.hpp>
+#include <boost/gil/pixel.hpp>
+#include <boost/gil/planar_pixel_reference.hpp>
+#include <boost/gil/typedefs.hpp>
+
+#include <boost/core/typeinfo.hpp>
+#include <boost/mp11.hpp>
+#include <boost/mp11/mpl.hpp> // for compatibility with Boost.Test
+
+#include <tuple>
+#include <type_traits>
+
+namespace boost { namespace gil {
+
+// Pixel has to implement operator<< to be printable for BOOST_TEST()
+template <typename ChannelValue, typename Layout>
+std::ostream& operator<<(std::ostream& os, pixel<ChannelValue, Layout> const& p)
+{
+    // TODO: Print {v1, v2...} channel values
+    os << "pixel<"
+       << "Channel=" << boost::core::demangled_name(typeid(ChannelValue))
+       << ", Layout=" << boost::core::demangled_name(typeid(Layout))
+       << ">"
+       << std::endl;
+    return os;
+}
+
+namespace test { namespace fixture {
+
+template <typename Pixel, int Tag = 0>
+class pixel_value
+{
+public:
+    using type = Pixel;
+    using pixel_t = type;
+    type pixel_{};
+
+    pixel_value() = default;
+    explicit pixel_value(pixel_t const& pixel)
+        : pixel_(pixel) // test copy constructor
+    {
+        type temp_pixel; // test default constructor
+        boost::function_requires<PixelValueConcept<pixel_t> >();
+    }
+};
+
+// Alias compatible with naming of equivalent class in the test/legacy/pixel.cpp
+// The core suffix indicates `Pixel` is GIL core pixel type.
+template <typename Pixel, int Tag = 0>
+using value_core = pixel_value<Pixel, Tag>;
+
+template <typename PixelRef, int Tag = 0>
+struct pixel_reference
+    : pixel_value
+    <
+        typename std::remove_reference<PixelRef>::type,
+        Tag
+    >
+{
+    static_assert(
+        std::is_reference<PixelRef>::value ||
+        gil::is_planar<PixelRef>::value, // poor-man test for specialization of planar_pixel_reference
+        "PixelRef must be reference or gil::planar_pixel_reference");
+
+    using type = PixelRef;
+    using pixel_t = typename std::remove_reference<PixelRef>::type;
+    using parent_t = pixel_value<typename pixel_t::value_type, Tag>;
+    using value_t = typename pixel_t::value_type;
+    type pixel_{}; // reference
+
+    pixel_reference() : parent_t{}, pixel_(parent_t::pixel_) {}
+    explicit pixel_reference(value_t const& pixel) : parent_t(pixel), pixel_(parent_t::pixel_)
+    {
+        boost::function_requires<PixelConcept<pixel_t>>();
+    }
+};
+
+// Alias compatible with naming of equivalent class in the test/legacy/pixel.cpp
+// The core suffix indicates `Pixel` is GIL core pixel type.
+template <typename Pixel, int Tag = 0>
+using reference_core = pixel_reference<Pixel, Tag>;
+
+// Metafunction to yield nested type of a representative pixel type
+template <typename PixelValueOrReference>
+using nested_type = typename PixelValueOrReference::type;
+
+// Metafunction to yield nested type of a representative pixel_t type
+template <typename PixelValueOrReference>
+using nested_pixel_type = typename PixelValueOrReference::pixel_t;
+
+// Subset of pixel models that covers all color spaces, channel depths,
+// reference/value, planar/interleaved, const/mutable.
+// Operations like color conversion will be invoked on pairs of those.
+using representative_pixel_types= ::boost::mp11::mp_list
+<
+    value_core<gil::gray8_pixel_t>,
+    reference_core<gil::gray16_pixel_t&>,
+    value_core<gil::bgr8_pixel_t>,
+    reference_core<gil::rgb8_planar_ref_t>,
+    value_core<gil::argb32_pixel_t>,
+    reference_core<gil::cmyk32f_pixel_t&>,
+    reference_core<gil::abgr16c_ref_t>, // immutable reference
+    reference_core<gil::rgb32fc_planar_ref_t>
+>;
+
+// List of all core pixel types (i.e. without cv-qualifiers)
+using pixel_types = ::boost::mp11::mp_list
+<
+    gil::gray8_pixel_t,
+    gil::gray8s_pixel_t,
+    gil::gray16_pixel_t,
+    gil::gray16s_pixel_t,
+    gil::gray32_pixel_t,
+    gil::gray32s_pixel_t,
+    gil::gray32f_pixel_t,
+    gil::bgr8_pixel_t,
+    gil::bgr8s_pixel_t,
+    gil::bgr16_pixel_t,
+    gil::bgr16s_pixel_t,
+    gil::bgr32_pixel_t,
+    gil::bgr32f_pixel_t,
+    gil::bgr32s_pixel_t,
+    gil::rgb8_pixel_t,
+    gil::rgb8s_pixel_t,
+    gil::rgb16_pixel_t,
+    gil::rgb16s_pixel_t,
+    gil::rgb32_pixel_t,
+    gil::rgb32f_pixel_t,
+    gil::rgb32s_pixel_t,
+    gil::abgr8_pixel_t,
+    gil::abgr8s_pixel_t,
+    gil::abgr16_pixel_t,
+    gil::abgr16s_pixel_t,
+    gil::abgr32_pixel_t,
+    gil::abgr32f_pixel_t,
+    gil::abgr32s_pixel_t,
+    gil::bgra8_pixel_t,
+    gil::bgra8s_pixel_t,
+    gil::bgra16_pixel_t,
+    gil::bgra16s_pixel_t,
+    gil::bgra32_pixel_t,
+    gil::bgra32f_pixel_t,
+    gil::bgra32s_pixel_t,
+    gil::cmyk8_pixel_t,
+    gil::cmyk8s_pixel_t,
+    gil::cmyk16_pixel_t,
+    gil::cmyk16s_pixel_t,
+    gil::cmyk32_pixel_t,
+    gil::cmyk32f_pixel_t,
+    gil::cmyk32s_pixel_t,
+    gil::rgba8_pixel_t,
+    gil::rgba8s_pixel_t,
+    gil::rgba16_pixel_t,
+    gil::rgba16s_pixel_t,
+    gil::rgba32_pixel_t,
+    gil::rgba32f_pixel_t,
+    gil::rgba32s_pixel_t
+>;
+
+// List of all core pixel typedefs (i.e. with cv-qualifiers)
+using pixel_typedefs = ::boost::mp11::mp_list
+<
+    gil::gray8_pixel_t,
+    gil::gray8c_pixel_t,
+    gil::gray8s_pixel_t,
+    gil::gray8sc_pixel_t,
+    gil::gray16_pixel_t,
+    gil::gray16c_pixel_t,
+    gil::gray16s_pixel_t,
+    gil::gray16sc_pixel_t,
+    gil::gray32_pixel_t,
+    gil::gray32c_pixel_t,
+    gil::gray32f_pixel_t,
+    gil::gray32fc_pixel_t,
+    gil::gray32s_pixel_t,
+    gil::gray32sc_pixel_t,
+    gil::bgr8_pixel_t,
+    gil::bgr8c_pixel_t,
+    gil::bgr8s_pixel_t,
+    gil::bgr8sc_pixel_t,
+    gil::bgr16_pixel_t,
+    gil::bgr16c_pixel_t,
+    gil::bgr16s_pixel_t,
+    gil::bgr16sc_pixel_t,
+    gil::bgr32_pixel_t,
+    gil::bgr32c_pixel_t,
+    gil::bgr32f_pixel_t,
+    gil::bgr32fc_pixel_t,
+    gil::bgr32s_pixel_t,
+    gil::bgr32sc_pixel_t,
+    gil::rgb8_pixel_t,
+    gil::rgb8c_pixel_t,
+    gil::rgb8s_pixel_t,
+    gil::rgb8sc_pixel_t,
+    gil::rgb16_pixel_t,
+    gil::rgb16c_pixel_t,
+    gil::rgb16s_pixel_t,
+    gil::rgb16sc_pixel_t,
+    gil::rgb32_pixel_t,
+    gil::rgb32c_pixel_t,
+    gil::rgb32f_pixel_t,
+    gil::rgb32fc_pixel_t,
+    gil::rgb32s_pixel_t,
+    gil::rgb32sc_pixel_t,
+    gil::abgr8_pixel_t,
+    gil::abgr8c_pixel_t,
+    gil::abgr8s_pixel_t,
+    gil::abgr8sc_pixel_t,
+    gil::abgr16_pixel_t,
+    gil::abgr16c_pixel_t,
+    gil::abgr16s_pixel_t,
+    gil::abgr16sc_pixel_t,
+    gil::abgr32_pixel_t,
+    gil::abgr32c_pixel_t,
+    gil::abgr32f_pixel_t,
+    gil::abgr32fc_pixel_t,
+    gil::abgr32s_pixel_t,
+    gil::abgr32sc_pixel_t,
+    gil::bgra8_pixel_t,
+    gil::bgra8c_pixel_t,
+    gil::bgra8s_pixel_t,
+    gil::bgra8sc_pixel_t,
+    gil::bgra16_pixel_t,
+    gil::bgra16c_pixel_t,
+    gil::bgra16s_pixel_t,
+    gil::bgra16sc_pixel_t,
+    gil::bgra32_pixel_t,
+    gil::bgra32c_pixel_t,
+    gil::bgra32f_pixel_t,
+    gil::bgra32fc_pixel_t,
+    gil::bgra32s_pixel_t,
+    gil::bgra32sc_pixel_t,
+    gil::cmyk8_pixel_t,
+    gil::cmyk8c_pixel_t,
+    gil::cmyk8s_pixel_t,
+    gil::cmyk8sc_pixel_t,
+    gil::cmyk16_pixel_t,
+    gil::cmyk16c_pixel_t,
+    gil::cmyk16s_pixel_t,
+    gil::cmyk16sc_pixel_t,
+    gil::cmyk32_pixel_t,
+    gil::cmyk32c_pixel_t,
+    gil::cmyk32f_pixel_t,
+    gil::cmyk32fc_pixel_t,
+    gil::cmyk32s_pixel_t,
+    gil::cmyk32sc_pixel_t,
+    gil::rgba8_pixel_t,
+    gil::rgba8c_pixel_t,
+    gil::rgba8s_pixel_t,
+    gil::rgba8sc_pixel_t,
+    gil::rgba16_pixel_t,
+    gil::rgba16c_pixel_t,
+    gil::rgba16s_pixel_t,
+    gil::rgba16sc_pixel_t,
+    gil::rgba32_pixel_t,
+    gil::rgba32c_pixel_t,
+    gil::rgba32f_pixel_t,
+    gil::rgba32fc_pixel_t,
+    gil::rgba32s_pixel_t,
+    gil::rgba32sc_pixel_t
+>;
+
+struct not_a_pixel_type {};
+
+using non_pixels = ::boost::mp11::mp_list
+<
+    not_a_pixel_type,
+    char,
+    short, int, long,
+    double, float,
+    std::size_t,
+    std::true_type,
+    std::false_type
+>;
+
+
+}}}} // namespace boost::gil::test::fixture

--- a/test/pixel/test_fixture.hpp
+++ b/test/pixel/test_fixture.hpp
@@ -35,12 +35,7 @@ struct print_color_base
     template <typename Element>
     void operator()(Element& c)
     {
-        using value_type = typename gil::channel_traits<Element>::value_type;
-        static_assert(
-            std::is_arithmetic<value_type>::value,
-            "color element should be an arithmetic type");
-
-        typename gil::promote_integral<value_type>::type const v(c);
+        typename gil::promote_integral<Element>::type const v(c);
         if (element_index_ > 0) os_ << ", ";
         os_ << "v" << element_index_ << "=" << v;
         ++element_index_;
@@ -143,10 +138,6 @@ using representative_pixel_types= ::boost::mp11::mp_list
 
 // List of all core pixel types (i.e. without cv-qualifiers)
 using pixel_types = ::boost::mp11::mp_list
-<
-    gil::gray32f_pixel_t
->;
-using pixel_types2 = ::boost::mp11::mp_list
 <
     gil::gray8_pixel_t,
     gil::gray8s_pixel_t,

--- a/test/pixel/test_fixture.hpp
+++ b/test/pixel/test_fixture.hpp
@@ -22,7 +22,7 @@ namespace boost { namespace gil {
 
 // Pixel has to implement operator<< to be printable for BOOST_TEST()
 template <typename ChannelValue, typename Layout>
-std::ostream& operator<<(std::ostream& os, pixel<ChannelValue, Layout> const& p)
+std::ostream& operator<<(std::ostream& os, pixel<ChannelValue, Layout> const& /*p*/)
 {
     // TODO: Print {v1, v2...} channel values
     os << "pixel<"

--- a/test/pixel/test_fixture.hpp
+++ b/test/pixel/test_fixture.hpp
@@ -6,6 +6,7 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
+#include <boost/gil/channel.hpp>
 #include <boost/gil/color_base_algorithm.hpp>
 #include <boost/gil/concepts/pixel.hpp>
 #include <boost/gil/pixel.hpp>
@@ -34,11 +35,12 @@ struct print_color_base
     template <typename Element>
     void operator()(Element& c)
     {
+        using value_type = typename gil::channel_traits<Element>::value_type;
         static_assert(
-            std::is_arithmetic<Element>::value,
+            std::is_arithmetic<value_type>::value,
             "color element should be an arithmetic type");
 
-        typename gil::promote_integral<Element>::type const v(c);
+        typename gil::promote_integral<value_type>::type const v(c);
         if (element_index_ > 0) os_ << ", ";
         os_ << "v" << element_index_ << "=" << v;
         ++element_index_;
@@ -141,6 +143,10 @@ using representative_pixel_types= ::boost::mp11::mp_list
 
 // List of all core pixel types (i.e. without cv-qualifiers)
 using pixel_types = ::boost::mp11::mp_list
+<
+    gil::gray32f_pixel_t
+>;
+using pixel_types2 = ::boost::mp11::mp_list
 <
     gil::gray8_pixel_t,
     gil::gray8s_pixel_t,

--- a/test/point/CMakeLists.txt
+++ b/test/point/CMakeLists.txt
@@ -18,7 +18,7 @@ foreach(_name
       gil_include_directories
       gil_dependencies)
   target_compile_definitions(${_target} PRIVATE BOOST_GIL_USE_CONCEPT_CHECK)
-  add_test(test.core.${_name} ${_target})
+  add_test(test.core.point.${_name} ${_target})
 
   unset(_name)
   unset(_target)


### PR DESCRIPTION
Add test for pixel_reference_is_mutable metafunction.

From the legacy tests
- port value_core and reference_core fixtures, see
  https://lists.boost.org/boost-gil/2019/02/0138.php
- port representative pixel types and verify with tests of some
  metafunctions.

See clarification of the `core` suffix in the class names: https://lists.boost.org/boost-gil/2019/02/0138.php

### Tasklist

- [x] Review
- [x] Adjust for comments
- [ ] All CI builds and checks have passed
