### PR TITLE
Use class for template template parameter

### DIFF
--- a/test/pixel/concepts.cpp
+++ b/test/pixel/concepts.cpp
@@ -21,7 +21,7 @@ namespace gil = boost::gil;
 using boost::function_requires;
 using namespace boost::mp11;
 
-template <template<typename> typename Concept>
+template <template<typename> class Concept>
 struct assert_concept
 {
     template <typename Pixel>
@@ -31,7 +31,7 @@ struct assert_concept
     }
 };
 
-template <template<typename> typename Concept, typename... Pixels>
+template <template<typename> class Concept, typename... Pixels>
 void test_concept()
 {
     mp_for_each<Pixels...>(assert_concept<Concept>());


### PR DESCRIPTION
The current definition using `typename` fails when compiling
with GCC 4.8 and 4.9, because `typename` is allowed since C++17.

### References

* The C++17 code was introduced in #248
* Failing CircleCI builds: https://circleci.com/gh/boostorg/gil/7123 and https://circleci.com/gh/boostorg/gil/7125

    ```
    libs/gil/test/pixel/concepts.cpp:24:39: error: expected 'class' before 'Concept'
    template <template<typename> typename Concept>
                                        ^
    ```

* https://en.cppreference.com/w/cpp/language/template_parameters#Template_template_parameter

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed

-----

By the way, we may want to consider using `class` instead of `typename` in general. For example, if we wanted to follow the [C++ Specification Style Guidelines](https://github.com/cplusplus/draft/wiki/Specification-Style-Guidelines):
> template type parameters use class not typename

@stefanseefeld, @chhenning Any preferences?