### PR TITLE
Use Boost.Build 'cxxstd' feature instead of '-std' compiler flag

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,23 +20,28 @@ environment:
     - TOOLSET: msvc-14.1
       ARCH: x86_64
       VARIANT: debug
+      CXXSTD: 11
       TEST_HEADERS: 1
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     - TOOLSET: msvc-14.1
       ARCH: x86_64
       VARIANT: release
+      CXXSTD: 11
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     - TOOLSET: msvc-14.1
       ARCH: x86
       VARIANT: debug
+      CXXSTD: 11
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     - TOOLSET: msvc-14.1
       ARCH: x86
       VARIANT: release
+      CXXSTD: 11
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     - TOOLSET: msvc-14.1
       ARCH: x86_64
       VARIANT: debug
+      CXXSTD: 11
       GENERATOR: "Visual Studio 15 2017 Win64"
       CMAKE_CONFIG: Debug
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
@@ -47,10 +52,12 @@ matrix:
     - TOOLSET: msvc-14.1
       ARCH: x86_64
       VARIANT: release
+      CXXSTD: 11
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     - TOOLSET: msvc-14.1
       ARCH: x86_64
       VARIANT: debug
+      CXXSTD: 11
       GENERATOR: "Visual Studio 15 2017 Win64"
       CMAKE_CONFIG: Debug
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
@@ -136,18 +143,18 @@ before_build:
   - xcopy /s /e /q %APPVEYOR_BUILD_FOLDER% libs\gil
   - cmd /c bootstrap
   - .\b2 headers
-  - if DEFINED GENERATOR .\b2 address-model=%AM% toolset=%TOOLSET% variant=%VARIANT% --with-filesystem --with-test stage
+  - if DEFINED GENERATOR .\b2 address-model=%AM% toolset=%TOOLSET% variant=%VARIANT% cxxstd=%CXXSTD% --with-filesystem --with-test stage
 
 build: off
 
 build_script:
   - cd c:\projects\boost
-  - if NOT DEFINED GENERATOR b2 address-model=%AM% toolset=%TOOLSET% variant=%VARIANT% libs/gil/test
-  - if NOT DEFINED GENERATOR b2 address-model=%AM% toolset=%TOOLSET% variant=%VARIANT% libs/gil/toolbox/test
-  - if NOT DEFINED GENERATOR b2 address-model=%AM% toolset=%TOOLSET% variant=%VARIANT% libs/gil/numeric/test
-  - if NOT DEFINED GENERATOR b2 address-model=%AM% toolset=%TOOLSET% variant=%VARIANT% include=%VCPKG_I% library-path=%VCPKG_L% libs/gil/io/test//simple
+  - if NOT DEFINED GENERATOR b2 address-model=%AM% toolset=%TOOLSET% variant=%VARIANT% cxxstd=%CXXSTD% libs/gil/test
+  - if NOT DEFINED GENERATOR b2 address-model=%AM% toolset=%TOOLSET% variant=%VARIANT% cxxstd=%CXXSTD% libs/gil/toolbox/test
+  - if NOT DEFINED GENERATOR b2 address-model=%AM% toolset=%TOOLSET% variant=%VARIANT% cxxstd=%CXXSTD% libs/gil/numeric/test
+  - if NOT DEFINED GENERATOR b2 address-model=%AM% toolset=%TOOLSET% variant=%VARIANT% cxxstd=%CXXSTD% include=%VCPKG_I% library-path=%VCPKG_L% libs/gil/io/test//simple
   - if DEFINED GENERATOR cd libs\gil && md build && cd build
-  - if DEFINED GENERATOR cmake -G "%GENERATOR%" -DBoost_DETAILED_FAILURE_MSG=ON -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake ..
+  - if DEFINED GENERATOR cmake -G "%GENERATOR%" -DCMAKE_CXX_STANDARD=%CXXSTD% -DBoost_DETAILED_FAILURE_MSG=ON -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake ..
   - if DEFINED GENERATOR cmake --build . --config %CMAKE_CONFIG %
 
 test_script:

--- a/.ci/build-and-test.sh
+++ b/.ci/build-and-test.sh
@@ -17,6 +17,10 @@ if [ -z ${VARIANT+x} ]; then
     exit 1
 fi
 
+if [ -z ${CXXSTD+x} ]; then
+    CXXSTD=11
+fi
+
 if [ -z ${B2_OPTIONS+x} ]; then
     B2_OPTIONS=""
 fi
@@ -34,7 +38,7 @@ fi
 echo "Running ./b2 -j $JOBS $B2_OPTIONS toolset=$TOOLSET variant=$VARIANT"
 
 set -euv
-./b2 -j $JOBS $B2_OPTIONS toolset=$TOOLSET variant=$VARIANT libs/gil/test
-./b2 -j $JOBS $B2_OPTIONS toolset=$TOOLSET variant=$VARIANT libs/gil/toolbox/test
-./b2 -j $JOBS $B2_OPTIONS toolset=$TOOLSET variant=$VARIANT libs/gil/numeric/test
-./b2 -j $JOBS $B2_OPTIONS toolset=$TOOLSET variant=$VARIANT libs/gil/io/test//simple
+./b2 -j $JOBS $B2_OPTIONS toolset=$TOOLSET variant=$VARIANT cxxstd=$CXXSTD libs/gil/test
+./b2 -j $JOBS $B2_OPTIONS toolset=$TOOLSET variant=$VARIANT cxxstd=$CXXSTD libs/gil/toolbox/test
+./b2 -j $JOBS $B2_OPTIONS toolset=$TOOLSET variant=$VARIANT cxxstd=$CXXSTD libs/gil/numeric/test
+./b2 -j $JOBS $B2_OPTIONS toolset=$TOOLSET variant=$VARIANT cxxstd=$CXXSTD libs/gil/io/test//simple

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ env_gcc_cpp11_dbg: &env_gcc_cpp11_dbg
     - TOOLSET: gcc
     - VARIANT: "variant=debug"
     - OPTIMIZ: ""
-    - CXXFLAG: "-std=c++11"
+    - CXXSTD: "11"
     - LNKFLAG: ""
 
 env_gcc_cpp11_opt_speed: &env_gcc_cpp11_opt_speed
@@ -90,7 +90,7 @@ env_gcc_cpp11_opt_speed: &env_gcc_cpp11_opt_speed
     - TOOLSET: gcc
     - VARIANT: "variant=release"
     - OPTIMIZ: "optimization=speed"
-    - CXXFLAG: "-std=c++11"
+    - CXXSTD: "11"
     - LNKFLAG: ""
 
 env_clang_cpp11_dbg: &env_clang_cpp11_dbg
@@ -98,7 +98,7 @@ env_clang_cpp11_dbg: &env_clang_cpp11_dbg
     - TOOLSET: clang
     - VARIANT: "variant=debug"
     - OPTIMIZ: ""
-    - CXXFLAG: "-std=c++11"
+    - CXXSTD: "11"
     - LNKFLAG: ""
 
 env_clang_cpp11_opt_speed: &env_clang_cpp11_opt_speed
@@ -106,7 +106,7 @@ env_clang_cpp11_opt_speed: &env_clang_cpp11_opt_speed
     - TOOLSET: clang
     - VARIANT: "variant=release"
     - OPTIMIZ: "optimization=speed"
-    - CXXFLAG: "-std=c++11"
+    - CXXSTD: "11"
     - LNKFLAG: ""
 
 ##############################################################################
@@ -255,7 +255,7 @@ run_compiler_version: &run_compiler_version
         echo TOOLSET=$TOOLSET
         echo VARIANT=$VARIANT
         echo OPTIMIZ=$OPTIMIZ
-        echo CXXFLAG=$CXXFLAG
+        echo CXXSTD=$CXXSTD
         echo LNKFLAG=$LNKFLAG
         $TOOLSET --version
 
@@ -273,25 +273,25 @@ steps_test_core: &steps_test_core
   steps:
     - *attach_workspace
     - *run_compiler_version
-    - run: cd boost && ./b2 toolset=$TOOLSET $VARIANT $OPTIMIZ cxxflags="$CXXFLAG" libs/gil/test
+    - run: cd boost && ./b2 toolset=$TOOLSET $VARIANT $OPTIMIZ cxxstd="$CXXSTD" libs/gil/test
 
 steps_test_toolbox: &steps_test_toolbox
   steps:
     - *attach_workspace
     - *run_compiler_version
-    - run: cd boost && ./b2 toolset=$TOOLSET $VARIANT $OPTIMIZ cxxflags="$CXXFLAG" libs/gil/toolbox/test
+    - run: cd boost && ./b2 toolset=$TOOLSET $VARIANT $OPTIMIZ cxxstd="$CXXSTD" libs/gil/toolbox/test
 
 steps_test_numeric: &steps_test_numeric
   steps:
     - *attach_workspace
     - *run_compiler_version
-    - run: cd boost && ./b2 toolset=$TOOLSET $VARIANT $OPTIMIZ cxxflags="$CXXFLAG" libs/gil/numeric/test
+    - run: cd boost && ./b2 toolset=$TOOLSET $VARIANT $OPTIMIZ cxxstd="$CXXSTD" libs/gil/numeric/test
 
 steps_test_io: &steps_test_io
   steps:
     - *attach_workspace
     - *run_compiler_version
-    - run: cd boost && ./b2 toolset=$TOOLSET $VARIANT $OPTIMIZ cxxflags="$CXXFLAG" libs/gil/io/test//simple
+    - run: cd boost && ./b2 toolset=$TOOLSET $VARIANT $OPTIMIZ cxxstd="$CXXSTD" libs/gil/io/test//simple
 
 ##############################################################################
 # Build jobs

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
     - env: BOGUS_JOB=true
   include:
     - os: linux
-      env: COMPILER=g++-5 VARIANT=debug TOOLSET=gcc CXXSTD=c++11 TEST_HEADERS=1
+      env: COMPILER=g++-5 VARIANT=debug TOOLSET=gcc CXXSTD=11 TEST_HEADERS=1
       addons:
         apt:
           packages:
@@ -35,7 +35,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - os: linux
-      env: COMPILER=g++-5 VARIANT=release TOOLSET=gcc CXXSTD=c++11
+      env: COMPILER=g++-5 VARIANT=release TOOLSET=gcc CXXSTD=11
       addons:
         apt:
           packages:
@@ -48,7 +48,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - os: linux
-      env: COMPILER=g++-6 VARIANT=debug TOOLSET=gcc CXXSTD=c++11
+      env: COMPILER=g++-6 VARIANT=debug TOOLSET=gcc CXXSTD=11
       addons:
         apt:
           packages:
@@ -61,7 +61,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - os: linux
-      env: COMPILER=g++-6 VARIANT=release TOOLSET=gcc CXXSTD=c++11
+      env: COMPILER=g++-6 VARIANT=release TOOLSET=gcc CXXSTD=11
       addons:
         apt:
           packages:
@@ -74,7 +74,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - os: linux
-      env: COMPILER=g++-7 VARIANT=debug TOOLSET=gcc CXXSTD=c++11
+      env: COMPILER=g++-7 VARIANT=debug TOOLSET=gcc CXXSTD=11
       addons:
         apt:
           packages:
@@ -87,7 +87,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - os: linux
-      env: COMPILER=g++-7 VARIANT=release TOOLSET=gcc CXXSTD=c++11
+      env: COMPILER=g++-7 VARIANT=release TOOLSET=gcc CXXSTD=11
       addons:
         apt:
           packages:
@@ -100,7 +100,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - os: linux
-      env: COMPILER=clang++-3.9 VARIANT=debug TOOLSET=clang CXXSTD=c++11
+      env: COMPILER=clang++-3.9 VARIANT=debug TOOLSET=clang CXXSTD=11
       addons:
         apt:
           packages:
@@ -114,7 +114,7 @@ matrix:
             - llvm-toolchain-precise-3.9
 
     - os: linux
-      env: COMPILER=clang++-3.9 VARIANT=release TOOLSET=clang CXXSTD=c++11
+      env: COMPILER=clang++-3.9 VARIANT=release TOOLSET=clang CXXSTD=11
       addons:
         apt:
           packages:
@@ -128,7 +128,7 @@ matrix:
             - llvm-toolchain-precise-3.9
 
     - os: linux
-      env: COMPILER=clang++-5.0 VARIANT=gil_ubsan_integer TOOLSET=clang CXXSTD=c++11 B2_OPTIONS="visibility=global" UBSAN_OPTIONS='print_stacktrace=1'
+      env: COMPILER=clang++-5.0 VARIANT=gil_ubsan_integer TOOLSET=clang CXXSTD=11 B2_OPTIONS="visibility=global" UBSAN_OPTIONS='print_stacktrace=1'
       addons:
         apt:
           packages:
@@ -142,7 +142,7 @@ matrix:
             - llvm-toolchain-trusty-5.0
 
     - os: linux
-      env: COMPILER=clang++-5.0 VARIANT=gil_ubsan_nullability TOOLSET=clang CXXSTD=c++11 B2_OPTIONS="visibility=global" UBSAN_OPTIONS='print_stacktrace=1'
+      env: COMPILER=clang++-5.0 VARIANT=gil_ubsan_nullability TOOLSET=clang CXXSTD=11 B2_OPTIONS="visibility=global" UBSAN_OPTIONS='print_stacktrace=1'
       addons:
         apt:
           packages:
@@ -156,7 +156,7 @@ matrix:
             - llvm-toolchain-trusty-5.0
 
     - os: linux
-      env: COMPILER=clang++-5.0 VARIANT=gil_ubsan_undefined TOOLSET=clang CXXSTD=c++11 B2_OPTIONS="visibility=global" UBSAN_OPTIONS='print_stacktrace=1'
+      env: COMPILER=clang++-5.0 VARIANT=gil_ubsan_undefined TOOLSET=clang CXXSTD=11 B2_OPTIONS="visibility=global" UBSAN_OPTIONS='print_stacktrace=1'
       addons:
         apt:
           packages:
@@ -170,10 +170,10 @@ matrix:
             - llvm-toolchain-trusty-5.0
 
     - os: osx
-      env: COMPILER=clang++ VARIANT=debug TOOLSET=clang CXXSTD=c++11
+      env: COMPILER=clang++ VARIANT=debug TOOLSET=clang CXXSTD=11
 
     - os: osx
-      env: COMPILER=clang++ VARIANT=release TOOLSET=clang CXXSTD=c++11
+      env: COMPILER=clang++ VARIANT=release TOOLSET=clang CXXSTD=11
 
     - env: DOC=1
       addons:
@@ -182,7 +182,7 @@ matrix:
             - doxygen
 
   allow_failures:
-    - env: COMPILER=clang++-5.0 VARIANT=gil_ubsan_integer TOOLSET=clang CXXSTD=c++11 B2_OPTIONS="visibility=global" UBSAN_OPTIONS='print_stacktrace=1'
+    - env: COMPILER=clang++-5.0 VARIANT=gil_ubsan_integer TOOLSET=clang CXXSTD=11 B2_OPTIONS="visibility=global" UBSAN_OPTIONS='print_stacktrace=1'
 
 install:
   - |-
@@ -266,7 +266,7 @@ script:
       ./b2 libs/gil/doc
     fi
   - |-
-    echo "using $TOOLSET : : $COMPILER : <cxxflags>-std=$CXXSTD ;" > ~/user-config.jam
+    echo "using $TOOLSET : : $COMPILER : ;" > ~/user-config.jam
   - travis_retry libs/gil/.ci/build-and-test.sh
 
 after_success:

--- a/Jamfile
+++ b/Jamfile
@@ -1,7 +1,7 @@
 # Boost.GIL (Generic Image Library)
 #
 # Copyright (c) 2013-2017 Vinnie Falco (vinnie dot falco at gmail dot com)
-# Copyright (c) 2018 Mateusz Loskot <mateusz@loskot.net>
+# Copyright (c) 2018-2019 Mateusz Loskot <mateusz@loskot.net>
 #
 # Use, modification and distribution is subject to the Boost Software License,
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -25,7 +25,6 @@ if ! [ os.environ CI ] && ! [ os.environ AGENT_JOBSTATUS ]
 project
     :
     requirements
-        # MSVC: Since VS2017, default is -std:c++14, so no explicit switch is required.
         <toolset>msvc:<asynch-exceptions>on
         <toolset>msvc:<cxxflags>/bigobj
         <toolset>msvc:<define>_SCL_SECURE_NO_DEPRECATE
@@ -33,11 +32,11 @@ project
         <toolset>msvc:<define>_CRT_NONSTDC_NO_DEPRECATE
         <toolset>msvc:<define>NOMINMAX
         <toolset>intel:<debug-symbols>off
-        <toolset>gcc:<cxxflags>"-std=c++11 -fstrict-aliasing -Wextra"
-        <toolset>darwin:<cxxflags>"-std=c++11 -fstrict-aliasing -Wextra"
+        <toolset>gcc:<cxxflags>"-fstrict-aliasing -Wextra"
+        <toolset>darwin:<cxxflags>"-fstrict-aliasing -Wextra"
         # variant filter for clang is necessary to allow ubsan_* variants declare distinct set of <cxxflags>
-        <toolset>clang,<variant>debug:<cxxflags>"-std=c++11 -fstrict-aliasing -Wextra"
-        <toolset>clang,<variant>release:<cxxflags>"-std=c++11 -fstrict-aliasing -Wextra"
+        <toolset>clang,<variant>debug:<cxxflags>"-fstrict-aliasing -Wextra"
+        <toolset>clang,<variant>release:<cxxflags>"-fstrict-aliasing -Wextra"
         $(DEVELOPMENT_EXTRA_WARNINGS)
         [ requires
             cxx11_constexpr
@@ -51,7 +50,7 @@ project
 variant gil_ubsan_integer
     : release
     :
-    <cxxflags>"-std=c++11 -Wno-unused -fstrict-aliasing -fno-omit-frame-pointer -fsanitize=integer -fno-sanitize-recover=integer -fsanitize-blacklist=libs/gil/.ci/blacklist.supp"
+    <cxxflags>"-Wno-unused -fstrict-aliasing -fno-omit-frame-pointer -fsanitize=integer -fno-sanitize-recover=integer -fsanitize-blacklist=libs/gil/.ci/blacklist.supp"
     <linkflags>"-fsanitize=integer"
     <debug-symbols>on
     <define>BOOST_USE_ASAN=1
@@ -60,7 +59,7 @@ variant gil_ubsan_integer
 variant gil_ubsan_nullability
     : release
     :
-    <cxxflags>"-std=c++11 -Wno-unused -fstrict-aliasing -fno-omit-frame-pointer -fsanitize=nullability -fno-sanitize-recover=nullability -fsanitize-blacklist=libs/gil/.ci/blacklist.supp"
+    <cxxflags>"-Wno-unused -fstrict-aliasing -fno-omit-frame-pointer -fsanitize=nullability -fno-sanitize-recover=nullability -fsanitize-blacklist=libs/gil/.ci/blacklist.supp"
     <linkflags>"-fsanitize=nullability"
     <debug-symbols>on
     <define>BOOST_USE_ASAN=1
@@ -69,7 +68,7 @@ variant gil_ubsan_nullability
 variant gil_ubsan_undefined
     : release
     :
-    <cxxflags>"-std=c++11 -Wno-unused -fstrict-aliasing -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-blacklist=libs/gil/.ci/blacklist.supp"
+    <cxxflags>"-Wno-unused -fstrict-aliasing -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-blacklist=libs/gil/.ci/blacklist.supp"
     <linkflags>"-fsanitize=undefined"
     <debug-symbols>on
     <define>BOOST_USE_ASAN=1


### PR DESCRIPTION
The `cxxstd=11,14,17,...` is the recommended way, announced here https://lists.boost.org/Archives/boost/2017/10/239485.php

### References

* #260 (and its discussion)

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed

-----

/cc @Kojoley 