### PR TITLE
Use just ::value where is possible

### DIFF
--- a/doc/design_guide.rst
+++ b/doc/design_guide.rst
@@ -685,7 +685,7 @@ Pixels model the following concepts::
 
   concept PixelConcept<typename P> : ColorBaseConcept<P>, PixelBasedConcept<P>
   {
-    where is_pixel<P>::type::value==true;
+    where is_pixel<P>::value==true;
     // where for each K [0..size<P>::value-1]:
     //      ChannelConcept<kth_element_type<K> >;
 
@@ -920,8 +920,8 @@ iterators or adaptors over another pixel iterator::
     where PixelValueConcept<value_type>;
     typename const_iterator_type<It>::type;
         where PixelIteratorConcept<const_iterator_type<It>::type>;
-    static const bool  iterator_is_mutable<It>::type::value;
-    static const bool  is_iterator_adaptor<It>::type::value;   // is it an iterator adaptor
+    static const bool  iterator_is_mutable<It>::value;
+    static const bool  is_iterator_adaptor<It>::value;   // is it an iterator adaptor
   };
 
   template <typename Iterator>

--- a/doc/doxygen/design_guide.dox
+++ b/doc/doxygen/design_guide.dox
@@ -774,7 +774,7 @@ Pixels model the following concepts:
 
 \code
 concept PixelConcept<typename P> : ColorBaseConcept<P>, PixelBasedConcept<P> {
-    where is_pixel<P>::type::value==true;
+    where is_pixel<P>::value==true;
     // where for each K [0..size<P>::value-1]:
     //      ChannelConcept<kth_element_type<K> >;
 
@@ -1027,8 +1027,8 @@ concept PixelIteratorConcept<RandomAccessTraversalIteratorConcept Iterator> : Pi
     where PixelValueConcept<value_type>;
     typename const_iterator_type<It>::type;
         where PixelIteratorConcept<const_iterator_type<It>::type>;
-    static const bool  iterator_is_mutable<It>::type::value;
-    static const bool  is_iterator_adaptor<It>::type::value;   // is it an iterator adaptor
+    static const bool  iterator_is_mutable<It>::value;
+    static const bool  is_iterator_adaptor<It>::value;   // is it an iterator adaptor
 };
 
 template <typename Iterator>

--- a/include/boost/gil/algorithm.hpp
+++ b/include/boost/gil/algorithm.hpp
@@ -420,7 +420,7 @@ void destruct_range_impl(Iterator first, Iterator last,
         <
             is_pointer<Iterator>,
             mpl::not_<std::is_trivially_destructible<typename std::iterator_traits<Iterator>::value_type>>
-        >::type::value
+        >::value
     >::type* /*ptr*/ = 0)
 {
     while (first != last)
@@ -439,7 +439,7 @@ void destruct_range_impl(Iterator /*first*/, Iterator /*last*/,
         <
             mpl::not_<is_pointer<Iterator>>,
             std::is_trivially_destructible<typename std::iterator_traits<Iterator>::value_type>
-        >::type::value
+        >::value
     >::type* /* ptr */ = nullptr)
 {
 }

--- a/include/boost/gil/concepts/pixel.hpp
+++ b/include/boost/gil/concepts/pixel.hpp
@@ -40,7 +40,7 @@ namespace boost { namespace gil {
 /// \code
 /// concept PixelConcept<typename P> : ColorBaseConcept<P>, PixelBasedConcept<P>
 /// {
-///     where is_pixel<P>::type::value == true;
+///     where is_pixel<P>::value == true;
 ///     // where for each K [0..size<P>::value - 1]:
 ///     //      ChannelConcept<kth_element_type<P, K>>;
 ///

--- a/include/boost/gil/concepts/pixel_based.hpp
+++ b/include/boost/gil/concepts/pixel_based.hpp
@@ -59,7 +59,7 @@ struct PixelBasedConcept
         using channel_mapping_t = typename channel_mapping_type<P>::type ;
         gil_function_requires<ChannelMappingConcept<channel_mapping_t>>();
 
-        static const bool planar = is_planar<P>::type::value;
+        static const bool planar = is_planar<P>::value;
         ignore_unused_variable_warning(planar);
 
         // This is not part of the concept, but should still work

--- a/include/boost/gil/concepts/pixel_iterator.hpp
+++ b/include/boost/gil/concepts/pixel_iterator.hpp
@@ -161,8 +161,8 @@ struct HasTransposedTypeConcept
 ///     where PixelValueConcept<value_type>;
 ///     typename const_iterator_type<It>::type;
 ///         where PixelIteratorConcept<const_iterator_type<It>::type>;
-///     static const bool  iterator_is_mutable<It>::type::value;
-///     static const bool  is_iterator_adaptor<It>::type::value;   // is it an iterator adaptor
+///     static const bool  iterator_is_mutable<It>::value;
+///     static const bool  is_iterator_adaptor<It>::value;   // is it an iterator adaptor
 /// };
 /// \endcode
 template <typename Iterator>
@@ -177,7 +177,7 @@ struct PixelIteratorConcept
         gil_function_requires<PixelValueConcept<value_type>>();
 
         using const_t = typename const_iterator_type<Iterator>::type;
-        static bool const is_mutable = iterator_is_mutable<Iterator>::type::value;
+        static bool const is_mutable = iterator_is_mutable<Iterator>::value;
         ignore_unused_variable_warning(is_mutable);
 
         // immutable iterator must be constructible from (possibly mutable) iterator

--- a/include/boost/gil/extension/io/png/detail/write.hpp
+++ b/include/boost/gil/extension/io/png/detail/write.hpp
@@ -170,13 +170,13 @@ private:
     template< typename Info > struct is_equal_to_sixteen : mpl::equal_to< mpl::int_< Info::_bit_depth >, mpl::int_< 16 > > {};
 
     template <typename Info>
-    void set_swap(typename std::enable_if<is_less_than_eight<Info>::type::value>::type* /*ptr*/ = 0)
+    void set_swap(typename std::enable_if<is_less_than_eight<Info>::value>::type* /*ptr*/ = 0)
     {
         png_set_packswap(this->get_struct());
     }
 
     template <typename Info>
-    void set_swap(typename std::enable_if<is_equal_to_sixteen<Info>::type::value>::type* /*ptr*/ = 0)
+    void set_swap(typename std::enable_if<is_equal_to_sixteen<Info>::value>::type* /*ptr*/ = 0)
     {
         png_set_swap(this->get_struct());
     }
@@ -189,7 +189,7 @@ private:
             <
                 mpl::not_<is_less_than_eight<Info>>,
                 mpl::not_<is_equal_to_sixteen<Info>>
-            >::type::value
+            >::value
         >::type* /*ptr*/ = nullptr)
     {
     }

--- a/include/boost/gil/extension/io/tiff/detail/is_allowed.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/is_allowed.hpp
@@ -33,7 +33,7 @@ struct Format_Type
         is_bit_aligned
         <
             typename get_pixel_type<View>::type
-        >::type::value
+        >::value
     >::type
 >
 {
@@ -55,7 +55,7 @@ struct Format_Type
                 typename is_bit_aligned<typename get_pixel_type<View>::type>::type
             >,
             is_unsigned<Channel>
-        >::type::value
+        >::value
     >::type
 >
 {
@@ -77,7 +77,7 @@ struct Format_Type
                 typename is_bit_aligned<typename get_pixel_type<View>::type>::type
             >,
             is_signed<Channel>
-        >::type::value
+        >::value
     >::type
 >
 {
@@ -99,7 +99,7 @@ struct Format_Type
                 typename is_bit_aligned<typename get_pixel_type<View>::type>::type
             >,
             is_floating_point<Channel>
-        >::type::value
+        >::value
     >::type
 >
 {

--- a/include/boost/gil/extension/io/tiff/detail/writer_backend.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/writer_backend.hpp
@@ -89,7 +89,7 @@ protected:
         this->_io_dev.template set_property<tiff_bits_per_sample>( bits_per_sample );
 
         // write sample format
-        tiff_sample_format::type sampl_format = detail::sample_format< channel_t >::type::value;
+        tiff_sample_format::type sampl_format = detail::sample_format< channel_t >::value;
         this->_io_dev.template set_property<tiff_sample_format>( sampl_format );
 
         // write photometric format

--- a/include/boost/gil/extension/toolbox/image_types/subchroma_image.hpp
+++ b/include/boost/gil/extension/toolbox/image_types/subchroma_image.hpp
@@ -32,13 +32,13 @@ namespace detail {
 template< int J, int A, int B>
 struct scaling_factors
 {
-    static_assert(mpl::equal_to< mpl::int_< J >, mpl::int_< 4 > >::type::value, "");
+    static_assert(mpl::equal_to< mpl::int_< J >, mpl::int_< 4 > >::value, "");
 
     static_assert(mpl::or_<mpl::equal_to< mpl::int_<A>, mpl::int_< 4 > >
                                   , mpl::or_< mpl::equal_to< mpl::int_<A>, mpl::int_< 2 > >
                                             , mpl::equal_to< mpl::int_<A>, mpl::int_< 1 > >
                                             >
-                                  >::type::value, "");
+                                  >::value, "");
 
     static_assert(mpl::or_< mpl::equal_to< mpl::int_<B>, mpl::int_< 4 > >
                                   , mpl::or_< mpl::equal_to< mpl::int_<B>, mpl::int_< 2 > >
@@ -46,14 +46,14 @@ struct scaling_factors
                                                       , mpl::equal_to< mpl::int_<B>, mpl::int_< 0 > >
                                                       >
                                             >
-                                  >::type::value, "");
+                                  >::value, "");
 
     static constexpr int ss_X =
         mpl::divides
         <
             mpl::int_<J>,
             mpl::int_<A>
-        >::type::value;
+        >::value;
 
     static constexpr int ss_Y =
         mpl::if_

--- a/include/boost/gil/extension/toolbox/metafunctions/channel_view.hpp
+++ b/include/boost/gil/extension/toolbox/metafunctions/channel_view.hpp
@@ -20,7 +20,7 @@ struct channel_type_to_index
 {
     static const int value = detail::type_to_index< typename color_space_type< View >::type // color (mpl::vector)
                                                   , Channel                                 // channel type
-                                                  >::type::value;                           //< index of the channel in the color (mpl::vector)
+                                                  >::value;                           //< index of the channel in the color (mpl::vector)
 };
 
 template< typename Channel

--- a/include/boost/gil/extension/toolbox/metafunctions/get_num_bits.hpp
+++ b/include/boost/gil/extension/toolbox/metafunctions/get_num_bits.hpp
@@ -61,7 +61,7 @@ struct get_num_bits
         <
             is_integral<T>,
             mpl::not_<is_class<T>>
-        >::type::value
+        >::value
     >::type
 > : mpl::size_t<sizeof(T) * 8>
 {

--- a/include/boost/gil/extension/toolbox/metafunctions/is_homogeneous.hpp
+++ b/include/boost/gil/extension/toolbox/metafunctions/is_homogeneous.hpp
@@ -51,7 +51,7 @@ struct is_homogeneous<packed_pixel< B, C, L > >
     : is_homogeneous_impl_p< C
                            , typename mpl::at_c< C, 0 >::type
                            , 1
-                           , mpl::size< C >::type::value
+                           , mpl::size< C >::value
                            > {};
 
 template< typename B
@@ -62,18 +62,18 @@ struct is_homogeneous< const packed_pixel< B, C, L > >
     : is_homogeneous_impl_p< C
                            , typename mpl::at_c<C,0>::type
                            , 1
-                           , mpl::size< C >::type::value
+                           , mpl::size< C >::value
                            > {};
 
 // for bit_aligned_pixel_reference
 template <typename B, typename C, typename L, bool M>
 struct is_homogeneous<bit_aligned_pixel_reference<B,C,L,M> >
-    : is_homogeneous_impl<C,typename mpl::at_c<C,0>::type,1,mpl::size<C>::type::value>
+    : is_homogeneous_impl<C,typename mpl::at_c<C,0>::type,1,mpl::size<C>::value>
 {};
 
 template <typename B, typename C, typename L, bool M>
 struct is_homogeneous<const bit_aligned_pixel_reference<B,C,L,M> >
-    : is_homogeneous_impl<C,typename mpl::at_c<C,0>::type,1,mpl::size<C>::type::value>
+    : is_homogeneous_impl<C,typename mpl::at_c<C,0>::type,1,mpl::size<C>::value>
 {};
 
 } // namespace gil

--- a/include/boost/gil/io/conversion_policies.hpp
+++ b/include/boost/gil/io/conversion_policies.hpp
@@ -34,7 +34,7 @@ public:
                     typename std::iterator_traits<InIterator>::value_type,
                     typename std::iterator_traits<OutIterator>::value_type
                 >
-            >::type::value
+            >::value
         >::type* /*dummy*/ = nullptr)
     {
         io_error("Data cannot be copied because the pixels are incompatible.");
@@ -48,7 +48,7 @@ public:
             <
                 typename std::iterator_traits<InIterator>::value_type,
                 typename std::iterator_traits<OutIterator>::value_type
-            >::type::value
+            >::value
         >::type* /*dummy*/ = nullptr)
     {
         std::copy(begin, end, out);

--- a/include/boost/gil/io/device.hpp
+++ b/include/boost/gil/io/device.hpp
@@ -565,7 +565,7 @@ struct is_adaptable_input_device
         <
             is_base_and_derived<std::istream, T>,
             is_same<std::istream, T>
-        >::type::value
+        >::value
     >::type
 > : mpl::true_
 {
@@ -603,7 +603,7 @@ struct is_read_device
         <
             is_input_device<FormatTag>,
             is_adaptable_input_device<FormatTag, T>
-        >::type::value
+        >::value
     >::type
 > : mpl::true_
 {
@@ -636,7 +636,7 @@ struct is_adaptable_output_device
         <
             is_base_and_derived<std::ostream, T>,
             is_same<std::ostream, T>
-        >::type::value
+        >::value
     >::type
 > : mpl::true_
 {
@@ -671,7 +671,7 @@ struct is_write_device
         <
             is_output_device<FormatTag>,
             is_adaptable_output_device<FormatTag, T>
-        >::type::value
+        >::value
     >::type
 > : mpl::true_
 {

--- a/include/boost/gil/io/get_read_device.hpp
+++ b/include/boost/gil/io/get_read_device.hpp
@@ -35,7 +35,7 @@ struct get_read_device
         <
             detail::is_adaptable_input_device<FormatTag, Device>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type
 >
 {
@@ -57,7 +57,7 @@ struct get_read_device
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type
 >
 {

--- a/include/boost/gil/io/get_reader.hpp
+++ b/include/boost/gil/io/get_reader.hpp
@@ -38,7 +38,7 @@ struct get_reader
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type
 >
 {
@@ -58,7 +58,7 @@ struct get_reader
         <
             detail::is_adaptable_input_device<FormatTag, Device>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type
 >
 {
@@ -83,7 +83,7 @@ struct get_dynamic_image_reader
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type
 >
 {
@@ -102,7 +102,7 @@ struct get_dynamic_image_reader
         <
             detail::is_adaptable_input_device<FormatTag, Device>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type
 >
 {
@@ -127,7 +127,7 @@ struct get_reader_backend
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type
 >
 {
@@ -146,7 +146,7 @@ struct get_reader_backend
         <
             detail::is_adaptable_input_device<FormatTag, Device>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type
 >
 {

--- a/include/boost/gil/io/get_write_device.hpp
+++ b/include/boost/gil/io/get_write_device.hpp
@@ -31,7 +31,7 @@ struct get_write_device
         <
             detail::is_adaptable_output_device<FormatTag, Device>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type
 >
 {
@@ -50,7 +50,7 @@ struct get_write_device
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type
 >
 {

--- a/include/boost/gil/io/get_writer.hpp
+++ b/include/boost/gil/io/get_writer.hpp
@@ -32,7 +32,7 @@ struct get_writer
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type
 >
 {
@@ -51,7 +51,7 @@ struct get_writer
         <
             detail::is_adaptable_output_device<FormatTag, Device>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type
 >
 {
@@ -74,7 +74,7 @@ struct get_dynamic_image_writer
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type
 >
 {
@@ -93,7 +93,7 @@ struct get_dynamic_image_writer
         <
             detail::is_write_device<FormatTag, Device>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type
 >
 {

--- a/include/boost/gil/io/make_backend.hpp
+++ b/include/boost/gil/io/make_backend.hpp
@@ -27,7 +27,7 @@ auto make_reader_backend(
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
     -> typename get_reader_backend<String, FormatTag>::type
 {
@@ -77,7 +77,7 @@ auto make_reader_backend(Device& io_dev, image_read_settings<FormatTag> const& s
         <
             detail::is_adaptable_input_device<FormatTag, Device>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
     -> typename get_reader_backend<Device, FormatTag>::type
 {
@@ -96,7 +96,7 @@ auto make_reader_backend(String const& file_name, FormatTag const&,
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
     -> typename get_reader_backend<String, FormatTag>::type
 {
@@ -112,7 +112,7 @@ auto make_reader_backend(Device& io_dev, FormatTag const&,
         <
             detail::is_adaptable_input_device<FormatTag, Device>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
     -> typename get_reader_backend<Device, FormatTag>::type
 {

--- a/include/boost/gil/io/make_dynamic_image_reader.hpp
+++ b/include/boost/gil/io/make_dynamic_image_reader.hpp
@@ -26,7 +26,7 @@ auto make_dynamic_image_reader(
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
     -> typename get_dynamic_image_reader<String, FormatTag>::type
 {
@@ -76,7 +76,7 @@ auto make_dynamic_image_reader(
         <
             detail::is_adaptable_input_device<FormatTag, Device>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
     -> typename get_dynamic_image_reader<Device, FormatTag>::type
 {
@@ -95,7 +95,7 @@ auto make_dynamic_image_reader(String const& file_name, FormatTag const&,
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
     -> typename get_dynamic_image_reader<String, FormatTag>::type
 {
@@ -129,7 +129,7 @@ auto make_dynamic_image_reader(Device& file, FormatTag const&,
         <
             detail::is_adaptable_input_device<FormatTag, Device>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
     ->  typename get_dynamic_image_reader<Device, FormatTag>::type
 {

--- a/include/boost/gil/io/make_dynamic_image_writer.hpp
+++ b/include/boost/gil/io/make_dynamic_image_writer.hpp
@@ -26,7 +26,7 @@ auto make_dynamic_image_writer(
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
     -> typename get_dynamic_image_writer<String, FormatTag>::type
 {
@@ -89,7 +89,7 @@ auto make_dynamic_image_writer(Device& file, image_write_info<FormatTag> const& 
         <
             typename detail::is_adaptable_output_device<FormatTag, Device>::type,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
     -> typename get_dynamic_image_writer<Device, FormatTag>::type
 {
@@ -108,7 +108,7 @@ auto make_dynamic_image_writer(String const& file_name, FormatTag const&,
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
     -> typename get_dynamic_image_writer<String, FormatTag>::type
 {
@@ -155,7 +155,7 @@ auto make_dynamic_image_writer(Device& file, FormatTag const&,
         <
             typename detail::is_adaptable_output_device<FormatTag, Device>::type,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
     -> typename get_dynamic_image_writer<Device, FormatTag>::type
 {

--- a/include/boost/gil/io/make_reader.hpp
+++ b/include/boost/gil/io/make_reader.hpp
@@ -28,7 +28,7 @@ auto make_reader(
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
     -> typename get_reader<String, FormatTag, ConversionPolicy>::type
 {
@@ -104,7 +104,7 @@ auto make_reader(
         <
             detail::is_adaptable_input_device<FormatTag, Device>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
     -> typename get_reader<Device, FormatTag, ConversionPolicy>::type
 {
@@ -128,7 +128,7 @@ auto make_reader(
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
     ->  typename get_reader<String, FormatTag, ConversionPolicy>::type
 {
@@ -187,7 +187,7 @@ auto make_reader(
         <
             detail::is_adaptable_input_device<FormatTag, Device>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
     -> typename get_reader<Device, FormatTag, ConversionPolicy>::type
 {

--- a/include/boost/gil/io/make_scanline_reader.hpp
+++ b/include/boost/gil/io/make_scanline_reader.hpp
@@ -25,7 +25,7 @@ auto make_scanline_reader(String const& file_name, FormatTag const&,
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
     -> typename get_scanline_reader<String, FormatTag>::type
 {
@@ -89,7 +89,7 @@ auto make_scanline_reader(Device& io_dev, FormatTag const&,
         <
             detail::is_adaptable_input_device<FormatTag, Device>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
     -> typename get_scanline_reader<Device, FormatTag>::type
 {

--- a/include/boost/gil/io/make_writer.hpp
+++ b/include/boost/gil/io/make_writer.hpp
@@ -25,7 +25,7 @@ auto make_writer(String const& file_name, image_write_info<FormatTag> const& inf
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
-        >::type::value>::type* /*dummy*/ = nullptr)
+        >::value>::type* /*dummy*/ = nullptr)
     -> typename get_writer<String, FormatTag>::type
 {
     typename get_write_device<String, FormatTag>::type device(
@@ -86,7 +86,7 @@ auto make_writer(Device& file, image_write_info<FormatTag> const& info,
         <
             typename detail::is_adaptable_output_device<FormatTag, Device>::type,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
     -> typename get_writer<Device, FormatTag>::type
 {
@@ -105,7 +105,7 @@ auto make_writer(String const& file_name, FormatTag const&,
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
     -> typename get_writer<String, FormatTag>::type
 {
@@ -151,7 +151,7 @@ auto make_writer(Device& file, FormatTag const&,
         <
             typename detail::is_adaptable_output_device<FormatTag, Device>::type,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
     -> typename get_writer<Device, FormatTag>::type
 {

--- a/include/boost/gil/io/read_and_convert_image.hpp
+++ b/include/boost/gil/io/read_and_convert_image.hpp
@@ -38,7 +38,7 @@ void read_and_convert_image(Reader& reader, Image& img,
         <
             detail::is_reader<Reader>,
             is_format_tag<typename Reader::format_tag_t>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     reader.init_image(img, reader._settings);
@@ -64,7 +64,7 @@ void read_and_convert_image(
         <
             detail::is_read_device<FormatTag, Device>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     using read_and_convert_t = detail::read_and_convert<ColorConverter>;
@@ -93,7 +93,7 @@ void read_and_convert_image(
         <
             is_format_tag<FormatTag>,
             detail::is_supported_path_spec<String>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     using read_and_convert_t = detail::read_and_convert<ColorConverter>;
@@ -122,7 +122,7 @@ void read_and_convert_image(
         <
             is_format_tag<FormatTag>,
             detail::is_supported_path_spec<String>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     using read_and_convert_t = detail::read_and_convert<ColorConverter>;
@@ -151,7 +151,7 @@ void read_and_convert_image(
         <
             detail::is_read_device<FormatTag, Device>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     using read_and_convert_t = detail::read_and_convert<ColorConverter>;
@@ -177,7 +177,7 @@ inline void read_and_convert_image(
         <
             is_format_tag<FormatTag>,
             detail::is_supported_path_spec<String>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     using read_and_convert_t = detail::read_and_convert<default_color_converter>;
@@ -203,7 +203,7 @@ inline void read_and_convert_image(
         <
             detail::is_read_device<FormatTag, Device>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     using read_and_convert_t = detail::read_and_convert<default_color_converter>;
@@ -230,7 +230,7 @@ void read_and_convert_image(
         <
             is_format_tag<FormatTag>,
             detail::is_supported_path_spec<String>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     using read_and_convert_t = detail::read_and_convert<default_color_converter>;
@@ -256,7 +256,7 @@ inline void read_and_convert_image(
         <
             detail::is_read_device<FormatTag, Device>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     using read_and_convert_t = detail::read_and_convert<default_color_converter>;

--- a/include/boost/gil/io/read_and_convert_view.hpp
+++ b/include/boost/gil/io/read_and_convert_view.hpp
@@ -38,7 +38,7 @@ void read_and_convert_view(Reader& reader, View const& view,
         <
             detail::is_reader<Reader>,
             is_format_tag<typename Reader::format_tag_t>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     reader.check_image_size(view.dimensions());
@@ -65,7 +65,7 @@ void read_and_convert_view(
         <
             detail::is_read_device<FormatTag, Device>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     using read_and_convert_t = detail::read_and_convert<ColorConverter>;
@@ -94,7 +94,7 @@ void read_and_convert_view(
         <
             is_format_tag<FormatTag>,
             detail::is_supported_path_spec<String>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     using read_and_convert_t = detail::read_and_convert<ColorConverter>;
@@ -123,7 +123,7 @@ void read_and_convert_view(
         <
             is_format_tag<FormatTag>,
             detail::is_supported_path_spec<String>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     using read_and_convert_t = detail::read_and_convert<ColorConverter>;
@@ -152,7 +152,7 @@ void read_and_convert_view(
         <
             detail::is_read_device<FormatTag, Device>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     using read_and_convert_t = detail::read_and_convert<ColorConverter>;
@@ -179,7 +179,7 @@ void read_and_convert_view(
         <
             is_format_tag<FormatTag>,
             detail::is_supported_path_spec<String>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     using read_and_convert_t = detail::read_and_convert<default_color_converter>;
@@ -206,7 +206,7 @@ void read_and_convert_view(
         <
             detail::is_read_device<FormatTag, Device>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     using read_and_convert_t = detail::read_and_convert<default_color_converter>;
@@ -233,7 +233,7 @@ void read_and_convert_view(
         <
             is_format_tag<FormatTag>,
             detail::is_supported_path_spec<String>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     using read_and_convert_t = detail::read_and_convert<default_color_converter>;
@@ -260,7 +260,7 @@ void read_and_convert_view(
         <
             detail::is_read_device<FormatTag, Device>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     using read_and_convert_t = detail::read_and_convert<default_color_converter>;

--- a/include/boost/gil/io/read_image.hpp
+++ b/include/boost/gil/io/read_image.hpp
@@ -43,7 +43,7 @@ void read_image(Reader reader, Image& img,
                 typename get_pixel_type<typename Image::view_t>::type,
                 typename Reader::format_tag_t
             >
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     reader.init_image(img, reader._settings);
@@ -72,7 +72,7 @@ void read_image(
                 typename get_pixel_type<typename Image::view_t>::type,
                 FormatTag
             >
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     using reader_t =
@@ -101,7 +101,7 @@ void read_image(Device& file, Image& img, FormatTag const& tag,
                 typename get_pixel_type<typename Image::view_t>::type,
                 FormatTag
             >
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     using reader_t =
@@ -133,7 +133,7 @@ void read_image(
                 typename get_pixel_type<typename Image::view_t>::type,
                 FormatTag
             >
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     using reader_t =
@@ -160,7 +160,7 @@ void read_image(String const& file_name, Image& img, FormatTag const& tag,
             typename get_pixel_type<typename Image::view_t>::type,
             FormatTag
         >
-    >::type::value
+    >::value
 >::type* /*dummy*/ = nullptr)
 {
     using reader_t =
@@ -181,7 +181,7 @@ void read_image(Reader& reader, any_image<Images>& images,
         <
             detail::is_dynamic_image_reader<Reader>,
             is_format_tag<typename Reader::format_tag_t>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     reader.apply(images);
@@ -204,7 +204,7 @@ void read_image(
         <
             detail::is_read_device<FormatTag, Device>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     using reader_t = typename get_dynamic_image_reader<Device, FormatTag>::type;
@@ -227,7 +227,7 @@ void read_image(Device& file, any_image<Images>& images, FormatTag const& tag,
         <
             detail::is_read_device<FormatTag, Device>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
         >::type* /*dummy*/ = nullptr)
 {
     using reader_t = typename get_dynamic_image_reader<Device, FormatTag>::type;
@@ -253,7 +253,7 @@ void read_image(
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     using reader_t = typename get_dynamic_image_reader<String, FormatTag>::type;
@@ -276,7 +276,7 @@ void read_image(String const& file_name, any_image<Images>& images, FormatTag co
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     using reader_t = typename get_dynamic_image_reader<String, FormatTag>::type;

--- a/include/boost/gil/io/read_image_info.hpp
+++ b/include/boost/gil/io/read_image_info.hpp
@@ -36,7 +36,7 @@ auto read_image_info(Device& file, image_read_settings<FormatTag> const& setting
         <
             detail::is_adaptable_input_device<FormatTag, Device>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
     -> typename get_reader_backend<Device, FormatTag>::type
 {
@@ -57,7 +57,7 @@ auto read_image_info(Device& file, FormatTag const&,
         <
             detail::is_adaptable_input_device<FormatTag, Device>,
             is_format_tag<FormatTag>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
     -> typename get_reader_backend<Device, FormatTag>::type
 {
@@ -79,7 +79,7 @@ auto read_image_info(
         <
             is_format_tag<FormatTag>,
             detail::is_supported_path_spec<String>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
     -> typename get_reader_backend<String, FormatTag>::type
 {
@@ -100,7 +100,7 @@ auto read_image_info(String const& file_name, FormatTag const&,
         <
             is_format_tag<FormatTag>,
             detail::is_supported_path_spec<String>
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
     -> typename get_reader_backend<String, FormatTag>::type
 {

--- a/include/boost/gil/io/read_view.hpp
+++ b/include/boost/gil/io/read_view.hpp
@@ -42,7 +42,7 @@ void read_view(Reader reader, View const& view,
                 typename get_pixel_type<View>::type,
                 typename Reader::format_tag_t
             >::type
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     reader.check_image_size(view.dimensions());
@@ -72,7 +72,7 @@ void read_view(
                 typename get_pixel_type<View>::type,
                 FormatTag
             >::type
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     using reader_t =
@@ -101,7 +101,7 @@ void read_view(Device& file, View const& view, FormatTag const& tag,
                 typename get_pixel_type<View>::type,
                 FormatTag
             >::type
-        >::type::value>::type* /*dummy*/ = nullptr)
+        >::value>::type* /*dummy*/ = nullptr)
 {
     using reader_t =
         typename get_reader<Device, FormatTag, detail::read_and_no_convert>::type;
@@ -132,7 +132,7 @@ void read_view(
                 typename get_pixel_type<View>::type,
                 FormatTag
             >::type
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     using reader_t =
@@ -161,7 +161,7 @@ void read_view(String const& file_name, View const& view, FormatTag const& tag,
                 typename get_pixel_type<View>::type,
                 FormatTag
             >::type
-        >::type::value
+        >::value
     >::type* /*dummy*/ = nullptr)
 {
     using reader_t =

--- a/include/boost/gil/io/row_buffer_helper.hpp
+++ b/include/boost/gil/io/row_buffer_helper.hpp
@@ -56,7 +56,7 @@ struct row_buffer_helper
     Pixel,
     typename std::enable_if
     <
-        is_bit_aligned<Pixel>::type::value
+        is_bit_aligned<Pixel>::value
     >::type
 >
 {
@@ -112,7 +112,7 @@ struct row_buffer_helper
         <
             typename is_bit_aligned<Pixel>::type,
             typename is_homogeneous<Pixel>::type
-        >::type::value
+        >::value
     >
 >
 {
@@ -125,14 +125,14 @@ struct row_buffer_helper
                      , bool        in_bytes
                      )
     : _c( ( width
-          * num_channels< pixel_type >::type::value
+          * num_channels< pixel_type >::value
           * channel_type< pixel_type >::type::num_bits
           )
           >> 3
         )
 
     , _r( width
-        * num_channels< pixel_type >::type::value
+        * num_channels< pixel_type >::value
         * channel_type< pixel_type >::type::num_bits
         - ( _c << 3 )
        )
@@ -184,7 +184,7 @@ struct row_buffer_helper_view
     View,
     typename std::enable_if
     <
-        is_bit_aligned<typename View::value_type>::type::value
+        is_bit_aligned<typename View::value_type>::value
     >::type
 > : row_buffer_helper<typename View::reference>
 {

--- a/include/boost/gil/io/write_view.hpp
+++ b/include/boost/gil/io/write_view.hpp
@@ -36,7 +36,7 @@ void write_view(Writer& writer, View const& view,
                 typename get_pixel_type<View>::type,
                 typename Writer::format_tag_t
             >::type
-        >::type::value
+        >::value
     >::type* /* ptr */ = nullptr)
 {
     writer.apply(view);
@@ -57,7 +57,7 @@ void write_view(Device& device, View const& view, FormatTag const& tag,
                 typename get_pixel_type<View>::type,
                 FormatTag
             >::type
-        >::type::value
+        >::value
     >::type* /* ptr */ = nullptr)
 {
     using writer_t = typename get_writer<Device, FormatTag>::type;
@@ -80,7 +80,7 @@ void write_view(String const& file_name, View const& view, FormatTag const& tag,
                 typename get_pixel_type<View>::type,
                 FormatTag
             >::type
-        >::type::value
+        >::value
     >::type* /* ptr */ = nullptr)
 {
     using writer_t = typename get_writer<String, FormatTag>::type;
@@ -104,7 +104,7 @@ void write_view(
                 typename get_pixel_type<View>::type,
                 FormatTag
             >::type
-        >::type::value
+        >::value
     >::type* /* ptr */ = nullptr)
 {
     using writer_t = typename get_writer<Device, FormatTag>::type;
@@ -128,7 +128,7 @@ void write_view(
                 typename get_pixel_type<View>::type,
                 FormatTag
             >::type
-        >::type::value
+        >::value
     >::type* /* ptr */ = nullptr)
 {
     using writer_t = typename get_writer<String, FormatTag>::type;
@@ -148,7 +148,7 @@ void write_view(Writer& writer, any_image_view<Views> const& view,
         <
             typename detail::is_dynamic_image_writer<Writer>::type,
             typename is_format_tag<typename Writer::format_tag_t>::type
-        >::type::value
+        >::value
     >::type * /* ptr */ = nullptr)
 {
     writer.apply(view);
@@ -165,7 +165,7 @@ void write_view(
         <
             typename detail::is_write_device<FormatTag, Device>::type,
             typename is_format_tag<FormatTag>::type
-        >::type::value
+        >::value
     >::type * /* ptr */ = 0)
 {
     using writer_t = typename get_dynamic_image_writer<Device, FormatTag>::type;
@@ -183,7 +183,7 @@ void write_view(
         <
             typename detail::is_supported_path_spec<String>::type,
             typename is_format_tag<FormatTag>::type
-        >::type::value
+        >::value
     >::type * /* ptr */ = nullptr)
 {
     using writer_t = typename get_dynamic_image_writer<String, FormatTag>::type;
@@ -203,7 +203,7 @@ void write_view(
         <
             typename detail::is_write_device<FormatTag, Device>::type,
             typename is_format_tag<FormatTag>::type
-        >::type::value
+        >::value
     >::type * /* ptr */ = 0)
 {
     using writer_t = typename get_dynamic_image_writer<Device, FormatTag>::type;
@@ -221,7 +221,7 @@ void write_view(
         <
             typename detail::is_supported_path_spec<String>::type,
             typename is_format_tag<FormatTag>::type
-        >::type::value
+        >::value
     >::type * /* ptr */ = nullptr)
 {
     using writer_t = typename get_dynamic_image_writer<String, FormatTag>::type;

--- a/include/boost/gil/metafunctions.hpp
+++ b/include/boost/gil/metafunctions.hpp
@@ -129,7 +129,7 @@ namespace detail {
 /// \brief Determines if the given iterator has a step that could be set dynamically
 template <typename I> struct iterator_is_step
     : public detail::iterator_is_step_impl<I,
-        !is_iterator_adaptor<I>::type::value,
+        !is_iterator_adaptor<I>::value,
         is_same<I,typename dynamic_x_step_type<I>::type>::value >{};
 
 /// \ingroup GILIsStep

--- a/include/boost/gil/promote_integral.hpp
+++ b/include/boost/gil/promote_integral.hpp
@@ -36,7 +36,7 @@ namespace detail { namespace promote_integral
 template
 <
     typename T,
-    bool IsFundamental = std::is_fundamental<T>::type::value
+    bool IsFundamental = std::is_fundamental<T>::value
 >
 struct bit_size {};
 
@@ -57,7 +57,7 @@ struct promote_to_larger
 
     using type = typename std::conditional
         <
-            (bit_size<current_type>::type::value >= MinSize),
+            (bit_size<current_type>::value >= MinSize),
             current_type,
             typename promote_to_larger
                 <
@@ -118,12 +118,12 @@ template
     typename T,
     bool PromoteUnsignedToUnsigned = false,
     bool UseCheckedInteger = false,
-    bool IsIntegral = std::is_integral<T>::type::value
+    bool IsIntegral = std::is_integral<T>::value
 >
 class promote_integral
 {
 private:
-    static bool const is_unsigned = std::is_unsigned<T>::type::value;
+    static bool const is_unsigned = std::is_unsigned<T>::value;
 
     using bit_size_type = detail::promote_integral::bit_size<T>;
 

--- a/include/boost/gil/utilities.hpp
+++ b/include/boost/gil/utilities.hpp
@@ -237,7 +237,7 @@ struct type_to_index
             typename mpl::find<Types,T>::type
         >::type
     {
-        static_assert(mpl::contains<Types, T>::type::value, "T should be element of Types");
+        static_assert(mpl::contains<Types, T>::value, "T should be element of Types");
     };
 } // namespace detail
 

--- a/test/legacy/pixel.cpp
+++ b/test/legacy/pixel.cpp
@@ -214,7 +214,7 @@ struct ccv2 {
     template <typename Pixel2>
     void operator()(Pixel2) {
         // convert from Pixel1 to Pixel2 (or, if Pixel2 is immutable, to its value type)
-        static const int p2_is_mutable = pixel_reference_is_mutable<typename Pixel2::type>::type::value;
+        static const int p2_is_mutable = pixel_reference_is_mutable<typename Pixel2::type>::value;
         using pixel_model_t = typename boost::remove_reference<typename Pixel2::type>::type;
         using p2_value_t = typename pixel_model_t::value_type;
         using pixel2_mutable = typename mpl::if_c<p2_is_mutable, Pixel2, value_core<p2_value_t>>::type;

--- a/test/promote_integral.cpp
+++ b/test/promote_integral.cpp
@@ -39,7 +39,7 @@ namespace bg = boost::gil;
 template
 <
     typename T,
-    bool Signed = std::is_fundamental<T>::type::value && !std::is_unsigned<T>::type::value
+    bool Signed = std::is_fundamental<T>::value && !std::is_unsigned<T>::type::value
 >
 struct absolute_value
 {
@@ -62,7 +62,7 @@ template
     <
         typename Integral,
         typename Promoted,
-        bool Signed = !std::is_unsigned<Promoted>::type::value
+        bool Signed = !std::is_unsigned<Promoted>::value
     >
 struct test_max_values
 {
@@ -113,7 +113,7 @@ struct test_max_values<Integral, Promoted, false>
 template
     <
         typename T,
-        bool IsFundamental = std::is_fundamental<T>::type::value
+        bool IsFundamental = std::is_fundamental<T>::value
     >
 struct bit_size_impl : std::integral_constant<std::size_t, 0>
 {};
@@ -125,7 +125,7 @@ struct bit_size_impl<T, true> : bg::detail::promote_integral::bit_size<T>::type
 template <typename T>
 std::size_t bit_size()
 {
-    return bit_size_impl<T>::type::value;
+    return bit_size_impl<T>::value;
 }
 
 template <bool PromoteUnsignedToUnsigned>
@@ -142,7 +142,7 @@ struct test_promote_integral
         bool const same_types = std::is_same
             <
                 promoted_integral_type, ExpectedPromotedType
-            >::type::value;
+            >::value;
 
         BOOST_CHECK_MESSAGE(same_types,
                             "case ID: " << case_id
@@ -152,7 +152,7 @@ struct test_promote_integral
                                         << "; expected: "
                                         << typeid(ExpectedPromotedType).name());
 
-        if (!std::is_same<Type, promoted_integral_type>::type::value)
+        if (!std::is_same<Type, promoted_integral_type>::value)
         {
             test_max_values<Type, promoted_integral_type>::apply();
         }
@@ -191,7 +191,7 @@ template
         <
                 typename T,
                 bool PromoteUnsignedToUnsigned = false,
-                bool IsSigned = !std::is_unsigned<T>::type::value
+                bool IsSigned = !std::is_unsigned<T>::value
         >
 struct test_promotion
 {


### PR DESCRIPTION
Fixes VS2015 failures.

Usually all boolean (like `is_*`, `or`, `and`) and integral (like `*size*`, `*num*`) metafunctions have `value` member.

### References

* Should help to fix #261