### PR TITLE
Add test for some bit-aligned pixel types and metafunctions

### DIFF
--- a/test/pixel/CMakeLists.txt
+++ b/test/pixel/CMakeLists.txt
@@ -7,9 +7,11 @@
 #
 foreach(_name
   concepts
+  bit_aligned_pixel_reference
   is_pixel
   is_planar
   num_channels
+  packed_pixel
   pixel_reference_is_mutable
   pixels_are_compatible
   test_fixture)

--- a/test/pixel/Jamfile
+++ b/test/pixel/Jamfile
@@ -13,12 +13,12 @@ project
     <include>..
     ;
 
-compile bit_aligned_pixel_reference ;
+compile bit_aligned_pixel_reference.cpp ;
 compile concepts.cpp ;
 compile is_pixel.cpp ;
 compile is_planar.cpp ;
 compile num_channels.cpp ;
-compile packed_pixel ;
+compile packed_pixel.cpp ;
 compile pixel_reference_is_mutable.cpp ;
 compile pixels_are_compatible.cpp ;
 

--- a/test/pixel/Jamfile
+++ b/test/pixel/Jamfile
@@ -13,10 +13,12 @@ project
     <include>..
     ;
 
+compile bit_aligned_pixel_reference ;
 compile concepts.cpp ;
 compile is_pixel.cpp ;
 compile is_planar.cpp ;
 compile num_channels.cpp ;
+compile packed_pixel ;
 compile pixel_reference_is_mutable.cpp ;
 compile pixels_are_compatible.cpp ;
 

--- a/test/pixel/bit_aligned_pixel_reference.cpp
+++ b/test/pixel/bit_aligned_pixel_reference.cpp
@@ -1,0 +1,46 @@
+//
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/gil/bit_aligned_pixel_reference.hpp>
+#include <boost/gil/packed_pixel.hpp>
+#include <boost/gil/rgb.hpp>
+#include <boost/mpl/vector_c.hpp>
+namespace gil = boost::gil;
+namespace mpl = boost::mpl;
+
+int main()
+{
+    using bgr121_ref_t = gil::bit_aligned_pixel_reference
+        <
+            std::uint8_t, mpl::vector3_c<int, 1, 2, 1>, gil::bgr_layout_t, true
+        >;
+
+    static_assert(bgr121_ref_t::bit_size == 4,
+        "bit size should be 4");
+
+    static_assert(std::is_same<bgr121_ref_t::bitfield_t, std::uint8_t>::value,
+        "bit field type should be std::uint8_t");
+
+    static_assert(std::is_same<bgr121_ref_t::layout_t, gil::bgr_layout_t>::value,
+        "layout type should be bgr");
+
+    static_assert(std::is_same<decltype(bgr121_ref_t::is_mutable), bool const>::value &&
+        bgr121_ref_t::is_mutable,
+        "is_mutable should be boolean");
+
+    using packed_pixel_t = gil::packed_pixel
+        <
+            std::uint8_t,
+            typename gil::detail::packed_channel_references_vector_type
+            <
+                std::uint8_t, mpl::vector3_c<int, 1, 2, 1>
+            >::type,
+            gil::bgr_layout_t
+        >;
+    static_assert(std::is_same<bgr121_ref_t::value_type, packed_pixel_t >::value,
+        "value_type should be specialization of packed_pixel");
+}

--- a/test/pixel/is_pixel.cpp
+++ b/test/pixel/is_pixel.cpp
@@ -5,9 +5,12 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
+#include <boost/gil/bit_aligned_pixel_reference.hpp>
+#include <boost/gil/packed_pixel.hpp>
 #include <boost/gil/pixel.hpp>
-#include <boost/gil/concepts/pixel.hpp>
+#include <boost/gil/rgb.hpp>
 #include <boost/gil/typedefs.hpp>
+#include <boost/gil/concepts/pixel.hpp>
 
 #include <boost/mp11.hpp>
 
@@ -40,7 +43,6 @@ int main()
         >::value,
         "is_pixel does not yield true for representative pixel types");
 
-
     static_assert(std::is_same
         <
             mp_all_of<gil::test::fixture::non_pixels, gil::is_pixel>,
@@ -54,4 +56,22 @@ int main()
             std::true_type
         >::value,
         "is_pixel yields true for non-pixel type");
+
+    using bgr121_ref_t = gil::bit_aligned_pixel_reference
+        <
+            std::uint8_t, boost::mpl::vector3_c<int, 1, 2, 1>, gil::bgr_layout_t, true
+        >;
+    static_assert(gil::is_pixel<bgr121_ref_t>::value,
+        "is_pixel does not yield true for bit_aligned_pixel_reference");
+
+    using rgb121_ref_t = gil::bit_aligned_pixel_reference
+        <
+            std::uint8_t, boost::mpl::vector3_c<int, 1, 2, 1>, gil::rgb_layout_t, true
+        >;
+    static_assert(gil::is_pixel<bgr121_ref_t>::value,
+        "is_pixel does not yield true for bit_aligned_pixel_reference");
+
+    using rgb121_packed_pixel_t = rgb121_ref_t::value_type;
+    static_assert(gil::is_pixel<rgb121_packed_pixel_t>::value,
+        "is_pixel does not yield true for packed_pixel");
 }

--- a/test/pixel/packed_pixel.cpp
+++ b/test/pixel/packed_pixel.cpp
@@ -1,0 +1,107 @@
+//
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/gil/channel.hpp>
+#include <boost/gil/packed_pixel.hpp>
+#include <boost/gil/rgb.hpp>
+#include <boost/mpl/at.hpp>
+#include <boost/mpl/int.hpp>
+#include <boost/mpl/size.hpp>
+#include <boost/mpl/vector_c.hpp>
+namespace gil = boost::gil;
+namespace mpl = boost::mpl;
+
+int main()
+{
+    using packed_channel_references_vector =
+        typename gil::detail::packed_channel_references_vector_type
+        <
+            std::uint8_t,
+            mpl::vector3_c<int, 1, 2, 1>
+        >::type;
+
+    using packed_pixel = gil::packed_pixel
+        <
+            std::uint8_t,
+            packed_channel_references_vector,
+            gil::bgr_layout_t
+        >;
+
+    // Verify packed_pixel members
+
+    static_assert(std::is_same<packed_pixel::layout_t, gil::bgr_layout_t>::value,
+        "layout should be bgr");
+
+    static_assert(std::is_same<packed_pixel::value_type, packed_pixel>::value,
+        "value_type member should be of the same type as the packed_pixel specialization");
+
+    static_assert(std::is_reference<packed_pixel::reference>::value,
+        "reference member should be a reference");
+
+    static_assert(std::is_reference<packed_pixel::const_reference>::value,
+        "const_reference member should be a reference");
+
+    static_assert(std::is_same<decltype(packed_pixel::is_mutable), bool const>::value &&
+        packed_pixel::is_mutable,
+        "is_mutable should be boolean");
+
+    // Verify metafunctions
+
+    using channel_references_t = packed_channel_references_vector::type;
+
+    static_assert(mpl::size<channel_references_t>::value == 3,
+        "packed_channel_references_vector_type should define three references to channel start bits");
+
+    using channel1_ref_t = mpl::at_c<channel_references_t, 0>::type;
+    static_assert(channel1_ref_t::num_bits == 1,
+        "1st channel of bgr121 pixel should be of 1-bit size");
+
+    using channel2_ref_t = mpl::at_c<channel_references_t, 1>::type;
+    static_assert(channel2_ref_t::num_bits == 2,
+        "2nd channel of bgr121 pixel should be of 2-bit size");
+
+    using channel3_ref_t = mpl::at_c<channel_references_t, 2>::type;
+    static_assert(channel3_ref_t::num_bits == 1,
+        "3rd channel of bgr121 pixel should be of 1-bit size");
+
+    static_assert(std::is_same
+        <
+            channel1_ref_t,
+            gil::packed_channel_reference<std::uint8_t, 0, 1, true> const
+        >::value,
+        "1st element of packed_channel_references_vector should be packed_channel_reference of 1st channel");
+
+    static_assert(std::is_same
+        <
+            channel2_ref_t,
+            gil::packed_channel_reference<std::uint8_t, 1, 2, true> const
+        >::value,
+        "2nd element of packed_channel_references_vector should be packed_channel_reference of 2nd channel");
+
+    static_assert(std::is_same
+        <
+            channel3_ref_t,
+            gil::packed_channel_reference<std::uint8_t, 3, 1, true> const
+        >::value,
+        "3rd element of packed_channel_references_vector should be packed_channel_reference of 3rd channel");
+
+    // double check intermediate metafunction packed_channel_reference_type
+    static_assert(std::is_same
+        <
+            gil::detail::packed_channel_reference_type<std::uint8_t, mpl::int_<0>, mpl::int_<1>>::type,
+            channel1_ref_t
+        >::value,
+        "packed_channel_reference_type should return packed_channel_reference");
+    static_assert(std::is_same
+        <
+            gil::detail::packed_channel_reference_type<std::uint8_t, mpl::int_<0>, mpl::int_<1>>::type,
+            gil::packed_channel_reference<std::uint8_t, 0, 1, true> const
+        >::value,
+        "packed_channel_reference_type should return packed_channel_reference");
+
+    return 0;
+}


### PR DESCRIPTION
Test `bit_aligned_pixel_reference` and `packed_pixel` as well as some of related metafunctions generating types of their members and intermediate specializations.

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed

-----

The new tests are part of MPL to MP11 verification. The uses of `boost::mpl` in the new tests will switch to `boost::mp11`.