### PR TITLE
Fix gray_t and gray_color_t mismatch in default_color_converter_impl

### DIFF
--- a/include/boost/gil/color_base_algorithm.hpp
+++ b/include/boost/gil/color_base_algorithm.hpp
@@ -14,6 +14,7 @@
 #include <boost/config.hpp>
 #include <boost/mpl/at.hpp>
 #include <boost/mpl/contains.hpp>
+#include <boost/mpl/size.hpp>
 #include <boost/type_traits.hpp>
 
 #include <algorithm>
@@ -81,8 +82,11 @@ red_channel = channel_traits<red_channel_reference_t>::max_value();
 template <typename ColorBase, int K>
 struct kth_semantic_element_type
 {
-    static constexpr int semantic_index =
-        mpl::at_c<typename ColorBase::layout_t::channel_mapping_t, K>::type::value;
+    using channel_mapping_t = typename ColorBase::layout_t::channel_mapping_t;
+    static_assert(K < mpl::size<channel_mapping_t>::value,
+        "K index should be less than size of channel_mapping_t sequence");
+
+    static constexpr int semantic_index = mpl::at_c<channel_mapping_t, K>::type::value;
     using type = typename kth_element_type<ColorBase, semantic_index>::type;
 };
 
@@ -91,14 +95,12 @@ struct kth_semantic_element_type
 template <typename ColorBase, int K>
 struct kth_semantic_element_reference_type
 {
-    static constexpr int semantic_index =
-        mpl::at_c
-        <
-            typename ColorBase::layout_t::channel_mapping_t,
-            K
-        >::type::value;
+    using channel_mapping_t = typename ColorBase::layout_t::channel_mapping_t;
+    static_assert(K < mpl::size<channel_mapping_t>::value,
+        "K index should be less than size of channel_mapping_t sequence");
 
-    using type = typename kth_element_reference_type<ColorBase,semantic_index>::type;
+    static constexpr int semantic_index = mpl::at_c<channel_mapping_t, K>::type::value;
+    using type = typename kth_element_reference_type<ColorBase, semantic_index>::type;
     static type get(ColorBase& cb) { return gil::at_c<semantic_index>(cb); }
 };
 
@@ -106,13 +108,11 @@ struct kth_semantic_element_reference_type
 /// \ingroup ColorBaseAlgorithmSemanticAtC
 template <typename ColorBase, int K> struct kth_semantic_element_const_reference_type
 {
-	static constexpr int semantic_index =
-        mpl::at_c
-        <
-            typename ColorBase::layout_t::channel_mapping_t,
-            K
-        >::type::value;
+    using channel_mapping_t = typename ColorBase::layout_t::channel_mapping_t;
+    static_assert(K < mpl::size<channel_mapping_t>::value,
+        "K index should be less than size of channel_mapping_t sequence");
 
+    static constexpr int semantic_index = mpl::at_c<channel_mapping_t, K>::type::value;
     using type = typename kth_element_const_reference_type<ColorBase,semantic_index>::type;
     static type get(const ColorBase& cb) { return gil::at_c<semantic_index>(cb); }
 };

--- a/include/boost/gil/color_convert.hpp
+++ b/include/boost/gil/color_convert.hpp
@@ -197,7 +197,7 @@ struct default_color_converter_impl<cmyk_t,gray_t> {
     template <typename P1, typename P2>
     void operator()(const P1& src, P2& dst) const  {
         get_color(dst,gray_color_t())=
-            channel_convert<typename color_element_type<P2,gray_t>::type>(
+            channel_convert<typename color_element_type<P2,gray_color_t>::type>(
                 channel_multiply(
                     channel_invert(
                        detail::rgb_to_luminance<typename color_element_type<P1,black_t>::type>(

--- a/include/boost/gil/utilities.hpp
+++ b/include/boost/gil/utilities.hpp
@@ -9,6 +9,7 @@
 #define BOOST_GIL_UTILITIES_HPP
 
 #include <boost/mpl/begin.hpp>
+#include <boost/mpl/contains.hpp>
 #include <boost/mpl/distance.hpp>
 #include <boost/mpl/find.hpp>
 #include <boost/mpl/range_c.hpp>
@@ -236,6 +237,7 @@ struct type_to_index
             typename mpl::find<Types,T>::type
         >::type
     {
+        static_assert(mpl::contains<Types, T>::type::value, "T should be element of Types");
     };
 } // namespace detail
 


### PR DESCRIPTION
Add number of static assertions to test indices used to access
elements of color mapping sequence are in range.

### References

Fixes #249

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed
