### PR TITLE
Replace Boost.MPL with Boost.MP11

### DIFF
--- a/example/dynamic_image.cpp
+++ b/example/dynamic_image.cpp
@@ -8,13 +8,13 @@
 #include <boost/gil.hpp>
 #include <boost/gil/extension/dynamic_image/any_image.hpp>
 #include <boost/gil/extension/io/jpeg.hpp>
-#include <boost/mpl/vector.hpp>
+#include <boost/mp11.hpp>
 
 int main()
 {
     namespace gil = boost::gil;
 
-    using my_images_t = boost::mpl::vector<gil::gray8_image_t, gil::rgb8_image_t, gil::gray16_image_t, gil::rgb16_image_t>;
+    using my_images_t = boost::mp11::mp_list<gil::gray8_image_t, gil::rgb8_image_t, gil::gray16_image_t, gil::rgb16_image_t>;
     gil::any_image<my_images_t> dynamic_image;
     gil::read_image("test.jpg", dynamic_image, gil::jpeg_tag());
     // Save the image upside down, preserving its native color space and channel depth

--- a/example/interleaved_ptr.hpp
+++ b/example/interleaved_ptr.hpp
@@ -9,6 +9,10 @@
 #define BOOST_GIL_EXAMPLE_INTERLEAVED_PTR_HPP
 
 #include <boost/gil/pixel_iterator.hpp>
+#include <boost/mp11.hpp>
+
+#include <type_traits>
+
 #include "interleaved_ref.hpp"
 
 // Example on how to create a pixel iterator
@@ -29,10 +33,13 @@ namespace boost { namespace gil {
 
 template <typename ChannelPtr,  // Models Channel Iterator (examples: unsigned char* or const unsigned char*)
           typename Layout>      // A layout (includes the color space and channel ordering)
-struct interleaved_ptr : public  boost::iterator_facade<interleaved_ptr<ChannelPtr,Layout>,
-                                   pixel<typename std::iterator_traits<ChannelPtr>::value_type,Layout>,
-                                   boost::random_access_traversal_tag,
-                                   const interleaved_ref<typename std::iterator_traits<ChannelPtr>::reference,Layout>>
+struct interleaved_ptr : boost::iterator_facade
+    <
+        interleaved_ptr<ChannelPtr, Layout>,
+        pixel<typename std::iterator_traits<ChannelPtr>::value_type, Layout>,
+        boost::random_access_traversal_tag,
+        interleaved_ref<typename std::iterator_traits<ChannelPtr>::reference, Layout> const
+    >
 {
 private:
     using parent_t boost::iterator_facade
@@ -75,7 +82,7 @@ public:
           ChannelPtr& channels()                  { return _channels; }
 
     // Not required by concepts but useful
-    static const std::size_t num_channels = mpl::size<typename Layout::color_space_t>::value;
+    static const std::size_t num_channels = mp11::mp_size<typename Layout::color_space_t>::value;
 private:
     ChannelPtr _channels;
     friend class boost::iterator_core_access;
@@ -110,12 +117,12 @@ public:
 };
 
 template <typename ChannelPtr, typename Layout>
-struct iterator_is_mutable<interleaved_ptr<ChannelPtr,Layout>> : public boost::mpl::true_ {};
+struct iterator_is_mutable<interleaved_ptr<ChannelPtr,Layout>> : std::true_type {};
 template <typename Channel, typename Layout>
-struct iterator_is_mutable<interleaved_ptr<const Channel*,Layout>> : public boost::mpl::false_ {};
+struct iterator_is_mutable<interleaved_ptr<const Channel*,Layout>> : std::false_type {};
 
 template <typename ChannelPtr, typename Layout>
-struct is_iterator_adaptor<interleaved_ptr<ChannelPtr,Layout>> : public boost::mpl::false_ {};
+struct is_iterator_adaptor<interleaved_ptr<ChannelPtr,Layout>> : std::false_type {};
 
 /////////////////////////////
 //  PixelBasedConcept
@@ -134,7 +141,7 @@ struct channel_mapping_type<interleaved_ptr<ChannelPtr,Layout>>
 };
 
 template <typename ChannelPtr, typename Layout>
-struct is_planar<interleaved_ptr<ChannelPtr,Layout>> : public mpl::false_ {};
+struct is_planar<interleaved_ptr<ChannelPtr,Layout>> : std::false_type {};
 
 /////////////////////////////
 //  HomogeneousPixelBasedConcept

--- a/example/interleaved_ref.hpp
+++ b/example/interleaved_ref.hpp
@@ -10,8 +10,7 @@
 
 #include <boost/gil/extension/dynamic_image/dynamic_image_all.hpp>
 
-#include <boost/mpl/range_c.hpp>
-#include <boost/mpl/vector_c.hpp>
+#include <type_traits>
 
 // Example on how to create a new model of a pixel reference
 
@@ -125,7 +124,7 @@ void swap(const interleaved_ref<ChannelReference,Layout>& x, const interleaved_r
 
 // Required by PixelConcept
 template <typename ChannelReference, typename Layout>
-struct is_pixel<interleaved_ref<ChannelReference,Layout>> : public boost::mpl::true_ {};
+struct is_pixel<interleaved_ref<ChannelReference,Layout>> : public std::true_type {};
 
 
 // Required by PixelBasedConcept
@@ -144,7 +143,7 @@ struct channel_mapping_type<interleaved_ref<ChannelReference, Layout>>
 
 // Required by PixelBasedConcept
 template <typename ChannelReference, typename Layout>
-struct is_planar<interleaved_ref<ChannelReference,Layout>> : mpl::false_ {};
+struct is_planar<interleaved_ref<ChannelReference,Layout>> : std::false_type {};
 
 // Required by HomogeneousPixelBasedConcept
 template <typename ChannelReference, typename Layout>

--- a/include/boost/gil/algorithm.hpp
+++ b/include/boost/gil/algorithm.hpp
@@ -13,11 +13,10 @@
 #include <boost/gil/concepts.hpp>
 #include <boost/gil/image_view.hpp>
 #include <boost/gil/image_view_factory.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <boost/assert.hpp>
 #include <boost/config.hpp>
-#include <boost/mpl/and.hpp>
-#include <boost/mpl/or.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -78,7 +77,8 @@ struct error_t {};
 /// You must provide apply_compatible(V1,V2) method in your subclass, but apply_incompatible(V1,V2)
 /// is not required and the default throws std::bad_cast.
 template <typename Derived, typename Result=void>
-struct binary_operation_obj {
+struct binary_operation_obj
+{
     using result_type = Result;
 
     template <typename V1, typename V2> BOOST_FORCEINLINE
@@ -96,28 +96,33 @@ private:
 
     // dispatch from apply overload to a function with distinct name
     template <typename V1, typename V2>
-    BOOST_FORCEINLINE result_type apply(const V1& v1, const V2& v2, mpl::false_) const {
-        return ((const Derived*)this)->apply_incompatible(v1,v2);
+    BOOST_FORCEINLINE
+    result_type apply(V1 const& v1, V2 const& v2, std::false_type) const
+    {
+        return ((const Derived*)this)->apply_incompatible(v1, v2);
     }
 
     // dispatch from apply overload to a function with distinct name
     template <typename V1, typename V2>
-    BOOST_FORCEINLINE result_type apply(const V1& v1, const V2& v2, mpl::true_) const {
-        return ((const Derived*)this)->apply_compatible(v1,v2);
+    BOOST_FORCEINLINE
+    result_type apply(V1 const& v1, V2 const& v2, std::true_type) const
+    {
+        return ((const Derived*)this)->apply_compatible(v1, v2);
     }
 
     // function with distinct name - it can be overloaded by subclasses
     template <typename V1, typename V2>
-    BOOST_FORCEINLINE result_type apply_incompatible(const V1&, const V2&) const {
+    BOOST_FORCEINLINE
+    result_type apply_incompatible(V1 const& /*v1*/, V2 const& /*v2*/) const
+    {
         throw std::bad_cast();
     }
 };
-} }  // namespace boost::gil
+
+}}  // namespace boost::gil
 
 //////////////////////////////////////////////////////////////////////////////////////
-///
-/// std::copy and gil::copy_pixels
-///
+// std::copy and gil::copy_pixels
 //////////////////////////////////////////////////////////////////////////////////////
 
 /// \defgroup ImageViewSTLAlgorithmsCopyPixels copy_pixels
@@ -125,22 +130,28 @@ private:
 /// \brief std::copy for image views
 
 namespace std {
+
 /// \ingroup STLOptimizations
 /// \brief Copy when both src and dst are interleaved and of the same type can be just memmove
-template<typename T, typename Cs>
-BOOST_FORCEINLINE boost::gil::pixel<T,Cs>*
-copy(boost::gil::pixel<T,Cs>* first, boost::gil::pixel<T,Cs>* last,
-     boost::gil::pixel<T,Cs>* dst) {
-    return (boost::gil::pixel<T,Cs>*)std::copy((unsigned char*)first,(unsigned char*)last, (unsigned char*)dst);
+template<typename T, typename CS>
+BOOST_FORCEINLINE
+auto copy(
+    boost::gil::pixel<T, CS>* first,
+    boost::gil::pixel<T, CS>* last,
+    boost::gil::pixel<T, CS>* dst)
+    ->  boost::gil::pixel<T, CS>*
+{
+    auto p = std::copy((unsigned char*)first, (unsigned char*)last, (unsigned char*)dst);
+    return reinterpret_cast<boost::gil::pixel<T, CS>*>(p);
 }
 
 /// \ingroup STLOptimizations
 /// \brief Copy when both src and dst are interleaved and of the same type can be just memmove
-template<typename T, typename Cs>
-BOOST_FORCEINLINE boost::gil::pixel<T,Cs>*
-copy(const boost::gil::pixel<T,Cs>* first, const boost::gil::pixel<T,Cs>* last,
-     boost::gil::pixel<T,Cs>* dst) {
-    return (boost::gil::pixel<T,Cs>*)std::copy((unsigned char*)first,(unsigned char*)last, (unsigned char*)dst);
+template<typename T, typename CS>
+BOOST_FORCEINLINE boost::gil::pixel<T,CS>*
+copy(const boost::gil::pixel<T,CS>* first, const boost::gil::pixel<T,CS>* last,
+     boost::gil::pixel<T,CS>* dst) {
+    return (boost::gil::pixel<T,CS>*)std::copy((unsigned char*)first,(unsigned char*)last, (unsigned char*)dst);
 }
 } // namespace std
 
@@ -155,9 +166,9 @@ template <typename I, typename O> struct copy_fn {
 namespace std {
 /// \ingroup STLOptimizations
 /// \brief Copy when both src and dst are planar pointers is copy for each channel
-template<typename Cs, typename IC1, typename IC2> BOOST_FORCEINLINE
-boost::gil::planar_pixel_iterator<IC2,Cs> copy(boost::gil::planar_pixel_iterator<IC1,Cs> first, boost::gil::planar_pixel_iterator<IC1,Cs> last, boost::gil::planar_pixel_iterator<IC2,Cs> dst) {
-    boost::gil::gil_function_requires<boost::gil::ChannelsCompatibleConcept<typename std::iterator_traits<IC1>::value_type,typename std::iterator_traits<IC2>::value_type> >();
+template<typename CS, typename IC1, typename IC2> BOOST_FORCEINLINE
+boost::gil::planar_pixel_iterator<IC2,CS> copy(boost::gil::planar_pixel_iterator<IC1,CS> first, boost::gil::planar_pixel_iterator<IC1,CS> last, boost::gil::planar_pixel_iterator<IC2,CS> dst) {
+    boost::gil::gil_function_requires<boost::gil::ChannelsCompatibleConcept<typename std::iterator_traits<IC1>::value_type,typename std::iterator_traits<IC2>::value_type>>();
     static_for_each(first,last,dst,boost::gil::detail::copy_fn<IC1,IC2>());
     return dst+(last-first);
 }
@@ -175,10 +186,10 @@ struct copier_n {
 /// Source range is delimited by image iterators
 template <typename IL, typename O>  // IL Models ConstPixelLocatorConcept, O Models PixelIteratorConcept
 struct copier_n<iterator_from_2d<IL>,O> {
-    using diff_t = typename std::iterator_traits<iterator_from_2d<IL> >::difference_type;
+    using diff_t = typename std::iterator_traits<iterator_from_2d<IL>>::difference_type;
     BOOST_FORCEINLINE void operator()(iterator_from_2d<IL> src, diff_t n, O dst) const {
-        gil_function_requires<PixelLocatorConcept<IL> >();
-        gil_function_requires<MutablePixelIteratorConcept<O> >();
+        gil_function_requires<PixelLocatorConcept<IL>>();
+        gil_function_requires<MutablePixelIteratorConcept<O>>();
         while (n>0) {
             diff_t l=src.width()-src.x_pos();
             diff_t numToCopy=(n<l ? n:l);
@@ -192,11 +203,11 @@ struct copier_n<iterator_from_2d<IL>,O> {
 
 /// Destination range is delimited by image iterators
 template <typename I, typename OL> // I Models ConstPixelIteratorConcept, OL Models PixelLocatorConcept
-struct copier_n<I,iterator_from_2d<OL> > {
+struct copier_n<I,iterator_from_2d<OL>> {
     using diff_t = typename std::iterator_traits<I>::difference_type;
     BOOST_FORCEINLINE void operator()(I src, diff_t n, iterator_from_2d<OL> dst) const {
-        gil_function_requires<PixelIteratorConcept<I> >();
-        gil_function_requires<MutablePixelLocatorConcept<OL> >();
+        gil_function_requires<PixelIteratorConcept<I>>();
+        gil_function_requires<MutablePixelLocatorConcept<OL>>();
         while (n>0) {
             diff_t l=dst.width()-dst.x_pos();
             diff_t numToCopy=(n<l ? n:l);
@@ -210,11 +221,11 @@ struct copier_n<I,iterator_from_2d<OL> > {
 
 /// Both source and destination ranges are delimited by image iterators
 template <typename IL, typename OL>
-struct copier_n<iterator_from_2d<IL>,iterator_from_2d<OL> > {
+struct copier_n<iterator_from_2d<IL>,iterator_from_2d<OL>> {
    using diff_t = typename iterator_from_2d<IL>::difference_type;
    BOOST_FORCEINLINE void operator()(iterator_from_2d<IL> src, diff_t n, iterator_from_2d<OL> dst) const {
-        gil_function_requires<PixelLocatorConcept<IL> >();
-        gil_function_requires<MutablePixelLocatorConcept<OL> >();
+        gil_function_requires<PixelLocatorConcept<IL>>();
+        gil_function_requires<MutablePixelLocatorConcept<OL>>();
         if (src.x_pos()!=dst.x_pos() || src.width()!=dst.width()) {
             while(n-->0) {
                 *dst++=*src++;
@@ -274,9 +285,7 @@ void copy_pixels(const View1& src, const View2& dst)
 }
 
 //////////////////////////////////////////////////////////////////////////////////////
-///
-/// copy_and_convert_pixels
-///
+// copy_and_convert_pixels
 //////////////////////////////////////////////////////////////////////////////////////
 
 /// \defgroup ImageViewSTLAlgorithmsCopyAndConvertPixels copy_and_convert_pixels
@@ -287,11 +296,12 @@ void copy_pixels(const View1& src, const View2& dst)
 
 namespace detail {
 template <typename CC>
-class copy_and_convert_pixels_fn : public binary_operation_obj<copy_and_convert_pixels_fn<CC> > {
+class copy_and_convert_pixels_fn : public binary_operation_obj<copy_and_convert_pixels_fn<CC>>
+{
 private:
     CC _cc;
 public:
-    using result_type = typename binary_operation_obj<copy_and_convert_pixels_fn<default_color_converter> >::result_type;
+    using result_type = typename binary_operation_obj<copy_and_convert_pixels_fn<default_color_converter>>::result_type;
     copy_and_convert_pixels_fn() {}
     copy_and_convert_pixels_fn(CC cc_in) : _cc(cc_in) {}
    // when the two color spaces are incompatible, a color conversion is performed
@@ -328,9 +338,7 @@ void copy_and_convert_pixels(const View1& src, const View2& dst) {
 } }  // namespace boost::gil
 
 //////////////////////////////////////////////////////////////////////////////////////
-//
 // std::fill and gil::fill_pixels
-//
 //////////////////////////////////////////////////////////////////////////////////////
 
 /// \defgroup ImageViewSTLAlgorithmsFillPixels fill_pixels
@@ -348,7 +356,7 @@ namespace std {
 /// resolves to fill of each row using the underlying pixel iterator, which is still faster
 template <typename IL, typename V>
 void fill(boost::gil::iterator_from_2d<IL> first, boost::gil::iterator_from_2d<IL> last, const V& val) {
-    boost::gil::gil_function_requires<boost::gil::MutablePixelLocatorConcept<IL> >();
+    boost::gil::gil_function_requires<boost::gil::MutablePixelLocatorConcept<IL>>();
     if (first.is_1d_traversable()) {
         std::fill(first.x(), last.x(), val);
     } else {
@@ -365,7 +373,9 @@ void fill(boost::gil::iterator_from_2d<IL> first, boost::gil::iterator_from_2d<I
 } // namespace std
 
 namespace boost { namespace gil {
+
 namespace detail {
+
 /// struct to do std::fill
 struct std_fill_t {
     template <typename It, typename P>
@@ -373,37 +383,46 @@ struct std_fill_t {
         std::fill(first,last,p_in);
     }
 };
+
 /// std::fill for planar iterators
 template <typename It, typename P>
 BOOST_FORCEINLINE
-void fill_aux(It first, It last, const P& p, mpl::true_) {
-    static_for_each(first,last,p,std_fill_t());
+void fill_aux(It first, It last, P const& p, std::true_type)
+{
+    static_for_each(first, last, p, std_fill_t());
 }
+
 /// std::fill for interleaved iterators
 template <typename It, typename P>
 BOOST_FORCEINLINE
-void fill_aux(It first, It last, const P& p,mpl::false_) {
-    std::fill(first,last,p);
+void fill_aux(It first, It last, P const& p, std::false_type)
+{
+    std::fill(first, last, p);
 }
+
 } // namespace detail
 
 /// \ingroup ImageViewSTLAlgorithmsFillPixels
 /// \brief std::fill for image views
-template <typename View, typename Value> BOOST_FORCEINLINE
-void fill_pixels(const View& img_view, const Value& val) {
-    if (img_view.is_1d_traversable())
-        detail::fill_aux(img_view.begin().x(), img_view.end().x(),
-                 val,is_planar<View>());
+template <typename View, typename Value>
+BOOST_FORCEINLINE
+void fill_pixels(View const& view, Value const& value)
+{
+    if (view.is_1d_traversable())
+    {
+        detail::fill_aux(
+            view.begin().x(), view.end().x(), value, is_planar<View>());
+    }
     else
-        for (std::ptrdiff_t y=0; y<img_view.height(); ++y)
-            detail::fill_aux(img_view.row_begin(y),img_view.row_end(y),
-                     val,is_planar<View>());
+    {
+        for (std::ptrdiff_t y = 0; y < view.height(); ++y)
+            detail::fill_aux(
+                view.row_begin(y), view.row_end(y), value, is_planar<View>());
+    }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////
-///
-/// destruct_pixels
-///
+// destruct_pixels
 //////////////////////////////////////////////////////////////////////////////////////
 
 /// \defgroup ImageViewSTLAlgorithmsDestructPixels destruct_pixels
@@ -416,10 +435,13 @@ BOOST_FORCEINLINE
 void destruct_range_impl(Iterator first, Iterator last,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
-            is_pointer<Iterator>,
-            mpl::not_<std::is_trivially_destructible<typename std::iterator_traits<Iterator>::value_type>>
+            std::is_pointer<Iterator>,
+            mp11::mp_not
+            <
+                std::is_trivially_destructible<typename std::iterator_traits<Iterator>>
+            >
         >::value
     >::type* /*ptr*/ = 0)
 {
@@ -435,10 +457,10 @@ BOOST_FORCEINLINE
 void destruct_range_impl(Iterator /*first*/, Iterator /*last*/,
     typename std::enable_if
     <
-        mpl::or_
+        mp11::mp_or
         <
-            mpl::not_<is_pointer<Iterator>>,
-            std::is_trivially_destructible<typename std::iterator_traits<Iterator>::value_type>
+            mp11::mp_not<std::is_pointer<Iterator>>,
+            std::is_trivially_destructible<typename std::iterator_traits<Iterator>>
         >::value
     >::type* /* ptr */ = nullptr)
 {
@@ -463,34 +485,42 @@ struct std_destruct_t
 /// destruct for planar iterators
 template <typename It>
 BOOST_FORCEINLINE
-void destruct_aux(It first, It last, mpl::true_) {
+void destruct_aux(It first, It last, std::true_type)
+{
     static_for_each(first,last,std_destruct_t());
 }
+
 /// destruct for interleaved iterators
 template <typename It>
 BOOST_FORCEINLINE
-void destruct_aux(It first, It last, mpl::false_) {
+void destruct_aux(It first, It last, std::false_type)
+{
     destruct_range(first,last);
 }
+
 } // namespace detail
 
 /// \ingroup ImageViewSTLAlgorithmsDestructPixels
 /// \brief Invokes the in-place destructor on every pixel of the view
-template <typename View> BOOST_FORCEINLINE
-void destruct_pixels(const View& img_view) {
-    if (img_view.is_1d_traversable())
-        detail::destruct_aux(img_view.begin().x(), img_view.end().x(),
-                                       is_planar<View>());
+template <typename View>
+BOOST_FORCEINLINE
+void destruct_pixels(View const& view)
+{
+    if (view.is_1d_traversable())
+    {
+        detail::destruct_aux(
+            view.begin().x(), view.end().x(), is_planar<View>());
+    }
     else
-        for (std::ptrdiff_t y=0; y<img_view.height(); ++y)
-            detail::destruct_aux(img_view.row_begin(y),img_view.row_end(y),
-                                           is_planar<View>());
+    {
+        for (std::ptrdiff_t y = 0; y < view.height(); ++y)
+            detail::destruct_aux(
+                view.row_begin(y), view.row_end(y), is_planar<View>());
+    }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////
-///
-/// uninitialized_fill_pixels
-///
+// uninitialized_fill_pixels
 //////////////////////////////////////////////////////////////////////////////////////
 
 /// \defgroup ImageViewSTLAlgorithmsUninitializedFillPixels uninitialized_fill_pixels
@@ -498,23 +528,31 @@ void destruct_pixels(const View& img_view) {
 /// \brief std::uninitialized_fill for image views
 
 namespace detail {
+
 /// std::uninitialized_fill for planar iterators
 /// If an exception is thrown destructs any in-place copy-constructed objects
 template <typename It, typename P>
 BOOST_FORCEINLINE
-void uninitialized_fill_aux(It first, It last,
-                            const P& p, mpl::true_) {
-    int channel=0;
-    try {
+void uninitialized_fill_aux(It first, It last, P const& p, std::true_type)
+{
+    int channel = 0;
+    try
+    {
         using pixel_t = typename std::iterator_traits<It>::value_type;
-        while (channel < num_channels<pixel_t>::value) {
-            std::uninitialized_fill(dynamic_at_c(first,channel), dynamic_at_c(last,channel),
-                                    dynamic_at_c(p,channel));
+        while (channel < num_channels<pixel_t>::value)
+        {
+            std::uninitialized_fill(
+                dynamic_at_c(first,channel),
+                dynamic_at_c(last,channel),
+                dynamic_at_c(p,channel));
+
             ++channel;
         }
-    } catch (...) {
-        for (int c=0; c<channel; ++c)
-            destruct_range(dynamic_at_c(first,c), dynamic_at_c(last,c));
+    }
+    catch (...)
+    {
+        for (int c = 0; c < channel; ++c)
+            destruct_range(dynamic_at_c(first, c), dynamic_at_c(last, c));
         throw;
     }
 }
@@ -523,10 +561,11 @@ void uninitialized_fill_aux(It first, It last,
 /// If an exception is thrown destructs any in-place copy-constructed objects
 template <typename It, typename P>
 BOOST_FORCEINLINE
-void uninitialized_fill_aux(It first, It last,
-                            const P& p,mpl::false_) {
+void uninitialized_fill_aux(It first, It last, P const& p, std::false_type)
+{
     std::uninitialized_fill(first,last,p);
 }
+
 } // namespace detail
 
 /// \ingroup ImageViewSTLAlgorithmsUninitializedFillPixels
@@ -534,28 +573,26 @@ void uninitialized_fill_aux(It first, It last,
 /// Does not support planar heterogeneous views.
 /// If an exception is thrown destructs any in-place copy-constructed pixels
 template <typename View, typename Value>
-void uninitialized_fill_pixels(const View& img_view, const Value& val) {
-    if (img_view.is_1d_traversable())
-        detail::uninitialized_fill_aux(img_view.begin().x(), img_view.end().x(),
+void uninitialized_fill_pixels(const View& view, const Value& val) {
+    if (view.is_1d_traversable())
+        detail::uninitialized_fill_aux(view.begin().x(), view.end().x(),
                                        val,is_planar<View>());
     else {
         typename View::y_coord_t y = 0;
         try {
-            for (y=0; y<img_view.height(); ++y)
-                detail::uninitialized_fill_aux(img_view.row_begin(y),img_view.row_end(y),
+            for (y=0; y<view.height(); ++y)
+                detail::uninitialized_fill_aux(view.row_begin(y),view.row_end(y),
                                                val,is_planar<View>());
         } catch(...) {
             for (typename View::y_coord_t y0=0; y0<y; ++y0)
-                detail::destruct_aux(img_view.row_begin(y0),img_view.row_end(y0), is_planar<View>());
+                detail::destruct_aux(view.row_begin(y0),view.row_end(y0), is_planar<View>());
             throw;
         }
     }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////
-///
-/// default_construct_pixels
-///
+// default_construct_pixels
 //////////////////////////////////////////////////////////////////////////////////////
 
 /// \defgroup ImageViewSTLAlgorithmsDefaultConstructPixels default_construct_pixels
@@ -564,40 +601,55 @@ void uninitialized_fill_pixels(const View& img_view, const Value& val) {
 
 namespace detail {
 template <typename It> BOOST_FORCEINLINE
-void default_construct_range_impl(It first, It last, mpl::true_) {
-    using value_t = typename std::iterator_traits<It>::value_type;
-    It first1=first;
-    try {
-        while (first!=last) {
+void default_construct_range_impl(It first, It last, std::true_type)
+{
+    It first1 = first;
+    try
+    {
+        using value_t = typename std::iterator_traits<It>::value_type;
+        while (first != last)
+        {
             new (first) value_t();
             ++first;
         }
-    } catch (...) {
-        destruct_range(first1,first);
+    }
+    catch (...)
+    {
+        destruct_range(first1, first);
         throw;
     }
 }
 
-template <typename It> BOOST_FORCEINLINE
-void default_construct_range_impl(It, It, mpl::false_) {}
+template <typename It>
+BOOST_FORCEINLINE
+void default_construct_range_impl(It, It, std::false_type) {}
 
-template <typename It> BOOST_FORCEINLINE
-void default_construct_range(It first, It last) { default_construct_range_impl(first, last, typename is_pointer<It>::type()); }
+template <typename It>
+BOOST_FORCEINLINE
+void default_construct_range(It first, It last)
+{
+    default_construct_range_impl(first, last, typename std::is_pointer<It>::type());
+}
 
 /// uninitialized_default_construct for planar iterators
 template <typename It>
 BOOST_FORCEINLINE
-void default_construct_aux(It first, It last, mpl::true_) {
-    int channel=0;
-    try {
+void default_construct_aux(It first, It last, std::true_type)
+{
+    int channel = 0;
+    try
+    {
         using pixel_t = typename std::iterator_traits<It>::value_type;
-        while (channel < num_channels<pixel_t>::value) {
-            default_construct_range(dynamic_at_c(first,channel), dynamic_at_c(last,channel));
+        while (channel < num_channels<pixel_t>::value)
+        {
+            default_construct_range(dynamic_at_c(first, channel), dynamic_at_c(last, channel));
             ++channel;
         }
-    } catch (...) {
-        for (int c=0; c<channel; ++c)
-            destruct_range(dynamic_at_c(first,c), dynamic_at_c(last,c));
+    }
+    catch (...)
+    {
+        for (int c = 0; c < channel; ++c)
+            destruct_range(dynamic_at_c(first, c), dynamic_at_c(last, c));
         throw;
     }
 }
@@ -605,57 +657,52 @@ void default_construct_aux(It first, It last, mpl::true_) {
 /// uninitialized_default_construct for interleaved iterators
 template <typename It>
 BOOST_FORCEINLINE
-void default_construct_aux(It first, It last, mpl::false_) {
-    default_construct_range(first,last);
+void default_construct_aux(It first, It last, std::false_type)
+{
+    default_construct_range(first, last);
 }
 
 template <typename View, bool IsPlanar>
-struct has_trivial_pixel_constructor : public boost::has_trivial_constructor<typename View::value_type> {};
-template <typename View>
-struct has_trivial_pixel_constructor<View, true> : public boost::has_trivial_constructor<typename channel_type<View>::type> {};
-} // namespace detail
+struct has_trivial_pixel_constructor
+    : std::is_trivially_default_constructible<typename View::value_type>
+{};
 
-namespace detail {
+template <typename View>
+struct has_trivial_pixel_constructor<View, true>
+    : std::is_trivially_default_constructible<typename channel_type<View>::type>
+{};
 
 template<typename View, bool IsTriviallyConstructible>
 BOOST_FORCEINLINE
 void default_construct_pixels_impl(
-    View const& img_view,
-    std::enable_if<!IsTriviallyConstructible>* /* ptr */ = nullptr)
+    View const& view,
+    std::enable_if<!IsTriviallyConstructible>* /*ptr*/ = nullptr)
 {
-    if( img_view.is_1d_traversable() )
+    if (view.is_1d_traversable())
     {
-        detail::default_construct_aux( img_view.begin().x()
-                                     , img_view.end().x()
-                                     , is_planar<View>()
-                                     );
+        detail::default_construct_aux(
+            view.begin().x(), view.end().x(), is_planar<View>());
     }
     else
     {
         typename View::y_coord_t y = 0;
         try
         {
-            for( y = 0; y < img_view.height(); ++y )
-            {
-                detail::default_construct_aux( img_view.row_begin( y )
-                                              ,img_view.row_end( y )
-                                              , is_planar<View>()
-                                              );
-            }
-        } catch(...)
+            for( y = 0; y < view.height(); ++y )
+                detail::default_construct_aux(
+                    view.row_begin(y), view.row_end(y), is_planar<View>());
+        }
+        catch(...)
         {
             for (typename View::y_coord_t y0 = 0; y0 < y; ++y0 )
-            {
-                detail::destruct_aux( img_view.row_begin(y0)
-                                    , img_view.row_end(y0)
-                                    , is_planar<View>()
-                                    );
-            }
+                detail::destruct_aux(
+                    view.row_begin(y0), view.row_end(y0), is_planar<View>());
 
             throw;
         }
     }
 }
+
 } // namespace detail
 
 /// \ingroup ImageViewSTLAlgorithmsDefaultConstructPixels
@@ -663,18 +710,21 @@ void default_construct_pixels_impl(
 /// Does not support planar heterogeneous views.
 /// If an exception is thrown destructs any in-place default-constructed pixels
 template <typename View>
-void default_construct_pixels(const View& img_view) {
-    detail::default_construct_pixels_impl< View
-                                        , detail::has_trivial_pixel_constructor< View
-                                                                               , is_planar< View >::value
-                                                                               >::value
-                                         >( img_view );
+void default_construct_pixels(View const& view)
+{
+    detail::default_construct_pixels_impl
+        <
+            View,
+            detail::has_trivial_pixel_constructor
+            <
+                View,
+                is_planar<View>::value
+            >::value
+        >(view);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////
-///
-/// uninitialized_copy_pixels
-///
+// uninitialized_copy_pixels
 //////////////////////////////////////////////////////////////////////////////////////
 
 /// \defgroup ImageViewSTLAlgorithmsUninitializedCopyPixels uninitialized_copy_pixels
@@ -682,32 +732,40 @@ void default_construct_pixels(const View& img_view) {
 /// \brief std::uninitialized_copy for image views
 
 namespace detail {
+
 /// std::uninitialized_copy for pairs of planar iterators
 template <typename It1, typename It2>
 BOOST_FORCEINLINE
-void uninitialized_copy_aux(It1 first1, It1 last1,
-                            It2 first2, mpl::true_) {
+void uninitialized_copy_aux(It1 first1, It1 last1, It2 first2, std::true_type)
+{
     int channel=0;
     try {
         using pixel_t = typename std::iterator_traits<It1>::value_type;
-        while (channel < num_channels<pixel_t>::value) {
-            std::uninitialized_copy(dynamic_at_c(first1,channel), dynamic_at_c(last1,channel), dynamic_at_c(first2,channel));
+        while (channel < num_channels<pixel_t>::value)
+        {
+            std::uninitialized_copy(
+                dynamic_at_c(first1, channel),
+                dynamic_at_c(last1, channel),
+                dynamic_at_c(first2, channel));
             ++channel;
         }
-    } catch (...) {
-        It2 last2=first2;
-        std::advance(last2, std::distance(first1,last1));
-        for (int c=0; c<channel; ++c)
-            destruct_range(dynamic_at_c(first2,c), dynamic_at_c(last2,c));
+    }
+    catch (...)
+    {
+        It2 last2 = first2;
+        std::advance(last2, std::distance(first1, last1));
+        for (int c = 0; c < channel; ++c)
+            destruct_range(dynamic_at_c(first2, c), dynamic_at_c(last2, c));
         throw;
     }
 }
+
 /// std::uninitialized_copy for interleaved or mixed iterators
 template <typename It1, typename It2>
 BOOST_FORCEINLINE
-void uninitialized_copy_aux(It1 first1, It1 last1,
-                            It2 first2,mpl::false_) {
-    std::uninitialized_copy(first1,last1,first2);
+void uninitialized_copy_aux(It1 first1, It1 last1, It2 first2, std::false_type)
+{
+    std::uninitialized_copy(first1, last1, first2);
 }
 } // namespace detail
 
@@ -716,32 +774,36 @@ void uninitialized_copy_aux(It1 first1, It1 last1,
 /// Does not support planar heterogeneous views.
 /// If an exception is thrown destructs any in-place copy-constructed objects
 template <typename View1, typename View2>
-void uninitialized_copy_pixels(const View1& view1, const View2& view2) {
-    using is_planar = mpl::bool_<is_planar<View1>::value && is_planar<View2>::value>;
+void uninitialized_copy_pixels(View1 const& view1, View2 const& view2)
+{
+    using is_planar = std::integral_constant<bool, is_planar<View1>::value && is_planar<View2>::value>;
     BOOST_ASSERT(view1.dimensions() == view2.dimensions());
+
     if (view1.is_1d_traversable() && view2.is_1d_traversable())
-        detail::uninitialized_copy_aux(view1.begin().x(), view1.end().x(),
-                                       view2.begin().x(),
-                                       is_planar());
-    else {
+    {
+        detail::uninitialized_copy_aux(
+            view1.begin().x(), view1.end().x(), view2.begin().x(), is_planar());
+    }
+    else
+    {
         typename View1::y_coord_t y = 0;
-        try {
-            for (y=0; y<view1.height(); ++y)
-                detail::uninitialized_copy_aux(view1.row_begin(y), view1.row_end(y),
-                                               view2.row_begin(y),
-                                               is_planar());
-        } catch(...) {
-            for (typename View1::y_coord_t y0=0; y0<y; ++y0)
-                detail::destruct_aux(view2.row_begin(y0),view2.row_end(y0), is_planar());
+        try
+        {
+            for (y = 0; y < view1.height(); ++y)
+                detail::uninitialized_copy_aux(
+                    view1.row_begin(y), view1.row_end(y), view2.row_begin(y), is_planar());
+        }
+        catch(...)
+        {
+            for (typename View1::y_coord_t y0 = 0; y0 < y; ++y0)
+                detail::destruct_aux(view2.row_begin(y0), view2.row_end(y0), is_planar());
             throw;
         }
     }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////
-///
-/// for_each_pixel
-///
+// for_each_pixel
 //////////////////////////////////////////////////////////////////////////////////////
 
 /// \defgroup ImageViewSTLAlgorithmsForEachPixel for_each_pixel
@@ -754,13 +816,17 @@ void uninitialized_copy_pixels(const View1& view1, const View2& view2) {
 /// pixel iterator, which is still faster
 
 /// \ingroup ImageViewSTLAlgorithmsForEachPixel
-template <typename V, typename F>
-F for_each_pixel(const V& img, F fun) {
-    if (img.is_1d_traversable()) {
-        return std::for_each(img.begin().x(), img.end().x(), fun);
-    } else {
-        for (std::ptrdiff_t y=0; y<img.height(); ++y)
-            std::for_each(img.row_begin(y),img.row_end(y),fun);
+template <typename View, typename F>
+F for_each_pixel(View const& view, F fun)
+{
+    if (view.is_1d_traversable())
+    {
+        return std::for_each(view.begin().x(), view.end().x(), fun);
+    }
+    else
+    {
+        for (std::ptrdiff_t y = 0; y < view.height(); ++y)
+            std::for_each(view.row_begin(y), view.row_end(y), fun);
         return fun;
     }
 }
@@ -771,20 +837,20 @@ F for_each_pixel(const V& img, F fun) {
 
 /// \ingroup ImageViewSTLAlgorithmsForEachPixelPosition
 template <typename View, typename F>
-F for_each_pixel_position(const View& img, F fun) {
-    typename View::xy_locator loc=img.xy_at(0,0);
-    for (std::ptrdiff_t y=0; y<img.height(); ++y) {
-        for (std::ptrdiff_t x=0; x<img.width(); ++x, ++loc.x())
+F for_each_pixel_position(View const& view, F fun)
+{
+    typename View::xy_locator loc = view.xy_at(0, 0);
+    for (std::ptrdiff_t y = 0; y < view.height(); ++y)
+    {
+        for (std::ptrdiff_t x = 0; x < view.width(); ++x, ++loc.x())
             fun(loc);
-        loc.x()-=img.width(); ++loc.y();
+        loc.x() -= view.width(); ++loc.y();
     }
     return fun;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////
-///
-/// generate_pixels
-///
+// generate_pixels
 //////////////////////////////////////////////////////////////////////////////////////
 
 /// \defgroup ImageViewSTLAlgorithmsGeneratePixels generate_pixels
@@ -794,90 +860,123 @@ F for_each_pixel_position(const View& img, F fun) {
 /// \ingroup ImageViewSTLAlgorithmsGeneratePixels
 /// \brief std::generate for image views
 template <typename View, typename F>
-void generate_pixels(const View& v, F fun) {
-    if (v.is_1d_traversable()) {
-        std::generate(v.begin().x(), v.end().x(), fun);
-    } else {
-        for (std::ptrdiff_t y=0; y<v.height(); ++y)
-            std::generate(v.row_begin(y),v.row_end(y),fun);
+void generate_pixels(View const& view, F fun)
+{
+    if (view.is_1d_traversable())
+    {
+        std::generate(view.begin().x(), view.end().x(), fun);
+    }
+    else
+    {
+        for (std::ptrdiff_t y = 0; y < view.height(); ++y)
+            std::generate(view.row_begin(y), view.row_end(y), fun);
     }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////
-///
-/// std::equal and gil::equal_pixels for GIL constructs
-///
+// std::equal and gil::equal_pixels for GIL constructs
 //////////////////////////////////////////////////////////////////////////////////////
 
 /// \defgroup ImageViewSTLAlgorithmsEqualPixels equal_pixels
 /// \ingroup ImageViewSTLAlgorithms
 /// \brief std::equal for image views
 
-template <typename I1, typename I2> BOOST_FORCEINLINE bool equal_n(I1 i1, std::ptrdiff_t n, I2 i2);
+template <typename I1, typename I2>
+BOOST_FORCEINLINE
+bool equal_n(I1 i1, std::ptrdiff_t n, I2 i2);
 
 namespace detail {
+
 template <typename I1, typename I2>
-struct equal_n_fn {
-    BOOST_FORCEINLINE bool operator()(I1 i1, std::ptrdiff_t n, I2 i2) const { return std::equal(i1,i1+n, i2); }
+struct equal_n_fn
+{
+    BOOST_FORCEINLINE
+    bool operator()(I1 i1, std::ptrdiff_t n, I2 i2) const
+    {
+        return std::equal(i1, i1 + n, i2);
+    }
 };
 
 /// Equal when both ranges are interleaved and of the same type.
 /// GIL pixels are bitwise comparable, so memcmp is used. User-defined pixels that are not bitwise comparable need to provide an overload
-template<typename T, typename Cs>
-struct equal_n_fn<const pixel<T,Cs>*, const pixel<T,Cs>*> {
-    BOOST_FORCEINLINE bool operator()(const pixel<T,Cs>* i1, std::ptrdiff_t n, const pixel<T,Cs>* i2) const {
-        return memcmp(i1, i2, n*sizeof(pixel<T,Cs>))==0;
+template<typename T, typename CS>
+struct equal_n_fn<pixel<T, CS> const*, pixel<T, CS> const*>
+{
+    BOOST_FORCEINLINE
+    bool operator()(pixel<T, CS> const* i1, std::ptrdiff_t n, pixel<T, CS> const* i2) const
+    {
+        return memcmp(i1, i2, n * sizeof(pixel<T, CS>)) == 0;
     }
 };
-template<typename T, typename Cs>
-struct equal_n_fn<pixel<T,Cs>*, pixel<T,Cs>*> : equal_n_fn<const pixel<T,Cs>*, const pixel<T,Cs>*> {};
+
+template<typename T, typename CS>
+struct equal_n_fn<pixel<T, CS>*, pixel<T, CS>*>
+    : equal_n_fn<pixel<T, CS> const*, pixel<T, CS> const*>
+{};
 
 /// EqualPixels
 /// Equal when both ranges are planar pointers of the same type. memcmp is invoked for each channel plane
 ///  User-defined channels that are not bitwise comparable need to provide an overload
-template<typename IC, typename Cs>
-struct equal_n_fn<planar_pixel_iterator<IC,Cs>, planar_pixel_iterator<IC,Cs> > {
-    BOOST_FORCEINLINE bool operator()(const planar_pixel_iterator<IC,Cs> i1, std::ptrdiff_t n, const planar_pixel_iterator<IC,Cs> i2) const {
-        std::ptrdiff_t numBytes=n*sizeof(typename std::iterator_traits<IC>::value_type);
-
-        for (std::ptrdiff_t i=0; i<mpl::size<Cs>::value; ++i)
-            if (memcmp(dynamic_at_c(i1,i), dynamic_at_c(i2,i), numBytes)!=0)
+template<typename IC, typename CS>
+struct equal_n_fn<planar_pixel_iterator<IC, CS>, planar_pixel_iterator<IC, CS>>
+{
+    BOOST_FORCEINLINE
+    bool operator()(planar_pixel_iterator<IC, CS> const i1, std::ptrdiff_t n, planar_pixel_iterator<IC, CS> const i2) const
+    {
+        // FIXME: ptrdiff_t vs size_t
+        constexpr std::ptrdiff_t byte_size = n * sizeof(typename std::iterator_traits<IC>::value_type);
+        for (std::ptrdiff_t i = 0; i < mp11::mp_size<CS>::value; ++i)
+        {
+            if (memcmp(dynamic_at_c(i1, i), dynamic_at_c(i2, i), byte_size) != 0)
                 return false;
+        }
         return true;
     }
 };
 
 /// Source range is delimited by image iterators
-template <typename Loc, typename I2>  // IL Models ConstPixelLocatorConcept, O Models PixelIteratorConcept
-struct equal_n_fn<boost::gil::iterator_from_2d<Loc>,I2> {
-    BOOST_FORCEINLINE bool operator()(boost::gil::iterator_from_2d<Loc> i1, std::ptrdiff_t n, I2 i2) const {
-        gil_function_requires<boost::gil::PixelLocatorConcept<Loc> >();
-        gil_function_requires<boost::gil::PixelIteratorConcept<I2> >();
-        while (n>0) {
-            std::ptrdiff_t num=std::min<const std::ptrdiff_t>(n, i1.width()-i1.x_pos());
+/// \tparam Loc Models ConstPixelLocatorConcept
+/// \tparam It Models PixelIteratorConcept
+template <typename Loc, typename It>
+struct equal_n_fn<boost::gil::iterator_from_2d<Loc>, It>
+{
+    BOOST_FORCEINLINE
+    bool operator()(boost::gil::iterator_from_2d<Loc> i1, std::ptrdiff_t n, It i2) const
+    {
+        gil_function_requires<boost::gil::PixelLocatorConcept<Loc>>();
+        gil_function_requires<boost::gil::PixelIteratorConcept<It>>();
+        while (n > 0)
+        {
+            std::ptrdiff_t const num = std::min<std::ptrdiff_t>(n, i1.width() - i1.x_pos());
             if (!equal_n(i1.x(), num, i2))
                 return false;
-            i1+=num;
-            i2+=num;
-            n-=num;
+            i1 += num;
+            i2 += num;
+            n -= num;
         }
         return true;
     }
 };
 
 /// Destination range is delimited by image iterators
-template <typename I1, typename Loc> // I Models PixelIteratorConcept, OL Models PixelLocatorConcept
-struct equal_n_fn<I1,boost::gil::iterator_from_2d<Loc> > {
-    BOOST_FORCEINLINE bool operator()(I1 i1, std::ptrdiff_t n, boost::gil::iterator_from_2d<Loc> i2) const {
-        gil_function_requires<boost::gil::PixelIteratorConcept<I1> >();
-        gil_function_requires<boost::gil::PixelLocatorConcept<Loc> >();
-        while (n>0) {
-            std::ptrdiff_t num=std::min<const std::ptrdiff_t>(n,i2.width()-i2.x_pos());
+/// \tparam It Models PixelIteratorConcept
+/// \tparam Loc Models PixelLocatorConcept
+template <typename It, typename Loc>
+struct equal_n_fn<It, boost::gil::iterator_from_2d<Loc>>
+{
+    BOOST_FORCEINLINE
+    bool operator()(It i1, std::ptrdiff_t n, boost::gil::iterator_from_2d<Loc> i2) const
+    {
+        gil_function_requires<boost::gil::PixelIteratorConcept<It>>();
+        gil_function_requires<boost::gil::PixelLocatorConcept<Loc>>();
+        while (n > 0)
+        {
+            std::ptrdiff_t const num = std::min<std::ptrdiff_t>(n, i2.width() - i2.x_pos());
             if (!equal_n(i1, num, i2.x()))
                 return false;
-            i1+=num;
-            i2+=num;
-            n-=num;
+            i1 += num;
+            i2 += num;
+            n -= num;
         }
         return true;
     }
@@ -885,10 +984,10 @@ struct equal_n_fn<I1,boost::gil::iterator_from_2d<Loc> > {
 
 /// Both source and destination ranges are delimited by image iterators
 template <typename Loc1, typename Loc2>
-struct equal_n_fn<boost::gil::iterator_from_2d<Loc1>,boost::gil::iterator_from_2d<Loc2> > {
+struct equal_n_fn<boost::gil::iterator_from_2d<Loc1>,boost::gil::iterator_from_2d<Loc2>> {
    BOOST_FORCEINLINE bool operator()(boost::gil::iterator_from_2d<Loc1> i1, std::ptrdiff_t n, boost::gil::iterator_from_2d<Loc2> i2) const {
-        gil_function_requires<boost::gil::PixelLocatorConcept<Loc1> >();
-        gil_function_requires<boost::gil::PixelLocatorConcept<Loc2> >();
+        gil_function_requires<boost::gil::PixelLocatorConcept<Loc1>>();
+        gil_function_requires<boost::gil::PixelLocatorConcept<Loc2>>();
         if (i1.x_pos()!=i2.x_pos() || i1.width()!=i2.width()) {
             while(n-->0) {
                 if (*i1++!=*i2++) return false;
@@ -927,19 +1026,19 @@ namespace std {
 /// to memcmp. Otherwise it resolves to copying each row using the underlying pixel iterator
 template <typename Loc1, typename Loc2> BOOST_FORCEINLINE
 bool equal(boost::gil::iterator_from_2d<Loc1> first, boost::gil::iterator_from_2d<Loc1> last, boost::gil::iterator_from_2d<Loc2> first2) {
-    boost::gil::gil_function_requires<boost::gil::PixelLocatorConcept<Loc1> >();
-    boost::gil::gil_function_requires<boost::gil::PixelLocatorConcept<Loc2> >();
+    boost::gil::gil_function_requires<boost::gil::PixelLocatorConcept<Loc1>>();
+    boost::gil::gil_function_requires<boost::gil::PixelLocatorConcept<Loc2>>();
     std::ptrdiff_t n=last-first;
     if (first.is_1d_traversable()) {
         if (first2.is_1d_traversable())
             return boost::gil::detail::equal_n_fn<typename Loc1::x_iterator,typename Loc2::x_iterator>()(first.x(),n, first2.x());
         else
-            return boost::gil::detail::equal_n_fn<typename Loc1::x_iterator,boost::gil::iterator_from_2d<Loc2> >()(first.x(),n, first2);
+            return boost::gil::detail::equal_n_fn<typename Loc1::x_iterator,boost::gil::iterator_from_2d<Loc2>>()(first.x(),n, first2);
     } else {
         if (first2.is_1d_traversable())
             return boost::gil::detail::equal_n_fn<boost::gil::iterator_from_2d<Loc1>,typename Loc2::x_iterator>()(first,n, first2.x());
         else
-            return boost::gil::detail::equal_n_fn<boost::gil::iterator_from_2d<Loc1>,boost::gil::iterator_from_2d<Loc2> >()(first,n,first2);
+            return boost::gil::detail::equal_n_fn<boost::gil::iterator_from_2d<Loc1>,boost::gil::iterator_from_2d<Loc2>>()(first,n,first2);
     }
 }
 } // namespace std

--- a/include/boost/gil/bit_aligned_pixel_iterator.hpp
+++ b/include/boost/gil/bit_aligned_pixel_iterator.hpp
@@ -15,6 +15,7 @@
 #include <boost/iterator/iterator_facade.hpp>
 
 #include <functional>
+#include <type_traits>
 
 namespace boost { namespace gil {
 
@@ -82,15 +83,21 @@ private:
 };
 
 template <typename NonAlignedPixelReference>
-struct const_iterator_type<bit_aligned_pixel_iterator<NonAlignedPixelReference> > {
-    using type = bit_aligned_pixel_iterator<typename NonAlignedPixelReference::const_reference>;
+struct const_iterator_type<bit_aligned_pixel_iterator<NonAlignedPixelReference>>
+{
+    using type =
+        bit_aligned_pixel_iterator<typename NonAlignedPixelReference::const_reference>;
 };
 
 template <typename NonAlignedPixelReference>
-struct iterator_is_mutable<bit_aligned_pixel_iterator<NonAlignedPixelReference> > : public mpl::bool_<NonAlignedPixelReference::is_mutable> {};
+struct iterator_is_mutable<bit_aligned_pixel_iterator<NonAlignedPixelReference>>
+    : std::integral_constant<bool, NonAlignedPixelReference::is_mutable>
+{};
 
 template <typename NonAlignedPixelReference>
-struct is_iterator_adaptor<bit_aligned_pixel_iterator<NonAlignedPixelReference> > : public mpl::false_ {};
+struct is_iterator_adaptor<bit_aligned_pixel_iterator<NonAlignedPixelReference>>
+    : std::false_type
+{};
 
 /////////////////////////////
 //  PixelBasedConcept
@@ -110,7 +117,9 @@ struct is_planar<bit_aligned_pixel_iterator<NonAlignedPixelReference> > : public
 /////////////////////////////
 
 template <typename NonAlignedPixelReference>
-struct byte_to_memunit<bit_aligned_pixel_iterator<NonAlignedPixelReference> > : public mpl::int_<8> {};
+struct byte_to_memunit<bit_aligned_pixel_iterator<NonAlignedPixelReference>>
+    : std::integral_constant<int, 8>
+{};
 
 template <typename NonAlignedPixelReference>
 inline std::ptrdiff_t memunit_step(const bit_aligned_pixel_iterator<NonAlignedPixelReference>&) {

--- a/include/boost/gil/bit_aligned_pixel_reference.hpp
+++ b/include/boost/gil/bit_aligned_pixel_reference.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright 2005-2007 Adobe Systems Incorporated
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
 //
 // Distributed under the Boost Software License, Version 1.0
 // See accompanying file LICENSE_1_0.txt or copy at
@@ -10,16 +11,10 @@
 
 #include <boost/gil/pixel.hpp>
 #include <boost/gil/channel.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <boost/assert.hpp>
 #include <boost/config.hpp>
-#include <boost/mpl/accumulate.hpp>
-#include <boost/mpl/at.hpp>
-#include <boost/mpl/bool.hpp>
-#include <boost/mpl/if.hpp>
-#include <boost/mpl/plus.hpp>
-#include <boost/mpl/push_back.hpp>
-#include <boost/mpl/vector.hpp>
 
 #include <functional>
 #include <type_traits>
@@ -35,10 +30,10 @@ namespace boost { namespace gil {
 //  Represents a range of bits that can span multiple consecutive bytes. The range has a size fixed at compile time, but the offset is specified at run time.
 /////////////////////////////
 
-template <int RangeSize, bool Mutable>
+template <int RangeSize, bool IsMutable>
 class bit_range {
 public:
-    using byte_t = typename mpl::if_c<Mutable,unsigned char,const unsigned char>::type;
+    using byte_t = mp11::mp_if_c<IsMutable, unsigned char, unsigned char const>;
     using difference_type = std::ptrdiff_t;
     template <int RS, bool M> friend class bit_range;
 private:
@@ -96,7 +91,7 @@ public:
 /// unsigned char data=0;
 ///
 /// // A mutable reference to a 6-bit BGR pixel in "123" format (1 bit for red, 2 bits for green, 3 bits for blue)
-/// using rgb123_ref_t = bit_aligned_pixel_reference<unsigned char, mpl::vector3_c<int,1,2,3>, rgb_layout_t, true> const;
+/// using rgb123_ref_t = bit_aligned_pixel_reference<unsigned char, mp11::mp_list_c<int,1,2,3>, rgb_layout_t, true> const;
 ///
 /// // create the pixel reference at bit offset 2
 /// // (i.e. red = [2], green = [3,4], blue = [5,6,7] bits)
@@ -113,23 +108,23 @@ public:
 /// \brief Heterogeneous pixel reference corresponding to non-byte-aligned bit range. Models ColorBaseConcept, PixelConcept, PixelBasedConcept
 ///
 /// \tparam BitField
-/// \tparam ChannelBitSizes MPL integral vector defining the number of bits for each channel. For example, for 565RGB, vector_c<int,5,6,5>
+/// \tparam ChannelBitSizes Boost.MP11-compatible list of integral types defining the number of bits for each channel. For example, for 565RGB, mp_list_c<int,5,6,5>
 /// \tparam Layout
 /// \tparam IsMutable
 template <typename BitField, typename ChannelBitSizes, typename Layout, bool IsMutable>
 struct bit_aligned_pixel_reference
 {
     static constexpr int bit_size =
-            mpl::accumulate
+            mp11::mp_fold
             <
                 ChannelBitSizes,
-                mpl::int_<0>,
-                mpl::plus<mpl::_1, mpl::_2>
-            >::type::value;
+                std::integral_constant<int, 0>,
+                mp11::mp_plus
+            >::value;
 
     using bit_range_t = boost::gil::bit_range<bit_size,IsMutable>;
     using bitfield_t = BitField;
-    using data_ptr_t =typename mpl::if_c<IsMutable,unsigned char*,const unsigned char*>::type;
+    using data_ptr_t = mp11::mp_if_c<IsMutable, unsigned char*, const unsigned char*>;
 
     using layout_t = Layout;
 
@@ -152,28 +147,63 @@ struct bit_aligned_pixel_reference
     }
 
     // Construct from another compatible pixel type
-    bit_aligned_pixel_reference(const bit_aligned_pixel_reference& p) : _bit_range(p._bit_range) {}
-    template <typename BF, typename CR> bit_aligned_pixel_reference(packed_pixel<BF,CR,Layout>& p) : _bit_range(static_cast<data_ptr_t>(&gil::at_c<0>(p)), gil::at_c<0>(p).first_bit()) {
-        check_compatible<packed_pixel<BF,CR,Layout> >();
+    bit_aligned_pixel_reference(bit_aligned_pixel_reference const& p)
+        : _bit_range(p._bit_range) {}
+
+    // TODO: Why p by non-const reference?
+    template <typename BF, typename CR>
+    bit_aligned_pixel_reference(packed_pixel<BF, CR, Layout>& p)
+        : _bit_range(static_cast<data_ptr_t>(&gil::at_c<0>(p)), gil::at_c<0>(p).first_bit())
+    {
+        check_compatible<packed_pixel<BF, CR, Layout>>();
     }
 
-    const bit_aligned_pixel_reference& operator=(const bit_aligned_pixel_reference& p) const { static_copy(p,*this); return *this; }
-    template <typename P> const bit_aligned_pixel_reference& operator=(const P& p) const { assign(p, mpl::bool_<is_pixel<P>::value>()); return *this; }
+    auto operator=(bit_aligned_pixel_reference const& p) const
+        -> bit_aligned_pixel_reference const&
+    {
+        static_copy(p, *this);
+        return *this;
+    }
 
-    template <typename P> bool operator==(const P& p) const { return equal(p, mpl::bool_<is_pixel<P>::value>()); }
-    template <typename P> bool operator!=(const P& p) const { return !(*this==p); }
+    template <typename P>
+    auto operator=(P const& p) const -> bit_aligned_pixel_reference const&
+    {
+        assign(p, is_pixel<P>());
+        return *this;
+    }
 
-    const bit_aligned_pixel_reference* operator->()    const { return this; }
+    template <typename P>
+    bool operator==(P const& p) const
+    {
+        return equal(p, is_pixel<P>());
+    }
 
-    const bit_range_t& bit_range() const { return _bit_range; }
+    template <typename P>
+    bool operator!=(P const& p) const { return !(*this==p); }
+
+    auto operator->() const -> bit_aligned_pixel_reference const* { return this; }
+
+    bit_range_t const& bit_range() const { return _bit_range; }
+
 private:
     mutable bit_range_t _bit_range;
     template <typename B, typename C, typename L, bool M> friend struct bit_aligned_pixel_reference;
 
     template <typename Pixel> static void check_compatible() { gil_function_requires<PixelsCompatibleConcept<Pixel,bit_aligned_pixel_reference> >(); }
 
-    template <typename Pixel> void assign(const Pixel& p, mpl::true_) const { check_compatible<Pixel>(); static_copy(p,*this); }
-    template <typename Pixel> bool  equal(const Pixel& p, mpl::true_) const { check_compatible<Pixel>(); return static_equal(*this,p); }
+    template <typename Pixel>
+    void assign(Pixel const& p, std::true_type) const
+    {
+        check_compatible<Pixel>();
+        static_copy(p, *this);
+    }
+
+    template <typename Pixel>
+    bool equal(Pixel const& p, std::true_type) const
+    {
+        check_compatible<Pixel>();
+        return static_equal(*this, p);
+    }
 
 private:
     static void check_gray()
@@ -181,8 +211,19 @@ private:
         static_assert(std::is_same<typename Layout::color_space_t, gray_t>::value, "");
     }
 
-    template <typename Channel> void assign(const Channel& chan, mpl::false_) const { check_gray(); gil::at_c<0>(*this)=chan; }
-    template <typename Channel> bool equal (const Channel& chan, mpl::false_) const { check_gray(); return gil::at_c<0>(*this)==chan; }
+    template <typename Channel>
+    void assign(Channel const& channel, std::false_type) const
+    {
+        check_gray();
+        gil::at_c<0>(*this) = channel;
+    }
+
+    template <typename Channel>
+    bool equal (Channel const& channel, std::false_type) const
+    {
+        check_gray();
+        return gil::at_c<0>(*this) == channel;
+    }
 };
 
 /////////////////////////////
@@ -190,9 +231,18 @@ private:
 /////////////////////////////
 
 template <typename BitField, typename ChannelBitSizes, typename L, bool IsMutable, int K>
-struct kth_element_type<bit_aligned_pixel_reference<BitField,ChannelBitSizes,L,IsMutable>, K>
+struct kth_element_type
+<
+    bit_aligned_pixel_reference<BitField, ChannelBitSizes, L, IsMutable>,
+    K
+>
 {
-    using type = packed_dynamic_channel_reference<BitField, mpl::at_c<ChannelBitSizes,K>::type::value, IsMutable> const;
+    using type = packed_dynamic_channel_reference
+        <
+            BitField,
+            mp11::mp_at_c<ChannelBitSizes, K>::value,
+            IsMutable
+        > const;
 };
 
 template <typename B, typename C, typename L, bool M, int K>
@@ -203,26 +253,35 @@ template <typename B, typename C, typename L, bool M, int K>
 struct kth_element_const_reference_type<bit_aligned_pixel_reference<B,C,L,M>, K>
     : public kth_element_type<bit_aligned_pixel_reference<B,C,L,M>, K> {};
 
-
 namespace detail {
-    // returns sum of IntegralVector[0] ... IntegralVector[K-1]
-    template <typename IntegralVector, int K>
-    struct sum_k : public mpl::plus<sum_k<IntegralVector,K-1>, typename mpl::at_c<IntegralVector,K-1>::type > {};
 
-    template <typename IntegralVector> struct sum_k<IntegralVector,0> : public mpl::int_<0> {};
-}
+// returns sum of IntegralVector[0] ... IntegralVector[K-1]
+template <typename IntegralVector, int K>
+struct sum_k
+    : mp11::mp_plus
+        <
+            sum_k<IntegralVector, K - 1>,
+            typename mp11::mp_at_c<IntegralVector, K - 1>::type
+        >
+{};
+
+template <typename IntegralVector>
+struct sum_k<IntegralVector, 0> : std::integral_constant<int, 0> {};
+
+} // namespace detail
 
 // at_c required by MutableColorBaseConcept
-template <int K, typename BitField, typename ChannelBitSizes, typename L, bool Mutable> inline
-typename kth_element_reference_type<bit_aligned_pixel_reference<BitField,ChannelBitSizes,L,Mutable>,K>::type
-at_c(const bit_aligned_pixel_reference<BitField,ChannelBitSizes,L,Mutable>& p)
+template <int K, typename BitField, typename ChannelBitSizes, typename L, bool IsMutable>
+inline
+auto at_c(const bit_aligned_pixel_reference<BitField, ChannelBitSizes, L, IsMutable>& p)
+    -> typename kth_element_reference_type<bit_aligned_pixel_reference<BitField, ChannelBitSizes, L, IsMutable>, K>::type
 {
-    using pixel_t = bit_aligned_pixel_reference<BitField,ChannelBitSizes,L,Mutable>;
-    using channel_t = typename kth_element_reference_type<pixel_t,K>::type;
+    using pixel_t = bit_aligned_pixel_reference<BitField, ChannelBitSizes, L, IsMutable>;
+    using channel_t = typename kth_element_reference_type<pixel_t, K>::type;
     using bit_range_t = typename pixel_t::bit_range_t;
 
     bit_range_t bit_range(p.bit_range());
-    bit_range.bit_advance(detail::sum_k<ChannelBitSizes,K>::value);
+    bit_range.bit_advance(detail::sum_k<ChannelBitSizes, K>::value);
 
     return channel_t(bit_range.current_byte(), bit_range.bit_offset());
 }
@@ -233,56 +292,67 @@ at_c(const bit_aligned_pixel_reference<BitField,ChannelBitSizes,L,Mutable>& p)
 
 /// Metafunction predicate that flags bit_aligned_pixel_reference as a model of PixelConcept. Required by PixelConcept
 template <typename B, typename C, typename L, bool M>
-struct is_pixel<bit_aligned_pixel_reference<B,C,L,M> > : public mpl::true_{};
+struct is_pixel<bit_aligned_pixel_reference<B, C, L, M> > : std::true_type {};
 
 /////////////////////////////
 //  PixelBasedConcept
 /////////////////////////////
 
 template <typename B, typename C, typename L, bool M>
-struct color_space_type<bit_aligned_pixel_reference<B,C,L,M> > {
+struct color_space_type<bit_aligned_pixel_reference<B, C, L, M>>
+{
     using type = typename L::color_space_t;
 };
 
 template <typename B, typename C, typename L, bool M>
-struct channel_mapping_type<bit_aligned_pixel_reference<B,C,L,M> > {
+struct channel_mapping_type<bit_aligned_pixel_reference<B, C, L, M>>
+{
     using type = typename L::channel_mapping_t;
 };
 
 template <typename B, typename C, typename L, bool M>
-struct is_planar<bit_aligned_pixel_reference<B,C,L,M> > : mpl::false_ {};
+struct is_planar<bit_aligned_pixel_reference<B, C, L, M>> : std::false_type {};
 
 /////////////////////////////
 //  pixel_reference_type
 /////////////////////////////
 
-namespace detail {
-    // returns a vector containing K copies of the type T
-    template <unsigned K, typename T> struct k_copies;
-    template <typename T> struct k_copies<0,T> {
-        using type = mpl::vector0<>;
-    };
-    template <unsigned K, typename T> struct k_copies : public mpl::push_back<typename k_copies<K-1,T>::type, T> {};
-}
-
 // Constructs a homogeneous bit_aligned_pixel_reference given a channel reference
 template <typename BitField, int NumBits, typename Layout>
-struct pixel_reference_type<const packed_dynamic_channel_reference<BitField,NumBits,false>, Layout, false, false>
+struct pixel_reference_type
+    <
+        packed_dynamic_channel_reference<BitField, NumBits, false> const,
+        Layout, false, false
+    >
 {
 private:
-    using size_t = typename mpl::size<typename Layout::color_space_t>::type;
-    using channel_bit_sizes_t = typename detail::k_copies<size_t::value,mpl::integral_c<unsigned,NumBits> >::type;
+    using channel_bit_sizes_t = mp11::mp_repeat
+        <
+            mp11::mp_list<std::integral_constant<unsigned, NumBits>>,
+            mp11::mp_size<typename Layout::color_space_t>
+        >;
+
 public:
-    using type = bit_aligned_pixel_reference<BitField, channel_bit_sizes_t, Layout, false>;
+    using type =
+        bit_aligned_pixel_reference<BitField, channel_bit_sizes_t, Layout, false>;
 };
 
-// Same but for the mutable case. We cannot combine the mutable and read-only cases because this triggers ambiguity
+// Same but for the mutable case. We cannot combine the mutable
+// and read-only cases because this triggers ambiguity
 template <typename BitField, int NumBits, typename Layout>
-struct pixel_reference_type<const packed_dynamic_channel_reference<BitField,NumBits,true>, Layout, false, true>
+struct pixel_reference_type
+    <
+        packed_dynamic_channel_reference<BitField, NumBits, true> const,
+        Layout, false, true
+    >
 {
 private:
-    using size_t = typename mpl::size<typename Layout::color_space_t>::type;
-    using channel_bit_sizes_t = typename detail::k_copies<size_t::value,mpl::integral_c<unsigned,NumBits>>::type;
+    using channel_bit_sizes_t = mp11::mp_repeat
+        <
+            mp11::mp_list<std::integral_constant<unsigned, NumBits>>,
+            mp11::mp_size<typename Layout::color_space_t>
+        >;
+
 public:
     using type = bit_aligned_pixel_reference<BitField, channel_bit_sizes_t, Layout, true>;
 };
@@ -290,6 +360,7 @@ public:
 } }  // namespace boost::gil
 
 namespace std {
+
 // We are forced to define swap inside std namespace because on some platforms (Visual Studio 8) STL calls swap qualified.
 // swap with 'left bias':
 // - swap between proxy and anything
@@ -313,5 +384,7 @@ template <typename B, typename C, typename L> inline
 void swap(const boost::gil::bit_aligned_pixel_reference<B,C,L,true> x, const boost::gil::bit_aligned_pixel_reference<B,C,L,true> y) {
     boost::gil::swap_proxy<typename boost::gil::bit_aligned_pixel_reference<B,C,L,true>::value_type>(x,y);
 }
-}   // namespace std
+
+} // namespace std
+
 #endif

--- a/include/boost/gil/channel.hpp
+++ b/include/boost/gil/channel.hpp
@@ -14,10 +14,10 @@
 #include <boost/config.hpp>
 #include <boost/config/pragma_message.hpp>
 #include <boost/integer/integer_mask.hpp>
-#include <boost/type_traits/remove_cv.hpp>
 
 #include <cstdint>
 #include <limits>
+#include <type_traits>
 
 #ifdef BOOST_GIL_DOXYGEN_ONLY
 /// \def BOOST_GIL_CONFIG_HAS_UNALIGNED_ACCESS
@@ -69,42 +69,48 @@ namespace boost { namespace gil {
 ///////////////////////////////////////////
 
 namespace detail {
-    template <typename T, bool is_class> struct channel_traits_impl;
 
-    // channel traits for custom class
-    template <typename T>
-    struct channel_traits_impl<T, true> {
-        using value_type = typename T::value_type;
-        using reference = typename T::reference;
-        using pointer = typename T::pointer;
-        using const_reference = typename T::const_reference;
-        using const_pointer = typename T::const_pointer;
-        static constexpr bool is_mutable = T::is_mutable;
-        static value_type min_value() { return T::min_value(); }
-        static value_type max_value() { return T::max_value(); }
-    };
+template <typename T, bool IsClass>
+struct channel_traits_impl;
 
-    // channel traits implementation for built-in integral or floating point channel type
-    template <typename T>
-    struct channel_traits_impl<T, false> {
-        using value_type = T;
-        using reference = T&;
-        using pointer = T*;
-        using const_reference = T const&;
-        using const_pointer = T const*;
-        static constexpr bool is_mutable = true;
-        static value_type min_value() { return (std::numeric_limits<T>::min)(); }
-        static value_type max_value() { return (std::numeric_limits<T>::max)(); }
-    };
+// channel traits for custom class
+template <typename T>
+struct channel_traits_impl<T, true>
+{
+    using value_type = typename T::value_type;
+    using reference = typename T::reference;
+    using pointer = typename T::pointer;
+    using const_reference = typename T::const_reference;
+    using const_pointer = typename T::const_pointer;
+    static constexpr bool is_mutable = T::is_mutable;
+    static value_type min_value() { return T::min_value(); }
+    static value_type max_value() { return T::max_value(); }
+};
 
-    // channel traits implementation for constant built-in scalar or floating point type
-    template <typename T>
-    struct channel_traits_impl<const T, false> : public channel_traits_impl<T, false> {
-        using reference = const T &;
-        using pointer = const T *;
-        static constexpr bool is_mutable = false;
-    };
-}
+// channel traits implementation for built-in integral or floating point channel type
+template <typename T>
+struct channel_traits_impl<T, false>
+{
+    using value_type = T;
+    using reference = T&;
+    using pointer = T*;
+    using const_reference = T const&;
+    using const_pointer = T const*;
+    static constexpr bool is_mutable = true;
+    static value_type min_value() { return (std::numeric_limits<T>::min)(); }
+    static value_type max_value() { return (std::numeric_limits<T>::max)(); }
+};
+
+// channel traits implementation for constant built-in scalar or floating point type
+template <typename T>
+struct channel_traits_impl<T const, false> : channel_traits_impl<T, false>
+{
+    using reference = T const&;
+    using pointer = T const*;
+    static constexpr bool is_mutable = false;
+};
+
+} // namespace detail
 
 /**
 \ingroup ChannelModel
@@ -125,14 +131,15 @@ struct channel_traits {
 \endcode
 */
 template <typename T>
-struct channel_traits : public detail::channel_traits_impl<T, is_class<T>::value> {};
+struct channel_traits : detail::channel_traits_impl<T, std::is_class<T>::value> {};
 
 // Channel traits for C++ reference type - remove the reference
-template <typename T> struct channel_traits<T&> : public channel_traits<T> {};
+template <typename T>
+struct channel_traits<T&> : channel_traits<T> {};
 
 // Channel traits for constant C++ reference type
 template <typename T>
-struct channel_traits<T const&> : public channel_traits<T>
+struct channel_traits<T const&> : channel_traits<T>
 {
     using reference = typename channel_traits<T>::const_reference;
     using pointer = typename channel_traits<T>::const_pointer;
@@ -140,9 +147,7 @@ struct channel_traits<T const&> : public channel_traits<T>
 };
 
 ///////////////////////////////////////////
-////
 ////  scoped_channel_value
-////
 ///////////////////////////////////////////
 
 /// \defgroup ScopedChannelValue scoped_channel_value
@@ -217,9 +222,7 @@ struct float_point_one
 };
 
 ///////////////////////////////////////////
-////
 ////  Support for sub-byte channels. These are integral channels whose value is contained in a range of bits inside an integral type
-////
 ///////////////////////////////////////////
 
 // It is necessary for packed channels to have their own value type. They cannot simply use an integral large enough to store the data. Here is why:
@@ -227,31 +230,39 @@ struct float_point_one
 //   That means that after getting the value of the channel we cannot properly do channel_convert, channel_invert, etc.
 // - Two channels are declared compatible if they have the same value type. That means that a packed channel is incorrectly declared compatible with an integral type
 namespace detail {
-    // returns the smallest fast unsigned integral type that has at least NumBits bits
-    template <int NumBits>
-    struct min_fast_uint : public mpl::if_c< (NumBits<=8),
-            uint_least8_t,
-            typename mpl::if_c< (NumBits<=16),
-                    uint_least16_t,
-                    typename mpl::if_c< (NumBits<=32),
-                            uint_least32_t,
-                            uintmax_t
-                    >::type
+
+// returns the smallest fast unsigned integral type that has at least NumBits bits
+template <int NumBits>
+struct min_fast_uint :
+    std::conditional
+    <
+        NumBits <= 8,
+        std::uint_least8_t,
+        typename std::conditional
+        <
+            NumBits <= 16,
+            std::uint_least16_t,
+            typename std::conditional
+            <
+                NumBits <= 32,
+                std::uint_least32_t,
+                std::uintmax_t
             >::type
-          > {};
+        >::type
+    >
+{};
 
-    template <int NumBits>
-    struct num_value_fn : public mpl::if_c< ( NumBits < 32 )
-                                          , uint32_t
-                                          , uint64_t
-                                          > {};
+template <int NumBits>
+struct num_value_fn
+    : std::conditional<NumBits < 32, std::uint32_t, std::uint64_t>
+{};
 
-    template <int NumBits>
-    struct max_value_fn : public mpl::if_c< ( NumBits <= 32 )
-                                          , uint32_t
-                                          , uint64_t
-                                          > {};
-}
+template <int NumBits>
+struct max_value_fn
+    : std::conditional<NumBits <= 32, std::uint32_t, std::uint64_t>
+{};
+
+} // namespace detail
 
 /// \defgroup PackedChannelValueModel packed_channel_value
 /// \ingroup ChannelModel
@@ -264,14 +275,14 @@ namespace detail {
 /// assert(channel_traits<bits4>::min_value()==0);
 /// assert(channel_traits<bits4>::max_value()==15);
 /// assert(sizeof(bits4)==1);
-/// static_assert(boost::is_integral<bits4>::value, "");
+/// static_assert(gil::is_channel_integral<bits4>::value, "");
 /// \endcode
 
 /// \ingroup PackedChannelValueModel
 /// \brief The value of a subbyte channel. Models: ChannelValueConcept
 template <int NumBits>
-class packed_channel_value {
-
+class packed_channel_value
+{
 public:
     using integer_t = typename detail::min_fast_uint<NumBits>::type;
 
@@ -308,22 +319,26 @@ private:
 namespace detail {
 
 template <std::size_t K>
-struct static_copy_bytes {
-    void operator()(const unsigned char* from, unsigned char* to) const {
+struct static_copy_bytes
+{
+    void operator()(unsigned char const* from, unsigned char* to) const
+    {
         *to = *from;
-        static_copy_bytes<K-1>()(++from,++to);
+        static_copy_bytes<K - 1>()(++from, ++to);
     }
 };
 
 template <>
-struct static_copy_bytes<0> {
-    void operator()(const unsigned char* , unsigned char*) const {}
+struct static_copy_bytes<0>
+{
+    void operator()(unsigned char const*, unsigned char*) const {}
 };
 
-template <typename Derived, typename BitField, int NumBits, bool Mutable>
-class packed_channel_reference_base {
+template <typename Derived, typename BitField, int NumBits, bool IsMutable>
+class packed_channel_reference_base
+{
 protected:
-    using data_ptr_t = typename mpl::if_c<Mutable,void*,const void*>::type;
+    using data_ptr_t = typename std::conditional<IsMutable, void*, void const*>::type;
 public:
     data_ptr_t _data_ptr;   // void* pointer to the first byte of the bit range
 
@@ -332,7 +347,7 @@ public:
     using pointer = value_type *;
     using const_pointer = const value_type *;
     static constexpr int num_bits = NumBits;
-    static constexpr bool is_mutable = Mutable;
+    static constexpr bool is_mutable = IsMutable;
 
     static value_type min_value()       { return channel_traits<value_type>::min_value(); }
     static value_type max_value()       { return channel_traits<value_type>::max_value(); }
@@ -402,28 +417,43 @@ private:
 /// assert(data == 6);                                          // == 3<<1 == 6
 /// \endcode
 
-template <typename BitField,        // A type that holds the bits of the pixel from which the channel is referenced. Typically an integral type, like std::uint16_t
-          int FirstBit, int NumBits,// Defines the sequence of bits in the data value that contain the channel
-          bool Mutable>             // true if the reference is mutable
+/// \tparam BitField A type that holds the bits of the pixel from which the channel is referenced. Typically an integral type, like std::uint16_t
+/// \tparam Defines the sequence of bits in the data value that contain the channel
+/// \tparam true if the reference is mutable
+template <typename BitField, int FirstBit, int NumBits, bool IsMutable>
 class packed_channel_reference;
 
-template <typename BitField,        // A type that holds the bits of the pixel from which the channel is referenced. Typically an integral type, like std::uint16_t
-          int NumBits,              // Defines the sequence of bits in the data value that contain the channel
-          bool Mutable>             // true if the reference is mutable
+/// \tparam A type that holds the bits of the pixel from which the channel is referenced. Typically an integral type, like std::uint16_t
+/// \tparam Defines the sequence of bits in the data value that contain the channel
+/// \tparam true if the reference is mutable
+template <typename BitField, int NumBits, bool IsMutable>
 class packed_dynamic_channel_reference;
 
 /// \ingroup PackedChannelReferenceModel
 /// \brief A constant subbyte channel reference whose bit offset is fixed at compile time. Models ChannelConcept
 template <typename BitField, int FirstBit, int NumBits>
-class packed_channel_reference<BitField,FirstBit,NumBits,false>
-   : public detail::packed_channel_reference_base<packed_channel_reference<BitField,FirstBit,NumBits,false>,BitField,NumBits,false>
+class packed_channel_reference<BitField, FirstBit, NumBits, false>
+    : public detail::packed_channel_reference_base
+        <
+            packed_channel_reference<BitField, FirstBit, NumBits, false>,
+            BitField,
+            NumBits,
+            false
+        >
 {
-    using parent_t = detail::packed_channel_reference_base<packed_channel_reference<BitField,FirstBit,NumBits,false>,BitField,NumBits,false>;
-    friend class packed_channel_reference<BitField,FirstBit,NumBits,true>;
+    using parent_t = detail::packed_channel_reference_base
+        <
+            packed_channel_reference<BitField, FirstBit, NumBits, false>,
+            BitField,
+            NumBits,
+            false
+        >;
 
-    static const BitField channel_mask = static_cast< BitField >( parent_t::max_val ) << FirstBit;
+    friend class packed_channel_reference<BitField, FirstBit, NumBits, true>;
 
-    void operator=(const packed_channel_reference&);
+    static const BitField channel_mask = static_cast<BitField>(parent_t::max_val) << FirstBit;
+
+    void operator=(packed_channel_reference const&);
 public:
     using const_reference = packed_channel_reference<BitField,FirstBit,NumBits,false> const;
     using mutable_reference = packed_channel_reference<BitField,FirstBit,NumBits,true> const;
@@ -478,7 +508,7 @@ private:
     void set_from_reference(const BitField& other_bits) const { this->set_data((this->get_data() & ~channel_mask) | (other_bits & channel_mask)); }
 };
 
-} }  // namespace boost::gil
+}}  // namespace boost::gil
 
 namespace std {
 // We are forced to define swap inside std namespace because on some platforms (Visual Studio 8) STL calls swap qualified.
@@ -489,25 +519,44 @@ namespace std {
 
 /// \ingroup PackedChannelReferenceModel
 /// \brief swap for packed_channel_reference
-template <typename BF, int FB, int NB, bool M, typename R> inline
-void swap(const boost::gil::packed_channel_reference<BF,FB,NB,M> x, R& y) {
-    boost::gil::swap_proxy<typename boost::gil::packed_channel_reference<BF,FB,NB,M>::value_type>(x,y);
+template <typename BF, int FB, int NB, bool M, typename R>
+inline
+void swap(boost::gil::packed_channel_reference<BF, FB, NB, M> const x, R& y)
+{
+    boost::gil::swap_proxy
+    <
+        typename boost::gil::packed_channel_reference<BF, FB, NB, M>::value_type
+    >(x, y);
 }
 
 
 /// \ingroup PackedChannelReferenceModel
 /// \brief swap for packed_channel_reference
-template <typename BF, int FB, int NB, bool M> inline
-void swap(typename boost::gil::packed_channel_reference<BF,FB,NB,M>::value_type& x, const boost::gil::packed_channel_reference<BF,FB,NB,M> y) {
-    boost::gil::swap_proxy<typename boost::gil::packed_channel_reference<BF,FB,NB,M>::value_type>(x,y);
+template <typename BF, int FB, int NB, bool M>
+inline
+void swap(
+    typename boost::gil::packed_channel_reference<BF, FB, NB, M>::value_type& x,
+    boost::gil::packed_channel_reference<BF, FB, NB, M> const y)
+{
+    boost::gil::swap_proxy
+    <
+        typename boost::gil::packed_channel_reference<BF, FB, NB, M>::value_type
+    >(x,y);
 }
 
 /// \ingroup PackedChannelReferenceModel
 /// \brief swap for packed_channel_reference
 template <typename BF, int FB, int NB, bool M> inline
-void swap(const boost::gil::packed_channel_reference<BF,FB,NB,M> x, const boost::gil::packed_channel_reference<BF,FB,NB,M> y) {
-    boost::gil::swap_proxy<typename boost::gil::packed_channel_reference<BF,FB,NB,M>::value_type>(x,y);
+void swap(
+    boost::gil::packed_channel_reference<BF, FB, NB, M> const x,
+    boost::gil::packed_channel_reference<BF, FB, NB, M> const y)
+{
+    boost::gil::swap_proxy
+    <
+        typename boost::gil::packed_channel_reference<BF, FB, NB, M>::value_type
+    >(x,y);
 }
+
 }   // namespace std
 
 namespace boost { namespace gil {
@@ -636,22 +685,6 @@ void swap(const boost::gil::packed_dynamic_channel_reference<BF,NB,M> x, const b
 }
 }   // namespace std
 
-namespace boost {
-
-template <int NumBits>
-struct is_integral<gil::packed_channel_value<NumBits> > : public mpl::true_ {};
-
-template <typename BitField, int FirstBit, int NumBits, bool IsMutable>
-struct is_integral<gil::packed_channel_reference<BitField,FirstBit,NumBits,IsMutable> > : public mpl::true_ {};
-
-template <typename BitField, int NumBits, bool IsMutable>
-struct is_integral<gil::packed_dynamic_channel_reference<BitField,NumBits,IsMutable> > : public mpl::true_ {};
-
-template <typename BaseChannelValue, typename MinVal, typename MaxVal>
-struct is_integral<gil::scoped_channel_value<BaseChannelValue,MinVal,MaxVal> > : public is_integral<BaseChannelValue> {};
-
-} // namespace boost
-
 // \brief Determines the fundamental type which may be used, e.g., to cast from larger to smaller channel types.
 namespace boost { namespace gil {
 template <typename T>
@@ -678,7 +711,7 @@ struct base_channel_type_impl<scoped_channel_value<ChannelValue, MinV, MaxV> >
 { using type = ChannelValue; };
 
 template <typename T>
-struct base_channel_type : base_channel_type_impl<typename remove_cv<T>::type > {};
+struct base_channel_type : base_channel_type_impl<typename std::remove_cv<T>::type> {};
 
 }} //namespace boost::gil
 

--- a/include/boost/gil/channel_algorithm.hpp
+++ b/include/boost/gil/channel_algorithm.hpp
@@ -11,56 +11,81 @@
 #include <boost/gil/channel.hpp>
 #include <boost/gil/promote_integral.hpp>
 #include <boost/gil/typedefs.hpp>
-
-#include <boost/mpl/less.hpp>
-#include <boost/mpl/integral_c.hpp>
-#include <boost/mpl/greater.hpp>
-#include <boost/type_traits.hpp>
+#include <boost/gil/detail/is_channel_integral.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <limits>
+#include <type_traits>
 
 namespace boost { namespace gil {
 
 namespace detail {
 
 // some forward declarations
-template <typename SrcChannelV, typename DstChannelV, bool SrcIsIntegral, bool DstIsIntegral> struct channel_converter_unsigned_impl;
-template <typename SrcChannelV, typename DstChannelV, bool SrcIsGreater> struct channel_converter_unsigned_integral;
-template <typename SrcChannelV, typename DstChannelV, bool SrcLessThanDst, bool SrcDivisible> struct channel_converter_unsigned_integral_impl;
-template <typename SrcChannelV, typename DstChannelV, bool SrcLessThanDst, bool CannotFitInInteger> struct channel_converter_unsigned_integral_nondivisible;
+template <typename SrcChannelV, typename DstChannelV, bool SrcIsIntegral, bool DstIsIntegral>
+struct channel_converter_unsigned_impl;
+
+template <typename SrcChannelV, typename DstChannelV, bool SrcIsGreater>
+struct channel_converter_unsigned_integral;
+
+template <typename SrcChannelV, typename DstChannelV, bool SrcLessThanDst, bool SrcDivisible>
+struct channel_converter_unsigned_integral_impl;
+
+template <typename SrcChannelV, typename DstChannelV, bool SrcLessThanDst, bool CannotFitInInteger>
+struct channel_converter_unsigned_integral_nondivisible;
 
 //////////////////////////////////////
-////  unsigned_integral_max_value - given an unsigned integral channel type, returns its maximum value as an MPL integral constant
-//////////////////////////////////////
-
-
-template <typename UnsignedIntegralChannel>
-struct unsigned_integral_max_value : public mpl::integral_c<UnsignedIntegralChannel,std::numeric_limits<UnsignedIntegralChannel>::max()> {};
-
-template <>
-struct unsigned_integral_max_value<uint8_t> : public mpl::integral_c<uint32_t,0xFF> {};
-template <>
-struct unsigned_integral_max_value<uint16_t> : public mpl::integral_c<uint32_t,0xFFFF> {};
-template <>
-struct unsigned_integral_max_value<uint32_t> : public mpl::integral_c<uintmax_t,0xFFFFFFFF> {};
-
-
-template <int K>
-struct unsigned_integral_max_value<packed_channel_value<K> >
-    : public mpl::integral_c<typename packed_channel_value<K>::integer_t, (uint64_t(1)<<K)-1> {};
-
-
-
-//////////////////////////////////////
-////  unsigned_integral_num_bits - given an unsigned integral channel type, returns the minimum number of bits needed to represent it
+////  unsigned_integral_max_value - given an unsigned integral channel type,
+//// returns its maximum value as an integral constant
 //////////////////////////////////////
 
 template <typename UnsignedIntegralChannel>
-struct unsigned_integral_num_bits : public mpl::int_<sizeof(UnsignedIntegralChannel)*8> {};
+struct unsigned_integral_max_value
+    : std::integral_constant
+    <
+        UnsignedIntegralChannel,
+        std::numeric_limits<UnsignedIntegralChannel>::max()
+    >
+{};
+
+template <>
+struct unsigned_integral_max_value<uint8_t>
+    : std::integral_constant<uint32_t, 0xFF>
+{};
+
+template <>
+struct unsigned_integral_max_value<uint16_t>
+    : std::integral_constant<uint32_t, 0xFFFF>
+{};
+
+template <>
+struct unsigned_integral_max_value<uint32_t>
+    : std::integral_constant<uintmax_t, 0xFFFFFFFF>
+{};
 
 template <int K>
-struct unsigned_integral_num_bits<packed_channel_value<K> >
-    : public mpl::int_<K> {};
+struct unsigned_integral_max_value<packed_channel_value<K>>
+    : std::integral_constant
+    <
+        typename packed_channel_value<K>::integer_t,
+        (uint64_t(1)<<K)-1
+    >
+{};
+
+//////////////////////////////////////
+//// unsigned_integral_num_bits - given an unsigned integral channel type,
+//// returns the minimum number of bits needed to represent it
+//////////////////////////////////////
+
+template <typename UnsignedIntegralChannel>
+struct unsigned_integral_num_bits
+    : std::integral_constant<int, sizeof(UnsignedIntegralChannel) * 8>
+{};
+
+template <int K>
+struct unsigned_integral_num_bits<packed_channel_value<K>>
+    : std::integral_constant<int, K>
+{};
 
 } // namespace detail
 
@@ -88,13 +113,11 @@ struct unsigned_integral_num_bits<packed_channel_value<K> >
 /// assert(dst_channel == 255);     // max value goes to max value
 /// \endcode
 
-
-/**
-\defgroup ChannelConvertUnsignedAlgorithm channel_converter_unsigned
-\ingroup ChannelConvertAlgorithm
-\brief Convert one unsigned/floating point channel to another. Converts both the channel type and range
- @{
- */
+///
+/// \defgroup ChannelConvertUnsignedAlgorithm channel_converter_unsigned
+/// \ingroup ChannelConvertAlgorithm
+/// \brief Convert one unsigned/floating point channel to another. Converts both the channel type and range
+/// @{
 
 //////////////////////////////////////
 ////  channel_converter_unsigned
@@ -102,12 +125,17 @@ struct unsigned_integral_num_bits<packed_channel_value<K> >
 
 template <typename SrcChannelV, typename DstChannelV>     // Model ChannelValueConcept
 struct channel_converter_unsigned
-    : public detail::channel_converter_unsigned_impl<SrcChannelV,DstChannelV,is_integral<SrcChannelV>::value,is_integral<DstChannelV>::value> {};
-
+    : detail::channel_converter_unsigned_impl
+    <
+        SrcChannelV,
+        DstChannelV,
+        detail::is_channel_integral<SrcChannelV>::value,
+        detail::is_channel_integral<DstChannelV>::value
+    >
+{};
 
 /// \brief Converting a channel to itself - identity operation
 template <typename T> struct channel_converter_unsigned<T,T> : public detail::identity<T> {};
-
 
 namespace detail {
 
@@ -133,10 +161,18 @@ private:
 
 // When both the source and the destination are integral channels, perform a faster conversion
 template <typename SrcChannelV, typename DstChannelV>
-struct channel_converter_unsigned_impl<SrcChannelV,DstChannelV,true,true>
-    : public channel_converter_unsigned_integral<SrcChannelV,DstChannelV,
-    mpl::less<unsigned_integral_max_value<SrcChannelV>,unsigned_integral_max_value<DstChannelV> >::value > {};
-
+struct channel_converter_unsigned_impl<SrcChannelV, DstChannelV, true, true>
+    : channel_converter_unsigned_integral
+    <
+        SrcChannelV,
+        DstChannelV,
+        mp11::mp_less
+        <
+            unsigned_integral_max_value<SrcChannelV>,
+            unsigned_integral_max_value<DstChannelV>
+        >::value
+    >
+{};
 
 //////////////////////////////////////
 ////  channel_converter_unsigned_integral
@@ -198,23 +234,37 @@ struct channel_converter_unsigned_integral_impl<uintmax_t,DstChannelV,false,true
 // and the dst max value is not divisible by the src max value
 // See if you can represent the expression (src * dst_max) / src_max in integral form
 template <typename SrcChannelV, typename DstChannelV, bool SrcLessThanDst>
-struct channel_converter_unsigned_integral_impl<SrcChannelV,DstChannelV,SrcLessThanDst,false>
-    : public channel_converter_unsigned_integral_nondivisible<SrcChannelV,DstChannelV,SrcLessThanDst,
-    mpl::greater<
-        mpl::plus<unsigned_integral_num_bits<SrcChannelV>,unsigned_integral_num_bits<DstChannelV> >,
-        unsigned_integral_num_bits<uintmax_t>
-    >::value> {};
-
+struct channel_converter_unsigned_integral_impl<SrcChannelV, DstChannelV, SrcLessThanDst, false>
+    : channel_converter_unsigned_integral_nondivisible
+    <
+        SrcChannelV,
+        DstChannelV,
+        SrcLessThanDst,
+        mp11::mp_less
+        <
+            unsigned_integral_num_bits<uintmax_t>,
+            mp11::mp_plus
+            <
+                unsigned_integral_num_bits<SrcChannelV>,
+                unsigned_integral_num_bits<DstChannelV>
+            >
+        >::value
+    >
+{};
 
 // Both source and destination are unsigned integral channels,
 // the src max value is less than the dst max value,
 // and the dst max value is not divisible by the src max value
 // The expression (src * dst_max) / src_max fits in an integer
 template <typename SrcChannelV, typename DstChannelV>
-struct channel_converter_unsigned_integral_nondivisible<SrcChannelV,DstChannelV,true,false> {
-    DstChannelV operator()(SrcChannelV src) const {
+struct channel_converter_unsigned_integral_nondivisible<SrcChannelV, DstChannelV, true, false>
+{
+    DstChannelV operator()(SrcChannelV src) const
+    {
         using dest_t = typename base_channel_type<DstChannelV>::type;
-        return DstChannelV(static_cast<dest_t>( src * unsigned_integral_max_value<DstChannelV>::value) / unsigned_integral_max_value<SrcChannelV>::value);
+        return DstChannelV(
+            static_cast<dest_t>(src * unsigned_integral_max_value<DstChannelV>::value)
+            / unsigned_integral_max_value<SrcChannelV>::value);
     }
 };
 
@@ -223,9 +273,13 @@ struct channel_converter_unsigned_integral_nondivisible<SrcChannelV,DstChannelV,
 // and the dst max value is not divisible by the src max value
 // The expression (src * dst_max) / src_max cannot fit in an integer (overflows). Use a double
 template <typename SrcChannelV, typename DstChannelV>
-struct channel_converter_unsigned_integral_nondivisible<SrcChannelV,DstChannelV,true,true> {
-    DstChannelV operator()(SrcChannelV src) const {
-        static const double mul = unsigned_integral_max_value<DstChannelV>::value / double(unsigned_integral_max_value<SrcChannelV>::value);
+struct channel_converter_unsigned_integral_nondivisible<SrcChannelV, DstChannelV, true, true>
+{
+    DstChannelV operator()(SrcChannelV src) const
+    {
+        static const double mul
+            = unsigned_integral_max_value<DstChannelV>::value
+            / double(unsigned_integral_max_value<SrcChannelV>::value);
         return DstChannelV(src * mul);
     }
 };

--- a/include/boost/gil/cmyk.hpp
+++ b/include/boost/gil/cmyk.hpp
@@ -9,9 +9,7 @@
 #define BOOST_GIL_CMYK_HPP
 
 #include <boost/gil/metafunctions.hpp>
-
-#include <boost/mpl/range_c.hpp>
-#include <boost/mpl/vector_c.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <cstddef>
 
@@ -34,7 +32,7 @@ struct black_t {};
 /// \}
 
 /// \ingroup ColorSpaceModel
-using cmyk_t = mpl::vector4<cyan_t,magenta_t,yellow_t,black_t>;
+using cmyk_t = mp11::mp_list<cyan_t, magenta_t, yellow_t, black_t>;
 
 /// \ingroup LayoutModel
 using cmyk_layout_t = layout<cmyk_t>;

--- a/include/boost/gil/color_base_algorithm.hpp
+++ b/include/boost/gil/color_base_algorithm.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright 2005-2007 Adobe Systems Incorporated
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
 //
 // Distributed under the Boost Software License, Version 1.0
 // See accompanying file LICENSE_1_0.txt or copy at
@@ -10,12 +11,9 @@
 
 #include <boost/gil/concepts.hpp>
 #include <boost/gil/utilities.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <boost/config.hpp>
-#include <boost/mpl/at.hpp>
-#include <boost/mpl/contains.hpp>
-#include <boost/mpl/size.hpp>
-#include <boost/type_traits.hpp>
 
 #include <algorithm>
 #include <type_traits>
@@ -23,15 +21,13 @@
 namespace boost { namespace gil {
 
 ///////////////////////////////////////
-///
 /// size:   Semantic channel size
-///
 ///////////////////////////////////////
 
 /**
 \defgroup ColorBaseAlgorithmSize size
 \ingroup ColorBaseAlgorithm
-\brief Returns an MPL integral type specifying the number of elements in a color base
+\brief Returns an integral constant type specifying the number of elements in a color base
 
 Example:
 \code
@@ -40,15 +36,13 @@ static_assert(size<cmyk8_planar_ptr_t>::value == 4, "");
 \endcode
 */
 
-/// \brief Returns an MPL integral type specifying the number of elements in a color base
+/// \brief Returns an integral constant type specifying the number of elements in a color base
 /// \ingroup ColorBaseAlgorithmSize
 template <typename ColorBase>
-struct size : public mpl::size<typename ColorBase::layout_t::color_space_t> {};
+struct size : public mp11::mp_size<typename ColorBase::layout_t::color_space_t> {};
 
 ///////////////////////////////////////
-///
 /// semantic_at_c:   Semantic channel accessors
-///
 ///////////////////////////////////////
 
 /**
@@ -63,7 +57,7 @@ All GIL color base algorithms taking multiple color bases use semantic indexing 
 Example:
 \code
 // 16-bit BGR pixel, 4 bits for the blue, 3 bits for the green, 2 bits for the red channel and 7 unused bits
-using bgr432_pixel_t = packed_pixel_type<uint16_t, mpl::vector3_c<unsigned,4,3,2>, bgr_layout_t>::type;
+using bgr432_pixel_t = packed_pixel_type<uint16_t, mp11::mp_list_c<unsigned,4,3,2>, bgr_layout_t>::type;
 
 // A reference to its red channel. Although the red channel is the third, its semantic index is 0 in the RGB color space
 using red_channel_reference_t = kth_semantic_element_reference_type<bgr432_pixel_t, 0>::type;
@@ -83,10 +77,10 @@ template <typename ColorBase, int K>
 struct kth_semantic_element_type
 {
     using channel_mapping_t = typename ColorBase::layout_t::channel_mapping_t;
-    static_assert(K < mpl::size<channel_mapping_t>::value,
+    static_assert(K < mp11::mp_size<channel_mapping_t>::value,
         "K index should be less than size of channel_mapping_t sequence");
 
-    static constexpr int semantic_index = mpl::at_c<channel_mapping_t, K>::type::value;
+    static constexpr int semantic_index = mp11::mp_at_c<channel_mapping_t, K>::type::value;
     using type = typename kth_element_type<ColorBase, semantic_index>::type;
 };
 
@@ -96,23 +90,24 @@ template <typename ColorBase, int K>
 struct kth_semantic_element_reference_type
 {
     using channel_mapping_t = typename ColorBase::layout_t::channel_mapping_t;
-    static_assert(K < mpl::size<channel_mapping_t>::value,
+    static_assert(K < mp11::mp_size<channel_mapping_t>::value,
         "K index should be less than size of channel_mapping_t sequence");
 
-    static constexpr int semantic_index = mpl::at_c<channel_mapping_t, K>::type::value;
+    static constexpr int semantic_index = mp11::mp_at_c<channel_mapping_t, K>::type::value;
     using type = typename kth_element_reference_type<ColorBase, semantic_index>::type;
     static type get(ColorBase& cb) { return gil::at_c<semantic_index>(cb); }
 };
 
 /// \brief Specifies the return type of the constant semantic_at_c<K>(color_base);
 /// \ingroup ColorBaseAlgorithmSemanticAtC
-template <typename ColorBase, int K> struct kth_semantic_element_const_reference_type
+template <typename ColorBase, int K>
+struct kth_semantic_element_const_reference_type
 {
     using channel_mapping_t = typename ColorBase::layout_t::channel_mapping_t;
-    static_assert(K < mpl::size<channel_mapping_t>::value,
+    static_assert(K < mp11::mp_size<channel_mapping_t>::value,
         "K index should be less than size of channel_mapping_t sequence");
 
-    static constexpr int semantic_index = mpl::at_c<channel_mapping_t, K>::type::value;
+    static constexpr int semantic_index = mp11::mp_at_c<channel_mapping_t, K>::type::value;
     using type = typename kth_element_const_reference_type<ColorBase,semantic_index>::type;
     static type get(const ColorBase& cb) { return gil::at_c<semantic_index>(cb); }
 };
@@ -128,21 +123,21 @@ auto semantic_at_c(ColorBase& p)
         typename kth_semantic_element_reference_type<ColorBase, K>::type
     >::type
 {
-    return kth_semantic_element_reference_type<ColorBase,K>::get(p);
+    return kth_semantic_element_reference_type<ColorBase, K>::get(p);
 }
 
 /// \brief A constant accessor to the K-th semantic element of a color base
 /// \ingroup ColorBaseAlgorithmSemanticAtC
-template <int K, typename ColorBase> inline
-typename kth_semantic_element_const_reference_type<ColorBase,K>::type
-semantic_at_c(const ColorBase& p) {
-    return kth_semantic_element_const_reference_type<ColorBase,K>::get(p);
+template <int K, typename ColorBase>
+inline
+auto semantic_at_c(ColorBase const& p)
+    -> typename kth_semantic_element_const_reference_type<ColorBase, K>::type
+{
+    return kth_semantic_element_const_reference_type<ColorBase, K>::get(p);
 }
 
 ///////////////////////////////////////
-///
 /// get_color:   Named channel accessors
-///
 ///////////////////////////////////////
 
 /**
@@ -167,7 +162,9 @@ void set_red_to_max(Pixel& pixel) {
 /// \brief A predicate metafunction determining whether a given color base contains a given color
 /// \ingroup ColorBaseAlgorithmColor
 template <typename ColorBase, typename Color>
-struct contains_color : public mpl::contains<typename ColorBase::layout_t::color_space_t,Color> {};
+struct contains_color
+    : mp11::mp_contains<typename ColorBase::layout_t::color_space_t, Color>
+{};
 
 template <typename ColorBase, typename Color>
 struct color_index_type : public detail::type_to_index<typename ColorBase::layout_t::color_space_t,Color> {};
@@ -539,7 +536,10 @@ bool static_equal(const P1& p1, const P2& p2) { return detail::element_recursion
 
 template <typename Src,typename Dst>
 BOOST_FORCEINLINE
-void static_copy(const Src& src, Dst& dst) {  detail::element_recursion<size<Dst>::value>::static_copy(src,dst); }
+void static_copy(const Src& src, Dst& dst)
+{
+    detail::element_recursion<size<Dst>::value>::static_copy(src, dst);
+}
 
 /// \}
 
@@ -557,7 +557,11 @@ void static_copy(const Src& src, Dst& dst) {  detail::element_recursion<size<Dst
 
 template <typename P,typename V>
 BOOST_FORCEINLINE
-void static_fill(P& p, const V& v) {  detail::element_recursion<size<P>::value>::static_fill(p,v); }
+void static_fill(P& p, const V& v)
+{
+    detail::element_recursion<size<P>::value>::static_fill(p,v);
+}
+
 /// \}
 
 /// \defgroup ColorBaseAlgorithmGenerate static_generate

--- a/include/boost/gil/color_convert.hpp
+++ b/include/boost/gil/color_convert.hpp
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <type_traits>
 
 namespace boost { namespace gil {
 
@@ -211,20 +212,27 @@ struct default_color_converter_impl<cmyk_t,gray_t> {
 };
 
 namespace detail {
+
 template <typename Pixel>
-typename channel_type<Pixel>::type alpha_or_max_impl(const Pixel& p, mpl::true_) {
+auto alpha_or_max_impl(Pixel const& p, std::true_type) -> typename channel_type<Pixel>::type
+{
     return get_color(p,alpha_t());
 }
 template <typename Pixel>
-typename channel_type<Pixel>::type alpha_or_max_impl(const Pixel&  , mpl::false_) {
+auto alpha_or_max_impl(Pixel const&, std::false_type) -> typename channel_type<Pixel>::type
+{
     return channel_traits<typename channel_type<Pixel>::type>::max_value();
 }
+
 } // namespace detail
 
 // Returns max_value if the pixel has no alpha channel. Otherwise returns the alpha.
 template <typename Pixel>
-typename channel_type<Pixel>::type alpha_or_max(const Pixel& p) {
-    return detail::alpha_or_max_impl(p, mpl::contains<typename color_space_type<Pixel>::type,alpha_t>());
+auto alpha_or_max(Pixel const& p) -> typename channel_type<Pixel>::type
+{
+    return detail::alpha_or_max_impl(
+        p,
+        mp11::mp_contains<typename color_space_type<Pixel>::type, alpha_t>());
 }
 
 

--- a/include/boost/gil/concepts/channel.hpp
+++ b/include/boost/gil/concepts/channel.hpp
@@ -15,6 +15,7 @@
 #include <boost/concept_check.hpp>
 
 #include <utility> // std::swap
+#include <type_traits>
 
 #if defined(BOOST_CLANG)
 #pragma clang diagnostic push
@@ -150,7 +151,7 @@ struct ChannelValueConcept
 /// \ingroup ChannelAlgorithm
 template <typename T1, typename T2>  // Models GIL Pixel
 struct channels_are_compatible
-    : is_same
+    : std::is_same
         <
             typename channel_traits<T1>::value_type,
             typename channel_traits<T2>::value_type

--- a/include/boost/gil/concepts/color.hpp
+++ b/include/boost/gil/concepts/color.hpp
@@ -10,7 +10,7 @@
 
 #include <boost/gil/concepts/concept_check.hpp>
 
-#include <boost/type_traits.hpp>
+#include <type_traits>
 
 #if defined(BOOST_CLANG)
 #pragma clang diagnostic push
@@ -29,7 +29,7 @@ namespace boost { namespace gil {
 /// \code
 /// concept ColorSpaceConcept<MPLRandomAccessSequence CS>
 /// {
-///    // An MPL Random Access Sequence, whose elements are color tags
+///    // Boost.MP11-compatible list, whose elements are color tags.
 /// };
 /// \endcode
 template <typename CS>
@@ -37,7 +37,7 @@ struct ColorSpaceConcept
 {
     void constraints()
     {
-        // An MPL Random Access Sequence, whose elements are color tags
+        // Boost.MP11-compatible list, whose elements are color tags
 
         // TODO: Is this incomplete?
     }
@@ -45,9 +45,7 @@ struct ColorSpaceConcept
 
 // Models ColorSpaceConcept
 template <typename CS1, typename CS2>
-struct color_spaces_are_compatible : is_same<CS1, CS2>
-{
-};
+struct color_spaces_are_compatible : std::is_same<CS1, CS2> {};
 
 /// \ingroup ColorSpaceAndLayoutConcept
 /// \brief Two color spaces are compatible if they are the same
@@ -71,7 +69,7 @@ struct ColorSpacesCompatibleConcept
 /// \code
 /// concept ChannelMappingConcept<MPLRandomAccessSequence CM>
 /// {
-///     // An MPL Random Access Sequence, whose elements
+///     // Boost.MP11-compatible list, whose elements
 ///     // model MPLIntegralConstant representing a permutation
 /// };
 /// \endcode
@@ -80,7 +78,7 @@ struct ChannelMappingConcept
 {
     void constraints()
     {
-        // An MPL Random Access Sequence, whose elements model
+        // Boost.MP11-compatible list, whose elements model
         // MPLIntegralConstant representing a permutation.
 
         // TODO: Is this incomplete?

--- a/include/boost/gil/concepts/color_base.hpp
+++ b/include/boost/gil/concepts/color_base.hpp
@@ -14,7 +14,7 @@
 #include <boost/gil/concepts/fwd.hpp>
 
 #include <boost/core/ignore_unused.hpp>
-#include <boost/type_traits.hpp>
+#include <type_traits>
 
 #if defined(BOOST_CLANG)
 #pragma clang diagnostic push
@@ -38,11 +38,11 @@ struct homogeneous_color_base;
 
 template <int K, typename E, typename L, int N>
 auto at_c(detail::homogeneous_color_base<E, L, N>& p)
-    -> typename add_reference<E>::type;
+    -> typename std::add_lvalue_reference<E>::type;
 
 template <int K, typename E, typename L, int N>
 auto at_c(detail::homogeneous_color_base<E, L, N> const& p)
-    -> typename add_reference<typename add_const<E>::type>::type;
+    -> typename std::add_lvalue_reference<typename std::add_const<E>::type>::type;
 
 template <typename P, typename C, typename L>
 struct packed_pixel;
@@ -144,7 +144,7 @@ struct ColorBaseConcept
         gil_function_requires<ColorSpaceConcept<color_space_t>>();
 
         using channel_mapping_t = typename ColorBase::layout_t::channel_mapping_t;
-        // TODO: channel_mapping_t must be an MPL RandomAccessSequence
+        // TODO: channel_mapping_t must be an Boost.MP11-compatible random access sequence
 
         static const int num_elements = size<ColorBase>::value;
 
@@ -152,7 +152,7 @@ struct ColorBaseConcept
         using RN = typename kth_element_const_reference_type<ColorBase, num_elements - 1>::type;
 
         RN r = gil::at_c<num_elements - 1>(cb);
-        ignore_unused_variable_warning(r);
+        boost::ignore_unused(r);
 
         // functions that work for every pixel (no need to require them)
         semantic_at_c<0>(cb);
@@ -234,7 +234,7 @@ struct HomogeneousColorBaseConcept
         using T0 = typename kth_element_type<ColorBase, 0>::type;
         using TN = typename kth_element_type<ColorBase, num_elements - 1>::type;
 
-        static_assert(is_same<T0, TN>::value, "");   // better than nothing
+        static_assert(std::is_same<T0, TN>::value, "");   // better than nothing
 
         using R0 = typename kth_element_const_reference_type<ColorBase, 0>::type;
         R0 r = dynamic_at_c(cb, 0);
@@ -303,7 +303,7 @@ struct ColorBasesCompatibleConcept
 {
     void constraints()
     {
-        static_assert(is_same
+        static_assert(std::is_same
             <
                 typename ColorBase1::layout_t::color_space_t,
                 typename ColorBase2::layout_t::color_space_t

--- a/include/boost/gil/concepts/detail/type_traits.hpp
+++ b/include/boost/gil/concepts/detail/type_traits.hpp
@@ -8,13 +8,14 @@
 #ifndef BOOST_GIL_CONCEPTS_DETAIL_TYPE_TRAITS_HPP
 #define BOOST_GIL_CONCEPTS_DETAIL_TYPE_TRAITS_HPP
 
-#include <boost/type_traits.hpp>
+#include <type_traits>
 
 namespace boost { namespace gil { namespace detail {
 
+// TODO: C++20: deprecate and replace with std::std_remove_cvref
 template <typename T>
 struct remove_const_and_reference
-    : ::boost::remove_const<typename ::boost::remove_reference<T>::type>
+    : std::remove_const<typename std::remove_reference<T>::type>
 {
 };
 

--- a/include/boost/gil/concepts/image.hpp
+++ b/include/boost/gil/concepts/image.hpp
@@ -13,8 +13,9 @@
 #include <boost/gil/concepts/fwd.hpp>
 #include <boost/gil/concepts/image_view.hpp>
 #include <boost/gil/concepts/point.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
-#include <boost/mpl/size.hpp>
+#include <type_traits>
 
 #if defined(BOOST_CLANG)
 #pragma clang diagnostic push
@@ -146,10 +147,10 @@ struct ImageConcept
         gil_function_requires<RandomAccess2DImageConcept<Image>>();
         gil_function_requires<MutableImageViewConcept<typename Image::view_t>>();
         using coord_t = typename Image::coord_t;
-        static_assert(num_channels<Image>::value == mpl::size<typename color_space_type<Image>::type>::value, "");
+        static_assert(num_channels<Image>::value == mp11::mp_size<typename color_space_type<Image>::type>::value, "");
 
-        static_assert(is_same<coord_t, typename Image::x_coord_t>::value, "");
-        static_assert(is_same<coord_t, typename Image::y_coord_t>::value, "");
+        static_assert(std::is_same<coord_t, typename Image::x_coord_t>::value, "");
+        static_assert(std::is_same<coord_t, typename Image::y_coord_t>::value, "");
     }
     Image image;
 };

--- a/include/boost/gil/concepts/image_view.hpp
+++ b/include/boost/gil/concepts/image_view.hpp
@@ -20,6 +20,7 @@
 
 #include <cstddef>
 #include <iterator>
+#include <type_traits>
 
 #if defined(BOOST_CLANG)
 #pragma clang diagnostic push
@@ -132,12 +133,12 @@ struct RandomAccessNDImageViewConcept
         // point_t must be an N-dimensional point, each dimension of which must have the same type as difference_type of the corresponding iterator
         gil_function_requires<PointNDConcept<point_t>>();
         static_assert(point_t::num_dimensions == N, "");
-        static_assert(is_same
+        static_assert(std::is_same
             <
                 typename std::iterator_traits<first_it_type>::difference_type,
                 typename point_t::template axis<0>::coord_t
             >::value, "");
-        static_assert(is_same
+        static_assert(std::is_same
             <
                 typename std::iterator_traits<last_it_type>::difference_type,
                 typename point_t::template axis<N-1>::coord_t
@@ -379,7 +380,7 @@ struct ImageViewConcept
         // TODO: This executes the requirements for RandomAccess2DLocatorConcept again. Fix it to improve compile time
         gil_function_requires<PixelLocatorConcept<typename View::xy_locator>>();
 
-        static_assert(is_same<typename View::x_coord_t, typename View::y_coord_t>::value, "");
+        static_assert(std::is_same<typename View::x_coord_t, typename View::y_coord_t>::value, "");
 
         using coord_t = typename View::coord_t; // 1D difference type (same for all dimensions)
         std::size_t num_chan = view.num_channels(); ignore_unused_variable_warning(num_chan);

--- a/include/boost/gil/concepts/pixel.hpp
+++ b/include/boost/gil/concepts/pixel.hpp
@@ -16,12 +16,10 @@
 #include <boost/gil/concepts/fwd.hpp>
 #include <boost/gil/concepts/pixel_based.hpp>
 #include <boost/gil/concepts/detail/type_traits.hpp>
-
-#include <boost/type_traits.hpp>
-#include <boost/mpl/and.hpp>
-#include <boost/mpl/bool.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <cstddef>
+#include <type_traits>
 
 #if defined(BOOST_CLANG)
 #pragma clang diagnostic push
@@ -192,7 +190,7 @@ struct HomogeneousPixelValueConcept
     {
         gil_function_requires<HomogeneousPixelConcept<P>>();
         gil_function_requires<Regular<P>>();
-        static_assert(is_same<P, typename P::value_type>::value, "");
+        static_assert(std::is_same<P, typename P::value_type>::value, "");
     }
 };
 
@@ -200,24 +198,20 @@ namespace detail {
 
 template <typename P1, typename P2, int K>
 struct channels_are_pairwise_compatible
-    : public
-        mpl::and_
+    : mp11::mp_and
+    <
+        channels_are_pairwise_compatible<P1, P2, K - 1>,
+        channels_are_compatible
         <
-            channels_are_pairwise_compatible<P1, P2, K - 1>,
-            channels_are_compatible
-            <
-                typename kth_semantic_element_reference_type<P1, K>::type,
-                typename kth_semantic_element_reference_type<P2, K>::type
-            >
+            typename kth_semantic_element_reference_type<P1, K>::type,
+            typename kth_semantic_element_reference_type<P2, K>::type
         >
+    >
 {
 };
 
 template <typename P1, typename P2>
-struct channels_are_pairwise_compatible<P1, P2, -1>
-    : public mpl::true_
-{
-};
+struct channels_are_pairwise_compatible<P1, P2, -1> : std::true_type {};
 
 } // namespace detail
 
@@ -229,8 +223,7 @@ struct channels_are_pairwise_compatible<P1, P2, -1>
 /// \tparam P2 Models PixelConcept
 template <typename P1, typename P2>
 struct pixels_are_compatible
-    : public
-        mpl::and_
+    : mp11::mp_and
         <
             typename color_spaces_are_compatible
             <

--- a/include/boost/gil/concepts/pixel_dereference.hpp
+++ b/include/boost/gil/concepts/pixel_dereference.hpp
@@ -15,9 +15,9 @@
 #include <boost/gil/concepts/detail/type_traits.hpp>
 
 #include <boost/concept_check.hpp>
-#include <boost/type_traits.hpp>
 
 #include <cstddef>
+#include <type_traits>
 
 #if defined(BOOST_CLANG)
 #pragma clang diagnostic push
@@ -93,8 +93,8 @@ struct PixelDereferenceAdaptorArchetype
     using argument_type = P;
     using result_type = P;
     using const_t = PixelDereferenceAdaptorArchetype;
-    using value_type = typename remove_reference<P>::type;
-    using reference = typename add_reference<P>::type;
+    using value_type = typename std::remove_reference<P>::type;
+    using reference = typename std::add_lvalue_reference<P>::type;
     using const_reference = reference;
 
     static const bool is_mutable = false;

--- a/include/boost/gil/concepts/pixel_iterator.hpp
+++ b/include/boost/gil/concepts/pixel_iterator.hpp
@@ -16,10 +16,10 @@
 #include <boost/gil/concepts/pixel_based.hpp>
 
 #include <boost/iterator/iterator_concepts.hpp>
-#include <boost/mpl/bool.hpp>
 
 #include <cstddef>
 #include <iterator>
+#include <type_traits>
 
 #if defined(BOOST_CLANG)
 #pragma clang diagnostic push
@@ -112,7 +112,7 @@ struct PixelIteratorIsMutableConcept
     {
         gil_function_requires<detail::RandomAccessIteratorIsMutableConcept<Iterator>>();
 
-        using ref_t = typename remove_reference
+        using ref_t = typename std::remove_reference
             <
                 typename std::iterator_traits<Iterator>::reference
             >::type;
@@ -187,9 +187,9 @@ struct PixelIteratorConcept
         check_base(typename is_iterator_adaptor<Iterator>::type());
     }
 
-    void check_base(mpl::false_) {}
+    void check_base(std::false_type) {}
 
-    void check_base(mpl::true_)
+    void check_base(std::true_type)
     {
         using base_t = typename iterator_adaptor_get_base<Iterator>::type;
         gil_function_requires<PixelIteratorConcept<base_t>>();
@@ -289,7 +289,7 @@ struct MutableStepIteratorConcept
 ///
 /// In addition to GIL iterator requirements,
 /// GIL iterator adaptors must provide the following metafunctions:
-///  - \p is_iterator_adaptor<Iterator>:             Returns \p mpl::true_
+///  - \p is_iterator_adaptor<Iterator>:             Returns \p std::true_type
 ///  - \p iterator_adaptor_get_base<Iterator>:       Returns the base iterator type
 ///  - \p iterator_adaptor_rebind<Iterator,NewBase>: Replaces the base iterator with the new one
 ///
@@ -298,7 +298,7 @@ struct MutableStepIteratorConcept
 /// \code
 /// concept IteratorAdaptorConcept<boost_concepts::ForwardTraversalConcept Iterator>
 /// {
-///     where SameType<is_iterator_adaptor<Iterator>::type, mpl::true_>;
+///     where SameType<is_iterator_adaptor<Iterator>::type, std::true_type>;
 ///
 ///     typename iterator_adaptor_get_base<Iterator>;
 ///         where Metafunction<iterator_adaptor_get_base<Iterator> >;

--- a/include/boost/gil/concepts/pixel_locator.hpp
+++ b/include/boost/gil/concepts/pixel_locator.hpp
@@ -18,6 +18,7 @@
 
 #include <cstddef>
 #include <iterator>
+#include <type_traits>
 
 #if defined(BOOST_CLANG)
 #pragma clang diagnostic push
@@ -140,12 +141,12 @@ struct RandomAccessNDLocatorConcept
         // have the same type as difference_type of the corresponding iterator
         gil_function_requires<PointNDConcept<point_t>>();
         static_assert(point_t::num_dimensions == N, "");
-        static_assert(is_same
+        static_assert(std::is_same
             <
                 typename std::iterator_traits<first_it_type>::difference_type,
                 typename point_t::template axis<0>::coord_t
             >::value, "");
-        static_assert(is_same
+        static_assert(std::is_same
             <
                 typename std::iterator_traits<last_it_type>::difference_type,
                 typename point_t::template axis<N-1>::coord_t
@@ -293,7 +294,7 @@ struct PixelLocatorConcept
         gil_function_requires<PixelIteratorConcept<typename Loc::x_iterator>>();
         gil_function_requires<PixelIteratorConcept<typename Loc::y_iterator>>();
         using coord_t = typename Loc::coord_t;
-        static_assert(is_same<typename Loc::x_coord_t, typename Loc::y_coord_t>::value, "");
+        static_assert(std::is_same<typename Loc::x_coord_t, typename Loc::y_coord_t>::value, "");
     }
     Loc loc;
 };

--- a/include/boost/gil/detail/is_channel_integral.hpp
+++ b/include/boost/gil/detail/is_channel_integral.hpp
@@ -1,0 +1,47 @@
+//
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+// Copyright 2005-2007 Adobe Systems Incorporated
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#ifndef BOOST_GIL_DETAIL_IS_CHANNEL_INTEGRAL_HPP
+#define BOOST_GIL_DETAIL_IS_CHANNEL_INTEGRAL_HPP
+
+#include <boost/gil/channel.hpp>
+
+#include <type_traits>
+
+namespace boost { namespace gil { namespace detail {
+
+template <typename ChannelValue>
+struct is_channel_integral : std::is_integral<ChannelValue> {};
+
+template <int NumBits>
+struct is_channel_integral<boost::gil::packed_channel_value<NumBits>> : std::true_type {};
+
+template <typename BitField, int FirstBit, int NumBits, bool IsMutable>
+struct is_channel_integral
+    <
+        boost::gil::packed_channel_reference<BitField, FirstBit, NumBits, IsMutable>
+    > : std::true_type
+{};
+
+template <typename BitField, int NumBits, bool IsMutable>
+struct is_channel_integral
+    <
+        boost::gil::packed_dynamic_channel_reference<BitField, NumBits, IsMutable>
+    > : std::true_type
+{};
+
+template <typename BaseChannelValue, typename MinVal, typename MaxVal>
+struct is_channel_integral
+    <
+        boost::gil::scoped_channel_value<BaseChannelValue, MinVal, MaxVal>
+    > : std::is_integral<BaseChannelValue>
+{};
+
+}}} //namespace boost::gil::detail
+
+#endif

--- a/include/boost/gil/detail/mp11.hpp
+++ b/include/boost/gil/detail/mp11.hpp
@@ -1,0 +1,26 @@
+//
+// Copyright 2017 Peter Dimov.
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#ifndef BOOST_GIL_DETAIL_MP11_HPP
+#define BOOST_GIL_DETAIL_MP11_HPP
+
+#include <boost/mp11.hpp>
+#include <boost/mp11/mpl.hpp> // required by dynamic_image and boost::variant (?)
+
+namespace boost { namespace gil { namespace detail {
+
+template<typename L>
+using mp_back = ::boost::mp11::mp_at_c<L, ::boost::mp11::mp_size<L>::value - 1>;
+
+template<typename L>
+using mp_pop_back = ::boost::mp11::mp_take_c<L, ::boost::mp11::mp_size<L>::value - 1>;
+
+
+}}}  // namespace boost::gil::detail
+
+#endif

--- a/include/boost/gil/device_n.hpp
+++ b/include/boost/gil/device_n.hpp
@@ -10,45 +10,50 @@
 
 #include <boost/gil/metafunctions.hpp>
 #include <boost/gil/utilities.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <boost/config.hpp>
-#include <boost/mpl/range_c.hpp>
-#include <boost/mpl/vector_c.hpp>
-#include <boost/type_traits.hpp>
 
 #include <cstddef>
+#include <type_traits>
 
 namespace boost { namespace gil {
 
+
+// TODO: Document the DeviceN Color Space and Color Model
+// with reference to the Adobe documentation
+// https://www.adobe.com/content/dam/acom/en/devnet/postscript/pdfs/TN5604.DeviceN_Color.pdf
+
 /// \brief unnamed color
 /// \ingroup ColorNameModel
-template <int N> struct devicen_color_t {};
+template <int N>
+struct devicen_color_t {};
 
-template <int N> struct devicen_t;
+template <int N>
+struct devicen_t;
 
-/// \brief unnamed color space of one channel
+/// \brief Unnamed color space of 1, 3, 4, or 5 channels
+/// \tparam N Number of color components (1, 3, 4 or 5).
 /// \ingroup ColorSpaceModel
-template <> struct devicen_t<1> : public mpl::vector1<devicen_color_t<0> > {};
+template <int N>
+struct devicen_t
+{
+private:
+    template <typename T>
+    using color_t = devicen_color_t<T::value>;
 
-/// \brief unnamed color space of two channels
-/// \ingroup ColorSpaceModel
-template <> struct devicen_t<2> : public mpl::vector2<devicen_color_t<0>, devicen_color_t<1> > {};
+    static_assert(
+        N == 1 || (3 <= N && N <= 5),
+        "invalid number of DeviceN color components");
 
-/// \brief unnamed color space of three channels
-/// \ingroup ColorSpaceModel
-template <> struct devicen_t<3> : public mpl::vector3<devicen_color_t<0>, devicen_color_t<1>, devicen_color_t<2> > {};
-
-/// \brief unnamed color space of four channels
-/// \ingroup ColorSpaceModel
-template <> struct devicen_t<4> : public mpl::vector4<devicen_color_t<0>, devicen_color_t<1>, devicen_color_t<2>, devicen_color_t<3> > {};
-
-/// \brief unnamed color space of five channels
-/// \ingroup ColorSpaceModel
-template <> struct devicen_t<5> : public mpl::vector5<devicen_color_t<0>, devicen_color_t<1>, devicen_color_t<2>, devicen_color_t<3>, devicen_color_t<4> > {};
+public:
+    using type = mp11::mp_transform<color_t, mp11::mp_iota_c<N>>;
+};
 
 /// \brief unnamed color layout of up to five channels
 /// \ingroup LayoutModel
-template <int N> struct devicen_layout_t : public layout<devicen_t<N> > {};
+template <int N>
+struct devicen_layout_t : layout<typename devicen_t<N>::type> {};
 
 /// \ingroup ImageViewConstructors
 /// \brief from 2-channel planar data
@@ -63,8 +68,9 @@ planar_devicen_view(std::size_t width, std::size_t height, IC c0, IC c1, std::pt
 /// \ingroup ImageViewConstructors
 /// \brief from 3-channel planar data
 template <typename IC>
-inline typename type_from_x_iterator<planar_pixel_iterator<IC,devicen_t<3>>>::view_t
-planar_devicen_view(std::size_t width, std::size_t height, IC c0, IC c1, IC c2, std::ptrdiff_t rowsize_in_bytes)
+inline
+auto planar_devicen_view(std::size_t width, std::size_t height, IC c0, IC c1, IC c2, std::ptrdiff_t rowsize_in_bytes)
+    -> typename type_from_x_iterator<planar_pixel_iterator<IC,devicen_t<3>>>::view_t
 {
     using view_t = typename type_from_x_iterator<planar_pixel_iterator<IC,devicen_t<3>>>::view_t;
     return view_t(width, height, typename view_t::locator(typename view_t::x_iterator(c0,c1,c2), rowsize_in_bytes));
@@ -73,8 +79,9 @@ planar_devicen_view(std::size_t width, std::size_t height, IC c0, IC c1, IC c2, 
 /// \ingroup ImageViewConstructors
 /// \brief from 4-channel planar data
 template <typename IC>
-inline typename type_from_x_iterator<planar_pixel_iterator<IC,devicen_t<4>>>::view_t
-planar_devicen_view(std::size_t width, std::size_t height, IC c0, IC c1, IC c2, IC c3, std::ptrdiff_t rowsize_in_bytes)
+inline
+auto planar_devicen_view(std::size_t width, std::size_t height, IC c0, IC c1, IC c2, IC c3, std::ptrdiff_t rowsize_in_bytes)
+    -> typename type_from_x_iterator<planar_pixel_iterator<IC,devicen_t<4>>>::view_t
 {
     using view_t = typename type_from_x_iterator<planar_pixel_iterator<IC,devicen_t<4>>>::view_t;
     return view_t(width, height, typename view_t::locator(typename view_t::x_iterator(c0,c1,c2,c3), rowsize_in_bytes));
@@ -83,13 +90,14 @@ planar_devicen_view(std::size_t width, std::size_t height, IC c0, IC c1, IC c2, 
 /// \ingroup ImageViewConstructors
 /// \brief from 5-channel planar data
 template <typename IC>
-inline typename type_from_x_iterator<planar_pixel_iterator<IC,devicen_t<5>>>::view_t
-planar_devicen_view(std::size_t width, std::size_t height, IC c0, IC c1, IC c2, IC c3, IC c4, std::ptrdiff_t rowsize_in_bytes)
+inline
+auto planar_devicen_view(std::size_t width, std::size_t height, IC c0, IC c1, IC c2, IC c3, IC c4, std::ptrdiff_t rowsize_in_bytes)
+    -> typename type_from_x_iterator<planar_pixel_iterator<IC,devicen_t<5>>>::view_t
 {
     using view_t = typename type_from_x_iterator<planar_pixel_iterator<IC,devicen_t<5>>>::view_t;
     return view_t(width, height, typename view_t::locator(typename view_t::x_iterator(c0,c1,c2,c3,c4), rowsize_in_bytes));
 }
 
-} }  // namespace boost::gil
+}}  // namespace boost::gil
 
 #endif

--- a/include/boost/gil/extension/dynamic_image/algorithm.hpp
+++ b/include/boost/gil/extension/dynamic_image/algorithm.hpp
@@ -40,7 +40,7 @@ struct equal_pixels_fn : binary_operation_obj<equal_pixels_fn, bool>
 } // namespace detail
 
 /// \ingroup ImageViewSTLAlgorithmsEqualPixels
-/// \tparam Types Model MPL Random Access Container of models of ImageViewConcept
+/// \tparam Types Model Boost.MP11-compatible list of models of ImageViewConcept
 /// \tparam View Model MutableImageViewConcept
 template <typename Types, typename View>
 bool equal_pixels(any_image_view<Types> const& src, View const& dst)
@@ -52,7 +52,7 @@ bool equal_pixels(any_image_view<Types> const& src, View const& dst)
 
 /// \ingroup ImageViewSTLAlgorithmsEqualPixels
 /// \tparam View Model ImageViewConcept
-/// \tparam Types Model MPL Random Access Container of models of MutableImageViewConcept
+/// \tparam Types Model Boost.MP11-compatible list of models of MutableImageViewConcept
 template <typename View, typename Types>
 bool equal_pixels(View const& src, any_image_view<Types> const& dst)
 {
@@ -62,8 +62,8 @@ bool equal_pixels(View const& src, any_image_view<Types> const& dst)
 }
 
 /// \ingroup ImageViewSTLAlgorithmsEqualPixels
-/// \tparam Types1 Model MPL Random Access Container of models of ImageViewConcept
-/// \tparam Types2 Model MPL Random Access Container of models of MutableImageViewConcept
+/// \tparam Types1 Model Boost.MP11-compatible list of models of ImageViewConcept
+/// \tparam Types2 Model Boost.MP11-compatible list of models of MutableImageViewConcept
 template <typename Types1, typename Types2>
 bool equal_pixels(any_image_view<Types1> const& src, any_image_view<Types2> const& dst)
 {
@@ -85,7 +85,7 @@ struct copy_pixels_fn : public binary_operation_obj<copy_pixels_fn>
 } // namespace detail
 
 /// \ingroup ImageViewSTLAlgorithmsCopyPixels
-/// \tparam Types Model MPL Random Access Container of models of ImageViewConcept
+/// \tparam Types Model Boost.MP11-compatible list of models of ImageViewConcept
 /// \tparam View Model MutableImageViewConcept
 template <typename Types, typename View>
 void copy_pixels(any_image_view<Types> const& src, View const& dst)
@@ -94,7 +94,7 @@ void copy_pixels(any_image_view<Types> const& src, View const& dst)
 }
 
 /// \ingroup ImageViewSTLAlgorithmsCopyPixels
-/// \tparam Types Model MPL Random Access Container of models of MutableImageViewConcept
+/// \tparam Types Model Boost.MP11-compatible list of models of MutableImageViewConcept
 /// \tparam View Model ImageViewConcept
 template <typename Types, typename View>
 void copy_pixels(View const& src, any_image_view<Types> const& dst)
@@ -103,8 +103,8 @@ void copy_pixels(View const& src, any_image_view<Types> const& dst)
 }
 
 /// \ingroup ImageViewSTLAlgorithmsCopyPixels
-/// \tparam Types1 Model MPL Random Access Container of models of ImageViewConcept
-/// \tparam Types2 Model MPL Random Access Container of models of MutableImageViewConcept
+/// \tparam Types1 Model Boost.MP11-compatible list of models of ImageViewConcept
+/// \tparam Types2 Model Boost.MP11-compatible list of models of MutableImageViewConcept
 template <typename Types1, typename Types2>
 void copy_pixels(any_image_view<Types1> const& src, any_image_view<Types2> const& dst)
 {
@@ -115,7 +115,7 @@ void copy_pixels(any_image_view<Types1> const& src, any_image_view<Types2> const
 struct default_color_converter;
 
 /// \ingroup ImageViewSTLAlgorithmsCopyAndConvertPixels
-/// \tparam Types Model MPL Random Access Container of models of ImageViewConcept
+/// \tparam Types Model Boost.MP11-compatible list of models of ImageViewConcept
 /// \tparam View Model MutableImageViewConcept
 /// \tparam CC Model ColorConverterConcept
 template <typename Types, typename View, typename CC>
@@ -126,7 +126,7 @@ void copy_and_convert_pixels(any_image_view<Types> const& src, View const& dst, 
 }
 
 /// \ingroup ImageViewSTLAlgorithmsCopyAndConvertPixels
-/// \tparam Types Model MPL Random Access Container of models of ImageViewConcept
+/// \tparam Types Model Boost.MP11-compatible list of models of ImageViewConcept
 /// \tparam View Model MutableImageViewConcept
 template <typename Types, typename View>
 void copy_and_convert_pixels(any_image_view<Types> const& src, View const& dst)
@@ -137,7 +137,7 @@ void copy_and_convert_pixels(any_image_view<Types> const& src, View const& dst)
 
 /// \ingroup ImageViewSTLAlgorithmsCopyAndConvertPixels
 /// \tparam View Model ImageViewConcept
-/// \tparam Types Model MPL Random Access Container of models of MutableImageViewConcept
+/// \tparam Types Model Boost.MP11-compatible list of models of MutableImageViewConcept
 /// \tparam CC Model ColorConverterConcept
 template <typename View, typename Types, typename CC>
 void copy_and_convert_pixels(View const& src, any_image_view<Types> const& dst, CC cc)
@@ -148,7 +148,7 @@ void copy_and_convert_pixels(View const& src, any_image_view<Types> const& dst, 
 
 /// \ingroup ImageViewSTLAlgorithmsCopyAndConvertPixels
 /// \tparam View Model ImageViewConcept
-/// \tparam Type Model MPL Random Access Container of models of MutableImageViewConcept
+/// \tparam Type Model Boost.MP11-compatible list of models of MutableImageViewConcept
 template <typename View, typename Types>
 void copy_and_convert_pixels(View const& src, any_image_view<Types> const& dst)
 {
@@ -157,8 +157,8 @@ void copy_and_convert_pixels(View const& src, any_image_view<Types> const& dst)
 }
 
 /// \ingroup ImageViewSTLAlgorithmsCopyAndConvertPixels
-/// \tparam Types1 Model MPL Random Access Container of models of ImageViewConcept
-/// \tparam Types2 Model MPL Random Access Container of models of MutableImageViewConcept
+/// \tparam Types1 Model Boost.MP11-compatible list of models of ImageViewConcept
+/// \tparam Types2 Model Boost.MP11-compatible list of models of MutableImageViewConcept
 /// \tparam CC Model ColorConverterConcept
 template <typename Types1, typename Types2, typename CC>
 void copy_and_convert_pixels(
@@ -169,8 +169,8 @@ void copy_and_convert_pixels(
 }
 
 /// \ingroup ImageViewSTLAlgorithmsCopyAndConvertPixels
-/// \tparam Types1 Model MPL Random Access Container of models of ImageViewConcept
-/// \tparam Types2 Model MPL Random Access Container of models of MutableImageViewConcept
+/// \tparam Types1 Model Boost.MP11-compatible list of models of ImageViewConcept
+/// \tparam Types2 Model Boost.MP11-compatible list of models of MutableImageViewConcept
 template <typename Types1, typename Types2>
 void copy_and_convert_pixels(
     any_image_view<Types1> const& src,
@@ -223,7 +223,7 @@ struct fill_pixels_fn
 
 /// \ingroup ImageViewSTLAlgorithmsFillPixels
 /// \brief fill_pixels for any image view. The pixel to fill with must be compatible with the current view
-/// \tparam Types Model MPL Random Access Container of models of MutableImageViewConcept
+/// \tparam Types Model Boost.MP11-compatible list of models of MutableImageViewConcept
 template <typename Types, typename Value>
 void fill_pixels(any_image_view<Types> const& view, Value const& val)
 {

--- a/include/boost/gil/extension/dynamic_image/any_image.hpp
+++ b/include/boost/gil/extension/dynamic_image/any_image.hpp
@@ -12,8 +12,10 @@
 #include <boost/gil/extension/dynamic_image/apply_operation.hpp>
 
 #include <boost/gil/image.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <boost/config.hpp>
+#include <boost/variant.hpp>
 
 #if BOOST_WORKAROUND(BOOST_MSVC, >= 1400)
 #pragma warning(push)
@@ -23,35 +25,53 @@
 namespace boost { namespace gil {
 
 namespace detail {
-    template <typename T> struct get_view_t       { using type = typename T::view_t; };
-    template <typename Images> struct images_get_views_t : public mpl::transform<Images, get_view_t<mpl::_1> > {};
 
-    template <typename T> struct get_const_view_t { using type = typename T::const_view_t; };
-    template <typename Images> struct images_get_const_views_t : public mpl::transform<Images, get_const_view_t<mpl::_1> > {};
+template <typename T>
+using get_view_t = typename T::view_t;
 
-    struct recreate_image_fnobj
+template <typename Images>
+using images_get_views_t = mp11::mp_transform<get_view_t, Images>;
+
+template <typename T>
+using get_const_view_t = typename T::const_view_t;
+
+template <typename Images>
+using images_get_const_views_t = mp11::mp_transform<get_const_view_t, Images>;
+
+struct recreate_image_fnobj
+{
+    using result_type = void;
+    point<std::ptrdiff_t> const& _dimensions;
+    unsigned _alignment;
+
+    recreate_image_fnobj(point<std::ptrdiff_t> const& dims, unsigned alignment)
+        : _dimensions(dims), _alignment(alignment)
+    {}
+
+    template <typename Image>
+    result_type operator()(Image& img) const { img.recreate(_dimensions,_alignment); }
+};
+
+template <typename AnyView>  // Models AnyViewConcept
+struct any_image_get_view
+{
+    using result_type = AnyView;
+    template <typename Image>
+    result_type operator()(Image& img) const
     {
-        using result_type = void;
-        point<std::ptrdiff_t> const& _dimensions;
-        unsigned _alignment;
+        return result_type(view(img));
+    }
+};
 
-        recreate_image_fnobj(point<std::ptrdiff_t> const& dims, unsigned alignment) : _dimensions(dims), _alignment(alignment) {}
-        template <typename Image>
-        result_type operator()(Image& img) const { img.recreate(_dimensions,_alignment); }
-    };
+template <typename AnyConstView>  // Models AnyConstViewConcept
+struct any_image_get_const_view
+{
+    using result_type = AnyConstView;
+    template <typename Image>
+    result_type operator()(Image const& img) const { return result_type{const_view(img)}; }
+};
 
-    template <typename AnyView>  // Models AnyViewConcept
-    struct any_image_get_view {
-        using result_type = AnyView;
-        template <typename Image> result_type operator()(      Image& img) const { return result_type(view(img)); }
-    };
-
-    template <typename AnyConstView>  // Models AnyConstViewConcept
-    struct any_image_get_const_view {
-        using result_type = AnyConstView;
-        template <typename Image> result_type operator()(const Image& img) const { return result_type(const_view(img)); }
-    };
-}
+} // namespce detail
 
 ////////////////////////////////////////////////////////////////////////////////////////
 /// \ingroup ImageModel
@@ -63,40 +83,74 @@ namespace detail {
 /// Other requirements, such as access to the pixels, would be inefficient to provide. Thus \p any_image does not fully model ImageConcept.
 /// In particular, its \p view and \p const_view methods return \p any_image_view, which does not fully model ImageViewConcept. See \p any_image_view for more.
 ////////////////////////////////////////////////////////////////////////////////////////
-template <typename ImageTypes>
-class any_image : public make_variant_over<ImageTypes>::type {
-    using parent_t = typename make_variant_over<ImageTypes>::type;
+
+template <typename Images>
+class any_image : public make_variant_over<Images>::type
+{
+    using parent_t = typename make_variant_over<Images>::type;
 public:
-    using const_view_t = any_image_view<typename detail::images_get_const_views_t<ImageTypes>::type>;
-    using view_t = any_image_view<typename detail::images_get_views_t<ImageTypes>::type>;
+    using view_t = any_image_view<detail::images_get_views_t<Images>>;
+    using const_view_t = any_image_view<detail::images_get_const_views_t<Images>>;
     using x_coord_t = std::ptrdiff_t;
     using y_coord_t = std::ptrdiff_t;
     using point_t = point<std::ptrdiff_t>;
 
-    any_image()                                                          : parent_t() {}
-    template <typename T> explicit any_image(const T& obj)               : parent_t(obj) {}
-    template <typename T> explicit any_image(T& obj, bool do_swap)       : parent_t(obj,do_swap) {}
-    any_image(const any_image& v)                                        : parent_t((const parent_t&)v)    {}
-    template <typename Types> any_image(const any_image<Types>& v)       : parent_t((const typename make_variant_over<Types>::type&)v)    {}
+    any_image() = default;
+    any_image(any_image const& img) : parent_t((parent_t const&)img) {}
 
-    template <typename T> any_image& operator=(const T& obj)                  { parent_t::operator=(obj); return *this; }
-    any_image&                       operator=(const any_image& v)            { parent_t::operator=((const parent_t&)v); return *this;}
-    template <typename Types> any_image& operator=(const any_image<Types>& v) { parent_t::operator=((const typename make_variant_over<Types>::type&)v); return *this;}
+    template <typename Image>
+    explicit any_image(Image const& img) : parent_t(img) {}
+
+    template <typename Image>
+    explicit any_image(Image& img, bool do_swap) : parent_t(img, do_swap) {}
+
+    template <typename OtherImages>
+    any_image(any_image<OtherImages> const& img)
+        : parent_t((typename make_variant_over<OtherImages>::type const&)img)
+    {}
+
+    any_image& operator=(any_image const& img)
+    {
+        parent_t::operator=((parent_t const&)img);
+        return *this;
+    }
+
+    template <typename Image>
+    any_image& operator=(Image const& img)
+    {
+        parent_t::operator=(img);
+        return *this;
+    }
+
+    template <typename OtherImages>
+    any_image& operator=(any_image<OtherImages> const& img)
+    {
+            parent_t::operator=((typename make_variant_over<OtherImages>::type const&)img);
+            return *this;
+    }
 
     void recreate(const point_t& dims, unsigned alignment=1)
     {
-        apply_operation(*this,detail::recreate_image_fnobj(dims,alignment));
+        apply_operation(*this, detail::recreate_image_fnobj(dims, alignment));
     }
 
     void recreate(x_coord_t width, y_coord_t height, unsigned alignment=1)
     {
-        recreate({width, height}, alignment);
+        recreate({ width, height }, alignment);
     }
 
-    std::size_t num_channels()  const { return apply_operation(*this, detail::any_type_get_num_channels()); }
-    point_t     dimensions()    const { return apply_operation(*this, detail::any_type_get_dimensions()); }
-    x_coord_t   width()         const { return dimensions().x; }
-    y_coord_t   height()        const { return dimensions().y; }
+    std::size_t num_channels() const
+    {
+        return apply_operation(*this, detail::any_type_get_num_channels());
+    }
+
+    point_t dimensions() const
+    {
+        return apply_operation(*this, detail::any_type_get_dimensions());
+    }
+
+    x_coord_t width()  const { return dimensions().x; }
+    y_coord_t height() const { return dimensions().y; }
 };
 
 ///@{
@@ -106,15 +160,23 @@ public:
 /// \ingroup ImageModel
 
 /// \brief Returns the non-constant-pixel view of any image. The returned view is any view.
-template <typename Types>  BOOST_FORCEINLINE // Models ImageVectorConcept
-typename any_image<Types>::view_t view(any_image<Types>& anyImage) {
-    return apply_operation(anyImage, detail::any_image_get_view<typename any_image<Types>::view_t>());
+/// \tparam Types Models ImageVectorConcept
+template <typename Types>
+BOOST_FORCEINLINE
+auto view(any_image<Types>& img) -> typename any_image<Types>::view_t
+{
+    using view_t = typename any_image<Types>::view_t;
+    return apply_operation(img, detail::any_image_get_view<view_t>());
 }
 
 /// \brief Returns the constant-pixel view of any image. The returned view is any view.
-template <typename Types> BOOST_FORCEINLINE // Models ImageVectorConcept
-typename any_image<Types>::const_view_t const_view(const any_image<Types>& anyImage) {
-    return apply_operation(anyImage, detail::any_image_get_const_view<typename any_image<Types>::const_view_t>());
+/// \tparam Types Models ImageVectorConcept
+template <typename Types>
+BOOST_FORCEINLINE
+auto const_view(any_image<Types> const& img) -> typename any_image<Types>::const_view_t
+{
+    using view_t = typename any_image<Types>::const_view_t;
+    return apply_operation(img, detail::any_image_get_const_view<view_t>());
 }
 ///@}
 

--- a/include/boost/gil/extension/dynamic_image/any_image_view.hpp
+++ b/include/boost/gil/extension/dynamic_image/any_image_view.hpp
@@ -12,36 +12,40 @@
 #include <boost/gil/image.hpp>
 #include <boost/gil/image_view.hpp>
 #include <boost/gil/point.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <boost/variant.hpp>
 
 namespace boost { namespace gil {
 
-namespace detail {
-    template <typename View> struct get_const_t { using type = typename View::const_t; };
-    template <typename Views> struct views_get_const_t : public mpl::transform<Views, get_const_t<mpl::_1> > {};
-}
-
-template <typename View> struct dynamic_xy_step_transposed_type;
+template <typename View>
+struct dynamic_xy_step_transposed_type;
 
 namespace detail {
 
-     // works for both image_view and image
-    struct any_type_get_num_channels
-    {
-        using result_type = int;
-        template <typename T>
-        result_type operator()(const T&) const { return num_channels<T>::value; }
-    };
+template <typename View>
+struct get_const_t { using type = typename View::const_t; };
 
-    // works for both image_view and image
-    struct any_type_get_dimensions
-    {
-        using result_type = point<std::ptrdiff_t>;
-        template <typename T>
-        result_type operator()(const T& v) const { return v.dimensions(); }
-    };
-}
+template <typename Views>
+struct views_get_const_t : mp11::mp_transform<get_const_t, Views> {};
+
+// works for both image_view and image
+struct any_type_get_num_channels
+{
+    using result_type = int;
+    template <typename T>
+    result_type operator()(const T&) const { return num_channels<T>::value; }
+};
+
+// works for both image_view and image
+struct any_type_get_dimensions
+{
+    using result_type = point<std::ptrdiff_t>;
+    template <typename T>
+    result_type operator()(const T& v) const { return v.dimensions(); }
+};
+
+} // namespace detail
 
 ////////////////////////////////////////////////////////////////////////////////////////
 /// CLASS any_image_view
@@ -57,23 +61,47 @@ namespace detail {
 ///
 /// To perform an algorithm on any_image_view, put the algorithm in a function object and invoke it by calling \p apply_operation(runtime_view, algorithm_fn);
 ////////////////////////////////////////////////////////////////////////////////////////
-template <typename ImageViewTypes>
-class any_image_view : public make_variant_over<ImageViewTypes>::type {
-    using parent_t = typename make_variant_over<ImageViewTypes>::type;
+
+template <typename Views>
+class any_image_view : public make_variant_over<Views>::type
+{
+    using parent_t = typename make_variant_over<Views>::type;
 public:
-    using const_t = any_image_view<typename detail::views_get_const_t<ImageViewTypes>::type>;
+    using const_t = any_image_view<detail::views_get_const_t<Views>>;
     using x_coord_t = std::ptrdiff_t;
     using y_coord_t = std::ptrdiff_t;
     using point_t = point<std::ptrdiff_t>;
 
-    any_image_view()                                                          : parent_t() {}
-    template <typename T> explicit any_image_view(const T& obj)               : parent_t(obj) {}
-    any_image_view(const any_image_view& v)                                   : parent_t((const parent_t&)v)    {}
-    template <typename Types> any_image_view(const any_image_view<Types>& v)  : parent_t((const typename make_variant_over<Types>::type&)v)    {}
+    any_image_view() = default;
+    any_image_view(any_image_view const& view) : parent_t((parent_t const&)view) {}
 
-    template <typename T> any_image_view&     operator=(const T& obj)                   { parent_t::operator=(obj); return *this; }
-    any_image_view&                           operator=(const any_image_view& v)        { parent_t::operator=((const parent_t&)v); return *this;}
-    template <typename Types> any_image_view& operator=(const any_image_view<Types>& v) { parent_t::operator=((const typename make_variant_over<Types>::type&)v); return *this;}
+    template <typename View>
+    explicit any_image_view(View const& view) : parent_t(view) {}
+
+    template <typename OtherViews>
+    any_image_view(any_image_view<OtherViews> const& view)
+        : parent_t((typename make_variant_over<OtherViews>::type const&)view)
+    {}
+
+    any_image_view& operator=(any_image_view const& view)
+    {
+        parent_t::operator=((parent_t const&)view);
+        return *this;
+    }
+
+    template <typename View>
+    any_image_view& operator=(View const& view)
+    {
+        parent_t::operator=(view);
+        return *this;
+    }
+
+    template <typename OtherViews>
+    any_image_view& operator=(any_image_view<OtherViews> const& view)
+    {
+        parent_t::operator=((typename make_variant_over<OtherViews>::type const&)view);
+        return *this;
+    }
 
     std::size_t num_channels()  const { return apply_operation(*this, detail::any_type_get_num_channels()); }
     point_t     dimensions()    const { return apply_operation(*this, detail::any_type_get_dimensions()); }
@@ -85,32 +113,68 @@ public:
 //  HasDynamicXStepTypeConcept
 /////////////////////////////
 
-template <typename IVTypes>
-struct dynamic_x_step_type<any_image_view<IVTypes>>
+template <typename Views>
+struct dynamic_x_step_type<any_image_view<Views>>
 {
-    using type = any_image_view<typename mpl::transform<IVTypes, dynamic_x_step_type<mpl::_1>>::type>;
+private:
+    // FIXME: Remove class name injection with gil:: qualification
+    // Required as workaround for Boost.MP11 issue that treats unqualified metafunction
+    // in the class definition of the same name as the specialization (Peter Dimov):
+    //    invalid template argument for template parameter 'F', expected a class template
+    template <typename T>
+    using dynamic_step_view = typename gil::dynamic_x_step_type<T>::type;
+
+public:
+    using type = any_image_view<mp11::mp_transform<dynamic_step_view, Views>>;
 };
 
 /////////////////////////////
 //  HasDynamicYStepTypeConcept
 /////////////////////////////
 
-template <typename IVTypes>
-struct dynamic_y_step_type<any_image_view<IVTypes>>
+template <typename Views>
+struct dynamic_y_step_type<any_image_view<Views>>
 {
-    using type = any_image_view<typename mpl::transform<IVTypes, dynamic_y_step_type<mpl::_1>>::type>;
+private:
+    // FIXME: Remove class name injection with gil:: qualification
+    // Required as workaround for Boost.MP11 issue that treats unqualified metafunction
+    // in the class definition of the same name as the specialization (Peter Dimov):
+    //    invalid template argument for template parameter 'F', expected a class template
+    template <typename T>
+    using dynamic_step_view = typename gil::dynamic_y_step_type<T>::type;
+
+public:
+    using type = any_image_view<mp11::mp_transform<dynamic_step_view, Views>>;
 };
 
-template <typename IVTypes>
-struct dynamic_xy_step_type<any_image_view<IVTypes>>
+template <typename Views>
+struct dynamic_xy_step_type<any_image_view<Views>>
 {
-    using type = any_image_view<typename mpl::transform<IVTypes, dynamic_xy_step_type<mpl::_1>>::type>;
+private:
+    // FIXME: Remove class name injection with gil:: qualification
+    // Required as workaround for Boost.MP11 issue that treats unqualified metafunction
+    // in the class definition of the same name as the specialization (Peter Dimov):
+    //    invalid template argument for template parameter 'F', expected a class template
+    template <typename T>
+    using dynamic_step_view = typename gil::dynamic_xy_step_type<T>::type;
+
+public:
+    using type = any_image_view<mp11::mp_transform<dynamic_step_view, Views>>;
 };
 
-template <typename IVTypes>
-struct dynamic_xy_step_transposed_type<any_image_view<IVTypes>>
+template <typename Views>
+struct dynamic_xy_step_transposed_type<any_image_view<Views>>
 {
-    using type = any_image_view<typename mpl::transform<IVTypes, dynamic_xy_step_transposed_type<mpl::_1>>::type>;
+private:
+    // FIXME: Remove class name injection with gil:: qualification
+    // Required as workaround for Boost.MP11 issue that treats unqualified metafunction
+    // in the class definition of the same name as the specialization (Peter Dimov):
+    //    invalid template argument for template parameter 'F', expected a class template
+    template <typename T>
+    using dynamic_step_view = typename gil::dynamic_xy_step_type<T>::type;
+
+public:
+    using type = any_image_view<mp11::mp_transform<dynamic_step_view, Views>>;
 };
 
 }}  // namespace boost::gil

--- a/include/boost/gil/extension/dynamic_image/apply_operation.hpp
+++ b/include/boost/gil/extension/dynamic_image/apply_operation.hpp
@@ -8,6 +8,8 @@
 #ifndef BOOST_GIL_EXTENSION_DYNAMIC_IMAGE_APPLY_OPERATION_HPP
 #define BOOST_GIL_EXTENSION_DYNAMIC_IMAGE_APPLY_OPERATION_HPP
 
+#include <boost/gil/detail/mp11.hpp>
+
 #include <boost/variant/apply_visitor.hpp>
 
 #ifdef BOOST_GIL_DOXYGEN_ONLY
@@ -60,8 +62,7 @@ auto apply_operation(
     -> typename BinaryOp::result_type
 #endif
 {
-    return apply_visitor(
-        op, arg1, arg2);
+    return apply_visitor(op, arg1, arg2);
 }
 
 }}  // namespace boost::gil

--- a/include/boost/gil/extension/dynamic_image/dynamic_at_c.hpp
+++ b/include/boost/gil/extension/dynamic_image/dynamic_at_c.hpp
@@ -8,8 +8,10 @@
 #ifndef BOOST_GIL_EXTENSION_DYNAMIC_IMAGE_DYNAMIC_AT_C_HPP
 #define BOOST_GIL_EXTENSION_DYNAMIC_IMAGE_DYNAMIC_AT_C_HPP
 
-#include <boost/mpl/at.hpp>
-#include <boost/mpl/size.hpp>
+#include <boost/gil/detail/mp11.hpp>
+
+#include <boost/preprocessor/facilities/empty.hpp>
+#include <boost/preprocessor/repetition/repeat.hpp>
 
 #include <stdexcept>
 
@@ -17,8 +19,8 @@ namespace boost { namespace gil {
 
 // Constructs for static-to-dynamic integer convesion
 
-#define GIL_AT_C_VALUE(z, N, text)    mpl::at_c<IntTypes,S+N>::type::value,
-#define GIL_DYNAMIC_AT_C_LIMIT        226    // size of the maximum vector to handle
+#define GIL_AT_C_VALUE(z, N, text) mp11::mp_at_c<IntTypes, S+N>::value,
+#define GIL_DYNAMIC_AT_C_LIMIT 226 // size of the maximum vector to handle
 
 #define GIL_AT_C_LOOKUP(z, NUM, text)                                   \
     template<std::size_t S>                                             \
@@ -43,7 +45,7 @@ namespace detail {
         struct at_c_impl<0> {
             template <typename IntTypes, typename ValueType> inline
             static ValueType apply(std::size_t index) {
-                return at_c_fn<0,mpl::size<IntTypes>::value>::template apply<IntTypes,ValueType>(index);
+                return at_c_fn<0, mp11::mp_size<IntTypes>::value>::template apply<IntTypes,ValueType>(index);
             }
         };
 
@@ -51,7 +53,7 @@ namespace detail {
         struct at_c_impl<1> {
             template <typename IntTypes, typename ValueType> inline
             static ValueType apply(std::size_t index) {
-                const std::size_t SIZE=mpl::size<IntTypes>::value;
+                const std::size_t SIZE = mp11::mp_size<IntTypes>::value;
                 const std::size_t REM = SIZE % GIL_DYNAMIC_AT_C_LIMIT;
                 switch (index / GIL_DYNAMIC_AT_C_LIMIT) {
                     case 0: return at_c_fn<0                   ,GIL_DYNAMIC_AT_C_LIMIT-1>::template apply<IntTypes,ValueType>(index);
@@ -65,7 +67,7 @@ namespace detail {
         struct at_c_impl<2> {
             template <typename IntTypes, typename ValueType> inline
             static ValueType apply(std::size_t index) {
-                const std::size_t SIZE=mpl::size<IntTypes>::value;
+                const std::size_t SIZE = mp11::mp_size<IntTypes>::value;
                 const std::size_t REM = SIZE % GIL_DYNAMIC_AT_C_LIMIT;
                 switch (index / GIL_DYNAMIC_AT_C_LIMIT) {
                     case 0: return at_c_fn<0                   ,GIL_DYNAMIC_AT_C_LIMIT-1>::template apply<IntTypes,ValueType>(index);
@@ -80,7 +82,7 @@ namespace detail {
         struct at_c_impl<3> {
             template <typename IntTypes, typename ValueType> inline
             static ValueType apply(std::size_t index) {
-                const std::size_t SIZE=mpl::size<IntTypes>::value;
+                const std::size_t SIZE = mp11::mp_size<IntTypes>::value;
                 const std::size_t REM = SIZE % GIL_DYNAMIC_AT_C_LIMIT;
                 switch (index / GIL_DYNAMIC_AT_C_LIMIT) {
                     case 0: return at_c_fn<0                   ,GIL_DYNAMIC_AT_C_LIMIT-1>::template apply<IntTypes,ValueType>(index);
@@ -96,14 +98,15 @@ namespace detail {
 
 ////////////////////////////////////////////////////////////////////////////////////
 ///
-///    \brief Given an MPL Random Access Sequence and a dynamic index n, returns the value of the n-th element
-///  It constructs a lookup table at compile time
+/// \brief Given an Boost.MP11-compatible list and a dynamic index n,
+/// returns the value of the n-th element.
+/// It constructs a lookup table at compile time.
 ///
 ////////////////////////////////////////////////////////////////////////////////////
 
 template <typename IntTypes, typename ValueType> inline
 ValueType at_c(std::size_t index) {
-    const std::size_t Size=mpl::size<IntTypes>::value;
+    const std::size_t Size=mp11::mp_size<IntTypes>::value;
     return detail::at_c::at_c_impl<Size/GIL_DYNAMIC_AT_C_LIMIT>::template apply<IntTypes,ValueType>(index);
 }
 

--- a/include/boost/gil/extension/dynamic_image/image_view_factory.hpp
+++ b/include/boost/gil/extension/dynamic_image/image_view_factory.hpp
@@ -13,6 +13,7 @@
 #include <boost/gil/dynamic_step.hpp>
 #include <boost/gil/image_view_factory.hpp>
 #include <boost/gil/point.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 namespace boost { namespace gil {
 
@@ -20,238 +21,384 @@ namespace boost { namespace gil {
 // Extends image view factory to runtime type-specified views (any_image_view)
 
 namespace detail {
-template <typename Result> struct flipped_up_down_view_fn {
-    using result_type = Result;
-    template <typename View> result_type operator()(const View& src) const { return result_type(flipped_up_down_view(src)); }
-};
-template <typename Result> struct flipped_left_right_view_fn {
-    using result_type = Result;
-    template <typename View> result_type operator()(const View& src) const { return result_type(flipped_left_right_view(src)); }
-};
-template <typename Result> struct rotated90cw_view_fn {
-    using result_type = Result;
-    template <typename View> result_type operator()(const View& src) const { return result_type(rotated90cw_view(src)); }
-};
-template <typename Result> struct rotated90ccw_view_fn {
-    using result_type = Result;
-    template <typename View> result_type operator()(const View& src) const { return result_type(rotated90ccw_view(src)); }
-};
-template <typename Result> struct tranposed_view_fn {
-    using result_type = Result;
-    template <typename View> result_type operator()(const View& src) const { return result_type(tranposed_view(src)); }
-};
-template <typename Result> struct rotated180_view_fn {
-    using result_type = Result;
-    template <typename View> result_type operator()(const View& src) const { return result_type(rotated180_view(src)); }
+
+template <typename ResultView>
+struct flipped_up_down_view_fn
+{
+    using result_type = ResultView;
+
+    template <typename View>
+    auto operator()(View const& src) const -> result_type
+    {
+        return result_type{flipped_up_down_view(src)};
+    }
 };
 
-template <typename Result>
+template <typename ResultView>
+struct flipped_left_right_view_fn
+{
+    using result_type = ResultView;
+
+    template <typename View>
+    auto operator()(View const& src) const -> result_type
+    {
+        return result_type{flipped_left_right_view(src)};
+    }
+};
+
+template <typename ResultView>
+struct rotated90cw_view_fn
+{
+    using result_type = ResultView;
+
+    template <typename View>
+    auto operator()(View const& src) const -> result_type
+    {
+        return result_type{rotated90cw_view(src)};
+    }
+};
+
+template <typename ResultView>
+struct rotated90ccw_view_fn
+{
+    using result_type = ResultView;
+
+    template <typename View>
+    auto operator()(View const& src) const -> result_type
+    {
+        return result_type{rotated90ccw_view(src)};
+    }
+};
+
+template <typename ResultView>
+struct tranposed_view_fn
+{
+    using result_type = ResultView;
+
+    template <typename View>
+    auto operator()(View const& src) const -> result_type
+    {
+        return result_type{tranposed_view(src)};
+    }
+};
+
+template <typename ResultView>
+struct rotated180_view_fn
+{
+    using result_type = ResultView;
+
+    template <typename View>
+    auto operator()(View const& src) const -> result_type
+    {
+        return result_type{rotated180_view(src)};
+    }
+};
+
+template <typename ResultView>
 struct subimage_view_fn
 {
-    using result_type = Result;
+    using result_type = ResultView;
+
     subimage_view_fn(point_t const& topleft, point_t const& dimensions)
         : _topleft(topleft), _size2(dimensions)
     {}
 
     template <typename View>
-    result_type operator()(const View& src) const
+    auto operator()(View const& src) const -> result_type
     {
-        return result_type(subimage_view(src,_topleft,_size2));
+        return result_type{subimage_view(src,_topleft,_size2)};
     }
 
     point_t _topleft;
     point_t _size2;
 };
 
-template <typename Result>
+template <typename ResultView>
 struct subsampled_view_fn
 {
-    using result_type = Result;
+    using result_type = ResultView;
+
     subsampled_view_fn(point_t const& step) : _step(step) {}
 
     template <typename View>
-    result_type operator()(const View& src) const
+    auto operator()(View const& src) const -> result_type
     {
-        return result_type(subsampled_view(src,_step));
+        return result_type{subsampled_view(src,_step)};
     }
 
     point_t _step;
 };
 
-template <typename Result> struct nth_channel_view_fn {
-    using result_type = Result;
+template <typename ResultView>
+struct nth_channel_view_fn
+{
+    using result_type = ResultView;
+
     nth_channel_view_fn(int n) : _n(n) {}
+
+    template <typename View>
+    auto operator()(View const& src) const -> result_type
+    {
+        return result_type(nth_channel_view(src,_n));
+    }
+
     int _n;
-    template <typename View> result_type operator()(const View& src) const { return result_type(nth_channel_view(src,_n)); }
 };
-template <typename DstP, typename Result, typename CC = default_color_converter> struct color_converted_view_fn {
-    using result_type = Result;
+
+template <typename DstP, typename ResultView, typename CC = default_color_converter>
+struct color_converted_view_fn
+{
+    using result_type = ResultView;
+
     color_converted_view_fn(CC cc = CC()): _cc(cc) {}
 
-    template <typename View> result_type operator()(const View& src) const { return result_type(color_converted_view<DstP>(src, _cc)); }
+    template <typename View>
+    auto operator()(View const& src) const -> result_type
+    {
+        return result_type{color_converted_view<DstP>(src, _cc)};
+    }
 
-    private:
-        CC _cc;
+private:
+    CC _cc;
 };
+
 } // namespace detail
 
-
 /// \ingroup ImageViewTransformationsFlipUD
-template <typename ViewTypes> inline // Models MPL Random Access Container of models of ImageViewConcept
-typename dynamic_y_step_type<any_image_view<ViewTypes> >::type flipped_up_down_view(const any_image_view<ViewTypes>& src) {
-    return apply_operation(src,detail::flipped_up_down_view_fn<typename dynamic_y_step_type<any_image_view<ViewTypes> >::type>());
+/// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
+template <typename Views>
+inline
+auto flipped_up_down_view(any_image_view<Views> const& src)
+    -> typename dynamic_y_step_type<any_image_view<Views>>::type
+{
+    using result_view_t = typename dynamic_y_step_type<any_image_view<Views>>::type;
+    return apply_operation(src, detail::flipped_up_down_view_fn<result_view_t>());
 }
 
 /// \ingroup ImageViewTransformationsFlipLR
-template <typename ViewTypes> inline // Models MPL Random Access Container of models of ImageViewConcept
-typename dynamic_x_step_type<any_image_view<ViewTypes> >::type flipped_left_right_view(const any_image_view<ViewTypes>& src) {
-    return apply_operation(src,detail::flipped_left_right_view_fn<typename dynamic_x_step_type<any_image_view<ViewTypes> >::type>());
+/// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
+template <typename Views>
+inline
+auto flipped_left_right_view(any_image_view<Views> const& src)
+    -> typename dynamic_x_step_type<any_image_view<Views>>::type
+{
+    using result_view_t = typename dynamic_x_step_type<any_image_view<Views>>::type;
+    return apply_operation(src, detail::flipped_left_right_view_fn<result_view_t>());
 }
 
 /// \ingroup ImageViewTransformationsTransposed
-template <typename ViewTypes> inline // Models MPL Random Access Container of models of ImageViewConcept
-typename dynamic_xy_step_transposed_type<any_image_view<ViewTypes> >::type transposed_view(const any_image_view<ViewTypes>& src) {
-    return apply_operation(src,detail::tranposed_view_fn<typename dynamic_xy_step_transposed_type<any_image_view<ViewTypes> >::type>());
+/// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
+template <typename Views>
+inline
+auto transposed_view(const any_image_view<Views>& src)
+    -> typename dynamic_xy_step_transposed_type<any_image_view<Views>>::type
+{
+    using result_view_t = typename dynamic_xy_step_transposed_type<any_image_view<Views>>::type;
+    return apply_operation(src, detail::tranposed_view_fn<result_view_t>());
 }
 
 /// \ingroup ImageViewTransformations90CW
-template <typename ViewTypes> inline // Models MPL Random Access Container of models of ImageViewConcept
-typename dynamic_xy_step_transposed_type<any_image_view<ViewTypes> >::type rotated90cw_view(const any_image_view<ViewTypes>& src) {
-    return apply_operation(src,detail::rotated90cw_view_fn<typename dynamic_xy_step_transposed_type<any_image_view<ViewTypes> >::type>());
+/// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
+template <typename Views>
+inline
+auto rotated90cw_view(const any_image_view<Views>& src)
+    -> typename dynamic_xy_step_transposed_type<any_image_view<Views>>::type
+{
+    using result_view_t = typename dynamic_xy_step_transposed_type<any_image_view<Views>>::type;
+    return apply_operation(src,detail::rotated90cw_view_fn<result_view_t>());
 }
 
 /// \ingroup ImageViewTransformations90CCW
-template <typename ViewTypes> inline // Models MPL Random Access Container of models of ImageViewConcept
-typename dynamic_xy_step_transposed_type<any_image_view<ViewTypes> >::type rotated90ccw_view(const any_image_view<ViewTypes>& src) {
-    return apply_operation(src,detail::rotated90ccw_view_fn<typename dynamic_xy_step_transposed_type<any_image_view<ViewTypes> >::type>());
+/// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
+template <typename Views>
+inline
+auto rotated90ccw_view(const any_image_view<Views>& src)
+    -> typename dynamic_xy_step_transposed_type<any_image_view<Views>>::type
+{
+    return apply_operation(src,detail::rotated90ccw_view_fn<typename dynamic_xy_step_transposed_type<any_image_view<Views>>::type>());
 }
 
 /// \ingroup ImageViewTransformations180
-/// Models MPL Random Access Container of models of ImageViewConcept
-template <typename ViewTypes>
-inline auto rotated180_view(const any_image_view<ViewTypes>& src)
-    -> typename dynamic_xy_step_type<any_image_view<ViewTypes>>::type
+/// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
+template <typename Views>
+inline
+auto rotated180_view(any_image_view<Views> const& src)
+    -> typename dynamic_xy_step_type<any_image_view<Views>>::type
 {
-    using step_type = typename dynamic_xy_step_type<any_image_view<ViewTypes>>::type;
+    using step_type = typename dynamic_xy_step_type<any_image_view<Views>>::type;
     return apply_operation(src, detail::rotated180_view_fn<step_type>());
 }
 
 /// \ingroup ImageViewTransformationsSubimage
-///  // Models MPL Random Access Container of models of ImageViewConcept
-template <typename ViewTypes>
-inline auto subimage_view(any_image_view<ViewTypes> const& src,
-                          point_t const& topleft, point_t const& dimensions)
-    -> any_image_view<ViewTypes>
+/// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
+template <typename Views>
+inline
+auto subimage_view(
+    any_image_view<Views> const& src,
+    point_t const& topleft,
+    point_t const& dimensions)
+    -> any_image_view<Views>
 {
-    using subimage_view_fn = detail::subimage_view_fn<any_image_view<ViewTypes>>;
+    using subimage_view_fn = detail::subimage_view_fn<any_image_view<Views>>;
     return apply_operation(src, subimage_view_fn(topleft, dimensions));
 }
 
 /// \ingroup ImageViewTransformationsSubimage
-/// Models MPL Random Access Container of models of ImageViewConcept
-template <typename ViewTypes>
-inline auto subimage_view(any_image_view<ViewTypes> const& src,
-                          int xMin, int yMin, int width, int height)
-    -> any_image_view<ViewTypes>
+/// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
+template <typename Views>
+inline
+auto subimage_view(
+    any_image_view<Views> const& src,
+    int xMin, int yMin, int width, int height)
+    -> any_image_view<Views>
 {
-    using subimage_view_fn = detail::subimage_view_fn<any_image_view<ViewTypes>>;
+    using subimage_view_fn = detail::subimage_view_fn<any_image_view<Views>>;
     return apply_operation(src, subimage_view_fn(point_t(xMin, yMin),point_t(width, height)));
 }
 
 /// \ingroup ImageViewTransformationsSubsampled
-/// Models MPL Random Access Container of models of ImageViewConcept
-template <typename ViewTypes>
-inline auto subsampled_view(any_image_view<ViewTypes> const& src, point_t const& step)
-    -> typename dynamic_xy_step_type<any_image_view<ViewTypes>>::type
+/// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
+template <typename Views>
+inline
+auto subsampled_view(any_image_view<Views> const& src, point_t const& step)
+    -> typename dynamic_xy_step_type<any_image_view<Views>>::type
 {
-    using step_type = typename dynamic_xy_step_type<any_image_view<ViewTypes>>::type;
+    using step_type = typename dynamic_xy_step_type<any_image_view<Views>>::type;
     using subsampled_view = detail::subsampled_view_fn<step_type>;
     return apply_operation(src, subsampled_view(step));
 }
 
 /// \ingroup ImageViewTransformationsSubsampled
-/// Models MPL Random Access Container of models of ImageViewConcept
-template <typename ViewTypes>
-inline auto subsampled_view(any_image_view<ViewTypes> const& src, int xStep, int yStep)
-    -> typename dynamic_xy_step_type<any_image_view<ViewTypes>>::type
+/// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
+template <typename Views>
+inline
+auto subsampled_view(any_image_view<Views> const& src, int xStep, int yStep)
+    -> typename dynamic_xy_step_type<any_image_view<Views>>::type
 {
-    using step_type = typename dynamic_xy_step_type<any_image_view<ViewTypes>>::type;
+    using step_type = typename dynamic_xy_step_type<any_image_view<Views>>::type;
     using subsampled_view_fn = detail::subsampled_view_fn<step_type>;
     return apply_operation(src, subsampled_view_fn(point_t(xStep, yStep)));
 }
 
 namespace detail {
-    template <typename View> struct get_nthchannel_type { using type = typename nth_channel_view_type<View>::type; };
-    template <typename Views> struct views_get_nthchannel_type : public mpl::transform<Views, get_nthchannel_type<mpl::_1> > {};
-}
+
+template <typename View>
+struct get_nthchannel_type { using type = typename nth_channel_view_type<View>::type; };
+
+template <typename Views>
+struct views_get_nthchannel_type : mp11::mp_transform<get_nthchannel_type, Views> {};
+
+} // namespace detail
 
 /// \ingroup ImageViewTransformationsNthChannel
 /// \brief Given a runtime source image view, returns the type of a runtime image view over a single channel of the source view
-template <typename ViewTypes>
-struct nth_channel_view_type<any_image_view<ViewTypes> > {
-    using type = any_image_view<typename detail::views_get_nthchannel_type<ViewTypes>::type>;
+template <typename Views>
+struct nth_channel_view_type<any_image_view<Views>>
+{
+    using type = any_image_view<typename detail::views_get_nthchannel_type<Views>::type>;
 };
 
 /// \ingroup ImageViewTransformationsNthChannel
-template <typename ViewTypes> inline // Models MPL Random Access Container of models of ImageViewConcept
-typename nth_channel_view_type<any_image_view<ViewTypes> >::type nth_channel_view(const any_image_view<ViewTypes>& src, int n) {
-    return apply_operation(src,detail::nth_channel_view_fn<typename nth_channel_view_type<any_image_view<ViewTypes> >::type>(n));
+/// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
+template <typename Views>
+inline
+auto nth_channel_view(const any_image_view<Views>& src, int n)
+    -> typename nth_channel_view_type<any_image_view<Views>>::type
+{
+    using result_view_t = typename nth_channel_view_type<any_image_view<Views>>::type;
+    return apply_operation(src,detail::nth_channel_view_fn<result_view_t>(n));
 }
 
 namespace detail {
-    template <typename View, typename DstP, typename CC> struct get_ccv_type : public color_converted_view_type<View, DstP, CC> {};
-    template <typename Views, typename DstP, typename CC> struct views_get_ccv_type : public mpl::transform<Views, get_ccv_type<mpl::_1,DstP,CC> > {};
-}
+
+template <typename View, typename DstP, typename CC>
+struct get_ccv_type : color_converted_view_type<View, DstP, CC> {};
+
+template <typename Views, typename DstP, typename CC>
+struct views_get_ccv_type
+{
+private:
+    // FIXME: Remove class name injection with detail:: qualification
+    // Required as workaround for MP11 issue that treats unqualified metafunction
+    // in the class definition of the same name as the specialization (Peter Dimov):
+    //    invalid template argument for template parameter 'F', expected a class template
+    template <typename T>
+    using ccvt = detail::get_ccv_type<T, DstP, CC>;
+
+public:
+    using type = mp11::mp_transform<ccvt, Views>;
+};
+
+} // namespace detail
 
 /// \ingroup ImageViewTransformationsColorConvert
 /// \brief Returns the type of a runtime-specified view, color-converted to a given pixel type with user specified color converter
-template <typename ViewTypes, typename DstP, typename CC>
-struct color_converted_view_type<any_image_view<ViewTypes>,DstP,CC>
+template <typename Views, typename DstP, typename CC>
+struct color_converted_view_type<any_image_view<Views>,DstP,CC>
 {
-    using type = any_image_view<typename detail::views_get_ccv_type<ViewTypes, DstP, CC>::type>;
+    using type = any_image_view<typename detail::views_get_ccv_type<Views, DstP, CC>::type>;
 };
 
 /// \ingroup ImageViewTransformationsColorConvert
 /// \brief overload of generic color_converted_view with user defined color-converter
-template <typename DstP, typename ViewTypes, typename CC> inline // Models MPL Random Access Container of models of ImageViewConcept
-typename color_converted_view_type<any_image_view<ViewTypes>, DstP, CC>::type color_converted_view(const any_image_view<ViewTypes>& src, CC) {
-    return apply_operation(src,detail::color_converted_view_fn<DstP,typename color_converted_view_type<any_image_view<ViewTypes>, DstP, CC>::type >());
+/// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
+template <typename DstP, typename Views, typename CC>
+inline
+auto color_converted_view(const any_image_view<Views>& src, CC)
+    -> typename color_converted_view_type<any_image_view<Views>, DstP, CC>::type
+{
+    using cc_view_t = typename color_converted_view_type<any_image_view<Views>, DstP, CC>::type;
+    return apply_operation(src, detail::color_converted_view_fn<DstP, cc_view_t>());
 }
 
 /// \ingroup ImageViewTransformationsColorConvert
 /// \brief Returns the type of a runtime-specified view, color-converted to a given pixel type with the default coor converter
-template <typename ViewTypes, typename DstP>
-struct color_converted_view_type<any_image_view<ViewTypes>,DstP>
+template <typename Views, typename DstP>
+struct color_converted_view_type<any_image_view<Views>,DstP>
 {
-    using type = any_image_view<typename detail::views_get_ccv_type<ViewTypes, DstP, default_color_converter>::type>;
+    using type = any_image_view<typename detail::views_get_ccv_type<Views, DstP, default_color_converter>::type>;
 };
 
 /// \ingroup ImageViewTransformationsColorConvert
 /// \brief overload of generic color_converted_view with the default color-converter
-template <typename DstP, typename ViewTypes> inline // Models MPL Random Access Container of models of ImageViewConcept
-typename color_converted_view_type<any_image_view<ViewTypes>, DstP>::type color_converted_view(const any_image_view<ViewTypes>& src) {
-    return apply_operation(src,detail::color_converted_view_fn<DstP,typename color_converted_view_type<any_image_view<ViewTypes>, DstP>::type >());
+/// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
+template <typename DstP, typename Views>
+inline
+auto color_converted_view(any_image_view<Views> const& src)
+    -> typename color_converted_view_type<any_image_view<Views>, DstP>::type
+{
+    using cc_view_t = typename color_converted_view_type<any_image_view<Views>, DstP>::type;
+    return apply_operation(src, detail::color_converted_view_fn<DstP, cc_view_t>());
 }
-
 
 /// \ingroup ImageViewTransformationsColorConvert
 /// \brief overload of generic color_converted_view with user defined color-converter
 ///        These are workarounds for GCC 3.4, which thinks color_converted_view is ambiguous with the same method for templated views (in gil/image_view_factory.hpp)
-template <typename DstP, typename ViewTypes, typename CC> inline // Models MPL Random Access Container of models of ImageViewConcept
-typename color_converted_view_type<any_image_view<ViewTypes>, DstP, CC>::type any_color_converted_view(const any_image_view<ViewTypes>& src, CC) {
-    return apply_operation(src,detail::color_converted_view_fn<DstP,typename color_converted_view_type<any_image_view<ViewTypes>, DstP, CC>::type >());
+/// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
+template <typename DstP, typename Views, typename CC>
+inline
+auto any_color_converted_view(const any_image_view<Views>& src, CC)
+    -> typename color_converted_view_type<any_image_view<Views>, DstP, CC>::type
+{
+    using cc_view_t = typename color_converted_view_type<any_image_view<Views>, DstP, CC>::type;
+    return apply_operation(src, detail::color_converted_view_fn<DstP, cc_view_t>());
 }
 
 /// \ingroup ImageViewTransformationsColorConvert
 /// \brief overload of generic color_converted_view with the default color-converter
 ///        These are workarounds for GCC 3.4, which thinks color_converted_view is ambiguous with the same method for templated views (in gil/image_view_factory.hpp)
-template <typename DstP, typename ViewTypes> inline // Models MPL Random Access Container of models of ImageViewConcept
-typename color_converted_view_type<any_image_view<ViewTypes>, DstP>::type any_color_converted_view(const any_image_view<ViewTypes>& src) {
-    return apply_operation(src,detail::color_converted_view_fn<DstP,typename color_converted_view_type<any_image_view<ViewTypes>, DstP>::type >());
+/// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
+template <typename DstP, typename Views>
+inline
+auto any_color_converted_view(const any_image_view<Views>& src)
+    -> typename color_converted_view_type<any_image_view<Views>, DstP>::type
+{
+    using cc_view_t = typename color_converted_view_type<any_image_view<Views>, DstP>::type;
+    return apply_operation(src, detail::color_converted_view_fn<DstP, cc_view_t>());
 }
 
 /// \}
 
-} }  // namespace boost::gil
+}}  // namespace boost::gil
 
 #endif

--- a/include/boost/gil/extension/dynamic_image/reduce.hpp
+++ b/include/boost/gil/extension/dynamic_image/reduce.hpp
@@ -29,6 +29,8 @@
 #include <boost/mpl/vector_c.hpp>
 #include <boost/mpl/transform.hpp>
 
+#include <type_traits>
+
 // Max number of cases in the cross-expension of binary operation for it to be reduced as unary
 #define GIL_BINARY_REDUCE_LIMIT 226
 
@@ -38,11 +40,11 @@ namespace boost { namespace mpl {
 
 ///////////////////////////////////////////////////////
 /// Mapping vector - represents the mapping of one type vector to another
-///  It is not a full-blown MPL Random Access Type sequence; just has at_c and size implemented
+///  It is not a full-blown Boost.MP11-compatible list; just has at_c and size implemented
 ///
-/// SrcTypes, DstTypes: MPL Random Access Type Sequences
+/// SrcTypes, DstTypes: Boost.MP11-compatible list
 ///
-/// Implements size and at_c to behave as if this is an MPL vector of integers
+/// Implements size and at_c to behave as if this is an Boost.MP11-compatible list of integers
 ///////////////////////////////////////////////////////
 
 template <typename SrcTypes, typename DstTypes>
@@ -51,7 +53,7 @@ struct mapping_vector {};
 template <typename SrcTypes, typename DstTypes, long K>
 struct at_c<mapping_vector<SrcTypes,DstTypes>, K>
 {
-    static const std::size_t value=size<DstTypes>::value - order<DstTypes, typename gil::at_c<SrcTypes,K>::type>::type::value +1;
+    static const std::size_t value=size<DstTypes>::value - order<DstTypes, typename gil::at_c<SrcTypes,K>::type>::value +1;
     using type = size_t<value>;
 };
 
@@ -784,7 +786,7 @@ namespace detail {
     template <typename CC, typename V1, typename V2, bool AreBasic>
     struct reduce_views_basic<copy_and_convert_pixels_fn<CC>, V1, V2, AreBasic>
     {
-        using Same = is_same<typename V1::pixel_t, typename V2::pixel_t>;
+        using Same = std::is_same<typename V1::pixel_t, typename V2::pixel_t>;
 
         using CsR = reduce_color_space<typename V1::color_space_t::base>;
         using Cs1 = typename mpl::if_<Same, typename CsR::type, typename V1::color_space_t>::type;

--- a/include/boost/gil/extension/io/bmp/detail/is_allowed.hpp
+++ b/include/boost/gil/extension/io/bmp/detail/is_allowed.hpp
@@ -11,13 +11,13 @@
 #include <boost/gil/extension/io/bmp/tags.hpp>
 #include <boost/gil/channel.hpp>
 
-#include <boost/mpl/bool_fwd.hpp>
+#include <type_traits>
 
 namespace boost { namespace gil { namespace detail {
 
 template< typename View >
 bool is_allowed( const image_read_info< bmp_tag >& info
-               , mpl::true_   // is read_and_no_convert
+               , std::true_type   // is read_and_no_convert
                )
 {
     bmp_bits_per_pixel::type src_bits_per_pixel = 0;
@@ -73,7 +73,7 @@ bool is_allowed( const image_read_info< bmp_tag >& info
 
 template< typename View >
 bool is_allowed( const image_read_info< bmp_tag >& /* info */
-               , mpl::false_  // is read_and_convert
+               , std::false_type  // is read_and_convert
                )
 {
     return true;

--- a/include/boost/gil/extension/io/bmp/detail/read.hpp
+++ b/include/boost/gil/extension/io/bmp/detail/read.hpp
@@ -21,7 +21,6 @@
 #include <boost/gil/io/typedefs.hpp>
 
 #include <boost/assert.hpp>
-#include <boost/type_traits/is_same.hpp>
 
 #include <type_traits>
 #include <vector>
@@ -99,7 +98,7 @@ public:
             io_error( "Image header was not read." );
         }
 
-        using is_read_and_convert_t = typename is_same
+        using is_read_and_convert_t = typename std::is_same
             <
                 ConversionPolicy,
                 detail::read_and_no_convert

--- a/include/boost/gil/extension/io/bmp/detail/supported_types.hpp
+++ b/include/boost/gil/extension/io/bmp/detail/supported_types.hpp
@@ -16,8 +16,7 @@
 #include <boost/gil/packed_pixel.hpp>
 #include <boost/gil/io/base.hpp>
 
-#include <boost/mpl/not.hpp>
-#include <boost/type_traits/is_same.hpp>
+#include <type_traits>
 
 namespace boost { namespace gil { namespace detail {
 
@@ -106,15 +105,17 @@ struct bmp_write_support<uint8_t
 
 } // namespace detail
 
-
-template< typename Pixel >
-struct is_read_supported< Pixel
-                        , bmp_tag
-                        >
-    : mpl::bool_< detail::bmp_read_support< typename channel_type< Pixel >::type
-                                          , typename color_space_type< Pixel >::type
-                                          >::is_supported
-                >
+template<typename Pixel>
+struct is_read_supported<Pixel, bmp_tag>
+    : std::integral_constant
+    <
+        bool,
+        detail::bmp_read_support
+        <
+            typename channel_type<Pixel>::type,
+            typename color_space_type<Pixel>::type
+        >::is_supported
+    >
 {
     using parent_t = detail::bmp_read_support
         <
@@ -125,14 +126,18 @@ struct is_read_supported< Pixel
     static const typename bmp_bits_per_pixel::type bpp = parent_t::bpp;
 };
 
-template< typename Pixel >
-struct is_write_supported< Pixel
-                         , bmp_tag
-                         >
-    : mpl::bool_< detail::bmp_write_support< typename channel_type< Pixel >::type
-                                           , typename color_space_type< Pixel >::type
-                                           >::is_supported
-                > {};
+template<typename Pixel>
+struct is_write_supported<Pixel, bmp_tag>
+    : std::integral_constant
+    <
+        bool,
+        detail::bmp_write_support
+        <
+            typename channel_type<Pixel>::type,
+            typename color_space_type<Pixel>::type
+        >::is_supported
+    >
+{};
 
 } // namespace gil
 } // namespace boost

--- a/include/boost/gil/extension/io/jpeg/detail/is_allowed.hpp
+++ b/include/boost/gil/extension/io/jpeg/detail/is_allowed.hpp
@@ -10,11 +10,13 @@
 
 #include <boost/gil/extension/io/jpeg/tags.hpp>
 
+#include <type_traits>
+
 namespace boost { namespace gil { namespace detail {
 
 template< typename View >
 bool is_allowed( const image_read_info< jpeg_tag >& info
-               , mpl::true_   // is read_and_no_convert
+               , std::true_type   // is read_and_no_convert
                )
 {
     if( info._color_space == JCS_YCbCr )
@@ -32,7 +34,7 @@ bool is_allowed( const image_read_info< jpeg_tag >& info
 
 template< typename View >
 bool is_allowed( const image_read_info< jpeg_tag >& /* info */
-               , mpl::false_  // is read_and_convert
+               , std::false_type  // is read_and_convert
                )
 {
     return true;

--- a/include/boost/gil/extension/io/jpeg/detail/read.hpp
+++ b/include/boost/gil/extension/io/jpeg/detail/read.hpp
@@ -20,6 +20,7 @@
 #include <boost/gil/io/typedefs.hpp>
 
 #include <csetjmp>
+#include <type_traits>
 #include <vector>
 
 namespace boost { namespace gil {
@@ -99,7 +100,7 @@ public:
 
         this->get()->dct_method = this->_settings._dct_method;
 
-        using is_read_and_convert_t = typename is_same
+        using is_read_and_convert_t = typename std::is_same
             <
                 ConversionPolicy,
                 detail::read_and_no_convert

--- a/include/boost/gil/extension/io/jpeg/detail/supported_types.hpp
+++ b/include/boost/gil/extension/io/jpeg/detail/supported_types.hpp
@@ -13,8 +13,7 @@
 #include <boost/gil/channel.hpp>
 #include <boost/gil/color_base.hpp>
 
-#include <boost/mpl/bool_fwd.hpp>
-#include <boost/type_traits/is_same.hpp>
+#include <type_traits>
 
 namespace boost { namespace gil { namespace detail {
 
@@ -78,14 +77,17 @@ struct jpeg_write_support<uint8_t
 
 } // namespace detail
 
-template< typename Pixel >
-struct is_read_supported< Pixel
-                        , jpeg_tag
-                        >
-    : mpl::bool_< detail::jpeg_read_support< typename channel_type< Pixel >::type
-                                           , typename color_space_type< Pixel >::type
-                                           >::is_supported
-                >
+template<typename Pixel>
+struct is_read_supported<Pixel, jpeg_tag>
+    : std::integral_constant
+    <
+        bool,
+        detail::jpeg_read_support
+        <
+            typename channel_type<Pixel>::type,
+            typename color_space_type<Pixel>::type
+        >::is_supported
+    >
 {
     using parent_t = detail::jpeg_read_support
         <
@@ -96,14 +98,17 @@ struct is_read_supported< Pixel
     static const typename jpeg_color_space::type _color_space = parent_t::_color_space;
 };
 
-template< typename Pixel >
-struct is_write_supported< Pixel
-                         , jpeg_tag
-                         >
-    : mpl::bool_< detail::jpeg_write_support< typename channel_type< Pixel >::type
-                                            , typename color_space_type< Pixel >::type
-                                            >::is_supported
-                >
+template<typename Pixel>
+struct is_write_supported<Pixel, jpeg_tag>
+    : std::integral_constant
+    <
+        bool,
+        detail::jpeg_write_support
+        <
+            typename channel_type<Pixel>::type,
+            typename color_space_type<Pixel>::type
+        >::is_supported
+    >
 {};
 
 } // namespace gil

--- a/include/boost/gil/extension/io/png/detail/is_allowed.hpp
+++ b/include/boost/gil/extension/io/png/detail/is_allowed.hpp
@@ -10,14 +10,13 @@
 
 #include <boost/gil/extension/io/png/tags.hpp>
 
-#include <boost/mpl/bool_fwd.hpp>
-#include <boost/mpl/for_each.hpp>
+#include <type_traits>
 
 namespace boost { namespace gil { namespace detail {
 
 template< typename View >
 bool is_allowed( const image_read_info< png_tag >& info
-               , mpl::true_   // is read_and_no_convert
+               , std::true_type   // is read_and_no_convert
                )
 {
     using pixel_t = typename get_pixel_type<View>::type;
@@ -33,7 +32,7 @@ bool is_allowed( const image_read_info< png_tag >& info
 
 template< typename View >
 bool is_allowed( const image_read_info< png_tag >& /* info */
-               , mpl::false_  // is read_and_convert
+               , std::false_type  // is read_and_convert
                )
 {
     return true;

--- a/include/boost/gil/extension/io/png/detail/read.hpp
+++ b/include/boost/gil/extension/io/png/detail/read.hpp
@@ -21,6 +21,8 @@
 #include <boost/gil/io/row_buffer_helper.hpp>
 #include <boost/gil/io/typedefs.hpp>
 
+#include <type_traits>
+
 namespace boost { namespace gil {
 
 #if BOOST_WORKAROUND(BOOST_MSVC, >= 1400)
@@ -232,7 +234,7 @@ private:
 
         using it_t = typename row_buffer_helper_t::iterator_t;
 
-        using is_read_and_convert_t = typename is_same
+        using is_read_and_convert_t = typename std::is_same
             <
                 ConversionPolicy,
                 detail::read_and_no_convert

--- a/include/boost/gil/extension/io/png/detail/supported_types.hpp
+++ b/include/boost/gil/extension/io/png/detail/supported_types.hpp
@@ -15,6 +15,7 @@
 #endif // BOOST_GIL_IO_ENABLE_GRAY_ALPHA
 
 #include <cstddef>
+#include <type_traits>
 
 namespace boost { namespace gil { namespace detail {
 
@@ -318,14 +319,17 @@ struct png_write_support<uint16_t
 
 } // namespace detail
 
-template< typename Pixel >
-struct is_read_supported< Pixel
-                        , png_tag
-                        >
-    : mpl::bool_< detail::png_read_support< typename channel_type< Pixel >::type
-                                          , typename color_space_type< Pixel >::type
-                                          >::is_supported
-                >
+template<typename Pixel>
+struct is_read_supported<Pixel, png_tag>
+    : std::integral_constant
+    <
+        bool,
+        detail::png_read_support
+        <
+            typename channel_type<Pixel>::type,
+            typename color_space_type<Pixel>::type
+        >::is_supported
+    >
 {
     using parent_t = detail::png_read_support
         <
@@ -337,14 +341,17 @@ struct is_read_supported< Pixel
     static const png_color_type::type _color_type = parent_t::_color_type;
 };
 
-template< typename Pixel >
-struct is_write_supported< Pixel
-                         , png_tag
-                         >
-    : mpl::bool_< detail::png_write_support< typename channel_type< Pixel >::type
-                                           , typename color_space_type< Pixel >::type
-                                           >::is_supported
-                >
+template<typename Pixel>
+struct is_write_supported<Pixel, png_tag>
+    : std::integral_constant
+    <
+        bool,
+        detail::png_write_support
+        <
+            typename channel_type<Pixel>::type,
+            typename color_space_type<Pixel>::type
+        >::is_supported
+    >
 {
     using parent_t = detail::png_write_support
         <

--- a/include/boost/gil/extension/io/png/detail/write.hpp
+++ b/include/boost/gil/extension/io/png/detail/write.hpp
@@ -13,11 +13,7 @@
 #include <boost/gil/io/device.hpp>
 #include <boost/gil/io/dynamic_io_new.hpp>
 #include <boost/gil/io/row_buffer_helper.hpp>
-
-#include <boost/mpl/and.hpp>
-#include <boost/mpl/equal_to.hpp>
-#include <boost/mpl/less.hpp>
-#include <boost/mpl/not.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <type_traits>
 
@@ -85,7 +81,7 @@ private:
 
     template<typename View>
     void write_view( const View& view
-                   ,  mpl::false_       // is bit aligned
+                   ,  std::false_type       // is bit aligned
                    )
     {
         using pixel_t = typename get_pixel_type<View>::type;
@@ -125,7 +121,7 @@ private:
 
     template<typename View>
     void write_view( const View& view
-                   , mpl::true_         // is bit aligned
+                   , std::true_type         // is bit aligned
                    )
     {
         using png_rw_info = detail::png_write_support
@@ -166,8 +162,21 @@ private:
                      );
     }
 
-    template< typename Info > struct is_less_than_eight : mpl::less< mpl::int_< Info::_bit_depth >, mpl::int_< 8 > > {};
-    template< typename Info > struct is_equal_to_sixteen : mpl::equal_to< mpl::int_< Info::_bit_depth >, mpl::int_< 16 > > {};
+    template<typename Info>
+    struct is_less_than_eight : mp11::mp_less
+        <
+            std::integral_constant<int, Info::_bit_depth>,
+            std::integral_constant<int, 8>
+        >
+    {};
+
+    template<typename Info>
+    struct is_equal_to_sixteen : mp11::mp_less
+        <
+            std::integral_constant<int, Info::_bit_depth>,
+            std::integral_constant<int, 16>
+        >
+    {};
 
     template <typename Info>
     void set_swap(typename std::enable_if<is_less_than_eight<Info>::value>::type* /*ptr*/ = 0)
@@ -185,10 +194,10 @@ private:
     void set_swap(
         typename std::enable_if
         <
-            mpl::and_
+            mp11::mp_and
             <
-                mpl::not_<is_less_than_eight<Info>>,
-                mpl::not_<is_equal_to_sixteen<Info>>
+                mp11::mp_not<is_less_than_eight<Info>>,
+                mp11::mp_not<is_equal_to_sixteen<Info>>
             >::value
         >::type* /*ptr*/ = nullptr)
     {

--- a/include/boost/gil/extension/io/pnm/detail/is_allowed.hpp
+++ b/include/boost/gil/extension/io/pnm/detail/is_allowed.hpp
@@ -10,11 +10,13 @@
 
 #include <boost/gil/extension/io/pnm/tags.hpp>
 
+#include <type_traits>
+
 namespace boost { namespace gil { namespace detail {
 
 template< typename View >
 bool is_allowed( const image_read_info< pnm_tag >& info
-               , mpl::true_   // is read_and_no_convert
+               , std::true_type   // is read_and_no_convert
                )
 {
     pnm_image_type::type asc_type = is_read_supported< typename get_pixel_type< View >::type
@@ -38,7 +40,7 @@ bool is_allowed( const image_read_info< pnm_tag >& info
 
 template< typename View >
 bool is_allowed( const image_read_info< pnm_tag >& /* info */
-               , mpl::false_  // is read_and_convert
+               , std::false_type  // is read_and_convert
                )
 {
     return true;

--- a/include/boost/gil/extension/io/pnm/detail/read.hpp
+++ b/include/boost/gil/extension/io/pnm/detail/read.hpp
@@ -85,7 +85,7 @@ public:
     template<typename View>
     void apply( const View& view )
     {
-        using is_read_and_convert_t = typename is_same
+        using is_read_and_convert_t = typename std::is_same
             <
                 ConversionPolicy,
                 detail::read_and_no_convert
@@ -237,7 +237,7 @@ private:
                      , View_Src >( dst
                                  , src
                                  , y
-                                 , typename is_same< View_Dst
+                                 , typename std::is_same< View_Dst
                                                    , gray1_image_t::view_t
                                                    >::type()
                                  );
@@ -250,7 +250,7 @@ private:
     void copy_data( const View_Dst&              dst
                   , const View_Src&              src
                   , typename View_Dst::y_coord_t y
-                  , mpl::true_ // is gray1_view
+                  , std::true_type // is gray1_view
                   )
     {
         if(  this->_info._max_value == 1 )
@@ -267,11 +267,7 @@ private:
         }
         else
         {
-            copy_data( dst
-                     , src
-                     , y
-                     , mpl::false_()
-                     );
+            copy_data(dst, src, y, std::false_type{});
         }
     }
 
@@ -281,7 +277,7 @@ private:
     void copy_data( const View_Dst&              view
                   , const View_Src&              src
                   , typename View_Dst::y_coord_t y
-                  , mpl::false_ // is gray1_view
+                  , std::false_type // is gray1_view
                   )
     {
         typename View_Src::x_iterator beg = src.row_begin( 0 ) + this->_settings._top_left.x;

--- a/include/boost/gil/extension/io/pnm/detail/supported_types.hpp
+++ b/include/boost/gil/extension/io/pnm/detail/supported_types.hpp
@@ -14,8 +14,7 @@
 #include <boost/gil/color_base.hpp>
 #include <boost/gil/io/base.hpp>
 
-#include <boost/mpl/not.hpp>
-#include <boost/type_traits/is_same.hpp>
+#include <type_traits>
 
 namespace boost { namespace gil { namespace detail {
 
@@ -105,14 +104,17 @@ struct pnm_write_support<uint8_t
 
 } // namespace detail
 
-template< typename Pixel >
-struct is_read_supported< Pixel
-                        , pnm_tag
-                        >
-    : mpl::bool_< detail::pnm_read_support< typename channel_type    < Pixel >::type
-                                          , typename color_space_type< Pixel >::type
-                                          >::is_supported
-                >
+template<typename Pixel>
+struct is_read_supported<Pixel, pnm_tag>
+    : std::integral_constant
+    <
+        bool,
+        detail::pnm_read_support
+        <
+            typename channel_type<Pixel>::type,
+            typename color_space_type<Pixel>::type
+        >::is_supported
+    >
 {
     using parent_t = detail::pnm_read_support
         <
@@ -124,14 +126,18 @@ struct is_read_supported< Pixel
     static const pnm_image_type::type _bin_type = parent_t::_bin_type;
 };
 
-template< typename Pixel >
-struct is_write_supported< Pixel
-                         , pnm_tag
-                         >
-    : mpl::bool_< detail::pnm_write_support< typename channel_type    < Pixel >::type
-                                           , typename color_space_type< Pixel >::type
-                                           >::is_supported
-                > {};
+template<typename Pixel>
+struct is_write_supported<Pixel, pnm_tag>
+    : std::integral_constant
+    <
+        bool,
+        detail::pnm_write_support
+        <
+            typename channel_type<Pixel>::type,
+            typename color_space_type<Pixel>::type
+        >::is_supported
+    >
+{};
 
 } // namespace gil
 } // namespace boost

--- a/include/boost/gil/extension/io/pnm/detail/write.hpp
+++ b/include/boost/gil/extension/io/pnm/detail/write.hpp
@@ -15,9 +15,11 @@
 #include <boost/gil/io/bit_operations.hpp>
 #include <boost/gil/io/device.hpp>
 #include <boost/gil/io/dynamic_io_new.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <cstdlib>
 #include <string>
+#include <type_traits>
 
 namespace boost { namespace gil {
 
@@ -108,30 +110,34 @@ public:
 private:
 
     template< int Channels >
-    unsigned int get_type( mpl::true_  /* is_bit_aligned */ )
+    unsigned int get_type( std::true_type  /* is_bit_aligned */ )
     {
-        return boost::mpl::if_c< Channels == 1
-                               , pnm_image_type::mono_bin_t
-                               , pnm_image_type::color_bin_t
-                               >::type::value;
+        return mp11::mp_if_c
+            <
+                Channels == 1,
+                pnm_image_type::mono_bin_t,
+                pnm_image_type::color_bin_t
+            >::value;
     }
 
     template< int Channels >
-    unsigned int get_type( mpl::false_ /* is_bit_aligned */ )
+    unsigned int get_type( std::false_type /* is_bit_aligned */ )
     {
-        return boost::mpl::if_c< Channels == 1
-                               , pnm_image_type::gray_bin_t
-                               , pnm_image_type::color_bin_t
-                               >::type::value;
+        return mp11::mp_if_c
+            <
+                Channels == 1,
+                pnm_image_type::gray_bin_t,
+                pnm_image_type::color_bin_t
+            >::value;
     }
 
     template< typename View >
     void write_data( const View&   src
                    , std::size_t   pitch
-                   , const mpl::true_&    // bit_aligned
+                   , const std::true_type&    // bit_aligned
                    )
     {
-        static_assert(is_same<View, typename gray1_image_t::view_t>::value, "");
+        static_assert(std::is_same<View, typename gray1_image_t::view_t>::value, "");
 
         byte_vector_t row( pitch / 8 );
 
@@ -154,7 +160,7 @@ private:
     template< typename View >
     void write_data( const View&   src
                    , std::size_t   pitch
-                   , const mpl::false_&    // bit_aligned
+                   , const std::false_type&    // bit_aligned
                    )
     {
         std::vector< pixel< typename channel_type< View >::type

--- a/include/boost/gil/extension/io/pnm/tags.hpp
+++ b/include/boost/gil/extension/io/pnm/tags.hpp
@@ -12,7 +12,7 @@
 
 #include <boost/gil/io/base.hpp>
 
-#include <boost/mpl/integral_c.hpp>
+#include <type_traits>
 
 namespace boost { namespace gil {
 
@@ -24,13 +24,13 @@ struct pnm_tag : format_tag {};
 /// Defines type for image type property.
 struct pnm_image_type : property_base< uint32_t >
 {
-    using mono_asc_t = boost::mpl::integral_c<type, 1>;
-    using gray_asc_t = boost::mpl::integral_c<type, 2>;
-    using color_asc_t = boost::mpl::integral_c<type, 3>;
+    using mono_asc_t = std::integral_constant<type, 1>;
+    using gray_asc_t = std::integral_constant<type, 2>;
+    using color_asc_t = std::integral_constant<type, 3>;
 
-    using mono_bin_t = boost::mpl::integral_c<type, 4>;
-    using gray_bin_t = boost::mpl::integral_c<type, 5>;
-    using color_bin_t = boost::mpl::integral_c<type, 6>;
+    using mono_bin_t = std::integral_constant<type, 4>;
+    using gray_bin_t = std::integral_constant<type, 5>;
+    using color_bin_t = std::integral_constant<type, 6>;
 };
 
 /// Defines type for image width property.

--- a/include/boost/gil/extension/io/raw/detail/device.hpp
+++ b/include/boost/gil/extension/io/raw/detail/device.hpp
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <string>
+#include <type_traits>
 
 namespace boost { namespace gil { namespace detail {
 
@@ -117,11 +118,7 @@ public:
 };
 
 template< typename FormatTag >
-struct is_adaptable_input_device< FormatTag
-                                , LibRaw
-                                , void
-                                >
-    : mpl::true_
+struct is_adaptable_input_device<FormatTag, LibRaw, void> : std::true_type
 {
     using device_type = file_stream_device<FormatTag>;
 };

--- a/include/boost/gil/extension/io/raw/detail/is_allowed.hpp
+++ b/include/boost/gil/extension/io/raw/detail/is_allowed.hpp
@@ -11,29 +11,31 @@
 #include <boost/gil/extension/io/raw/tags.hpp>
 #include <boost/gil/io/base.hpp>
 
+#include <type_traits>
+
 namespace boost { namespace gil { namespace detail {
 
 template< typename View >
 bool is_allowed( const image_read_info< raw_tag >& info
-               , mpl::true_   // is read_and_no_convert
+               , std::true_type   // is read_and_no_convert
                )
 {
     using pixel_t = typename get_pixel_type<View>::type;
     using num_channel_t = typename num_channels<pixel_t>::value_type;
     using channel_t = typename channel_traits<typename element_type<typename View::value_type>::type>::value_type;
 
-    const num_channel_t dst_samples_per_pixel = num_channels< pixel_t >::value;
-    const unsigned int  dst_bits_per_pixel    = detail::unsigned_integral_num_bits< channel_t >::value;
-    const bool          is_type_signed        = boost::is_signed< channel_t >::value;
+    constexpr num_channel_t dst_samples_per_pixel = num_channels<pixel_t>::value;
+    constexpr unsigned int dst_bits_per_pixel = detail::unsigned_integral_num_bits<channel_t>::value;
+    constexpr bool is_type_signed = std::is_signed<channel_t>::value;
 
-    return( dst_samples_per_pixel == info._samples_per_pixel &&
-            dst_bits_per_pixel    == static_cast<unsigned int>(info._bits_per_pixel) &&
-            !is_type_signed );
+    return (dst_samples_per_pixel == info._samples_per_pixel &&
+            dst_bits_per_pixel == static_cast<unsigned int>(info._bits_per_pixel) &&
+            !is_type_signed);
 }
 
 template< typename View >
 bool is_allowed( const image_read_info< raw_tag >& /* info */
-               , mpl::false_  // is read_and_convert
+               , std::false_type  // is read_and_convert
                )
 {
     return true;

--- a/include/boost/gil/extension/io/raw/detail/read.hpp
+++ b/include/boost/gil/extension/io/raw/detail/read.hpp
@@ -24,6 +24,7 @@
 
 #include <cstdio>
 #include <sstream>
+#include <type_traits>
 #include <vector>
 
 namespace boost { namespace gil {
@@ -100,7 +101,7 @@ public:
             io_error( "Image header was not read." );
         }
 
-        using is_read_and_convert_t = typename is_same
+        using is_read_and_convert_t = typename std::is_same
             <
                 ConversionPolicy,
                 detail::read_and_no_convert
@@ -165,10 +166,7 @@ struct raw_type_format_checker
     bool apply()
     {
         using view_t = typename Image::view_t;
-
-        return is_allowed< view_t >( _info
-                                   , mpl::true_()
-                                   );
+        return is_allowed<view_t>(_info, std::true_type{});
     }
 
 private:

--- a/include/boost/gil/extension/io/raw/detail/supported_types.hpp
+++ b/include/boost/gil/extension/io/raw/detail/supported_types.hpp
@@ -14,8 +14,7 @@
 #include <boost/gil/color_base.hpp>
 #include <boost/gil/io/base.hpp>
 
-#include <boost/mpl/not.hpp>
-#include <boost/type_traits/is_same.hpp>
+#include <type_traits>
 
 namespace boost { namespace gil { namespace detail {
 
@@ -52,23 +51,24 @@ struct raw_write_support : write_support_false {};
 
 } // namespace detail
 
-template< typename Pixel >
-struct is_read_supported< Pixel,
-                        raw_tag
-                        >
-    : mpl::bool_< detail::raw_read_support< typename channel_type< Pixel >::type
-                                          , typename color_space_type< Pixel >::type
-                                          >::is_supported > {};
-
-template< typename Pixel >
-struct is_write_supported< Pixel
-                         , raw_tag
-                         >
-    : mpl::bool_< detail::raw_write_support::is_supported >
+template<typename Pixel>
+struct is_read_supported<Pixel,raw_tag>
+    : std::integral_constant
+        <
+            bool,
+            detail::raw_read_support
+            <
+                typename channel_type<Pixel>::type,
+                typename color_space_type<Pixel>::type
+            >::is_supported
+        >
 {};
 
-} // namespace gil
-} // namespace boost
+template<typename Pixel>
+struct is_write_supported<Pixel, raw_tag>
+    : std::integral_constant<bool, detail::raw_write_support::is_supported>
+{};
 
+}} // namespace boost::gil
 
 #endif

--- a/include/boost/gil/extension/io/targa/detail/is_allowed.hpp
+++ b/include/boost/gil/extension/io/targa/detail/is_allowed.hpp
@@ -10,11 +10,13 @@
 
 #include <boost/gil/extension/io/targa/tags.hpp>
 
+#include <type_traits>
+
 namespace boost { namespace gil { namespace detail {
 
 template< typename View >
 bool is_allowed( const image_read_info< targa_tag >& info
-               , mpl::true_   // is read_and_no_convert
+               , std::true_type   // is read_and_no_convert
                )
 {
     targa_depth::type src_bits_per_pixel = 0;
@@ -42,7 +44,7 @@ bool is_allowed( const image_read_info< targa_tag >& info
 
 template< typename View >
 bool is_allowed( const image_read_info< targa_tag >& /* info */
-               , mpl::false_  // is read_and_convert
+               , std::false_type  // is read_and_convert
                )
 {
     return true;

--- a/include/boost/gil/extension/io/targa/detail/read.hpp
+++ b/include/boost/gil/extension/io/targa/detail/read.hpp
@@ -21,6 +21,7 @@
 #include <boost/gil/io/row_buffer_helper.hpp>
 #include <boost/gil/io/typedefs.hpp>
 
+#include <type_traits>
 #include <vector>
 
 namespace boost { namespace gil {
@@ -82,7 +83,7 @@ public:
     template< typename View >
     void apply( const View& dst_view )
     {
-        using is_read_and_convert_t = typename is_same
+        using is_read_and_convert_t = typename std::is_same
             <
                 ConversionPolicy,
                 detail::read_and_no_convert

--- a/include/boost/gil/extension/io/targa/detail/supported_types.hpp
+++ b/include/boost/gil/extension/io/targa/detail/supported_types.hpp
@@ -14,8 +14,7 @@
 #include <boost/gil/color_base.hpp>
 #include <boost/gil/io/base.hpp>
 
-#include <boost/mpl/not.hpp>
-#include <boost/type_traits/is_same.hpp>
+#include <type_traits>
 
 namespace boost { namespace gil { namespace detail {
 
@@ -67,15 +66,17 @@ struct targa_write_support<uint8_t
 
 } // namespace detail
 
-
-template< typename Pixel >
-struct is_read_supported< Pixel
-                        , targa_tag
-                        >
-    : mpl::bool_< detail::targa_read_support< typename channel_type< Pixel >::type
-                                            , typename color_space_type< Pixel >::type
-                                            >::is_supported
-                >
+template<typename Pixel>
+struct is_read_supported<Pixel, targa_tag>
+    : std::integral_constant
+        <
+            bool,
+            detail::targa_read_support
+            <
+                typename channel_type<Pixel>::type,
+                typename color_space_type<Pixel>::type
+            >::is_supported
+        >
 {
     using parent_t = detail::targa_read_support
         <
@@ -86,17 +87,19 @@ struct is_read_supported< Pixel
     static const typename targa_depth::type bpp = parent_t::bpp;
 };
 
-template< typename Pixel >
-struct is_write_supported< Pixel
-                         , targa_tag
-                         >
-    : mpl::bool_< detail::targa_write_support< typename channel_type< Pixel >::type
-                                             , typename color_space_type< Pixel >::type
-                                             >::is_supported
-                > {};
+template<typename Pixel>
+struct is_write_supported<Pixel, targa_tag>
+    : std::integral_constant
+        <
+            bool,
+            detail::targa_write_support
+            <
+                typename channel_type<Pixel>::type,
+                typename color_space_type<Pixel>::type
+            >::is_supported
+        >
+{};
 
-} // namespace gil
-} // namespace boost
-
+}} // namespace boost::gil
 
 #endif

--- a/include/boost/gil/extension/io/tiff/detail/is_allowed.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/is_allowed.hpp
@@ -9,9 +9,9 @@
 #define BOOST_GIL_EXTENSION_IO_TIFF_DETAIL_IS_ALLOWED_HPP
 
 #include <boost/gil/extension/io/tiff/tags.hpp>
+#include <boost/gil/extension/toolbox/metafunctions/is_bit_aligned.hpp>
+#include <boost/gil/detail/mp11.hpp>
 #include <boost/gil/io/base.hpp>
-
-#include <boost/mpl/for_each.hpp>
 
 #include <type_traits>
 
@@ -48,13 +48,13 @@ struct Format_Type
     Channel,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
-            mpl::not_
+            mp11::mp_not
             <
                 typename is_bit_aligned<typename get_pixel_type<View>::type>::type
             >,
-            is_unsigned<Channel>
+            std::is_unsigned<Channel>
         >::value
     >::type
 >
@@ -70,13 +70,13 @@ struct Format_Type
     Channel,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
-            mpl::not_
+            mp11::mp_not
             <
                 typename is_bit_aligned<typename get_pixel_type<View>::type>::type
             >,
-            is_signed<Channel>
+            std::is_signed<Channel>
         >::value
     >::type
 >
@@ -92,9 +92,9 @@ struct Format_Type
     Channel,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
-            mpl::not_
+            mp11::mp_not
             <
                 typename is_bit_aligned<typename get_pixel_type<View>::type>::type
             >,
@@ -107,13 +107,13 @@ struct Format_Type
 };
 
 //template< typename Channel >
-//int format_value( mpl::true_ ) // is_bit_aligned
+//int format_value( std::true_type ) // is_bit_aligned
 //{
 //    return SAMPLEFORMAT_UINT;
 //}
 //
 //template< typename Channel >
-//int format_value( mpl::false_ ) // is_bit_aligned
+//int format_value( std::false_type ) // is_bit_aligned
 //{
 //    if( is_unsigned< Channel >::value )
 //    {
@@ -137,8 +137,8 @@ struct Format_Type
 // a pixel_t as template parameter whereas the other is using reference_t.
 template< typename View >
 bool compare_channel_sizes( const channel_sizes_t& channel_sizes // in bits
-                          , mpl::false_                          // is_bit_aligned
-                          , mpl::true_                           // is_homogeneous
+                          , std::false_type                      // is_bit_aligned
+                          , std::true_type                       // is_homogeneous
                           )
 {
     using pixel_t = typename View::value_type;
@@ -152,8 +152,8 @@ bool compare_channel_sizes( const channel_sizes_t& channel_sizes // in bits
 
 template< typename View >
 bool compare_channel_sizes( const channel_sizes_t& channel_sizes // in bits
-                          , mpl::true_                           // is_bit_aligned
-                          , mpl::true_                           // is_homogeneous
+                          , std::true_type                       // is_bit_aligned
+                          , std::true_type                       // is_homogeneous
                           )
 {
     using ref_t = typename View::reference;
@@ -197,8 +197,8 @@ struct channel_sizes_type< const bit_aligned_pixel_reference< B, C, L, M > > { u
 
 template< typename View >
 bool compare_channel_sizes( channel_sizes_t& channel_sizes // in bits
-                          , mpl::true_                     // is_bit_aligned
-                          , mpl::false_                    // is_homogeneous
+                          , std::true_type                 // is_bit_aligned
+                          , std::false_type                // is_homogeneous
                           )
 {
     // loop through all channels and compare
@@ -207,14 +207,14 @@ bool compare_channel_sizes( channel_sizes_t& channel_sizes // in bits
     using cs_t = typename channel_sizes_type<ref_t>::type;
 
     compare_channel_sizes_fn fn( &channel_sizes.front() );
-    mpl::for_each< cs_t >( fn );
+    mp11::mp_for_each<cs_t>(fn);
 
     return fn._b;
 }
 
 template< typename View >
 bool is_allowed( const image_read_info< tiff_tag >& info
-               , mpl::true_ // is read_and_no_convert
+               , std::true_type // is read_and_no_convert
                )
 {
     channel_sizes_t channel_sizes( info._samples_per_pixel
@@ -243,7 +243,7 @@ bool is_allowed( const image_read_info< tiff_tag >& info
 
 template< typename View >
 bool is_allowed( const image_read_info< tiff_tag >& /* info */
-               , mpl::false_ // is read_and_no_convert
+               , std::false_type // is read_and_no_convert
                )
 {
     return true;

--- a/include/boost/gil/extension/io/tiff/detail/read.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/read.hpp
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 // taken from jpegxx - https://bitbucket.org/edd/jpegxx/src/ea2492a1a4a6/src/ijg_headers.hpp
@@ -173,7 +174,7 @@ public:
             // the tiff type need to compatible. Which means:
             // color_spaces_are_compatible && channels_are_pairwise_compatible
 
-            using is_read_only = typename is_same
+            using is_read_only = typename std::is_same
                 <
                     ConversionPolicy,
                     detail::read_and_no_convert
@@ -208,7 +209,7 @@ private:
 
     template< typename View >
     void read( View v
-             , mpl::true_ // is_read_only
+             , std::true_type // is_read_only
              )
     {
         read_data< detail::row_buffer_helper_view< View > >( v, 0 );
@@ -216,7 +217,7 @@ private:
 
     template< typename View >
     void read( View v
-             , mpl::false_  // is_read_only
+             , std::false_type  // is_read_only
              )
     {
         // the read_data function needs to know what gil type the source image is
@@ -302,11 +303,13 @@ private:
                           , this->_info._height - this->_settings._top_left.y );
 
       // read the palette first
-      read_data< detail::row_buffer_helper_view< typename PaletteImage::view_t > >( view( indices ), 0 );
+      read_data< detail::row_buffer_helper_view
+          <
+            typename PaletteImage::view_t>
+        >(view(indices), 0);
 
-      read_palette_image( dst_view
-                        , view( indices )
-                        , typename is_same< View, rgb16_view_t >::type() );
+      read_palette_image(dst_view, view(indices),
+          typename std::is_same<View, rgb16_view_t>::type());
    }
 
    template< typename View
@@ -314,7 +317,7 @@ private:
            >
    void read_palette_image( const View&         dst_view
                           , const Indices_View& indices_view
-                          , mpl::true_   // is View rgb16_view_t
+                          , std::true_type   // is View rgb16_view_t
                           )
    {
       tiff_color_map::red_t   red   = nullptr;
@@ -356,7 +359,7 @@ private:
    inline
    void read_palette_image( const View&         /* dst_view     */
                           , const Indices_View& /* indices_view */
-                          , mpl::false_  // is View rgb16_view_t
+                          , std::false_type  // is View rgb16_view_t
                           )
    {
       io_error( "User supplied image type must be rgb16_image_t." );
@@ -653,7 +656,7 @@ private:
 
     template< typename Pixel >
     std::size_t buffer_size( std::size_t width
-                           , mpl::false_ // is_bit_aligned
+                           , std::false_type // is_bit_aligned
                            )
     {
         std::size_t scanline_size_in_bytes = this->_io_dev.get_scanline_size();
@@ -669,7 +672,7 @@ private:
 
     template< typename Pixel >
     std::size_t buffer_size( std::size_t /* width */
-                            , mpl::true_  // is_bit_aligned
+                            , std::true_type  // is_bit_aligned
                             )
     {
         return this->_io_dev.get_scanline_size();
@@ -694,7 +697,7 @@ struct tiff_type_format_checker
         using view_t = typename Image::view_t;
 
         return is_allowed< view_t >( _info
-                                   , mpl::true_()
+                                   , std::true_type()
                                    );
     }
 

--- a/include/boost/gil/extension/io/tiff/detail/supported_types.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/supported_types.hpp
@@ -14,8 +14,7 @@
 #include <boost/gil/color_base.hpp>
 #include <boost/gil/io/base.hpp>
 
-#include <boost/mpl/not.hpp>
-#include <boost/type_traits/is_same.hpp>
+#include <type_traits>
 
 namespace boost{ namespace gil {
 
@@ -35,20 +34,16 @@ struct tiff_write_support : write_support_true
 
 } // namespace detail
 
-template< typename Pixel >
-struct is_read_supported< Pixel
-                        , tiff_tag
-                        >
-    : mpl::bool_< detail::tiff_read_support::is_supported > {};
-
-template< typename Pixel >
-struct is_write_supported< Pixel
-                         , tiff_tag
-                         >
-    : mpl::bool_< detail::tiff_write_support::is_supported >
+template<typename Pixel>
+struct is_read_supported<Pixel, tiff_tag>
+    : std::integral_constant<bool, detail::tiff_read_support::is_supported>
 {};
 
-} // namespace gil
-} // namespace boost
+template<typename Pixel>
+struct is_write_supported<Pixel, tiff_tag>
+    : std::integral_constant<bool, detail::tiff_write_support::is_supported>
+{};
+
+}} // namespace boost::gil
 
 #endif

--- a/include/boost/gil/extension/io/tiff/detail/write.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/write.hpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 extern "C" {
@@ -39,7 +40,8 @@ template <typename PixelReference>
 struct my_interleaved_pixel_iterator_type_from_pixel_reference
 {
 private:
-    using pixel_t = typename remove_reference<PixelReference>::type::value_type;
+    using pixel_t = typename std::remove_reference<PixelReference>::type::value_type;
+
 public:
     using type = typename iterator_type_from_pixel
         <
@@ -162,7 +164,7 @@ private:
 	template<typename View>
 	void write_bit_aligned_view_to_dev( const View&       view
                                       , const std::size_t row_size_in_bytes
-                                      , const mpl::true_&    // has_alpha
+                                      , const std::true_type&    // has_alpha
                                       )
     {
         byte_vector_t row( row_size_in_bytes );
@@ -192,7 +194,7 @@ private:
 	template<typename View>
 	void write_bit_aligned_view_to_dev( const View&       view
                                       , const std::size_t row_size_in_bytes
-                                      , const mpl::false_&    // has_alpha
+                                      , const std::false_type&    // has_alpha
                                       )
     {
         byte_vector_t row( row_size_in_bytes );
@@ -222,11 +224,11 @@ private:
     template< typename View >
     void write_data( const View&   view
                    , std::size_t   row_size_in_bytes
-                   , const mpl::true_&    // bit_aligned
+                   , const std::true_type&    // bit_aligned
                    )
     {
         using colour_space_t = typename color_space_type<typename View::value_type>::type;
-        using has_alpha_t = mpl::bool_<mpl::contains<colour_space_t, alpha_t>::value>;
+        using has_alpha_t = mp11::mp_contains<colour_space_t, alpha_t>;
 
         write_bit_aligned_view_to_dev(view, row_size_in_bytes, has_alpha_t());
     }
@@ -235,7 +237,7 @@ private:
     void write_tiled_data( const View&            view
                          , tiff_tile_width::type  tw
                          , tiff_tile_length::type th
-                         , const mpl::true_&    // bit_aligned
+                         , const std::true_type&    // bit_aligned
                          )
     {
         byte_vector_t row( this->_io_dev.get_tile_size() );
@@ -249,7 +251,7 @@ private:
     template< typename View >
     void write_data( const View&   view
                    , std::size_t
-                   , const mpl::false_&    // bit_aligned
+                   , const std::false_type&    // bit_aligned
                    )
     {
         std::vector< pixel< typename channel_type< View >::type
@@ -283,7 +285,7 @@ private:
     void write_tiled_data( const View&            view
                          , tiff_tile_width::type  tw
                          , tiff_tile_length::type th
-                         , const mpl::false_&    // bit_aligned
+                         , const std::false_type&    // bit_aligned
                          )
     {
         byte_vector_t row( this->_io_dev.get_tile_size() );
@@ -302,7 +304,7 @@ private:
             >
 	void write_tiled_view_to_dev( const View&  view
                                 , IteratorType it
-                                , const mpl::true_& // has_alpha
+                                , const std::true_type& // has_alpha
                                 )
     {
         auto pm_view = premultiply_view <typename View:: value_type>( view );
@@ -319,7 +321,7 @@ private:
             >
 	void write_tiled_view_to_dev( const View&  view
                                 , IteratorType it
-                                , const mpl::false_& // has_alpha
+                                , const std::false_type& // has_alpha
                                 )
     {
         std::copy( view.begin()
@@ -359,7 +361,7 @@ private:
                                                       );
 
                     using colour_space_t = typename color_space_type<typename View::value_type>::type;
-                    using has_alpha_t = mpl::bool_<mpl::contains<colour_space_t, alpha_t>::value>;
+                    using has_alpha_t = mp11::mp_contains<colour_space_t, alpha_t>;
 
                     write_tiled_view_to_dev(tile_subimage_view, it, has_alpha_t());
                 }

--- a/include/boost/gil/extension/io/tiff/detail/writer_backend.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/writer_backend.hpp
@@ -11,7 +11,7 @@
 #include <boost/gil/extension/io/tiff/tags.hpp>
 #include <boost/gil/extension/io/tiff/detail/device.hpp>
 
-#include <boost/mpl/contains.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 namespace boost { namespace gil {
 
@@ -78,10 +78,12 @@ protected:
         tiff_samples_per_pixel::type samples_per_pixel = num_channels< pixel_t >::value;
         this->_io_dev.template set_property<tiff_samples_per_pixel>( samples_per_pixel );
 
-        if (mpl:: contains <color_space_t, alpha_t>:: value) {
+        if /*constexpr*/ (mp11::mp_contains<color_space_t, alpha_t>::value)
+        {
           std:: vector <uint16_t> extra_samples {EXTRASAMPLE_ASSOCALPHA};
           this->_io_dev.template set_property<tiff_extra_samples>( extra_samples );
         }
+
         // write bits per sample
         // @todo: Settings this value usually requires to write for each sample the bit
         // value seperately in case they are different, like rgb556.

--- a/include/boost/gil/extension/io/tiff/tags.hpp
+++ b/include/boost/gil/extension/io/tiff/tags.hpp
@@ -10,9 +10,10 @@
 
 #include <boost/gil/extension/io/tiff/detail/log.hpp>
 
+#include <boost/gil/detail/mp11.hpp>
 #include <boost/gil/io/base.hpp>
 
-#include <boost/mpl/vector.hpp>
+#include <type_traits>
 
 // taken from jpegxx - https://bitbucket.org/edd/jpegxx/src/ea2492a1a4a6/src/ijg_headers.hpp
 #ifndef BOOST_GIL_EXTENSION_IO_TIFF_C_LIB_COMPILED_AS_CPLUSPLUS
@@ -44,7 +45,7 @@ struct tiff_property_base : property_base< T >
     /// this property:
     /// http://www.remotesensing.org/libtiff/man/TIFFGetField.3tiff.html
     /// http://www.remotesensing.org/libtiff/man/TIFFSetField.3tiff.html
-    using arg_types = mpl::vector<typename property_base<unsigned short>::type>;
+    using arg_types = mp11::mp_list<typename property_base<unsigned short>::type>;
 };
 
 /// baseline tags
@@ -153,9 +154,9 @@ struct tiff_color_map
 };
 
 /// Defines type for extra samples property.
-struct tiff_extra_samples : tiff_property_base<std:: vector <uint16_t>, TIFFTAG_EXTRASAMPLES>
+struct tiff_extra_samples : tiff_property_base<std::vector<uint16_t>, TIFFTAG_EXTRASAMPLES>
 {
-    using arg_types = mpl::vector<uint16_t, uint16_t const *>;
+    using arg_types = mp11::mp_list<uint16_t, uint16_t const*>;
 };
 
 /// Defines type for copyright property.
@@ -182,10 +183,9 @@ struct tiff_tile_width : tiff_property_base< long, TIFFTAG_TILEWIDTH > {};
 struct tiff_tile_length : tiff_property_base< long, TIFFTAG_TILELENGTH > {};
 
 /// Defines the page to read in a multipage tiff file.
-#include <boost/mpl/integral_c.hpp>
 struct tiff_directory : property_base< tdir_t >
 {
-    using default_value = boost::mpl::integral_c<type, 0>;
+    using default_value = std::integral_constant<type, 0>;
 };
 
 /// Non-baseline tags
@@ -193,7 +193,7 @@ struct tiff_directory : property_base< tdir_t >
 /// Defines type for icc profile property.
 struct tiff_icc_profile : tiff_property_base<std::vector<uint8_t>, TIFFTAG_ICCPROFILE>
 {
-    using arg_types = mpl::vector<uint32_t, void const *>;
+    using arg_types = mp11::mp_list<uint32_t, void const*>;
 };
 
 /// Read information for tiff images.

--- a/include/boost/gil/extension/numeric/algorithm.hpp
+++ b/include/boost/gil/extension/numeric/algorithm.hpp
@@ -25,7 +25,7 @@ namespace boost { namespace gil {
 ///
 /// The reference proxy is the reference type, but with stripped-out C++ reference. It models PixelConcept
 template <typename T>
-struct pixel_proxy : public remove_reference<typename T::reference> {};
+struct pixel_proxy : std::remove_reference<typename T::reference> {};
 
 /// \brief std::for_each for a pair of iterators
 template <typename Iterator1,typename Iterator2,typename BinaryFunction>

--- a/include/boost/gil/extension/numeric/sampler.hpp
+++ b/include/boost/gil/extension/numeric/sampler.hpp
@@ -180,7 +180,6 @@ bool sample(bilinear_sampler, SrcView const& src, point<F> const& p, DstP& resul
 	cast_pixel(mp,src_result);
 
 	color_convert(src_result, result);
-
 	return true;
 }
 

--- a/include/boost/gil/extension/toolbox/color_spaces/cmyka.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/cmyka.hpp
@@ -12,13 +12,12 @@
 #include <boost/gil/color_convert.hpp>
 #include <boost/gil/rgba.hpp>
 #include <boost/gil/typedefs.hpp>
-
-#include <boost/mpl/vector.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 namespace boost{ namespace gil {
 
 /// \ingroup ColorSpaceModel
-using cmyka_t = mpl::vector5<cyan_t, magenta_t, yellow_t, black_t, alpha_t>;
+using cmyka_t = mp11::mp_list<cyan_t, magenta_t, yellow_t, black_t, alpha_t>;
 
 /// \ingroup LayoutModel
 using cmyka_layout_t = layout<cmyka_t>;

--- a/include/boost/gil/extension/toolbox/color_spaces/gray_alpha.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/gray_alpha.hpp
@@ -12,15 +12,14 @@
 #include <boost/gil/gray.hpp>
 #include <boost/gil/typedefs.hpp>
 
-#include <boost/mpl/contains.hpp>
-#include <boost/mpl/vector.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 namespace boost{ namespace gil {
 
-using gray_alpha_t = mpl::vector2<gray_color_t,alpha_t>;
+using gray_alpha_t = mp11::mp_list<gray_color_t,alpha_t>;
 
 using gray_alpha_layout_t = layout<gray_alpha_t>;
-using alpha_gray_layout_t = layout<gray_alpha_layout_t, mpl::vector2_c<int,1,0>>;
+using alpha_gray_layout_t = layout<gray_alpha_layout_t, mp11::mp_list_c<int,1,0>>;
 
 GIL_DEFINE_BASE_TYPEDEFS(8, uint8_t, alpha_gray)
 GIL_DEFINE_BASE_TYPEDEFS(8s, int8_t, alpha_gray)

--- a/include/boost/gil/extension/toolbox/color_spaces/hsl.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/hsl.hpp
@@ -10,6 +10,7 @@
 
 #include <boost/gil/color_convert.hpp>
 #include <boost/gil/typedefs.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 namespace boost{ namespace gil {
 
@@ -27,12 +28,12 @@ struct lightness_t {};
 /// \}
 
 /// \ingroup ColorSpaceModel
-using hsl_t = mpl::vector3
-    <
-        hsl_color_space::hue_t,
-        hsl_color_space::saturation_t,
-        hsl_color_space::lightness_t
-    >;
+using hsl_t = mp11::mp_list
+<
+    hsl_color_space::hue_t,
+    hsl_color_space::saturation_t,
+    hsl_color_space::lightness_t
+>;
 
 /// \ingroup LayoutModel
 using hsl_layout_t = layout<hsl_t>;

--- a/include/boost/gil/extension/toolbox/color_spaces/hsv.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/hsv.hpp
@@ -12,8 +12,7 @@
 
 #include <boost/gil/color_convert.hpp>
 #include <boost/gil/typedefs.hpp>
-
-#include <boost/mpl/vector.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -34,12 +33,12 @@ struct value_t {};
 /// \}
 
 /// \ingroup ColorSpaceModel
-using hsv_t = mpl::vector3
-    <
-        hsv_color_space::hue_t,
-        hsv_color_space::saturation_t,
-        hsv_color_space::value_t
-    >;
+using hsv_t = mp11::mp_list
+<
+    hsv_color_space::hue_t,
+    hsv_color_space::saturation_t,
+    hsv_color_space::value_t
+>;
 
 /// \ingroup LayoutModel
 using hsv_layout_t = layout<hsv_t>;

--- a/include/boost/gil/extension/toolbox/color_spaces/lab.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/lab.hpp
@@ -12,8 +12,7 @@
 
 #include <boost/gil/color_convert.hpp>
 #include <boost/gil.hpp> // FIXME: Include what you use, not everything, even in extensions!
-
-#include <boost/mpl/vector.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 namespace boost{ namespace gil {
 
@@ -31,12 +30,12 @@ struct b_color_opponent_t {};
 /// \}
 
 /// \ingroup ColorSpaceModel
-using lab_t = mpl::vector3
-    <
-        lab_color_space::luminance_t,
-        lab_color_space::a_color_opponent_t,
-        lab_color_space::b_color_opponent_t
-    >;
+using lab_t = mp11::mp_list
+<
+    lab_color_space::luminance_t,
+    lab_color_space::a_color_opponent_t,
+    lab_color_space::b_color_opponent_t
+>;
 
 /// \ingroup LayoutModel
 using lab_layout_t = layout<lab_t>;

--- a/include/boost/gil/extension/toolbox/color_spaces/xyz.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/xyz.hpp
@@ -10,8 +10,7 @@
 
 #include <boost/gil/color_convert.hpp>
 #include <boost/gil/typedefs.hpp>
-
-#include <boost/mpl/vector.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 namespace boost{ namespace gil {
 
@@ -29,12 +28,12 @@ struct z_t {};
 /// \}
 
 /// \ingroup ColorSpaceModel
-using xyz_t = mpl::vector3
-    <
-        xyz_color_space::x_t,
-        xyz_color_space::y_t,
-        xyz_color_space::z_t
-    >;
+using xyz_t = mp11::mp_list
+<
+    xyz_color_space::x_t,
+    xyz_color_space::y_t,
+    xyz_color_space::z_t
+>;
 
 /// \ingroup LayoutModel
 using xyz_layout_t = layout<xyz_t>;

--- a/include/boost/gil/extension/toolbox/color_spaces/ycbcr.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/ycbcr.hpp
@@ -12,16 +12,14 @@
 
 #include <boost/gil/color_convert.hpp>
 #include <boost/gil.hpp> // FIXME: Include what you use!
+#include <boost/gil/detail/mp11.hpp>
 
 #include <boost/config.hpp>
-#include <boost/mpl/identity.hpp>
-#include <boost/mpl/range_c.hpp>
-#include <boost/mpl/vector_c.hpp>
 
 #include <cstdint>
 #include <type_traits>
 
-namespace boost{ namespace gil {
+namespace boost { namespace gil {
 
 /// \addtogroup ColorNameModel
 /// \{
@@ -47,20 +45,20 @@ struct cr_t {};
 /// \}
 
 /// \ingroup ColorSpaceModel
-using ycbcr_601__t = boost::mpl::vector3
-    <
-        ycbcr_601_color_space::y_t,
-        ycbcr_601_color_space::cb_t,
-        ycbcr_601_color_space::cr_t>
-    ;
+using ycbcr_601__t = mp11::mp_list
+<
+    ycbcr_601_color_space::y_t,
+    ycbcr_601_color_space::cb_t,
+    ycbcr_601_color_space::cr_t
+>;
 
 /// \ingroup ColorSpaceModel
-using ycbcr_709__t = boost::mpl::vector3
-    <
-        ycbcr_709_color_space::y_t,
-        ycbcr_709_color_space::cb_t,
-        ycbcr_709_color_space::cr_t
-    >;
+using ycbcr_709__t = mp11::mp_list
+<
+    ycbcr_709_color_space::y_t,
+    ycbcr_709_color_space::cb_t,
+    ycbcr_709_color_space::cr_t
+>;
 
 /// \ingroup LayoutModel
 using ycbcr_601__layout_t = boost::gil::layout<ycbcr_601__t>;
@@ -74,9 +72,11 @@ namespace detail {
 
 // Source:boost/algorithm/clamp.hpp
 template<typename T>
-BOOST_CXX14_CONSTEXPR T const& clamp(T const& val,
-    typename boost::mpl::identity<T>::type const & lo,
-    typename boost::mpl::identity<T>::type const & hi)
+BOOST_CXX14_CONSTEXPR
+T const& clamp(
+    T const& val,
+    typename boost::mp11::mp_identity<T>::type const & lo,
+    typename boost::mp11::mp_identity<T>::type const & hi)
 {
     // assert ( !p ( hi, lo )); // Can't assert p ( lo, hi ) b/c they might be equal
     auto const p = std::less<T>();
@@ -105,8 +105,8 @@ struct default_color_converter_impl<ycbcr_601__t, rgb_t>
         using dst_channel_t = typename channel_type<DSTP>::type;
         convert(src, dst, typename std::is_same
             <
-                typename mpl::int_<sizeof(dst_channel_t)>::type,
-                typename mpl::int_<1>::type
+                std::integral_constant<int, sizeof(dst_channel_t)>,
+                std::integral_constant<int, 1>
             >::type());
 	}
 
@@ -118,7 +118,7 @@ private:
             >
     void convert( const Src_Pixel& src
                 ,       Dst_Pixel& dst
-                , mpl::true_ // is 8 bit channel
+                , std::true_type // is 8 bit channel
                 ) const
     {
         using namespace ycbcr_601_color_space;
@@ -149,7 +149,7 @@ private:
             >
     void convert( const Src_Pixel& src
                 ,       Dst_Pixel& dst
-                , mpl::false_ // is 8 bit channel
+                , std::false_type // is 8 bit channel
                 ) const
     {
         using namespace ycbcr_601_color_space;

--- a/include/boost/gil/extension/toolbox/dynamic_images.hpp
+++ b/include/boost/gil/extension/toolbox/dynamic_images.hpp
@@ -10,9 +10,6 @@
 
 #include <boost/gil/extension/dynamic_image/dynamic_image_all.hpp>
 
-#include <boost/mpl/at.hpp>
-#include <boost/mpl/size.hpp>
-
 namespace boost { namespace gil {
 
 // need this for various meta functions.

--- a/include/boost/gil/extension/toolbox/image_types/indexed_image.hpp
+++ b/include/boost/gil/extension/toolbox/image_types/indexed_image.hpp
@@ -13,20 +13,24 @@
 #include <boost/gil/image.hpp>
 #include <boost/gil/point.hpp>
 #include <boost/gil/virtual_locator.hpp>
-
-#include <boost/mpl/if.hpp>
-#include <boost/type_traits/is_integral.hpp>
+#include <boost/gil/detail/is_channel_integral.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <cstddef>
 #include <memory>
 
-namespace boost{ namespace gil {
+namespace boost { namespace gil {
 
 template< typename Locator >
-struct get_pixel_type_locator : mpl::if_< typename is_bit_aligned< typename Locator::value_type >::type
-                                        , typename Locator::reference
-                                        , typename Locator::value_type
-                                        > {};
+struct get_pixel_type_locator
+{
+    using type = mp11::mp_if
+        <
+            typename is_bit_aligned<typename Locator::value_type>::type,
+            typename Locator::reference,
+            typename Locator::value_type
+        >;
+};
 
 // used for virtual locator
 template< typename IndicesLoc
@@ -110,7 +114,7 @@ struct indexed_image_deref_fn
     PaletteLoc,
     typename std::enable_if
     <
-        std::is_integral<typename IndicesLoc::value_type>::value
+        detail::is_channel_integral<typename IndicesLoc::value_type>::value
     >::type
 > : indexed_image_deref_fn_base<IndicesLoc, PaletteLoc>
 {

--- a/include/boost/gil/extension/toolbox/image_types/subchroma_image.hpp
+++ b/include/boost/gil/extension/toolbox/image_types/subchroma_image.hpp
@@ -13,17 +13,11 @@
 #include <boost/gil/image_view.hpp>
 #include <boost/gil/point.hpp>
 #include <boost/gil/virtual_locator.hpp>
-
-#include <boost/mpl/at.hpp>
-#include <boost/mpl/divides.hpp>
-#include <boost/mpl/equal_to.hpp>
-#include <boost/mpl/if.hpp>
-#include <boost/mpl/int.hpp>
-#include <boost/mpl/or.hpp>
-#include <boost/mpl/vector_c.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <cstddef>
 #include <memory>
+#include <type_traits>
 
 namespace boost { namespace gil {
 
@@ -32,41 +26,36 @@ namespace detail {
 template< int J, int A, int B>
 struct scaling_factors
 {
-    static_assert(mpl::equal_to< mpl::int_< J >, mpl::int_< 4 > >::value, "");
+    static_assert(std::integral_constant<int, J>::value == 4, "");
 
-    static_assert(mpl::or_<mpl::equal_to< mpl::int_<A>, mpl::int_< 4 > >
-                                  , mpl::or_< mpl::equal_to< mpl::int_<A>, mpl::int_< 2 > >
-                                            , mpl::equal_to< mpl::int_<A>, mpl::int_< 1 > >
-                                            >
-                                  >::value, "");
+    static_assert(
+        std::integral_constant<int, A>::value == 4 ||
+        std::integral_constant<int, A>::value == 2 ||
+        std::integral_constant<int, A>::value == 1,
+        "");
 
-    static_assert(mpl::or_< mpl::equal_to< mpl::int_<B>, mpl::int_< 4 > >
-                                  , mpl::or_< mpl::equal_to< mpl::int_<B>, mpl::int_< 2 > >
-                                            , mpl::or_< mpl::equal_to< mpl::int_<B>, mpl::int_< 1 > >
-                                                      , mpl::equal_to< mpl::int_<B>, mpl::int_< 0 > >
-                                                      >
-                                            >
-                                  >::value, "");
+    static_assert(
+        std::integral_constant<int, B>::value == 4 ||
+        std::integral_constant<int, B>::value == 2 ||
+        std::integral_constant<int, B>::value == 1 ||
+        std::integral_constant<int, B>::value == 0,
+        "");
 
     static constexpr int ss_X =
-        mpl::divides
-        <
-            mpl::int_<J>,
-            mpl::int_<A>
-        >::value;
+        std::integral_constant<int, J>::value / std::integral_constant<int, A>::value;
 
     static constexpr int ss_Y =
-        mpl::if_
+        mp11::mp_if_c
         <
-            mpl::equal_to<mpl::int_<B>, mpl::int_<0>>,
-            mpl::int_<2>,
-            typename mpl::if_
+            std::integral_constant<int, B>::value == 0,
+            std::integral_constant<int, 2>,
+            mp11::mp_if_c
             <
-                mpl::equal_to<mpl::int_<A>, mpl::int_<B>>,
-                mpl::int_<1>,
-                mpl::int_<4>
-            >::type
-        >::type::value;
+                std::integral_constant<int, A>::value == std::integral_constant<int, B>::value,
+                std::integral_constant<int, 1>,
+                std::integral_constant<int, 4>
+            >
+        >::value;
 };
 
 } // namespace detail
@@ -111,9 +100,9 @@ struct subchroma_image_deref_fn
     {
         using scaling_factors_t = detail::scaling_factors
             <
-                mpl::at_c<Factors, 0>::type::value,
-                mpl::at_c<Factors, 1>::type::value,
-                mpl::at_c<Factors, 2>::type::value
+                mp11::mp_at_c<Factors, 0>::value,
+                mp11::mp_at_c<Factors, 1>::value,
+                mp11::mp_at_c<Factors, 2>::value
             >;
 
         plane_locator_t y = _y_locator.xy_at( p );
@@ -215,10 +204,12 @@ struct transposed_type< subchroma_image_locator< Locator, Factors > >
 /// \brief A lightweight object that interprets a subchroma image.
 ///
 ////////////////////////////////////////////////////////////////////////////////////////
-template< typename Locator
-        , typename Factors = mpl::vector_c< int, 4, 4, 4 >
-        >
-class subchroma_image_view : public image_view< Locator >
+template
+<
+    typename Locator,
+    typename Factors = mp11::mp_list_c<int, 4, 4, 4>
+>
+class subchroma_image_view : public image_view<Locator>
 {
 public:
 
@@ -339,21 +330,27 @@ struct transposed_type< subchroma_image_view< Locator, Factors > >
 /// A subchroma image holds a bunch of planes which don't need to have the same resolution.
 ///
 ////////////////////////////////////////////////////////////////////////////////////////
-template< typename Pixel
-        , typename Factors   = mpl::vector_c< int, 4, 4, 4 >
-        , typename Allocator = std::allocator< unsigned char >
-        >
-class subchroma_image : public detail::scaling_factors< mpl::at_c< Factors, 0 >::type::value
-                                              , mpl::at_c< Factors, 1 >::type::value
-                                              , mpl::at_c< Factors, 2 >::type::value
-                                              >
+template
+<
+    typename Pixel,
+    typename Factors = mp11::mp_list_c<int, 4, 4, 4>,
+    typename Allocator = std::allocator<unsigned char>
+>
+class subchroma_image : public detail::scaling_factors
+    <
+        mp11::mp_at_c<Factors, 0>::value,
+        mp11::mp_at_c<Factors, 1>::value,
+        mp11::mp_at_c<Factors, 2>::value
+    >
 {
 
 private:
-    using parent_t = detail::scaling_factors< mpl::at_c< Factors, 0 >::type::value
-                                              , mpl::at_c< Factors, 1 >::type::value
-                                              , mpl::at_c< Factors, 2 >::type::value
-                                              >;
+    using parent_t = detail::scaling_factors
+        <
+            mp11::mp_at_c<Factors, 0>::value,
+            mp11::mp_at_c<Factors, 1>::value,
+            mp11::mp_at_c<Factors, 2>::value
+        >;
 
 public:
 
@@ -436,19 +433,20 @@ private:
 
 template < typename Pixel, typename Factors, typename Alloc >
 struct channel_type< subchroma_image< Pixel, Factors, Alloc > >
-    : public channel_type< Pixel > {};
+    : channel_type< Pixel > {};
 
 template < typename Pixel, typename Factors, typename Alloc >
 struct color_space_type< subchroma_image< Pixel, Factors, Alloc > >
-    : public color_space_type< Pixel > {};
+    : color_space_type< Pixel > {};
 
 template < typename Pixel, typename Factors, typename Alloc >
 struct channel_mapping_type<  subchroma_image< Pixel, Factors, Alloc > >
-    : public channel_mapping_type< Pixel > {};
+    : channel_mapping_type< Pixel > {};
 
 template < typename Pixel, typename Factors, typename Alloc >
 struct is_planar< subchroma_image< Pixel, Factors, Alloc > >
-    : public mpl::bool_< false > {};
+    : std::integral_constant<bool, false>
+{};
 
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -514,9 +512,9 @@ typename subchroma_image< Pixel
 {
     using scaling_factors_t = detail::scaling_factors
         <
-            mpl::at_c<Factors, 0>::type::value,
-            mpl::at_c<Factors, 1>::type::value,
-            mpl::at_c<Factors, 2>::type::value
+            mp11::mp_at_c<Factors, 0>::type::value,
+            mp11::mp_at_c<Factors, 1>::type::value,
+            mp11::mp_at_c<Factors, 2>::type::value
         >;
 
     std::size_t y_channel_size = 1;

--- a/include/boost/gil/extension/toolbox/metafunctions/channel_type.hpp
+++ b/include/boost/gil/extension/toolbox/metafunctions/channel_type.hpp
@@ -14,8 +14,8 @@
 
 #include <boost/gil/bit_aligned_pixel_reference.hpp>
 #include <boost/gil/channel.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
-#include <boost/mpl/at.hpp>
 #include <boost/utility/enable_if.hpp> // boost::lazy_enable_if
 
 namespace boost{ namespace gil {
@@ -29,7 +29,7 @@ struct gen_chan_ref
     using type = packed_dynamic_channel_reference
         <
             B,
-            mpl::at_c<C, 0>::type::value,
+            mp11::mp_at_c<C, 0>::value,
             M
         >;
 };
@@ -58,27 +58,27 @@ struct gen_chan_ref_p
     using type = packed_dynamic_channel_reference
         <
             B,
-            get_num_bits<typename mpl::at_c<C, 0>::type>::value,
+            get_num_bits<mp11::mp_at_c<C, 0>>::value,
             true
         >;
 };
 
 // packed_pixel
 template < typename BitField
-         , typename ChannelRefVec
+         , typename ChannelRefs
          , typename Layout
          >
 struct channel_type< packed_pixel< BitField
-                                 , ChannelRefVec
+                                 , ChannelRefs
                                  , Layout
                                  >
                    > : lazy_enable_if< is_homogeneous< packed_pixel< BitField
-                                                                   , ChannelRefVec
+                                                                   , ChannelRefs
                                                                    , Layout
                                                                    >
                                                      >
                                      , gen_chan_ref_p< BitField
-                                                     , ChannelRefVec
+                                                     , ChannelRefs
                                                      , Layout
                                                      >
                                      > {};

--- a/include/boost/gil/extension/toolbox/metafunctions/channel_view.hpp
+++ b/include/boost/gil/extension/toolbox/metafunctions/channel_view.hpp
@@ -13,28 +13,28 @@
 namespace boost {
 namespace gil {
 
-template < typename Channel
-         , typename View
-         >
+template <typename Channel, typename View>
 struct channel_type_to_index
 {
-    static const int value = detail::type_to_index< typename color_space_type< View >::type // color (mpl::vector)
-                                                  , Channel                                 // channel type
-                                                  >::value;                           //< index of the channel in the color (mpl::vector)
+    static constexpr int value = detail::type_to_index
+        <
+            typename color_space_type<View>::type, // color (Boost.MP11-compatible list)
+            Channel                                // channel type
+        >::value;                                  // index of the channel in the color (Boost.MP11-compatible list)
 };
 
-template< typename Channel
-        , typename View
-        >
-struct channel_view_type : public kth_channel_view_type< channel_type_to_index< Channel
-                                                                              , View
-                                                                              >::value
-                                                       , View
-                                                       >
+template<typename Channel, typename View>
+struct channel_view_type : kth_channel_view_type
+    <
+        channel_type_to_index<Channel, View>::value,
+        View
+    >
 {
-    static const int index = channel_type_to_index< Channel
-                                                  , View
-                                                  >::value;
+    static constexpr int index = channel_type_to_index
+        <
+            Channel,
+            View
+        >::value;
 
     using parent_t = kth_channel_view_type<index, View>;
     using type = typename parent_t::type;
@@ -46,19 +46,13 @@ struct channel_view_type : public kth_channel_view_type< channel_type_to_index< 
 };
 
 /// \ingroup ImageViewTransformationsKthChannel
-template< typename Channel
-        , typename View
-        >
-typename channel_view_type< Channel
-                          , View
-                          >::type channel_view( const View& src )
+template<typename Channel, typename View>
+auto channel_view(View const& src)
+    -> typename channel_view_type<Channel, View>::type
 {
-   return channel_view_type< Channel
-                           , View
-                           >::make( src );
+   return channel_view_type<Channel, View>::make(src);
 }
 
-} // namespace gil
-} // namespace boost
+}} // namespace boost::gil
 
 #endif

--- a/include/boost/gil/extension/toolbox/metafunctions/get_num_bits.hpp
+++ b/include/boost/gil/extension/toolbox/metafunctions/get_num_bits.hpp
@@ -9,13 +9,8 @@
 #define BOOST_GIL_EXTENSION_TOOLBOX_METAFUNCTIONS_GET_NUM_BITS_HPP
 
 #include <boost/gil/channel.hpp>
-
-#include <boost/mpl/and.hpp>
-#include <boost/mpl/int.hpp>
-#include <boost/mpl/not.hpp>
-#include <boost/mpl/size_t.hpp>
-#include <boost/type_traits/is_integral.hpp>
-#include <boost/type_traits/is_class.hpp>
+#include <boost/gil/detail/is_channel_integral.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <type_traits>
 
@@ -24,50 +19,53 @@ namespace boost{ namespace gil {
 /// get_num_bits metafunctions
 /// \brief Determines the numbers of bits for the given channel type.
 
-template <typename T, class = void >
+template <typename T, class = void>
 struct get_num_bits;
 
-template< typename B, int I, int S, bool M >
-struct get_num_bits< packed_channel_reference< B, I, S, M > > : mpl::int_< S >
+template<typename B, int I, int S, bool M>
+struct get_num_bits<packed_channel_reference<B, I, S, M>>
+    : std::integral_constant<int, S>
 {};
 
-template< typename B, int I, int S, bool M >
-struct get_num_bits< const packed_channel_reference< B, I, S, M > > : mpl::int_< S >
+template<typename B, int I, int S, bool M>
+struct get_num_bits<packed_channel_reference<B, I, S, M> const>
+    : std::integral_constant<int, S>
 {};
 
 template<typename B, int I, bool M>
-struct get_num_bits< packed_dynamic_channel_reference< B, I, M > > : mpl::int_< I >
+struct get_num_bits<packed_dynamic_channel_reference<B, I, M>>
+    : std::integral_constant<int, I>
 {};
 
 template<typename B, int I, bool M>
-struct get_num_bits< const packed_dynamic_channel_reference< B, I, M > > : mpl::int_< I >
+struct get_num_bits<packed_dynamic_channel_reference<B, I, M> const>
+    : std::integral_constant<int, I>
 {};
 
-template< int N >
-struct get_num_bits< packed_channel_value< N > > : mpl::int_< N >
+template<int N>
+struct get_num_bits<packed_channel_value<N>> : std::integral_constant<int, N>
 {};
 
-template< int N >
-struct get_num_bits< const packed_channel_value< N > > : mpl::int_< N >
+template<int N>
+struct get_num_bits<packed_channel_value<N> const> : std::integral_constant<int, N>
 {};
 
 template <typename T>
 struct get_num_bits
-<
-    T,
-    typename std::enable_if
     <
-        mpl::and_
+        T,
+        typename std::enable_if
         <
-            is_integral<T>,
-            mpl::not_<is_class<T>>
-        >::value
-    >::type
-> : mpl::size_t<sizeof(T) * 8>
-{
-};
+            mp11::mp_and
+            <
+                detail::is_channel_integral<T>,
+                mp11::mp_not<std::is_class<T>>
+           >::value
+       >::type
+    >
+    : std::integral_constant<std::size_t, sizeof(T) * 8>
+{};
 
-} // namespace gil
-} // namespace boost
+}} // namespace boost::gil
 
 #endif

--- a/include/boost/gil/extension/toolbox/metafunctions/get_pixel_type.hpp
+++ b/include/boost/gil/extension/toolbox/metafunctions/get_pixel_type.hpp
@@ -11,25 +11,31 @@
 #include <boost/gil/extension/toolbox/dynamic_images.hpp>
 #include <boost/gil/extension/toolbox/metafunctions/is_bit_aligned.hpp>
 
+#include <boost/gil/detail/mp11.hpp>
+
 namespace boost{ namespace gil {
 
 /// get_pixel_type metafunction
 /// \brief Depending on Image this function generates either
 ///        the pixel type or the reference type in case
 ///        the image is bit_aligned.
-template< typename View >
-struct get_pixel_type : mpl::if_< typename is_bit_aligned< typename View::value_type >::type
-                                , typename View::reference
-                                , typename View::value_type
-                                > {};
+template<typename View>
+struct get_pixel_type
+{
+    using type = mp11::mp_if
+        <
+            is_bit_aligned<typename View::value_type>,
+            typename View::reference,
+            typename View::value_type
+        >;
+};
 
-template< typename ImageViewTypes >
-struct get_pixel_type< any_image_view< ImageViewTypes > >
+template<typename Views>
+struct get_pixel_type<any_image_view<Views>>
 {
     using type = any_image_pixel_t;
 };
 
-} // namespace gil
-} // namespace boost
+}} // namespace boost::gil
 
 #endif

--- a/include/boost/gil/extension/toolbox/metafunctions/is_bit_aligned.hpp
+++ b/include/boost/gil/extension/toolbox/metafunctions/is_bit_aligned.hpp
@@ -10,27 +10,28 @@
 
 #include <boost/gil/bit_aligned_pixel_reference.hpp>
 
+#include <type_traits>
+
 namespace boost{ namespace gil {
 
 /// is_bit_aligned metafunctions
 /// \brief Determines whether the given type is bit_aligned.
 
 template< typename PixelRef >
-struct is_bit_aligned : mpl::false_{};
+struct is_bit_aligned : std::false_type {};
 
 template <typename B, typename C, typename L, bool M>
-struct is_bit_aligned<bit_aligned_pixel_reference<B,C,L,M> > : mpl::true_{};
+struct is_bit_aligned<bit_aligned_pixel_reference<B, C, L, M>> : std::true_type {};
 
 template <typename B, typename C, typename L, bool M>
-struct is_bit_aligned<const bit_aligned_pixel_reference<B,C,L,M> > : mpl::true_{};
+struct is_bit_aligned<bit_aligned_pixel_reference<B, C, L, M> const> : std::true_type {};
 
 template <typename B, typename C, typename L>
-struct is_bit_aligned<packed_pixel<B,C,L> > : mpl::true_{};
+struct is_bit_aligned<packed_pixel<B, C, L>> : std::true_type {};
 
 template <typename B, typename C, typename L>
-struct is_bit_aligned<const packed_pixel<B,C,L> > : mpl::true_{};
+struct is_bit_aligned<packed_pixel<B, C, L> const> : std::true_type {};
 
-} // namespace gil
-} // namespace boost
+}} // namespace boost::gil
 
 #endif

--- a/include/boost/gil/extension/toolbox/metafunctions/is_homogeneous.hpp
+++ b/include/boost/gil/extension/toolbox/metafunctions/is_homogeneous.hpp
@@ -9,74 +9,91 @@
 #define BOOST_GIL_EXTENSION_TOOLBOX_METAFUNCTIONS_IS_HOMOGENEOUS_HPP
 
 #include <boost/gil/pixel.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
-#include <boost/mpl/and.hpp>
-#include <boost/mpl/at.hpp>
+#include <type_traits>
 
 namespace boost{ namespace gil {
 
 /// is_homogeneous metafunctions
 /// \brief Determines if a pixel types are homogeneous.
 
-template<typename C,typename CMP, int Next, int Last> struct is_homogeneous_impl;
-
-template<typename C,typename CMP, int Last>
-struct is_homogeneous_impl<C,CMP,Last,Last> : mpl::true_{};
-
 template<typename C,typename CMP, int Next, int Last>
-struct is_homogeneous_impl : mpl::and_< is_homogeneous_impl< C, CMP,Next + 1, Last >
-                                      , is_same< CMP, typename mpl::at_c<C,Next>::type
-                                      > > {};
+struct is_homogeneous_impl;
 
-template < typename P > struct is_homogeneous : mpl::false_ {};
+template<typename C, typename CMP, int Last>
+struct is_homogeneous_impl<C, CMP, Last, Last> : std::true_type {};
+
+template<typename C, typename CMP, int Next, int Last>
+struct is_homogeneous_impl
+    : mp11::mp_and
+        <
+            is_homogeneous_impl<C, CMP, Next + 1, Last>,
+            std::is_same<CMP, mp11::mp_at_c<C, Next>>
+        >
+{};
+
+template <typename P>
+struct is_homogeneous : std::false_type {};
 
 // pixel
-template < typename C, typename L > struct is_homogeneous< pixel<C,L> > : mpl::true_ {};
-template < typename C, typename L > struct is_homogeneous<const pixel<C,L> > : mpl::true_ {};
-template < typename C, typename L > struct is_homogeneous< pixel<C,L>& > : mpl::true_ {};
-template < typename C, typename L > struct is_homogeneous<const pixel<C,L>& > : mpl::true_ {};
+template <typename C, typename L>
+struct is_homogeneous<pixel<C, L>> : std::true_type {};
+
+template <typename C, typename L >
+struct is_homogeneous<pixel<C, L> const> : std::true_type {};
+
+template <typename C, typename L>
+struct is_homogeneous<pixel<C, L>&> : std::true_type {};
+
+template <typename C, typename L>
+struct is_homogeneous<pixel<C, L> const&> : std::true_type {};
 
 // planar pixel reference
 template <typename Channel, typename ColorSpace>
-struct is_homogeneous< planar_pixel_reference< Channel, ColorSpace > > : mpl::true_ {};
-template <typename Channel, typename ColorSpace>
-struct is_homogeneous< const planar_pixel_reference< Channel, ColorSpace > > : mpl::true_ {};
+struct is_homogeneous<planar_pixel_reference<Channel, ColorSpace>> : std::true_type {};
 
-template<typename C,typename CMP, int I,int Last>
+template <typename Channel, typename ColorSpace>
+struct is_homogeneous<planar_pixel_reference<Channel, ColorSpace> const> : std::true_type {};
+
+template<typename C, typename CMP, int I, int Last>
 struct is_homogeneous_impl_p {};
 
 // for packed_pixel
-template <typename B, typename C, typename L >
-struct is_homogeneous<packed_pixel< B, C, L > >
-    : is_homogeneous_impl_p< C
-                           , typename mpl::at_c< C, 0 >::type
-                           , 1
-                           , mpl::size< C >::value
-                           > {};
+template <typename B, typename C, typename L>
+struct is_homogeneous<packed_pixel<B, C, L>>
+    : is_homogeneous_impl_p
+    <
+        C,
+        mp11::mp_at_c<C, 0>,
+        1,
+        mp11::mp_size<C>::value
+    > {};
 
 template< typename B
         , typename C
         , typename L
         >
-struct is_homogeneous< const packed_pixel< B, C, L > >
-    : is_homogeneous_impl_p< C
-                           , typename mpl::at_c<C,0>::type
-                           , 1
-                           , mpl::size< C >::value
-                           > {};
+struct is_homogeneous<packed_pixel<B, C, L> const>
+    : is_homogeneous_impl_p
+    <
+        C,
+        mp11::mp_at_c<C, 0>,
+        1,
+        mp11::mp_size<C>::value
+    > {};
 
 // for bit_aligned_pixel_reference
 template <typename B, typename C, typename L, bool M>
-struct is_homogeneous<bit_aligned_pixel_reference<B,C,L,M> >
-    : is_homogeneous_impl<C,typename mpl::at_c<C,0>::type,1,mpl::size<C>::value>
+struct is_homogeneous<bit_aligned_pixel_reference<B, C, L, M>>
+    : is_homogeneous_impl<C, mp11::mp_at_c<C, 0>, 1, mp11::mp_size<C>::value>
 {};
 
 template <typename B, typename C, typename L, bool M>
-struct is_homogeneous<const bit_aligned_pixel_reference<B,C,L,M> >
-    : is_homogeneous_impl<C,typename mpl::at_c<C,0>::type,1,mpl::size<C>::value>
+struct is_homogeneous<const bit_aligned_pixel_reference<B, C, L, M> >
+    : is_homogeneous_impl<C, mp11::mp_at_c<C, 0>, 1, mp11::mp_size<C>::value>
 {};
 
-} // namespace gil
-} // namespace boost
+}} // namespace boost::gil
 
 #endif

--- a/include/boost/gil/extension/toolbox/metafunctions/is_similar.hpp
+++ b/include/boost/gil/extension/toolbox/metafunctions/is_similar.hpp
@@ -10,23 +10,26 @@
 
 #include <boost/gil/channel.hpp>
 
+#include <type_traits>
+
 namespace boost{ namespace gil {
 
 /// is_similar metafunctions
 /// \brief Determines if two pixel types are similar.
 
-template< typename A, typename B >
-struct is_similar : mpl::false_ {};
+template<typename A, typename B>
+struct is_similar : std::false_type {};
 
 template<typename A>
-struct is_similar< A, A > : mpl::true_ {};
+struct is_similar<A, A> : std::true_type {};
 
 template<typename B,int I, int S, bool M, int I2>
-struct is_similar< packed_channel_reference< B,  I, S, M >
-                 , packed_channel_reference< B, I2, S, M >
-                 > : mpl::true_ {};
+struct is_similar
+    <
+        packed_channel_reference<B,  I, S, M>,
+        packed_channel_reference<B, I2, S, M>
+    > : std::true_type {};
 
-} // namespace gil
-} // namespace boost
+}} // namespace boost::gil
 
 #endif

--- a/include/boost/gil/extension/toolbox/metafunctions/pixel_bit_size.hpp
+++ b/include/boost/gil/extension/toolbox/metafunctions/pixel_bit_size.hpp
@@ -11,9 +11,6 @@
 #include <boost/gil/bit_aligned_pixel_reference.hpp>
 #include <boost/gil/packed_pixel.hpp>
 
-#include <boost/mpl/accumulate.hpp>
-#include <boost/mpl/int.hpp>
-
 namespace boost{ namespace gil {
 
 /// pixel_bit_size metafunctions
@@ -23,22 +20,50 @@ namespace boost{ namespace gil {
 /// using image_t = bit_aligned_image5_type<16, 16, 16, 8, 8, devicen_layout_t<5>>::type;
 /// const int size = pixel_bit_size<image_t::view_t::reference>::value;
 /// \endcode
-template< typename PixelRef >
-struct pixel_bit_size : mpl::int_<0> {};
+template< typename PixelRef>
+struct pixel_bit_size : std::integral_constant<int, 0> {};
 
 template <typename B, typename C, typename L, bool M>
-struct pixel_bit_size<bit_aligned_pixel_reference<B,C,L,M> > : mpl::int_< mpl::accumulate< C, mpl::int_<0>, mpl::plus<mpl::_1, mpl::_2> >::type::value >{};
+struct pixel_bit_size<bit_aligned_pixel_reference<B, C, L, M>>
+    : mp11::mp_fold
+    <
+        C,
+        std::integral_constant<int, 0>,
+        mp11::mp_plus
+    >
+{};
 
 template <typename B, typename C, typename L, bool M>
-struct pixel_bit_size<const bit_aligned_pixel_reference<B,C,L,M> > : mpl::int_< mpl::accumulate< C, mpl::int_<0>, mpl::plus<mpl::_1, mpl::_2> >::type::value >{};
+struct pixel_bit_size<bit_aligned_pixel_reference<B, C, L, M> const>
+    : mp11::mp_fold
+    <
+        C,
+        std::integral_constant<int, 0>,
+        mp11::mp_plus
+    >
+{};
 
 template <typename B, typename C, typename L>
-struct pixel_bit_size<packed_pixel<B,C,L> > : mpl::int_< mpl::accumulate< C, mpl::int_<0>, mpl::plus<mpl::_1, mpl::_2> >::type::value >{};
+struct pixel_bit_size<packed_pixel<B, C, L>>
+    : mp11::mp_fold
+    <
+        C,
+        std::integral_constant<int, 0>,
+        mp11::mp_plus
+    >
+
+{};
 
 template <typename B, typename C, typename L>
-struct pixel_bit_size<const packed_pixel<B,C,L> > : mpl::int_< mpl::accumulate< C, mpl::int_<0>, mpl::plus<mpl::_1, mpl::_2> >::type::value >{};
+struct pixel_bit_size<const packed_pixel<B,C,L> >
+    : mp11::mp_fold
+    <
+        C,
+        std::integral_constant<int, 0>,
+        mp11::mp_plus
+    >
+{};
 
-} // namespace gil
-} // namespace boost
+}} // namespace boost::gil
 
 #endif

--- a/include/boost/gil/gray.hpp
+++ b/include/boost/gil/gray.hpp
@@ -8,11 +8,8 @@
 #ifndef BOOST_GIL_GRAY_HPP
 #define BOOST_GIL_GRAY_HPP
 
-#include <boost/mpl/range_c.hpp>
-#include <boost/mpl/vector_c.hpp>
-#include <boost/type_traits.hpp>
-
 #include <boost/gil/utilities.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 namespace boost { namespace gil {
 
@@ -21,12 +18,12 @@ namespace boost { namespace gil {
 struct gray_color_t {};
 
 /// \ingroup ColorSpaceModel
-using gray_t = mpl::vector1<gray_color_t>;
+using gray_t = mp11::mp_list<gray_color_t>;
 
 /// \ingroup LayoutModel
 using gray_layout_t = layout<gray_t>;
 
-} }  // namespace boost::gil
+}}  // namespace boost::gil
 
 #endif
 

--- a/include/boost/gil/image.hpp
+++ b/include/boost/gil/image.hpp
@@ -11,13 +11,11 @@
 #include <boost/gil/algorithm.hpp>
 #include <boost/gil/image_view.hpp>
 #include <boost/gil/metafunctions.hpp>
-
-#include <boost/mpl/arithmetic.hpp>
-#include <boost/mpl/bool.hpp>
-#include <boost/mpl/if.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <cstddef>
 #include <memory>
+#include <type_traits>
 
 namespace boost { namespace gil {
 
@@ -143,62 +141,48 @@ public:
     /////////////////////
 
     // without Allocator
-
-    void recreate( const point_t& dims, std::size_t alignment = 0 )
+    void recreate(const point_t& dims, std::size_t alignment = 0)
     {
-        if( dims == _view.dimensions() && _align_in_bytes == alignment )
-        {
+        if (dims == _view.dimensions() && _align_in_bytes == alignment)
             return;
-        }
-
+        
         _align_in_bytes = alignment;
 
-        if( _allocated_bytes >= total_allocated_size_in_bytes( dims ) )
+        if (_allocated_bytes >= total_allocated_size_in_bytes(dims))
         {
-            destruct_pixels( _view );
-
-            create_view( dims
-                       , typename mpl::bool_<IsPlanar>()
-                       );
-
-            default_construct_pixels( _view );
+            destruct_pixels(_view);
+            create_view(dims, std::integral_constant<bool, IsPlanar>());
+            default_construct_pixels(_view);
         }
         else
         {
-            image tmp( dims, alignment );
-            swap( tmp );
+            image tmp(dims, alignment);
+            swap(tmp);
         }
     }
 
-    void recreate( x_coord_t width, y_coord_t height, std::size_t alignment = 0 )
+    void recreate(x_coord_t width, y_coord_t height, std::size_t alignment = 0)
     {
-        recreate( point_t( width, height ), alignment );
+        recreate(point_t(width, height), alignment);
     }
 
-
-    void recreate( const point_t& dims, const Pixel& p_in, std::size_t alignment = 0 )
+    void recreate(const point_t& dims, const Pixel& p_in, std::size_t alignment = 0)
     {
-        if( dims == _view.dimensions() && _align_in_bytes == alignment )
-        {
+        if (dims == _view.dimensions() && _align_in_bytes == alignment)
             return;
-        }
 
         _align_in_bytes = alignment;
 
-        if(  _allocated_bytes >= total_allocated_size_in_bytes( dims ) )
+        if (_allocated_bytes >= total_allocated_size_in_bytes(dims))
         {
-            destruct_pixels( _view );
-
-            create_view( dims
-                       , typename mpl::bool_<IsPlanar>()
-                       );
-
+            destruct_pixels(_view);
+            create_view(dims, typename std::integral_constant<bool, IsPlanar>());
             uninitialized_fill_pixels(_view, p_in);
         }
         else
         {
-            image tmp( dims, p_in, alignment );
-            swap( tmp );
+            image tmp(dims, p_in, alignment);
+            swap(tmp);
         }
     }
 
@@ -207,77 +191,56 @@ public:
         recreate( point_t( width, height ), p_in, alignment );
     }
 
-
     // with Allocator
-    void recreate(const point_t& dims, std::size_t alignment, const Alloc alloc_in )
+    void recreate(const point_t& dims, std::size_t alignment, const Alloc alloc_in)
     {
-        if(  dims            == _view.dimensions()
-          && _align_in_bytes == alignment
-          && alloc_in        == _alloc
-          )
-        {
+        if (dims == _view.dimensions() && _align_in_bytes == alignment && alloc_in == _alloc)
             return;
-        }
-
+        
         _align_in_bytes = alignment;
 
-        if(  _allocated_bytes >= total_allocated_size_in_bytes( dims ) )
+        if (_allocated_bytes >= total_allocated_size_in_bytes(dims))
         {
-            destruct_pixels( _view );
-
-            create_view( dims
-                       , typename mpl::bool_<IsPlanar>()
-                       );
-
-            default_construct_pixels( _view );
+            destruct_pixels(_view);
+            create_view(dims, std::integral_constant<bool, IsPlanar>());
+            default_construct_pixels(_view);
         }
         else
         {
-            image tmp( dims, alignment, alloc_in );
-            swap( tmp );
+            image tmp(dims, alignment, alloc_in);
+            swap(tmp);
         }
     }
 
-    void recreate( x_coord_t width, y_coord_t height, std::size_t alignment, const Alloc alloc_in )
+    void recreate(x_coord_t width, y_coord_t height, std::size_t alignment, const Alloc alloc_in)
     {
-        recreate( point_t( width, height ), alignment, alloc_in );
+        recreate(point_t(width, height), alignment, alloc_in);
     }
 
-    void recreate(const point_t& dims, const Pixel& p_in, std::size_t alignment, const Alloc alloc_in )
+    void recreate(const point_t& dims, const Pixel& p_in, std::size_t alignment, const Alloc alloc_in)
     {
-        if(  dims            == _view.dimensions()
-          && _align_in_bytes == alignment
-          && alloc_in        == _alloc
-          )
-        {
+        if (dims == _view.dimensions() && _align_in_bytes == alignment && alloc_in == _alloc)
             return;
-        }
 
         _align_in_bytes = alignment;
 
-        if(  _allocated_bytes >= total_allocated_size_in_bytes( dims ) )
+        if (_allocated_bytes >= total_allocated_size_in_bytes(dims))
         {
-            destruct_pixels( _view );
-
-            create_view( dims
-                       , typename mpl::bool_<IsPlanar>()
-                       );
-
+            destruct_pixels(_view);
+            create_view(dims, std::integral_constant<bool, IsPlanar>());
             uninitialized_fill_pixels(_view, p_in);
         }
         else
         {
-            image tmp( dims, p_in, alignment, alloc_in );
-            swap( tmp );
+            image tmp(dims, p_in, alignment, alloc_in);
+            swap(tmp);
         }
     }
 
     void recreate(x_coord_t width, y_coord_t height, const Pixel& p_in, std::size_t alignment, const Alloc alloc_in )
     {
-        recreate( point_t( width, height ), p_in,alignment, alloc_in );
+        recreate(point_t(width, height), p_in, alignment, alloc_in);
     }
-
-
 
     view_t       _view;      // contains pointer to the pixels, the image size and ways to navigate pixels
 private:
@@ -287,66 +250,76 @@ private:
 
     std::size_t _allocated_bytes;
 
-
-    void allocate_and_default_construct(const point_t& dimensions) {
-        try {
-            allocate_(dimensions,mpl::bool_<IsPlanar>());
+    void allocate_and_default_construct(point_t const& dimensions)
+    {
+        try
+        {
+            allocate_(dimensions, std::integral_constant<bool, IsPlanar>());
             default_construct_pixels(_view);
-        } catch(...) { deallocate(); throw; }
+        }
+        catch (...) { deallocate(); throw; }
     }
 
-    void allocate_and_fill(const point_t& dimensions, const Pixel& p_in) {
-        try {
-            allocate_(dimensions,mpl::bool_<IsPlanar>());
+    void allocate_and_fill(const point_t& dimensions, Pixel const& p_in)
+    {
+        try
+        {
+            allocate_(dimensions, std::integral_constant<bool, IsPlanar>());
             uninitialized_fill_pixels(_view, p_in);
-        } catch(...) { deallocate(); throw; }
+        }
+        catch(...) { deallocate(); throw; }
     }
 
     template <typename View>
-    void allocate_and_copy(const point_t& dimensions, const View& v) {
-        try {
-            allocate_(dimensions,mpl::bool_<IsPlanar>());
-            uninitialized_copy_pixels(v,_view);
-        } catch(...) { deallocate(); throw; }
-    }
-
-    void deallocate() {
-        if (_memory && _allocated_bytes > 0 )
+    void allocate_and_copy(const point_t& dimensions, View const& v)
+    {
+        try
         {
-            _alloc.deallocate(_memory, _allocated_bytes );
+            allocate_(dimensions, std::integral_constant<bool, IsPlanar>());
+            uninitialized_copy_pixels(v, _view);
         }
+        catch(...) { deallocate(); throw; }
     }
 
-    std::size_t is_planar_impl( const std::size_t size_in_units
-                              , const std::size_t channels_in_image
-                              , mpl::true_
-                              ) const
+    void deallocate()
+    {
+        if (_memory && _allocated_bytes > 0)
+            _alloc.deallocate(_memory, _allocated_bytes);
+    }
+
+    std::size_t is_planar_impl(
+        std::size_t const size_in_units,
+        std::size_t const channels_in_image,
+        std::true_type) const
     {
         return size_in_units * channels_in_image;
     }
 
-    std::size_t is_planar_impl( const std::size_t size_in_units
-                              , const std::size_t
-                              , mpl::false_
-                              ) const
+    std::size_t is_planar_impl(
+        std::size_t const size_in_units,
+        std::size_t const,
+        std::false_type) const
     {
         return size_in_units;
     }
 
-    std::size_t total_allocated_size_in_bytes(const point_t& dimensions) const {
-
+    std::size_t total_allocated_size_in_bytes(point_t const& dimensions) const
+    {
         using x_iterator = typename view_t::x_iterator;
 
         // when value_type is a non-pixel, like int or float, num_channels< ... > doesn't work.
-        const std::size_t _channels_in_image = mpl::eval_if< is_pixel< value_type >
-                                                           , num_channels< view_t >
-                                                           , mpl::int_< 1 >
-														   >::type::value;
+        constexpr std::size_t _channels_in_image =
+            std::conditional
+            <
+                is_pixel<value_type>::value,
+                num_channels<view_t>,
+                std::integral_constant<std::size_t, 1>
+            >::type::value;
 
-        std::size_t size_in_units = is_planar_impl( get_row_size_in_memunits( dimensions.x ) * dimensions.y
-                                                  , _channels_in_image
-                                                  , typename mpl::bool_<IsPlanar>()
-                                                  );
+        std::size_t size_in_units = is_planar_impl(
+            get_row_size_in_memunits(dimensions.x) * dimensions.y,
+            _channels_in_image,
+            std::integral_constant<bool, IsPlanar>());
 
         // return the size rounded up to the nearest byte
         return ( size_in_units + byte_to_memunit< x_iterator >::value - 1 )
@@ -363,8 +336,9 @@ private:
         return size_in_memunits;
     }
 
-    void allocate_(const point_t& dimensions, mpl::false_) {  // if it throws and _memory!=0 the client must deallocate _memory
-
+    void allocate_(point_t const& dimensions, std::false_type)
+    {
+        // if it throws and _memory!=0 the client must deallocate _memory
         _allocated_bytes = total_allocated_size_in_bytes(dimensions);
         _memory=_alloc.allocate( _allocated_bytes );
 
@@ -372,7 +346,9 @@ private:
         _view=view_t(dimensions,typename view_t::locator(typename view_t::x_iterator(tmp),get_row_size_in_memunits(dimensions.x)));
     }
 
-    void allocate_(const point_t& dimensions, mpl::true_) {   // if it throws and _memory!=0 the client must deallocate _memory
+    void allocate_(point_t const& dimensions, std::true_type)
+    {
+        // if it throws and _memory!=0 the client must deallocate _memory
         std::size_t row_size=get_row_size_in_memunits(dimensions.x);
         std::size_t plane_size=row_size*dimensions.y;
 
@@ -389,9 +365,7 @@ private:
         _view=view_t(dimensions, typename view_t::locator(first, row_size));
     }
 
-    void create_view( const point_t& dims
-                    , mpl::true_ // is planar
-                    )
+    void create_view(point_t const& dims, std::true_type) // is planar
     {
         std::size_t row_size=get_row_size_in_memunits(dims.x);
         std::size_t plane_size=row_size*dims.y;
@@ -418,9 +392,7 @@ private:
                     );
     }
 
-    void create_view( const point_t& dims
-                    , mpl::false_ // is planar
-                    )
+    void create_view(point_t const& dims, std::false_type) // is planar
     {
         unsigned char* tmp = ( _align_in_bytes > 0 ) ? ( unsigned char* ) align( (std::size_t) _memory
                                                                                , _align_in_bytes
@@ -471,16 +443,16 @@ const typename image<Pixel,IsPlanar,Alloc>::const_view_t const_view(const image<
 /////////////////////////////
 
 template <typename Pixel, bool IsPlanar, typename Alloc>
-struct channel_type<image<Pixel,IsPlanar,Alloc> > : public channel_type<Pixel> {};
+struct channel_type<image<Pixel, IsPlanar, Alloc>> : channel_type<Pixel> {};
 
 template <typename Pixel, bool IsPlanar, typename Alloc>
-struct color_space_type<image<Pixel,IsPlanar,Alloc> >  : public color_space_type<Pixel> {};
+struct color_space_type<image<Pixel, IsPlanar, Alloc>> : color_space_type<Pixel> {};
 
 template <typename Pixel, bool IsPlanar, typename Alloc>
-struct channel_mapping_type<image<Pixel,IsPlanar,Alloc> > : public channel_mapping_type<Pixel> {};
+struct channel_mapping_type<image<Pixel, IsPlanar, Alloc>> : channel_mapping_type<Pixel> {};
 
 template <typename Pixel, bool IsPlanar, typename Alloc>
-struct is_planar<image<Pixel,IsPlanar,Alloc> > : public mpl::bool_<IsPlanar> {};
+struct is_planar<image<Pixel, IsPlanar, Alloc>> : std::integral_constant<bool, IsPlanar> {};
 
 }}  // namespace boost::gil
 

--- a/include/boost/gil/image_view.hpp
+++ b/include/boost/gil/image_view.hpp
@@ -212,8 +212,9 @@ struct is_planar<image_view<L> > : public is_planar<L> {};
 /////////////////////////////
 
 template <typename L>
-struct dynamic_x_step_type<image_view<L> > {
-    using type = image_view<typename dynamic_x_step_type<L>::type>;
+struct dynamic_x_step_type<image_view<L>>
+{
+    using type = image_view<typename gil::dynamic_x_step_type<L>::type>;
 };
 
 /////////////////////////////
@@ -221,8 +222,9 @@ struct dynamic_x_step_type<image_view<L> > {
 /////////////////////////////
 
 template <typename L>
-struct dynamic_y_step_type<image_view<L> > {
-    using type = image_view<typename dynamic_y_step_type<L>::type>;
+struct dynamic_y_step_type<image_view<L>>
+{
+    using type = image_view<typename gil::dynamic_y_step_type<L>::type>;
 };
 
 /////////////////////////////
@@ -230,7 +232,8 @@ struct dynamic_y_step_type<image_view<L> > {
 /////////////////////////////
 
 template <typename L>
-struct transposed_type<image_view<L> > {
+struct transposed_type<image_view<L>>
+{
     using type = image_view<typename transposed_type<L>::type>;
 };
 

--- a/include/boost/gil/image_view_factory.hpp
+++ b/include/boost/gil/image_view_factory.hpp
@@ -11,8 +11,10 @@
 #include <boost/gil/color_convert.hpp>
 #include <boost/gil/dynamic_step.hpp>
 #include <boost/gil/gray.hpp>
+#include <boost/gil/image_view.hpp>
 #include <boost/gil/metafunctions.hpp>
 #include <boost/gil/point.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <boost/assert.hpp>
 
@@ -32,6 +34,7 @@
 /// \brief Methods for constructing one image view from another
 
 namespace boost { namespace gil {
+
 struct default_color_converter;
 
 template <typename T> struct transposed_type;
@@ -39,13 +42,14 @@ template <typename T> struct transposed_type;
 /// \brief Returns the type of a view that has a dynamic step along both X and Y
 /// \ingroup ImageViewTransformations
 template <typename View>
-struct dynamic_xy_step_type : public dynamic_y_step_type<typename dynamic_x_step_type<View>::type> {};
+struct dynamic_xy_step_type
+    : dynamic_y_step_type<typename dynamic_x_step_type<View>::type> {};
 
 /// \brief Returns the type of a transposed view that has a dynamic step along both X and Y
 /// \ingroup ImageViewTransformations
 template <typename View>
-struct dynamic_xy_step_transposed_type : public dynamic_xy_step_type<typename transposed_type<View>::type> {};
-
+struct dynamic_xy_step_transposed_type
+    : dynamic_xy_step_type<typename transposed_type<View>::type> {};
 
 /// \ingroup ImageViewConstructors
 /// \brief Constructing image views from raw interleaved pixel data
@@ -343,7 +347,7 @@ namespace detail {
         static constexpr bool is_mutable =
             pixel_is_reference<SrcP>::value && pixel_reference_is_mutable<SrcP>::value;
     private:
-        using src_pixel_t = typename remove_reference<SrcP>::type;
+        using src_pixel_t = typename std::remove_reference<SrcP>::type;
         using channel_t = typename channel_type<src_pixel_t>::type;
         using const_ref_t = typename src_pixel_t::const_reference;
         using ref_t = typename pixel_reference_type<channel_t,gray_layout_t,false,is_mutable>::type;
@@ -352,7 +356,7 @@ namespace detail {
         using value_type = typename pixel_value_type<channel_t,gray_layout_t>::type;
         using const_reference = typename pixel_reference_type<channel_t,gray_layout_t,false,false>::type;
         using argument_type = SrcP;
-        using reference = typename mpl::if_c<is_mutable, ref_t, value_type>::type;
+        using reference = mp11::mp_if_c<is_mutable, ref_t, value_type>;
         using result_type = reference;
 
         nth_channel_deref_fn(int n=0) : _n(n) {}
@@ -479,7 +483,7 @@ namespace detail {
             pixel_is_reference<SrcP>::value && pixel_reference_is_mutable<SrcP>::value;
 
     private:
-        using src_pixel_t = typename remove_reference<SrcP>::type;
+        using src_pixel_t = typename std::remove_reference<SrcP>::type;
         using channel_t = typename kth_element_type<src_pixel_t, K>::type;
         using const_ref_t = typename src_pixel_t::const_reference;
         using ref_t = typename pixel_reference_type<channel_t,gray_layout_t,false,is_mutable>::type;
@@ -489,7 +493,7 @@ namespace detail {
         using value_type = typename pixel_value_type<channel_t,gray_layout_t>::type;
         using const_reference = typename pixel_reference_type<channel_t,gray_layout_t,false,false>::type;
         using argument_type = SrcP;
-        using reference = typename mpl::if_c<is_mutable, ref_t, value_type>::type;
+        using reference = mp11::mp_if_c<is_mutable, ref_t, value_type>;
         using result_type = reference;
 
         kth_channel_deref_fn() {}

--- a/include/boost/gil/io/base.hpp
+++ b/include/boost/gil/io/base.hpp
@@ -17,10 +17,9 @@
 #include <boost/gil/io/error.hpp>
 #include <boost/gil/io/typedefs.hpp>
 
-#include <boost/type_traits/is_base_of.hpp>
-
 #include <istream>
 #include <ostream>
+#include <type_traits>
 #include <vector>
 
 namespace boost { namespace gil {
@@ -33,9 +32,8 @@ struct property_base
     using type = Property;
 };
 
-template<typename FormatTag> struct is_format_tag : is_base_and_derived< format_tag
-                                                                       , FormatTag
-                                                                       > {};
+template<typename FormatTag>
+struct is_format_tag : std::is_base_of<format_tag, FormatTag> {};
 
 struct image_read_settings_base
 {
@@ -71,7 +69,7 @@ public:
 };
 
 /**
- * Boolean meta function, mpl::true_ if the pixel type \a PixelType is supported
+ * Boolean meta function, std::true_type if the pixel type \a PixelType is supported
  * by the image format identified with \a FormatTag.
  * \todo the name is_supported is to generic, pick something more IO realted.
  */

--- a/include/boost/gil/io/conversion_policies.hpp
+++ b/include/boost/gil/io/conversion_policies.hpp
@@ -9,13 +9,14 @@
 #define BOOST_GIL_IO_CONVERSION_POLICIES_HPP
 
 #include <boost/gil/image_view_factory.hpp>
+#include <boost/gil/detail/mp11.hpp>
 #include <boost/gil/io/error.hpp>
 
 #include <algorithm>
 #include <iterator>
 #include <type_traits>
 
-namespace boost{namespace gil{ namespace detail {
+namespace boost{ namespace gil { namespace detail {
 
 struct read_and_no_convert
 {
@@ -27,7 +28,7 @@ public:
         InIterator const& /*begin*/, InIterator const& /*end*/ , OutIterator /*out*/,
         typename std::enable_if
         <
-            mpl::not_
+            mp11::mp_not
             <
                 pixels_are_compatible
                 <
@@ -93,10 +94,10 @@ public:
 /// is_read_only metafunction
 /// \brief Determines if reader type is read only ( no conversion ).
 template< typename Conversion_Policy >
-struct is_read_only : mpl::false_ {};
+struct is_read_only : std::false_type {};
 
 template<>
-struct is_read_only< detail::read_and_no_convert > : mpl::true_ {};
+struct is_read_only<detail::read_and_no_convert> : std::true_type {};
 
 } // namespace detail
 } // namespace gil

--- a/include/boost/gil/io/device.hpp
+++ b/include/boost/gil/io/device.hpp
@@ -8,6 +8,7 @@
 #ifndef BOOST_GIL_IO_DEVICE_HPP
 #define BOOST_GIL_IO_DEVICE_HPP
 
+#include <boost/gil/detail/mp11.hpp>
 #include <boost/gil/io/base.hpp>
 
 #include <boost/assert.hpp>
@@ -544,15 +545,15 @@ private:
  * Metafunction to detect input devices.
  * Should be replaced by an external facility in the future.
  */
-template< typename IODevice  > struct is_input_device : mpl::false_{};
-template< typename FormatTag > struct is_input_device< file_stream_device< FormatTag > > : mpl::true_{};
-template< typename FormatTag > struct is_input_device<     istream_device< FormatTag > > : mpl::true_{};
+template< typename IODevice  > struct is_input_device : std::false_type{};
+template< typename FormatTag > struct is_input_device< file_stream_device< FormatTag > > : std::true_type{};
+template< typename FormatTag > struct is_input_device<     istream_device< FormatTag > > : std::true_type{};
 
 template< typename FormatTag
         , typename T
         , typename D = void
         >
-struct is_adaptable_input_device : mpl::false_{};
+struct is_adaptable_input_device : std::false_type{};
 
 template <typename FormatTag, typename T>
 struct is_adaptable_input_device
@@ -561,13 +562,13 @@ struct is_adaptable_input_device
     T,
     typename std::enable_if
     <
-        mpl::or_
+        mp11::mp_or
         <
-            is_base_and_derived<std::istream, T>,
-            is_same<std::istream, T>
+            std::is_base_of<std::istream, T>,
+            std::is_same<std::istream, T>
         >::value
     >::type
-> : mpl::true_
+> : std::true_type
 {
     using device_type = istream_device<FormatTag>;
 };
@@ -577,7 +578,7 @@ struct is_adaptable_input_device< FormatTag
                                 , FILE*
                                 , void
                                 >
-    : mpl::true_
+    : std::true_type
 {
     using device_type = file_stream_device<FormatTag>;
 };
@@ -589,7 +590,7 @@ template< typename FormatTag
         , typename T
         , typename D = void
         >
-struct is_read_device : mpl::false_
+struct is_read_device : std::false_type
 {};
 
 template <typename FormatTag, typename T>
@@ -599,13 +600,13 @@ struct is_read_device
     T,
     typename std::enable_if
     <
-        mpl::or_
+        mp11::mp_or
         <
             is_input_device<FormatTag>,
             is_adaptable_input_device<FormatTag, T>
         >::value
     >::type
-> : mpl::true_
+> : std::true_type
 {
 };
 
@@ -614,16 +615,16 @@ struct is_read_device
  * Metafunction to detect output devices.
  * Should be replaced by an external facility in the future.
  */
-template<typename IODevice> struct is_output_device : mpl::false_{};
+template<typename IODevice> struct is_output_device : std::false_type{};
 
-template< typename FormatTag > struct is_output_device< file_stream_device< FormatTag > > : mpl::true_{};
-template< typename FormatTag > struct is_output_device< ostream_device    < FormatTag > > : mpl::true_{};
+template< typename FormatTag > struct is_output_device< file_stream_device< FormatTag > > : std::true_type{};
+template< typename FormatTag > struct is_output_device< ostream_device    < FormatTag > > : std::true_type{};
 
 template< typename FormatTag
         , typename IODevice
         , typename D = void
         >
-struct is_adaptable_output_device : mpl::false_ {};
+struct is_adaptable_output_device : std::false_type {};
 
 template <typename FormatTag, typename T>
 struct is_adaptable_output_device
@@ -632,19 +633,19 @@ struct is_adaptable_output_device
     T,
     typename std::enable_if
     <
-        mpl::or_
+        mp11::mp_or
         <
-            is_base_and_derived<std::ostream, T>,
-            is_same<std::ostream, T>
+            std::is_base_of<std::ostream, T>,
+            std::is_same<std::ostream, T>
         >::value
     >::type
-> : mpl::true_
+> : std::true_type
 {
     using device_type = ostream_device<FormatTag>;
 };
 
 template<typename FormatTag> struct is_adaptable_output_device<FormatTag,FILE*,void>
-  : mpl::true_
+  : std::true_type
 {
     using device_type = file_stream_device<FormatTag>;
 };
@@ -657,7 +658,7 @@ template< typename FormatTag
         , typename T
         , typename D = void
         >
-struct is_write_device : mpl::false_
+struct is_write_device : std::false_type
 {};
 
 template <typename FormatTag, typename T>
@@ -667,13 +668,13 @@ struct is_write_device
     T,
     typename std::enable_if
     <
-        mpl::or_
+        mp11::mp_or
         <
             is_output_device<FormatTag>,
             is_adaptable_output_device<FormatTag, T>
         >::value
     >::type
-> : mpl::true_
+> : std::true_type
 {
 };
 
@@ -691,7 +692,7 @@ template< typename Device, typename FormatTag, typename Log = no_log > class dyn
 namespace detail {
 
 template< typename T >
-struct is_reader : mpl::false_
+struct is_reader : std::false_type
 {};
 
 template< typename Device
@@ -702,11 +703,11 @@ struct is_reader< reader< Device
                         , FormatTag
                         , ConversionPolicy
                         >
-                > : mpl::true_
+                > : std::true_type
 {};
 
 template< typename T >
-struct is_dynamic_image_reader : mpl::false_
+struct is_dynamic_image_reader : std::false_type
 {};
 
 template< typename Device
@@ -715,11 +716,11 @@ template< typename Device
 struct is_dynamic_image_reader< dynamic_image_reader< Device
                                                     , FormatTag
                                                     >
-                              > : mpl::true_
+                              > : std::true_type
 {};
 
 template< typename T >
-struct is_writer : mpl::false_
+struct is_writer : std::false_type
 {};
 
 template< typename Device
@@ -728,11 +729,11 @@ template< typename Device
 struct is_writer< writer< Device
                         , FormatTag
                         >
-                > : mpl::true_
+                > : std::true_type
 {};
 
 template< typename T >
-struct is_dynamic_image_writer : mpl::false_
+struct is_dynamic_image_writer : std::false_type
 {};
 
 template< typename Device
@@ -741,7 +742,7 @@ template< typename Device
 struct is_dynamic_image_writer< dynamic_image_writer< Device
                                                     , FormatTag
                                                     >
-                > : mpl::true_
+                > : std::true_type
 {};
 
 } // namespace detail

--- a/include/boost/gil/io/dynamic_io_new.hpp
+++ b/include/boost/gil/io/dynamic_io_new.hpp
@@ -10,61 +10,64 @@
 
 #include <boost/gil/extension/dynamic_image/dynamic_image_all.hpp>
 
+#include <boost/gil/detail/mp11.hpp>
 #include <boost/gil/io/error.hpp>
 
-#include <boost/mpl/at.hpp>
-#include <boost/mpl/size.hpp>
+#include <type_traits>
 
 namespace boost { namespace gil {
 
 namespace detail {
 
 template <long N>
-struct construct_matched_t {
+struct construct_matched_t
+{
     template <typename Images,typename Pred>
-    static bool apply(any_image<Images>& im,Pred pred) {
-        if (pred.template apply<typename mpl::at_c<Images,N-1>::type>()) {
-            typename mpl::at_c<Images,N-1>::type x;
-            im = std::move(x);
+    static bool apply(any_image<Images>& img, Pred pred)
+    {
+        if (pred.template apply<mp11::mp_at_c<Images, N-1>>())
+        {
+            using image_t = mp11::mp_at_c<Images, N-1>;
+            image_t x;
+            img = std::move(x);
             return true;
-        } else return construct_matched_t<N-1>::apply(im,pred);
+        }
+        else
+            return construct_matched_t<N-1>::apply(img, pred);
     }
 };
 template <>
-struct construct_matched_t<0> {
+struct construct_matched_t<0>
+{
     template <typename Images,typename Pred>
-    static bool apply(any_image<Images>&,Pred) {return false;}
+    static bool apply(any_image<Images>&,Pred) { return false; }
 };
 
 // A function object that can be passed to apply_operation.
-// Given a predicate IsSupported taking a view type and returning an MPL boolean,
+// Given a predicate IsSupported taking a view type and returning an boolean integral coonstant,
 // calls the apply method of OpClass with the view if the given view IsSupported, or throws an exception otherwise
 template <typename IsSupported, typename OpClass>
-class dynamic_io_fnobj {
+class dynamic_io_fnobj
+{
+private:
     OpClass* _op;
 
     template <typename View>
-    void apply(const View& view,mpl::true_ ) {_op->apply(view);}
+    void apply(View const& view, std::true_type) { _op->apply(view); }
 
-    template <typename View, typename Info >
-    void apply( const View& view
-              , const Info& info
-              , const mpl::true_
-              )
-    {
-        _op->apply( view, info );
-    }
+    template <typename View, typename Info>
+    void apply(View const& view, Info const & info, const std::true_type) { _op->apply(view, info); }
 
     template <typename View>
-    void apply(const View& /* view */ ,mpl::false_) {io_error("dynamic_io: unsupported view type for the given file format");}
+    void apply(View const& /* view */, std::false_type)
+    {
+        io_error("dynamic_io: unsupported view type for the given file format");
+    }
 
     template <typename View, typename Info >
-    void apply( const View& /* view */
-              , const Info& /* info */
-              , const mpl::false_
-              )
+    void apply(View const& /* view */, Info const& /* info */, const std::false_type)
     {
-        io_error( "dynamic_io: unsupported view type for the given file format" );
+        io_error("dynamic_io: unsupported view type for the given file format");
     }
 
 public:
@@ -73,17 +76,16 @@ public:
     using result_type = void;
 
     template <typename View>
-    void operator()(const View& view) {apply(view,typename IsSupported::template apply<View>::type());}
-
-    template< typename View, typename Info >
-    void operator()(const View& view, const Info& info )
+    void operator()(View const& view)
     {
-        apply( view
-             , info
-             , typename IsSupported::template apply< View >::type()
-             );
+        apply(view, typename IsSupported::template apply<View>::type());
     }
 
+    template< typename View, typename Info >
+    void operator()(View const& view, Info const& info)
+    {
+        apply(view, info, typename IsSupported::template apply<View>::type());
+    }
 };
 
 } // namespace detail
@@ -91,8 +93,10 @@ public:
 /// \brief Within the any_image, constructs an image with the given dimensions
 ///        and a type that satisfies the given predicate
 template <typename Images,typename Pred>
-inline bool construct_matched(any_image<Images>& im,Pred pred) {
-    return detail::construct_matched_t<mpl::size<Images>::value>::apply(im,pred);
+inline bool construct_matched(any_image<Images>& img, Pred pred)
+{
+    constexpr auto size = mp11::mp_size<Images>::value;
+    return detail::construct_matched_t<size>::apply(img, pred);
 }
 
 } }  // namespace boost::gil

--- a/include/boost/gil/io/get_read_device.hpp
+++ b/include/boost/gil/io/get_read_device.hpp
@@ -8,10 +8,9 @@
 #ifndef BOOST_GIL_IO_GET_READ_DEVICE_HPP
 #define BOOST_GIL_IO_GET_READ_DEVICE_HPP
 
+#include <boost/gil/detail/mp11.hpp>
 #include <boost/gil/io/device.hpp>
 #include <boost/gil/io/path_spec.hpp>
-
-#include <boost/mpl/and.hpp>
 
 #include <type_traits>
 
@@ -31,7 +30,7 @@ struct get_read_device
     FormatTag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_adaptable_input_device<FormatTag, Device>,
             is_format_tag<FormatTag>
@@ -53,7 +52,7 @@ struct get_read_device
     FormatTag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>

--- a/include/boost/gil/io/get_reader.hpp
+++ b/include/boost/gil/io/get_reader.hpp
@@ -9,8 +9,7 @@
 #define BOOST_GIL_IO_GET_READER_HPP
 
 #include <boost/gil/io/get_read_device.hpp>
-
-#include <boost/mpl/and.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <type_traits>
 
@@ -34,7 +33,7 @@ struct get_reader
     ConversionPolicy,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
@@ -54,7 +53,7 @@ struct get_reader
     ConversionPolicy,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_adaptable_input_device<FormatTag, Device>,
             is_format_tag<FormatTag>
@@ -79,7 +78,7 @@ struct get_dynamic_image_reader
     FormatTag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
@@ -98,7 +97,7 @@ struct get_dynamic_image_reader
     FormatTag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_adaptable_input_device<FormatTag, Device>,
             is_format_tag<FormatTag>
@@ -123,7 +122,7 @@ struct get_reader_backend
     FormatTag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
@@ -142,7 +141,7 @@ struct get_reader_backend
     FormatTag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_adaptable_input_device<FormatTag, Device>,
             is_format_tag<FormatTag>

--- a/include/boost/gil/io/get_write_device.hpp
+++ b/include/boost/gil/io/get_write_device.hpp
@@ -8,10 +8,9 @@
 #ifndef BOOST_GIL_IO_GET_WRITE_DEVICE_HPP
 #define BOOST_GIL_IO_GET_WRITE_DEVICE_HPP
 
+#include <boost/gil/detail/mp11.hpp>
 #include <boost/gil/io/device.hpp>
 #include <boost/gil/io/path_spec.hpp>
-
-#include <boost/mpl/and.hpp>
 
 #include <type_traits>
 
@@ -27,7 +26,7 @@ struct get_write_device
     FormatTag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_adaptable_output_device<FormatTag, Device>,
             is_format_tag<FormatTag>
@@ -46,7 +45,7 @@ struct get_write_device
     FormatTag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>

--- a/include/boost/gil/io/get_writer.hpp
+++ b/include/boost/gil/io/get_writer.hpp
@@ -8,9 +8,8 @@
 #ifndef BOOST_GIL_IO_GET_WRITER_HPP
 #define BOOST_GIL_IO_GET_WRITER_HPP
 
+#include <boost/gil/detail/mp11.hpp>
 #include <boost/gil/io/get_write_device.hpp>
-
-#include <boost/mpl/and.hpp>
 
 #include <type_traits>
 
@@ -28,7 +27,7 @@ struct get_writer
     FormatTag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
@@ -47,7 +46,7 @@ struct get_writer
     FormatTag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_adaptable_output_device<FormatTag, Device>,
             is_format_tag<FormatTag>
@@ -70,7 +69,7 @@ struct get_dynamic_image_writer
     FormatTag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
@@ -89,7 +88,7 @@ struct get_dynamic_image_writer
     FormatTag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_write_device<FormatTag, Device>,
             is_format_tag<FormatTag>

--- a/include/boost/gil/io/make_backend.hpp
+++ b/include/boost/gil/io/make_backend.hpp
@@ -9,9 +9,8 @@
 #ifndef BOOST_GIL_IO_MAKE_BACKEND_HPP
 #define BOOST_GIL_IO_MAKE_BACKEND_HPP
 
+#include <boost/gil/detail/mp11.hpp>
 #include <boost/gil/io/get_reader.hpp>
-
-#include <boost/mpl/and.hpp>
 
 #include <type_traits>
 
@@ -23,7 +22,7 @@ auto make_reader_backend(
     String const& file_name, image_read_settings<FormatTag> const& settings,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
@@ -73,7 +72,7 @@ inline
 auto make_reader_backend(Device& io_dev, image_read_settings<FormatTag> const& settings,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_adaptable_input_device<FormatTag, Device>,
             is_format_tag<FormatTag>
@@ -92,7 +91,7 @@ inline
 auto make_reader_backend(String const& file_name, FormatTag const&,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
@@ -108,7 +107,7 @@ inline
 auto make_reader_backend(Device& io_dev, FormatTag const&,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_adaptable_input_device<FormatTag, Device>,
             is_format_tag<FormatTag>

--- a/include/boost/gil/io/make_dynamic_image_reader.hpp
+++ b/include/boost/gil/io/make_dynamic_image_reader.hpp
@@ -8,9 +8,8 @@
 #ifndef BOOST_GIL_IO_MAKE_DYNAMIC_IMAGE_READER_HPP
 #define BOOST_GIL_IO_MAKE_DYNAMIC_IMAGE_READER_HPP
 
+#include <boost/gil/detail/mp11.hpp>
 #include <boost/gil/io/get_reader.hpp>
-
-#include <boost/mpl/and.hpp>
 
 #include <type_traits>
 
@@ -22,7 +21,7 @@ auto make_dynamic_image_reader(
     String const& file_name, image_read_settings<FormatTag> const& settings,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
@@ -72,7 +71,7 @@ auto make_dynamic_image_reader(
     Device& file, image_read_settings<FormatTag> const& settings,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_adaptable_input_device<FormatTag, Device>,
             is_format_tag<FormatTag>
@@ -91,7 +90,7 @@ inline
 auto make_dynamic_image_reader(String const& file_name, FormatTag const&,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
@@ -125,7 +124,7 @@ inline
 auto make_dynamic_image_reader(Device& file, FormatTag const&,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_adaptable_input_device<FormatTag, Device>,
             is_format_tag<FormatTag>

--- a/include/boost/gil/io/make_dynamic_image_writer.hpp
+++ b/include/boost/gil/io/make_dynamic_image_writer.hpp
@@ -8,9 +8,8 @@
 #ifndef BOOST_GIL_IO_MAKE_DYNAMIC_IMAGE_WRITER_HPP
 #define BOOST_GIL_IO_MAKE_DYNAMIC_IMAGE_WRITER_HPP
 
+#include <boost/gil/detail/mp11.hpp>
 #include <boost/gil/io/get_writer.hpp>
-
-#include <boost/mpl/and.hpp>
 
 #include <type_traits>
 
@@ -22,7 +21,7 @@ auto make_dynamic_image_writer(
     String const& file_name, image_write_info<FormatTag> const& info,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
@@ -85,7 +84,7 @@ inline
 auto make_dynamic_image_writer(Device& file, image_write_info<FormatTag> const& info,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             typename detail::is_adaptable_output_device<FormatTag, Device>::type,
             is_format_tag<FormatTag>
@@ -104,7 +103,7 @@ inline
 auto make_dynamic_image_writer(String const& file_name, FormatTag const&,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
@@ -151,7 +150,7 @@ inline
 auto make_dynamic_image_writer(Device& file, FormatTag const&,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             typename detail::is_adaptable_output_device<FormatTag, Device>::type,
             is_format_tag<FormatTag>

--- a/include/boost/gil/io/make_reader.hpp
+++ b/include/boost/gil/io/make_reader.hpp
@@ -8,9 +8,8 @@
 #ifndef BOOST_GIL_IO_MAKE_READER_HPP
 #define BOOST_GIL_IO_MAKE_READER_HPP
 
+#include <boost/gil/detail/mp11.hpp>
 #include <boost/gil/io/get_reader.hpp>
-
-#include <boost/mpl/and.hpp>
 
 #include <type_traits>
 
@@ -24,7 +23,7 @@ auto make_reader(
     ConversionPolicy const&,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
@@ -100,7 +99,7 @@ auto make_reader(
     ConversionPolicy const&,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_adaptable_input_device<FormatTag, Device>,
             is_format_tag<FormatTag>
@@ -124,7 +123,7 @@ auto make_reader(
     ConversionPolicy const& cc,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
@@ -183,7 +182,7 @@ auto make_reader(
     ConversionPolicy const& cc,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_adaptable_input_device<FormatTag, Device>,
             is_format_tag<FormatTag>

--- a/include/boost/gil/io/make_scanline_reader.hpp
+++ b/include/boost/gil/io/make_scanline_reader.hpp
@@ -8,9 +8,8 @@
 #ifndef BOOST_GIL_IO_MAKE_SCANLINE_READER_HPP
 #define BOOST_GIL_IO_MAKE_SCANLINE_READER_HPP
 
+#include <boost/gil/detail/mp11.hpp>
 #include <boost/gil/io/get_reader.hpp>
-
-#include <boost/mpl/and.hpp>
 
 #include <type_traits>
 
@@ -21,7 +20,7 @@ inline
 auto make_scanline_reader(String const& file_name, FormatTag const&,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
@@ -85,7 +84,7 @@ inline
 auto make_scanline_reader(Device& io_dev, FormatTag const&,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_adaptable_input_device<FormatTag, Device>,
             is_format_tag<FormatTag>

--- a/include/boost/gil/io/make_writer.hpp
+++ b/include/boost/gil/io/make_writer.hpp
@@ -8,9 +8,8 @@
 #ifndef BOOST_GIL_IO_MAKE_WRITER_HPP
 #define BOOST_GIL_IO_MAKE_WRITER_HPP
 
+#include <boost/gil/detail/mp11.hpp>
 #include <boost/gil/io/get_writer.hpp>
-
-#include <boost/mpl/and.hpp>
 
 #include <type_traits>
 
@@ -21,7 +20,7 @@ inline
 auto make_writer(String const& file_name, image_write_info<FormatTag> const& info,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
@@ -82,7 +81,7 @@ inline
 auto make_writer(Device& file, image_write_info<FormatTag> const& info,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             typename detail::is_adaptable_output_device<FormatTag, Device>::type,
             is_format_tag<FormatTag>
@@ -101,7 +100,7 @@ inline
 auto make_writer(String const& file_name, FormatTag const&,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
@@ -147,7 +146,7 @@ inline
 auto make_writer(Device& file, FormatTag const&,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             typename detail::is_adaptable_output_device<FormatTag, Device>::type,
             is_format_tag<FormatTag>

--- a/include/boost/gil/io/path_spec.hpp
+++ b/include/boost/gil/io/path_spec.hpp
@@ -32,31 +32,30 @@
 #endif
 #endif // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 
-#include <boost/mpl/bool.hpp> // for complete types of true_ and false_
-
 #include <cstdlib>
 #include <string>
+#include <type_traits>
 
 namespace boost { namespace gil { namespace detail {
 
-template<typename P> struct is_supported_path_spec              : mpl::false_ {};
-template<> struct is_supported_path_spec< std::string >         : mpl::true_ {};
-template<> struct is_supported_path_spec< const std::string >   : mpl::true_ {};
-template<> struct is_supported_path_spec< std::wstring >        : mpl::true_ {};
-template<> struct is_supported_path_spec< const std::wstring >  : mpl::true_ {};
-template<> struct is_supported_path_spec< const char* >         : mpl::true_ {};
-template<> struct is_supported_path_spec< char* >               : mpl::true_ {};
-template<> struct is_supported_path_spec< const wchar_t* >      : mpl::true_ {};
-template<> struct is_supported_path_spec< wchar_t* >            : mpl::true_ {};
+template<typename P> struct is_supported_path_spec              : std::false_type {};
+template<> struct is_supported_path_spec< std::string >         : std::true_type {};
+template<> struct is_supported_path_spec< const std::string >   : std::true_type {};
+template<> struct is_supported_path_spec< std::wstring >        : std::true_type {};
+template<> struct is_supported_path_spec< const std::wstring >  : std::true_type {};
+template<> struct is_supported_path_spec< const char* >         : std::true_type {};
+template<> struct is_supported_path_spec< char* >               : std::true_type {};
+template<> struct is_supported_path_spec< const wchar_t* >      : std::true_type {};
+template<> struct is_supported_path_spec< wchar_t* >            : std::true_type {};
 
-template<int i> struct is_supported_path_spec<const char [i]>       : mpl::true_ {};
-template<int i> struct is_supported_path_spec<char [i]>             : mpl::true_ {};
-template<int i> struct is_supported_path_spec<const wchar_t [i]>    : mpl::true_ {};
-template<int i> struct is_supported_path_spec<wchar_t [i]>          : mpl::true_ {};
+template<int i> struct is_supported_path_spec<const char [i]>       : std::true_type {};
+template<int i> struct is_supported_path_spec<char [i]>             : std::true_type {};
+template<int i> struct is_supported_path_spec<const wchar_t [i]>    : std::true_type {};
+template<int i> struct is_supported_path_spec<wchar_t [i]>          : std::true_type {};
 
 #ifdef BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
-template<> struct is_supported_path_spec< filesystem::path > : mpl::true_ {};
-template<> struct is_supported_path_spec< const filesystem::path > : mpl::true_ {};
+template<> struct is_supported_path_spec< filesystem::path > : std::true_type {};
+template<> struct is_supported_path_spec< const filesystem::path > : std::true_type {};
 #endif // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 
 

--- a/include/boost/gil/io/read_and_convert_image.hpp
+++ b/include/boost/gil/io/read_and_convert_image.hpp
@@ -13,9 +13,7 @@
 #include <boost/gil/io/device.hpp>
 #include <boost/gil/io/get_reader.hpp>
 #include <boost/gil/io/path_spec.hpp>
-
-#include <boost/mpl/and.hpp>
-#include <boost/type_traits/is_base_and_derived.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <type_traits>
 
@@ -34,7 +32,7 @@ inline
 void read_and_convert_image(Reader& reader, Image& img,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_reader<Reader>,
             is_format_tag<typename Reader::format_tag_t>
@@ -60,7 +58,7 @@ void read_and_convert_image(
     ColorConverter const& cc,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_read_device<FormatTag, Device>,
             is_format_tag<FormatTag>
@@ -89,7 +87,7 @@ void read_and_convert_image(
     ColorConverter const& cc,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             is_format_tag<FormatTag>,
             detail::is_supported_path_spec<String>
@@ -118,7 +116,7 @@ void read_and_convert_image(
     FormatTag const& tag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             is_format_tag<FormatTag>,
             detail::is_supported_path_spec<String>
@@ -147,7 +145,7 @@ void read_and_convert_image(
     FormatTag const& tag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_read_device<FormatTag, Device>,
             is_format_tag<FormatTag>
@@ -173,7 +171,7 @@ inline void read_and_convert_image(
     image_read_settings<FormatTag> const& settings,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             is_format_tag<FormatTag>,
             detail::is_supported_path_spec<String>
@@ -199,7 +197,7 @@ inline void read_and_convert_image(
     image_read_settings<FormatTag> const& settings,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_read_device<FormatTag, Device>,
             is_format_tag<FormatTag>
@@ -226,7 +224,7 @@ void read_and_convert_image(
     FormatTag const& tag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             is_format_tag<FormatTag>,
             detail::is_supported_path_spec<String>
@@ -252,7 +250,7 @@ inline void read_and_convert_image(
     FormatTag const& tag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_read_device<FormatTag, Device>,
             is_format_tag<FormatTag>

--- a/include/boost/gil/io/read_and_convert_view.hpp
+++ b/include/boost/gil/io/read_and_convert_view.hpp
@@ -13,9 +13,7 @@
 #include <boost/gil/io/device.hpp>
 #include <boost/gil/io/get_reader.hpp>
 #include <boost/gil/io/path_spec.hpp>
-
-#include <boost/mpl/and.hpp>
-#include <boost/type_traits/is_base_and_derived.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <type_traits>
 
@@ -34,7 +32,7 @@ inline
 void read_and_convert_view(Reader& reader, View const& view,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_reader<Reader>,
             is_format_tag<typename Reader::format_tag_t>
@@ -61,7 +59,7 @@ void read_and_convert_view(
     ColorConverter const& cc,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_read_device<FormatTag, Device>,
             is_format_tag<FormatTag>
@@ -90,7 +88,7 @@ void read_and_convert_view(
     ColorConverter const& cc,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             is_format_tag<FormatTag>,
             detail::is_supported_path_spec<String>
@@ -119,7 +117,7 @@ void read_and_convert_view(
     FormatTag const& tag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             is_format_tag<FormatTag>,
             detail::is_supported_path_spec<String>
@@ -148,7 +146,7 @@ void read_and_convert_view(
     FormatTag const& tag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_read_device<FormatTag, Device>,
             is_format_tag<FormatTag>
@@ -175,7 +173,7 @@ void read_and_convert_view(
     image_read_settings<FormatTag> const& settings,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             is_format_tag<FormatTag>,
             detail::is_supported_path_spec<String>
@@ -202,7 +200,7 @@ void read_and_convert_view(
     image_read_settings<FormatTag> const& settings,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_read_device<FormatTag, Device>,
             is_format_tag<FormatTag>
@@ -229,7 +227,7 @@ void read_and_convert_view(
     FormatTag const& tag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             is_format_tag<FormatTag>,
             detail::is_supported_path_spec<String>
@@ -256,7 +254,7 @@ void read_and_convert_view(
     FormatTag const& tag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_read_device<FormatTag, Device>,
             is_format_tag<FormatTag>

--- a/include/boost/gil/io/read_image.hpp
+++ b/include/boost/gil/io/read_image.hpp
@@ -15,9 +15,7 @@
 #include <boost/gil/io/device.hpp>
 #include <boost/gil/io/get_reader.hpp>
 #include <boost/gil/io/path_spec.hpp>
-
-#include <boost/mpl/and.hpp>
-#include <boost/type_traits/is_base_and_derived.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <type_traits>
 
@@ -34,7 +32,7 @@ inline
 void read_image(Reader reader, Image& img,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_reader<Reader>,
             is_format_tag<typename Reader::format_tag_t>,
@@ -63,7 +61,7 @@ void read_image(
     image_read_settings<FormatTag> const& settings,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_read_device<FormatTag, Device>,
             is_format_tag<FormatTag>,
@@ -92,7 +90,7 @@ inline
 void read_image(Device& file, Image& img, FormatTag const& tag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_read_device<FormatTag, Device>,
             is_format_tag<FormatTag>,
@@ -124,7 +122,7 @@ void read_image(
     image_read_settings<FormatTag> const& settings,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>,
@@ -153,7 +151,7 @@ inline
 void read_image(String const& file_name, Image& img, FormatTag const& tag,
     typename std::enable_if
     <
-        mpl::and_<detail::is_supported_path_spec<String>,
+        mp11::mp_and<detail::is_supported_path_spec<String>,
         is_format_tag<FormatTag>,
         is_read_supported
         <
@@ -177,7 +175,7 @@ inline
 void read_image(Reader& reader, any_image<Images>& images,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_dynamic_image_reader<Reader>,
             is_format_tag<typename Reader::format_tag_t>
@@ -189,7 +187,7 @@ void read_image(Reader& reader, any_image<Images>& images,
 
 /// \brief Reads an image without conversion. Image memory is allocated.
 /// \param file      It's a device. Must satisfy is_adaptable_input_device metafunction.
-/// \param images    Dynamic image ( mpl::vector ). See boost::gil::dynamic_image extension.
+/// \param images    Dynamic image (mp11::mp_list). See boost::gil::dynamic_image extension.
 /// \param settings  Specifies read settings depending on the image format.
 /// \throw std::ios_base::failure
 template <typename Device, typename Images, typename FormatTag>
@@ -200,7 +198,7 @@ void read_image(
     image_read_settings<FormatTag> const& settings,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_read_device<FormatTag, Device>,
             is_format_tag<FormatTag>
@@ -215,7 +213,7 @@ void read_image(
 
 /// \brief Reads an image without conversion. Image memory is allocated.
 /// \param file      It's a device. Must satisfy is_adaptable_input_device metafunction.
-/// \param images    Dynamic image ( mpl::vector ). See boost::gil::dynamic_image extension.
+/// \param images    Dynamic image (mp11::mp_list). See boost::gil::dynamic_image extension.
 /// \param tag       Defines the image format. Must satisfy is_format_tag metafunction.
 /// \throw std::ios_base::failure
 template <typename Device, typename Images, typename FormatTag>
@@ -223,7 +221,7 @@ inline
 void read_image(Device& file, any_image<Images>& images, FormatTag const& tag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_read_device<FormatTag, Device>,
             is_format_tag<FormatTag>
@@ -238,7 +236,7 @@ void read_image(Device& file, any_image<Images>& images, FormatTag const& tag,
 
 /// \brief Reads an image without conversion. Image memory is allocated.
 /// \param file_name File name. Must satisfy is_supported_path_spec metafunction.
-/// \param images    Dynamic image ( mpl::vector ). See boost::gil::dynamic_image extension.
+/// \param images    Dynamic image (mp11::mp_list). See boost::gil::dynamic_image extension.
 /// \param settings  Specifies read settings depending on the image format.
 /// \throw std::ios_base::failure
 template <typename String, typename Images, typename FormatTag>
@@ -249,7 +247,7 @@ void read_image(
     image_read_settings<FormatTag> const& settings,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>
@@ -264,7 +262,7 @@ void read_image(
 
 /// \brief Reads an image without conversion. Image memory is allocated.
 /// \param file_name File name. Must satisfy is_supported_path_spec metafunction.
-/// \param images    Dynamic image ( mpl::vector ). See boost::gil::dynamic_image extension.
+/// \param images    Dynamic image (mp11::mp_list). See boost::gil::dynamic_image extension.
 /// \param tag       Defines the image format. Must satisfy is_format_tag metafunction.
 /// \throw std::ios_base::failure
 template <typename String, typename Images, typename FormatTag>
@@ -272,7 +270,7 @@ inline
 void read_image(String const& file_name, any_image<Images>& images, FormatTag const& tag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_supported_path_spec<String>,
             is_format_tag<FormatTag>

--- a/include/boost/gil/io/read_image_info.hpp
+++ b/include/boost/gil/io/read_image_info.hpp
@@ -12,9 +12,7 @@
 #include <boost/gil/io/device.hpp>
 #include <boost/gil/io/get_reader.hpp>
 #include <boost/gil/io/path_spec.hpp>
-
-#include <boost/mpl/and.hpp>
-#include <boost/type_traits/is_base_and_derived.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <type_traits>
 
@@ -32,7 +30,7 @@ inline
 auto read_image_info(Device& file, image_read_settings<FormatTag> const& settings,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_adaptable_input_device<FormatTag, Device>,
             is_format_tag<FormatTag>
@@ -53,7 +51,7 @@ inline
 auto read_image_info(Device& file, FormatTag const&,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_adaptable_input_device<FormatTag, Device>,
             is_format_tag<FormatTag>
@@ -75,7 +73,7 @@ auto read_image_info(
     String const& file_name, image_read_settings<FormatTag> const& settings,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             is_format_tag<FormatTag>,
             detail::is_supported_path_spec<String>
@@ -96,7 +94,7 @@ inline
 auto read_image_info(String const& file_name, FormatTag const&,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             is_format_tag<FormatTag>,
             detail::is_supported_path_spec<String>

--- a/include/boost/gil/io/read_view.hpp
+++ b/include/boost/gil/io/read_view.hpp
@@ -13,9 +13,7 @@
 #include <boost/gil/io/device.hpp>
 #include <boost/gil/io/get_reader.hpp>
 #include <boost/gil/io/path_spec.hpp>
-
-#include <boost/mpl/and.hpp>
-#include <boost/type_traits/is_base_and_derived.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <type_traits>
 
@@ -33,7 +31,7 @@ inline
 void read_view(Reader reader, View const& view,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_reader<Reader>,
             typename is_format_tag<typename Reader::format_tag_t>::type,
@@ -63,7 +61,7 @@ void read_view(
     image_read_settings<FormatTag> const& settings,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             detail::is_read_device<FormatTag, Device>,
             typename is_format_tag<FormatTag>::type,
@@ -92,7 +90,7 @@ inline
 void read_view(Device& file, View const& view, FormatTag const& tag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             typename is_format_tag<FormatTag>::type,
             detail::is_read_device<FormatTag, Device>,
@@ -123,7 +121,7 @@ void read_view(
     image_read_settings<FormatTag> const& settings,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             typename detail::is_supported_path_spec<String>::type,
             typename is_format_tag<FormatTag>::type,
@@ -152,7 +150,7 @@ inline
 void read_view(String const& file_name, View const& view, FormatTag const& tag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             typename detail::is_supported_path_spec<String>::type,
             typename is_format_tag<FormatTag>::type,

--- a/include/boost/gil/io/row_buffer_helper.hpp
+++ b/include/boost/gil/io/row_buffer_helper.hpp
@@ -13,9 +13,8 @@
 #include <boost/gil/extension/toolbox/metafunctions/is_homogeneous.hpp>
 #include <boost/gil/extension/toolbox/metafunctions/pixel_bit_size.hpp>
 
+#include <boost/gil/detail/mp11.hpp>
 #include <boost/gil/io/typedefs.hpp>
-
-#include <boost/mpl/and.hpp>
 
 #include <cstddef>
 #include <type_traits>
@@ -108,7 +107,7 @@ struct row_buffer_helper
     Pixel,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             typename is_bit_aligned<Pixel>::type,
             typename is_homogeneous<Pixel>::type

--- a/include/boost/gil/io/typedefs.hpp
+++ b/include/boost/gil/io/typedefs.hpp
@@ -16,8 +16,7 @@
 #include <boost/gil/point.hpp>
 #include <boost/gil/utilities.hpp>
 
-#include <boost/type_traits/is_base_of.hpp>
-
+#include <type_traits>
 #include <vector>
 
 namespace boost { namespace gil {
@@ -32,8 +31,8 @@ using byte_vector_t = std::vector<byte_t>;
 
 namespace boost {
 
-template<> struct is_floating_point<gil::float32_t> : mpl::true_ {};
-template<> struct is_floating_point<gil::float64_t> : mpl::true_ {};
+template<> struct is_floating_point<gil::float32_t> : std::true_type {};
+template<> struct is_floating_point<gil::float64_t> : std::true_type {};
 
 } // namespace boost
 

--- a/include/boost/gil/io/write_view.hpp
+++ b/include/boost/gil/io/write_view.hpp
@@ -13,9 +13,7 @@
 #include <boost/gil/io/device.hpp>
 #include <boost/gil/io/get_writer.hpp>
 #include <boost/gil/io/path_spec.hpp>
-
-#include <boost/mpl/and.hpp>
-#include <boost/type_traits/is_base_and_derived.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <type_traits>
 
@@ -27,7 +25,7 @@ inline
 void write_view(Writer& writer, View const& view,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             typename detail::is_writer<Writer>::type,
             typename is_format_tag<typename Writer::format_tag_t>::type,
@@ -48,7 +46,7 @@ inline
 void write_view(Device& device, View const& view, FormatTag const& tag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             typename detail::is_write_device<FormatTag, Device>::type,
             typename is_format_tag<FormatTag>::type,
@@ -71,7 +69,7 @@ inline
 void write_view(String const& file_name, View const& view, FormatTag const& tag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             typename detail::is_supported_path_spec<String>::type,
             typename is_format_tag<FormatTag>::type,
@@ -95,7 +93,7 @@ void write_view(
     Device& device, View const& view, image_write_info<FormatTag, Log> const& info,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             typename detail::is_write_device<FormatTag, Device>::type,
             typename is_format_tag<FormatTag>::type,
@@ -119,7 +117,7 @@ void write_view(
     String const& file_name, View const& view, image_write_info<FormatTag, Log> const& info,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             typename detail::is_supported_path_spec<String>::type,
             typename is_format_tag<FormatTag>::type,
@@ -144,7 +142,7 @@ inline
 void write_view(Writer& writer, any_image_view<Views> const& view,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             typename detail::is_dynamic_image_writer<Writer>::type,
             typename is_format_tag<typename Writer::format_tag_t>::type
@@ -161,7 +159,7 @@ void write_view(
     Device& device, any_image_view<Views> const& views, FormatTag const& tag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             typename detail::is_write_device<FormatTag, Device>::type,
             typename is_format_tag<FormatTag>::type
@@ -179,7 +177,7 @@ void write_view(
     String const& file_name, any_image_view<Views> const& views, FormatTag const& tag,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             typename detail::is_supported_path_spec<String>::type,
             typename is_format_tag<FormatTag>::type
@@ -199,7 +197,7 @@ void write_view(
     Device& device, any_image_view<Views> const& views, image_write_info<FormatTag, Log> const& info,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             typename detail::is_write_device<FormatTag, Device>::type,
             typename is_format_tag<FormatTag>::type
@@ -217,7 +215,7 @@ void write_view(
     String const& file_name, any_image_view<Views> const& views, image_write_info<FormatTag, Log> const& info,
     typename std::enable_if
     <
-        mpl::and_
+        mp11::mp_and
         <
             typename detail::is_supported_path_spec<String>::type,
             typename is_format_tag<FormatTag>::type

--- a/include/boost/gil/metafunctions.hpp
+++ b/include/boost/gil/metafunctions.hpp
@@ -11,25 +11,17 @@
 #include <boost/gil/channel.hpp>
 #include <boost/gil/dynamic_step.hpp>
 #include <boost/gil/concepts.hpp>
-
-#include <boost/mpl/accumulate.hpp>
-#include <boost/mpl/back.hpp>
-#include <boost/mpl/bool.hpp>
-#include <boost/mpl/if.hpp>
-#include <boost/mpl/pop_back.hpp>
-#include <boost/mpl/push_back.hpp>
-#include <boost/mpl/transform.hpp>
-#include <boost/mpl/vector.hpp>
-#include <boost/mpl/vector_c.hpp>
-#include <boost/type_traits.hpp>
+#include <boost/gil/concepts/detail/type_traits.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <iterator>
+#include <type_traits>
 
 namespace boost { namespace gil {
 
 // forward declarations
 template <typename T, typename L> struct pixel;
-template <typename BitField,typename ChannelRefVec,typename Layout> struct packed_pixel;
+template <typename BitField,typename ChannelRefs,typename Layout> struct packed_pixel;
 template <typename T, typename C> struct planar_pixel_reference;
 template <typename IC, typename C> struct planar_pixel_iterator;
 template <typename I> class memory_based_step_iterator;
@@ -61,76 +53,132 @@ template <typename BitField, typename ChannelBitSizes, typename Layout, bool IsM
 /// \brief Determines if a given pixel reference is basic
 ///    Basic references must use gil::pixel& (if interleaved), gil::planar_pixel_reference (if planar). They must use the standard constness rules.
 /// \ingroup GILIsBasic
-template <typename PixelRef>        struct pixel_reference_is_basic                     : public mpl::false_ {};
-template <typename T,  typename L>  struct pixel_reference_is_basic<      pixel<T,L>&>  : public mpl::true_ {};
-template <typename T,  typename L>  struct pixel_reference_is_basic<const pixel<T,L>&>  : public mpl::true_ {};
-template <typename TR, typename Cs> struct pixel_reference_is_basic<planar_pixel_reference<TR,Cs> > : public mpl::true_ {};
-template <typename TR, typename Cs> struct pixel_reference_is_basic<const planar_pixel_reference<TR,Cs> > : public mpl::true_ {};
+template <typename PixelRef>
+struct pixel_reference_is_basic : public std::false_type {};
 
+template <typename T, typename L>
+struct pixel_reference_is_basic<pixel<T, L>&> : std::true_type {};
+
+template <typename T, typename L>
+struct pixel_reference_is_basic<const pixel<T, L>&> : std::true_type {};
+
+template <typename TR, typename CS>
+struct pixel_reference_is_basic<planar_pixel_reference<TR, CS>> : std::true_type {};
+
+template <typename TR, typename CS>
+struct pixel_reference_is_basic<const planar_pixel_reference<TR, CS>> : std::true_type {};
 
 /// \brief Determines if a given pixel iterator is basic
 ///    Basic iterators must use gil::pixel (if interleaved), gil::planar_pixel_iterator (if planar) and gil::memory_based_step_iterator (if step). They must use the standard constness rules.
 /// \ingroup GILIsBasic
 template <typename Iterator>
-struct iterator_is_basic : public mpl::false_ {};
-template <typename T, typename L>  // mutable   interleaved
-struct iterator_is_basic<      pixel<T,L>*      > : public mpl::true_ {};
-template <typename T, typename L>  // immutable interleaved
-struct iterator_is_basic<const pixel<T,L>*      > : public mpl::true_ {};
-template <typename T, typename Cs>  // mutable   planar
-struct iterator_is_basic<planar_pixel_iterator<      T*,Cs> > : public mpl::true_ {};
-template <typename T, typename Cs>    // immutable planar
-struct iterator_is_basic<planar_pixel_iterator<const T*,Cs> > : public mpl::true_ {};
-template <typename T, typename L>  // mutable   interleaved step
-struct iterator_is_basic<memory_based_step_iterator<      pixel<T,L>*> > : public mpl::true_ {};
-template <typename T, typename L>  // immutable interleaved step
-struct iterator_is_basic<memory_based_step_iterator<const pixel<T,L>*> > : public mpl::true_ {};
-template <typename T, typename Cs>  // mutable   planar step
-struct iterator_is_basic<memory_based_step_iterator<planar_pixel_iterator<      T*,Cs> > > : public mpl::true_ {};
-template <typename T, typename Cs>    // immutable planar step
-struct iterator_is_basic<memory_based_step_iterator<planar_pixel_iterator<const T*,Cs> > > : public mpl::true_ {};
+struct iterator_is_basic : std::false_type {};
+
+/// \tparam T mutable interleaved pixel type
+template <typename T, typename L>
+struct iterator_is_basic<pixel<T, L>*> : std::true_type {};
+
+/// \tparam T immutable interleaved pixel type
+template <typename T, typename L>
+struct iterator_is_basic<pixel<T, L> const*> : std::true_type {};
+
+/// \tparam T mutable planar pixel type
+template <typename T, typename CS>
+struct iterator_is_basic<planar_pixel_iterator<T*, CS>> : std::true_type {};
+
+/// \tparam T immutable planar pixel type
+template <typename T, typename CS>
+struct iterator_is_basic<planar_pixel_iterator<T const*, CS>> : std::true_type {};
+
+/// \tparam T mutable interleaved step
+template <typename T, typename L>
+struct iterator_is_basic<memory_based_step_iterator<pixel<T, L>*>> : std::true_type {};
+
+/// \tparam T immutable interleaved step
+template <typename T, typename L>
+struct iterator_is_basic<memory_based_step_iterator<pixel<T, L> const*>> : std::true_type {};
+
+/// \tparam T mutable planar step
+template <typename T, typename CS>
+struct iterator_is_basic<memory_based_step_iterator<planar_pixel_iterator<T*, CS>>>
+    : std::true_type
+{};
+
+/// \tparam T immutable planar step
+template <typename T, typename CS>
+struct iterator_is_basic<memory_based_step_iterator<planar_pixel_iterator<T const*, CS>>>
+    : std::true_type
+{};
 
 
 /// \ingroup GILIsBasic
 /// \brief Determines if a given locator is basic. A basic locator is memory-based and has basic x_iterator and y_iterator
-template <typename Loc> struct locator_is_basic : public mpl::false_ {};
-template <typename Iterator> struct locator_is_basic<memory_based_2d_locator<memory_based_step_iterator<Iterator> > > : public iterator_is_basic<Iterator> {};
+template <typename Loc>
+struct locator_is_basic : std::false_type {};
+
+template <typename Iterator>
+struct locator_is_basic
+    <
+        memory_based_2d_locator<memory_based_step_iterator<Iterator>>
+    > : iterator_is_basic<Iterator>
+{};
 
 /// \ingroup GILIsBasic
 /// \brief Basic views must be over basic locators
-template <typename View> struct view_is_basic : public mpl::false_ {};
-template <typename Loc> struct view_is_basic<image_view<Loc> > : public locator_is_basic<Loc> {};
+template <typename View>
+struct view_is_basic : std::false_type {};
+
+template <typename Loc>
+struct view_is_basic<image_view<Loc>> : locator_is_basic<Loc> {};
 
 /// \ingroup GILIsBasic
 /// \brief Basic images must use basic views and std::allocator
-template <typename Img> struct image_is_basic : public mpl::false_ {};
-template <typename Pixel, bool IsPlanar, typename Alloc> struct image_is_basic<image<Pixel,IsPlanar,Alloc> > : public mpl::true_ {};
+template <typename Img>
+struct image_is_basic : std::false_type {};
+
+template <typename Pixel, bool IsPlanar, typename Alloc>
+struct image_is_basic<image<Pixel, IsPlanar, Alloc>> : std::true_type {};
 
 
 /// \defgroup GILIsStep xxx_is_step
 /// \ingroup TypeAnalysis
 /// \brief Determines if the given iterator/locator/view has a step that could be set dynamically
 
-template <typename I> struct iterator_is_step;
+template <typename I>
+struct iterator_is_step;
+
 namespace detail {
-    template <typename It, bool IsBase, bool EqualsStepType> struct iterator_is_step_impl;
-    // iterator that has the same type as its dynamic_x_step_type must be a step iterator
-    template <typename It, bool IsBase> struct iterator_is_step_impl<It,IsBase,true> : public mpl::true_{};
 
-    // base iterator can never be a step iterator
-    template <typename It> struct iterator_is_step_impl<It,true,false> : public mpl::false_{};
+template <typename It, bool IsBase, bool EqualsStepType>
+struct iterator_is_step_impl;
 
-    // for an iterator adaptor, see if its base is step
-    template <typename It> struct iterator_is_step_impl<It,false,false>
-        : public iterator_is_step<typename iterator_adaptor_get_base<It>::type>{};
-}
+// iterator that has the same type as its dynamic_x_step_type must be a step iterator
+template <typename It, bool IsBase>
+struct iterator_is_step_impl<It, IsBase, true> : std::true_type {};
+
+// base iterator can never be a step iterator
+template <typename It>
+struct iterator_is_step_impl<It, true, false> : std::false_type {};
+
+// for an iterator adaptor, see if its base is step
+template <typename It>
+struct iterator_is_step_impl<It, false, false>
+    : public iterator_is_step<typename iterator_adaptor_get_base<It>::type> {};
+
+} // namespace detail
 
 /// \ingroup GILIsStep
 /// \brief Determines if the given iterator has a step that could be set dynamically
-template <typename I> struct iterator_is_step
-    : public detail::iterator_is_step_impl<I,
+template <typename I>
+struct iterator_is_step
+    : detail::iterator_is_step_impl
+    <
+        I,
         !is_iterator_adaptor<I>::value,
-        is_same<I,typename dynamic_x_step_type<I>::type>::value >{};
+        std::is_same<I, typename dynamic_x_step_type<I>::type
+    >::value
+>
+{};
 
 /// \ingroup GILIsStep
 /// \brief Determines if the given locator has a horizontal step that could be set dynamically
@@ -152,13 +200,21 @@ template <typename V> struct view_is_step_in_y : public locator_is_step_in_y<typ
 /// \ingroup TypeAnalysis
 template <typename PixelReference>
 struct pixel_reference_is_proxy
-    : public mpl::not_<is_same<typename detail::remove_const_and_reference<PixelReference>::type,
-                               typename detail::remove_const_and_reference<PixelReference>::type::value_type> > {};
+    : mp11::mp_not
+    <
+        std::is_same
+        <
+            typename detail::remove_const_and_reference<PixelReference>::type,
+            typename detail::remove_const_and_reference<PixelReference>::type::value_type
+        >
+    >
+{};
 
 /// \brief Given a model of a pixel, determines whether the model represents a pixel reference (as opposed to pixel value)
 /// \ingroup TypeAnalysis
 template <typename Pixel>
-struct pixel_is_reference : public mpl::or_<is_reference<Pixel>, pixel_reference_is_proxy<Pixel> > {};
+struct pixel_is_reference
+    : mp11::mp_or<is_reference<Pixel>, pixel_reference_is_proxy<Pixel>> {};
 
 /// \defgroup GILIsMutable xxx_is_mutable
 /// \ingroup TypeAnalysis
@@ -168,9 +224,15 @@ struct pixel_is_reference : public mpl::or_<is_reference<Pixel>, pixel_reference
 /// \brief Determines if the given pixel reference is mutable (i.e. its channels can be changed)
 ///
 /// Note that built-in C++ references obey the const qualifier but reference proxy classes do not.
-template <typename R> struct pixel_reference_is_mutable : public mpl::bool_<remove_reference<R>::type::is_mutable> {};
-template <typename R> struct pixel_reference_is_mutable<const R&>
-    : public mpl::and_<pixel_reference_is_proxy<R>, pixel_reference_is_mutable<R> > {};
+template <typename R>
+struct pixel_reference_is_mutable
+    : std::integral_constant<bool, std::remove_reference<R>::type::is_mutable>
+{};
+
+template <typename R>
+struct pixel_reference_is_mutable<R const&>
+    : mp11::mp_and<pixel_reference_is_proxy<R>, pixel_reference_is_mutable<R>>
+{};
 
 /// \ingroup GILIsMutable
 /// \brief Determines if the given locator is mutable (i.e. its pixels can be changed)
@@ -236,43 +298,82 @@ template <typename T, typename L, bool IsPlanar, bool IsMutable> struct iterator
 /// \brief Given a pixel iterator defining access to pixels along a row, returns the types of the corresponding built-in step_iterator, xy_locator, image_view
 /// \ingroup TypeFactory
 template <typename XIterator>
-struct type_from_x_iterator {
+struct type_from_x_iterator
+{
     using step_iterator_t = memory_based_step_iterator<XIterator>;
     using xy_locator_t = memory_based_2d_locator<step_iterator_t>;
     using view_t = image_view<xy_locator_t>;
 };
 
 namespace detail {
-    template <typename BitField, typename FirstBit, typename NumBits>
-    struct packed_channel_reference_type {
-        using type = packed_channel_reference<BitField,FirstBit::value,NumBits::value,true> const;
-    };
 
-    template <typename BitField, typename ChannelBitSizesVector>
-    class packed_channel_references_vector_type {
-        // If ChannelBitSizesVector is mpl::vector<int,7,7,2>
-        // Then first_bits_vector will be mpl::vector<int,0,7,14,16>
-        using first_bits_vector = typename mpl::accumulate<ChannelBitSizesVector, mpl::vector1<mpl::int_<0> >,
-            mpl::push_back<mpl::_1, mpl::plus<mpl::back<mpl::_1>, mpl::_2> > >::type;
-    public:
-        using type = typename mpl::transform<typename mpl::pop_back<first_bits_vector>::type, ChannelBitSizesVector,
-               packed_channel_reference_type<BitField, mpl::_1,mpl::_2> >::type;
-    };
+template <typename BitField, typename FirstBit, typename NumBits>
+struct packed_channel_reference_type
+{
+    using type = packed_channel_reference
+        <
+            BitField, FirstBit::value, NumBits::value, true
+        > const;
+};
 
-}
+template <typename BitField, typename ChannelBitSizes>
+class packed_channel_references_vector_type
+{
+    template <typename FirstBit, typename NumBits>
+    using reference_type = typename packed_channel_reference_type<BitField, FirstBit, NumBits>::type;
+
+    // If ChannelBitSizesVector is mp11::mp_list_c<int,7,7,2>
+    // Then first_bits_vector will be mp11::mp_list_c<int,0,7,14,16>
+    using first_bit_list = mp11::mp_fold_q
+        <
+            ChannelBitSizes,
+            mp11::mp_list<std::integral_constant<int, 0>>,
+            mp11::mp_bind
+            <
+                mp11::mp_push_back,
+                mp11::_1,
+                mp11::mp_bind
+                <
+                    mp11::mp_plus,
+                    mp11::mp_bind<mp_back, mp11::_1>,
+                    mp11::_2
+                >
+            >
+        >;
+
+    static_assert(mp11::mp_at_c<first_bit_list, 0>::value == 0, "packed channel first bit must be 0");
+
+public:
+    using type = mp11::mp_transform
+        <
+            reference_type,
+            mp_pop_back<first_bit_list>,
+            ChannelBitSizes
+        >;
+};
+
+} // namespace detail
 
 /// \ingroup TypeFactoryFromElements
 /// \brief Returns the type of a packed pixel given its bitfield type, the bit size of its channels and its layout.
 ///
 /// A packed pixel has channels that cover bit ranges but itself is byte aligned. RGB565 pixel is an example.
 ///
-/// The size of ChannelBitSizeVector must equal the number of channels in the given layout
+/// The size of ChannelBitSizes must equal the number of channels in the given layout
 /// The sum of bit sizes for all channels must be less than or equal to the number of bits in BitField (and cannot exceed 64).
 ///  If it is less than the number of bits in BitField, the last bits will be unused.
-template <typename BitField, typename ChannelBitSizeVector, typename Layout>
+template <typename BitField, typename ChannelBitSizes, typename Layout>
 struct packed_pixel_type
 {
-    using type = packed_pixel<BitField, typename detail::packed_channel_references_vector_type<BitField,ChannelBitSizeVector>::type, Layout>;
+    using type = packed_pixel
+        <
+            BitField,
+            typename detail::packed_channel_references_vector_type
+            <
+                BitField,
+                ChannelBitSizes
+            >::type,
+        Layout>;
 };
 
 /// \defgroup TypeFactoryPacked packed_image_type,bit_aligned_image_type
@@ -286,35 +387,45 @@ struct packed_pixel_type
 
 /// \ingroup TypeFactoryPacked
 /// \brief Returns the type of an interleaved packed image: an image whose channels may not be byte-aligned, but whose pixels are byte aligned.
-template <typename BitField, typename ChannelBitSizeVector, typename Layout, typename Alloc=std::allocator<unsigned char> >
-struct packed_image_type {
-    using type = image<typename packed_pixel_type<BitField,ChannelBitSizeVector,Layout>::type,false,Alloc>;
+template <typename BitField, typename ChannelBitSizes, typename Layout, typename Alloc=std::allocator<unsigned char>>
+struct packed_image_type
+{
+    using type = image<typename packed_pixel_type<BitField,ChannelBitSizes,Layout>::type,false,Alloc>;
 };
 
 /// \ingroup TypeFactoryPacked
 /// \brief Returns the type of a single-channel image given its bitfield type, the bit size of its channel and its layout
-template <typename BitField, unsigned Size1, typename Layout, typename Alloc=std::allocator<unsigned char> >
-struct packed_image1_type : public packed_image_type<BitField, mpl::vector1_c<unsigned, Size1>, Layout, Alloc> {};
+template <typename BitField, unsigned Size1, typename Layout, typename Alloc = std::allocator<unsigned char>>
+struct packed_image1_type
+    : packed_image_type<BitField, mp11::mp_list_c<unsigned, Size1>, Layout, Alloc>
+{};
 
 /// \ingroup TypeFactoryPacked
 /// \brief Returns the type of a two channel image given its bitfield type, the bit size of its channels and its layout
-template <typename BitField, unsigned Size1, unsigned Size2, typename Layout, typename Alloc=std::allocator<unsigned char> >
-struct packed_image2_type : public packed_image_type<BitField, mpl::vector2_c<unsigned, Size1, Size2>, Layout, Alloc> {};
+template <typename BitField, unsigned Size1, unsigned Size2, typename Layout, typename Alloc = std::allocator<unsigned char>>
+struct packed_image2_type
+    : packed_image_type<BitField, mp11::mp_list_c<unsigned, Size1, Size2>, Layout, Alloc>
+{};
 
 /// \ingroup TypeFactoryPacked
 /// \brief Returns the type of a three channel image given its bitfield type, the bit size of its channels and its layout
-template <typename BitField, unsigned Size1, unsigned Size2, unsigned Size3, typename Layout, typename Alloc=std::allocator<unsigned char> >
-struct packed_image3_type : public packed_image_type<BitField, mpl::vector3_c<unsigned, Size1, Size2, Size3>, Layout, Alloc> {};
+template <typename BitField, unsigned Size1, unsigned Size2, unsigned Size3, typename Layout, typename Alloc = std::allocator<unsigned char>>
+struct packed_image3_type
+    : packed_image_type<BitField, mp11::mp_list_c<unsigned, Size1, Size2, Size3>, Layout, Alloc>
+{};
 
 /// \ingroup TypeFactoryPacked
 /// \brief Returns the type of a four channel image given its bitfield type, the bit size of its channels and its layout
-template <typename BitField, unsigned Size1, unsigned Size2, unsigned Size3, unsigned Size4, typename Layout, typename Alloc=std::allocator<unsigned char> >
-struct packed_image4_type : public packed_image_type<BitField, mpl::vector4_c<unsigned, Size1, Size2, Size3, Size4>, Layout, Alloc> {};
+template <typename BitField, unsigned Size1, unsigned Size2, unsigned Size3, unsigned Size4, typename Layout, typename Alloc = std::allocator<unsigned char>>
+struct packed_image4_type
+    : packed_image_type<BitField, mp11::mp_list_c<unsigned, Size1, Size2, Size3, Size4>, Layout, Alloc>
+{};
 
 /// \ingroup TypeFactoryPacked
 /// \brief Returns the type of a five channel image given its bitfield type, the bit size of its channels and its layout
-template <typename BitField, unsigned Size1, unsigned Size2, unsigned Size3, unsigned Size4, unsigned Size5, typename Layout, typename Alloc=std::allocator<unsigned char> >
-struct packed_image5_type : public packed_image_type<BitField, mpl::vector5_c<unsigned, Size1, Size2, Size3, Size4, Size5>, Layout, Alloc> {};
+template <typename BitField, unsigned Size1, unsigned Size2, unsigned Size3, unsigned Size4, unsigned Size5, typename Layout, typename Alloc = std::allocator<unsigned char>>
+struct packed_image5_type
+    : packed_image_type<BitField, mp11::mp_list_c<unsigned, Size1, Size2, Size3, Size4, Size5>, Layout, Alloc> {};
 
 
 /// \ingroup TypeFactoryPacked
@@ -325,23 +436,24 @@ struct packed_image5_type : public packed_image_type<BitField, mpl::vector5_c<un
 ///
 template
 <
-    typename ChannelBitSizeVector,
+    typename ChannelBitSizes,
     typename Layout,
     typename Alloc = std::allocator<unsigned char>
 >
 struct bit_aligned_image_type
 {
 private:
+
     static constexpr int bit_size =
-        mpl::accumulate
+        mp11::mp_fold
         <
-            ChannelBitSizeVector,
-            mpl::int_<0>,
-            mpl::plus<mpl::_1, mpl::_2>
-        >::type::value;
+            ChannelBitSizes,
+            std::integral_constant<int, 0>,
+            mp11::mp_plus
+        >::value;
 
     using bitfield_t = typename detail::min_fast_uint<bit_size + 7>::type;
-    using bit_alignedref_t = bit_aligned_pixel_reference<bitfield_t, ChannelBitSizeVector, Layout, true> const;
+    using bit_alignedref_t = bit_aligned_pixel_reference<bitfield_t, ChannelBitSizes, Layout, true> const;
 
 public:
     using type = image<bit_alignedref_t,false,Alloc>;
@@ -349,77 +461,93 @@ public:
 
 /// \ingroup TypeFactoryPacked
 /// \brief Returns the type of a single-channel bit-aligned image given the bit size of its channel and its layout
-template <unsigned Size1, typename Layout, typename Alloc=std::allocator<unsigned char> >
-struct bit_aligned_image1_type : public bit_aligned_image_type<mpl::vector1_c<unsigned, Size1>, Layout, Alloc> {};
+template <unsigned Size1, typename Layout, typename Alloc = std::allocator<unsigned char>>
+struct bit_aligned_image1_type : bit_aligned_image_type<mp11::mp_list_c<unsigned, Size1>, Layout, Alloc> {};
 
 /// \ingroup TypeFactoryPacked
 /// \brief Returns the type of a two channel bit-aligned image given the bit size of its channels and its layout
-template <unsigned Size1, unsigned Size2, typename Layout, typename Alloc=std::allocator<unsigned char> >
-struct bit_aligned_image2_type : public bit_aligned_image_type<mpl::vector2_c<unsigned, Size1, Size2>, Layout, Alloc> {};
+template <unsigned Size1, unsigned Size2, typename Layout, typename Alloc = std::allocator<unsigned char>>
+struct bit_aligned_image2_type : bit_aligned_image_type<mp11::mp_list_c<unsigned, Size1, Size2>, Layout, Alloc> {};
 
 /// \ingroup TypeFactoryPacked
 /// \brief Returns the type of a three channel bit-aligned image given the bit size of its channels and its layout
-template <unsigned Size1, unsigned Size2, unsigned Size3, typename Layout, typename Alloc=std::allocator<unsigned char> >
-struct bit_aligned_image3_type : public bit_aligned_image_type<mpl::vector3_c<unsigned, Size1, Size2, Size3>, Layout, Alloc> {};
+template <unsigned Size1, unsigned Size2, unsigned Size3, typename Layout, typename Alloc = std::allocator<unsigned char>>
+struct bit_aligned_image3_type : bit_aligned_image_type<mp11::mp_list_c<unsigned, Size1, Size2, Size3>, Layout, Alloc> {};
 
 /// \ingroup TypeFactoryPacked
 /// \brief Returns the type of a four channel bit-aligned image given the bit size of its channels and its layout
-template <unsigned Size1, unsigned Size2, unsigned Size3, unsigned Size4, typename Layout, typename Alloc=std::allocator<unsigned char> >
-struct bit_aligned_image4_type : public bit_aligned_image_type<mpl::vector4_c<unsigned, Size1, Size2, Size3, Size4>, Layout, Alloc> {};
+template <unsigned Size1, unsigned Size2, unsigned Size3, unsigned Size4, typename Layout, typename Alloc = std::allocator<unsigned char>>
+struct bit_aligned_image4_type : bit_aligned_image_type<mp11::mp_list_c<unsigned, Size1, Size2, Size3, Size4>, Layout, Alloc> {};
 
 /// \ingroup TypeFactoryPacked
 /// \brief Returns the type of a five channel bit-aligned image given the bit size of its channels and its layout
-template <unsigned Size1, unsigned Size2, unsigned Size3, unsigned Size4, unsigned Size5, typename Layout, typename Alloc=std::allocator<unsigned char> >
-struct bit_aligned_image5_type : public bit_aligned_image_type<mpl::vector5_c<unsigned, Size1, Size2, Size3, Size4, Size5>, Layout, Alloc> {};
-
+template <unsigned Size1, unsigned Size2, unsigned Size3, unsigned Size4, unsigned Size5, typename Layout, typename Alloc = std::allocator<unsigned char>>
+struct bit_aligned_image5_type : bit_aligned_image_type<mp11::mp_list_c<unsigned, Size1, Size2, Size3, Size4, Size5>, Layout, Alloc> {};
 
 
 /// \ingroup TypeFactoryFromElements
 /// \brief Returns the type of a homogeneous pixel given the channel type and layout
 template <typename Channel, typename Layout>
-struct pixel_value_type {
-    using type = pixel<Channel,Layout>;     // by default use gil::pixel. Specializations are provided for
+struct pixel_value_type
+{
+    // by default use gil::pixel. Specializations are provided for
+    using type = pixel<Channel, Layout>;
 };
 
 // Specializations for packed channels
 template <typename BitField, int NumBits, bool IsMutable, typename Layout>
-struct pixel_value_type<      packed_dynamic_channel_reference<BitField,NumBits,IsMutable>,Layout> :
-    public packed_pixel_type<BitField, mpl::vector1_c<unsigned,NumBits>, Layout> {};
+struct pixel_value_type<packed_dynamic_channel_reference<BitField, NumBits, IsMutable>, Layout>
+    : packed_pixel_type<BitField, mp11::mp_list_c<unsigned, NumBits>, Layout>
+{};
+
 template <typename BitField, int NumBits, bool IsMutable, typename Layout>
-struct pixel_value_type<const packed_dynamic_channel_reference<BitField,NumBits,IsMutable>,Layout> :
-    public packed_pixel_type<BitField, mpl::vector1_c<unsigned,NumBits>, Layout> {};
+struct pixel_value_type<packed_dynamic_channel_reference<BitField, NumBits, IsMutable> const, Layout>
+    : packed_pixel_type<BitField, mp11::mp_list_c<unsigned, NumBits>, Layout>
+{};
 
 template <typename BitField, int FirstBit, int NumBits, bool IsMutable, typename Layout>
-struct pixel_value_type<      packed_channel_reference<BitField,FirstBit,NumBits,IsMutable>,Layout> :
-    public packed_pixel_type<BitField, mpl::vector1_c<unsigned,NumBits>, Layout> {};
+struct pixel_value_type<packed_channel_reference<BitField, FirstBit, NumBits, IsMutable>, Layout>
+    : packed_pixel_type<BitField, mp11::mp_list_c<unsigned, NumBits>, Layout>
+{};
+
 template <typename BitField, int FirstBit, int NumBits, bool IsMutable, typename Layout>
-struct pixel_value_type<const packed_channel_reference<BitField,FirstBit,NumBits,IsMutable>,Layout> :
-    public packed_pixel_type<BitField, mpl::vector1_c<unsigned,NumBits>, Layout> {};
+struct pixel_value_type<packed_channel_reference<BitField, FirstBit, NumBits, IsMutable> const, Layout>
+    : packed_pixel_type<BitField, mp11::mp_list_c<unsigned, NumBits>, Layout>
+{};
 
 template <int NumBits, typename Layout>
-struct pixel_value_type<packed_channel_value<NumBits>,Layout> :
-    public packed_pixel_type<typename detail::min_fast_uint<NumBits>::type, mpl::vector1_c<unsigned,NumBits>, Layout> {};
-
+struct pixel_value_type<packed_channel_value<NumBits>, Layout>
+    : packed_pixel_type<typename detail::min_fast_uint<NumBits>::type, mp11::mp_list_c<unsigned, NumBits>, Layout>
+{};
 
 /// \ingroup TypeFactoryFromElements
 /// \brief Returns the type of a homogeneous locator given the channel type, layout, whether it operates on planar data and whether it has a step horizontally
-template <typename T, typename L, bool IsPlanar=false, bool IsStepX=false, bool IsMutable=true>
-struct locator_type {
-    using type = typename type_from_x_iterator<typename iterator_type<T,L,IsPlanar,IsStepX,IsMutable>::type>::xy_locator_type;
+template <typename T, typename L, bool IsPlanar = false, bool IsStepX = false, bool IsMutable = true>
+struct locator_type
+{
+    using type = typename type_from_x_iterator
+        <
+            typename iterator_type<T, L, IsPlanar, IsStepX, IsMutable>::type
+        >::xy_locator_type;
 };
 
 /// \ingroup TypeFactoryFromElements
 /// \brief Returns the type of a homogeneous view given the channel type, layout, whether it operates on planar data and whether it has a step horizontally
-template <typename T, typename L, bool IsPlanar=false, bool IsStepX=false, bool IsMutable=true>
-struct view_type {
-    using type = typename type_from_x_iterator<typename iterator_type<T,L,IsPlanar,IsStepX,IsMutable>::type>::view_t;
+template <typename T, typename L, bool IsPlanar = false, bool IsStepX = false, bool IsMutable = true>
+struct view_type
+{
+    using type = typename type_from_x_iterator
+        <
+            typename iterator_type<T, L, IsPlanar, IsStepX, IsMutable>::type
+        >::view_t;
 };
 
 /// \ingroup TypeFactoryFromElements
 /// \brief Returns the type of a homogeneous image given the channel type, layout, and whether it operates on planar data
-template <typename T, typename L, bool IsPlanar=false, typename Alloc=std::allocator<unsigned char> >
-struct image_type {
-    using type = image<pixel<T,L>, IsPlanar, Alloc>;
+template <typename T, typename L, bool IsPlanar = false, typename Alloc = std::allocator<unsigned char>>
+struct image_type
+{
+    using type = image<pixel<T, L>, IsPlanar, Alloc>;
 };
 
 /// \ingroup TypeFactoryFromPixel
@@ -433,14 +561,49 @@ struct view_type_from_pixel {
 /// \brief Constructs a pixel reference type from a source pixel reference type by changing some of the properties.
 /// \ingroup TypeFactoryDerived
 ///  Use use_default for the properties of the source view that you want to keep
-template <typename Ref, typename T=use_default, typename L=use_default, typename IsPlanar=use_default, typename IsMutable=use_default>
-class derived_pixel_reference_type {
-    using pixel_t = typename remove_reference<Ref>::type;
-    using channel_t = typename  mpl::if_<is_same<T, use_default>, typename channel_type<pixel_t>::type, T>::type;
-    using layout_t = typename  mpl::if_<is_same<L, use_default>,
-        layout<typename color_space_type<pixel_t>::type, typename channel_mapping_type<pixel_t>::type>, L>::type;
-    static const bool mut   =mpl::if_<is_same<IsMutable,use_default>, pixel_reference_is_mutable<Ref>, IsMutable>::type::value;
-    static const bool planar=mpl::if_<is_same<IsPlanar,use_default>,  is_planar<pixel_t>,  IsPlanar>::type::value;
+template
+<
+        typename Ref,
+        typename T = use_default,
+        typename L = use_default,
+        typename IsPlanar = use_default,
+        typename IsMutable = use_default>
+class derived_pixel_reference_type
+{
+    using pixel_t = typename std::remove_reference<Ref>::type;
+
+    using channel_t = typename mp11::mp_if
+        <
+            std::is_same<T, use_default>,
+            typename channel_type<pixel_t>::type,
+            T
+        >::type;
+
+    using layout_t = typename  mp11::mp_if
+        <
+            std::is_same<L, use_default>,
+            layout
+            <
+                typename color_space_type<pixel_t>::type,
+                typename channel_mapping_type<pixel_t>::type
+            >,
+            L
+        >::type;
+
+    static bool const mut = mp11::mp_if
+        <
+            std::is_same<IsMutable, use_default>,
+            pixel_reference_is_mutable<Ref>,
+            IsMutable
+        >::value;
+
+    static bool const planar = mp11::mp_if
+        <
+            std::is_same<IsPlanar, use_default>,
+            is_planar<pixel_t>,
+            IsPlanar
+        >::value;
+
 public:
     using type = typename pixel_reference_type<channel_t, layout_t, planar, mut>::type;
 };
@@ -448,15 +611,56 @@ public:
 /// \brief Constructs a pixel iterator type from a source pixel iterator type by changing some of the properties.
 /// \ingroup TypeFactoryDerived
 ///  Use use_default for the properties of the source view that you want to keep
-template <typename Iterator, typename T=use_default, typename L=use_default, typename IsPlanar=use_default, typename IsStep=use_default, typename IsMutable=use_default>
-class derived_iterator_type {
-    using channel_t = typename  mpl::if_<is_same<T ,use_default>, typename channel_type<Iterator>::type, T>::type;
-    using layout_t = typename  mpl::if_<is_same<L,use_default>,
-        layout<typename color_space_type<Iterator>::type, typename channel_mapping_type<Iterator>::type>, L>::type;
+template
+<
+    typename Iterator,
+    typename T = use_default,
+    typename L = use_default,
+    typename IsPlanar = use_default,
+    typename IsStep = use_default,
+    typename IsMutable = use_default
+>
+class derived_iterator_type
+{
+    using channel_t = typename mp11::mp_if
+        <
+            std::is_same<T, use_default>,
+            typename channel_type<Iterator>::type,
+            T
+        >::type;
 
-    static const bool mut   =mpl::if_<is_same<IsMutable,use_default>, iterator_is_mutable<Iterator>, IsMutable>::type::value;
-    static const bool planar=mpl::if_<is_same<IsPlanar,use_default>,         is_planar<Iterator>,  IsPlanar>::type::value;
-    static const bool step  =mpl::if_<is_same<IsStep  ,use_default>,  iterator_is_step<Iterator>,    IsStep>::type::value;
+    using layout_t = typename mp11::mp_if
+        <
+            std::is_same<L, use_default>,
+            layout
+            <
+                typename color_space_type<Iterator>::type,
+                typename channel_mapping_type<Iterator>::type
+            >,
+            L
+        >::type;
+
+    static const bool mut = mp11::mp_if
+        <
+            std::is_same<IsMutable, use_default>,
+            iterator_is_mutable<Iterator>,
+            IsMutable
+        >::value;
+
+    static bool const planar = mp11::mp_if
+        <
+            std::is_same<IsPlanar, use_default>,
+            is_planar<Iterator>,
+            IsPlanar
+        >::value;
+
+    static bool const step = mp11::mp_if
+        <
+            std::is_same<IsStep, use_default>,
+            iterator_is_step<Iterator>,
+            IsStep
+        >::type::value;
+
 public:
     using type = typename iterator_type<channel_t, layout_t, planar, step, mut>::type;
 };
@@ -464,14 +668,48 @@ public:
 /// \brief Constructs an image view type from a source view type by changing some of the properties.
 /// \ingroup TypeFactoryDerived
 ///  Use use_default for the properties of the source view that you want to keep
-template <typename View, typename T=use_default, typename L=use_default, typename IsPlanar=use_default, typename StepX=use_default, typename IsMutable=use_default>
-class derived_view_type {
-    using channel_t = typename  mpl::if_<is_same<T ,use_default>, typename channel_type<View>::type, T>::type;
-    using layout_t = typename  mpl::if_<is_same<L,use_default>,
-        layout<typename color_space_type<View>::type, typename channel_mapping_type<View>::type>, L>::type;
-    static const bool mut   =mpl::if_<is_same<IsMutable,use_default>, view_is_mutable<View>, IsMutable>::type::value;
-    static const bool planar=mpl::if_<is_same<IsPlanar,use_default>,  is_planar<View>,  IsPlanar>::type::value;
-    static const bool step  =mpl::if_<is_same<StepX ,use_default>,  view_is_step_in_x<View>,StepX>::type::value;
+template <typename View, typename T = use_default, typename L = use_default, typename IsPlanar = use_default, typename StepX = use_default, typename IsMutable = use_default>
+class derived_view_type
+{
+    using channel_t = typename mp11::mp_if
+        <
+            std::is_same<T, use_default>,
+            typename channel_type<View>::type,
+            T
+        >;
+
+    using layout_t = typename mp11::mp_if
+        <
+            std::is_same<L, use_default>,
+            layout
+            <
+                typename color_space_type<View>::type,
+                typename channel_mapping_type<View>::type
+            >,
+            L
+        >;
+
+    static bool const mut = mp11::mp_if
+        <
+            std::is_same<IsMutable, use_default>,
+            view_is_mutable<View>,
+            IsMutable
+        >::value;
+
+    static bool const planar = mp11::mp_if
+        <
+            std::is_same<IsPlanar, use_default>,
+            is_planar<View>,
+            IsPlanar
+        >::value;
+
+    static bool const step = mp11::mp_if
+        <
+            std::is_same<StepX, use_default>,
+            view_is_step_in_x<View>,
+            StepX
+        >::value;
+
 public:
     using type = typename view_type<channel_t, layout_t, planar, step, mut>::type;
 };
@@ -479,12 +717,33 @@ public:
 /// \brief Constructs a homogeneous image type from a source image type by changing some of the properties.
 /// \ingroup TypeFactoryDerived
 ///  Use use_default for the properties of the source image that you want to keep
-template <typename Image, typename T=use_default, typename L=use_default, typename IsPlanar=use_default>
-class derived_image_type {
-    using channel_t = typename  mpl::if_<is_same<T ,use_default>, typename channel_type<Image>::type, T>::type;
-    using layout_t = typename  mpl::if_<is_same<L,use_default>,
-        layout<typename color_space_type<Image>::type, typename channel_mapping_type<Image>::type>, L>::type;
-    static const bool planar=mpl::if_<is_same<IsPlanar,use_default>,  is_planar<Image>,  IsPlanar>::type::value;
+template <typename Image, typename T = use_default, typename L = use_default, typename IsPlanar = use_default>
+class derived_image_type
+{
+    using channel_t = typename mp11::mp_if
+        <
+            std::is_same<T, use_default>,
+            typename channel_type<Image>::type,
+            T
+        >::type;
+
+    using layout_t = typename mp11::mp_if
+        <
+            std::is_same<L, use_default>,
+            layout
+            <
+                typename color_space_type<Image>::type,
+                typename channel_mapping_type<Image>::type>,
+                L
+            >::type;
+
+    static bool const planar = mp11::mp_if
+        <
+            std::is_same<IsPlanar, use_default>,
+            is_planar<Image>,
+            IsPlanar
+        >::value;
+
 public:
     using type = typename image_type<channel_t, layout_t, planar>::type;
 };

--- a/include/boost/gil/packed_pixel.hpp
+++ b/include/boost/gil/packed_pixel.hpp
@@ -9,10 +9,7 @@
 #define BOOST_GIL_PACKED_PIXEL_HPP
 
 #include <boost/gil/pixel.hpp>
-
-#include <boost/core/ignore_unused.hpp>
-#include <boost/mpl/bool.hpp>
-#include <boost/mpl/front.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <functional>
 #include <type_traits>
@@ -32,7 +29,7 @@ namespace boost { namespace gil {
 ///
 /// Example:
 /// \code
-/// using rgb565_pixel_t = packed_pixel_type<uint16_t, mpl::vector3_c<unsigned,5,6,5>, rgb_layout_t>::type;
+/// using rgb565_pixel_t = packed_pixel_type<uint16_t, mp11::mp_list-c<unsigned,5,6,5>, rgb_layout_t>::type;
 /// static_assert(sizeof(rgb565_pixel_t) == 2, "");
 ///
 /// rgb565_pixel_t r565;
@@ -45,20 +42,21 @@ namespace boost { namespace gil {
 /// \ingroup ColorBaseModelPackedPixel PixelModelPackedPixel PixelBasedModel
 /// \brief Heterogeneous pixel value whose channel references can be constructed from the pixel bitfield and their index. Models ColorBaseValueConcept, PixelValueConcept, PixelBasedConcept
 /// Typical use for this is a model of a packed pixel (like 565 RGB)
-template <typename BitField,      // A type that holds the bits of the pixel. Typically an integral type, like std::uint16_t
-          typename ChannelRefVec, // An MPL vector whose elements are packed channels. They must be constructible from BitField. GIL uses packed_channel_reference
-          typename Layout>        // Layout defining the color space and ordering of the channels. Example value: rgb_layout_t
+/// \tparam BitField Type that holds the bits of the pixel. Typically an integral type, like std::uint16_t.
+/// \tparam ChannelRefs MP11 list whose elements are packed channels. They must be constructible from BitField. GIL uses packed_channel_reference
+/// \tparam Layout defining the color space and ordering of the channels. Example value: rgb_layout_t
+template <typename BitField, typename ChannelRefs, typename Layout>
 struct packed_pixel
 {
-    BitField _bitfield{0};
+    BitField _bitfield{0}; // TODO: Make private
 
     using layout_t = Layout;
-    using value_type = packed_pixel<BitField, ChannelRefVec, Layout>;
+    using value_type = packed_pixel<BitField, ChannelRefs, Layout>;
     using reference = value_type&;
     using const_reference = value_type const&;
 
     static constexpr bool is_mutable =
-        channel_traits<typename mpl::front<ChannelRefVec>::type>::is_mutable;
+        channel_traits<mp11::mp_front<ChannelRefs>>::is_mutable;
 
     packed_pixel() = default;
     explicit packed_pixel(const BitField& bitfield) : _bitfield(bitfield) {}
@@ -66,83 +64,172 @@ struct packed_pixel
     // Construct from another compatible pixel type
     packed_pixel(const packed_pixel& p) : _bitfield(p._bitfield) {}
 
-    template <typename P>
-    packed_pixel(P const& p,
-        typename std::enable_if<is_pixel<P>::value>::type* /*dummy*/ = nullptr)
+    template <typename Pixel>
+    packed_pixel(Pixel const& p,
+        typename std::enable_if<is_pixel<Pixel>::value>::type* /*dummy*/ = nullptr)
     {
-        check_compatible<P>();
+        check_compatible<Pixel>();
         static_copy(p, *this);
     }
 
-    packed_pixel(int chan0, int chan1) : _bitfield(0) {
+    packed_pixel(int chan0, int chan1)
+        : _bitfield(0)
+    {
         static_assert(num_channels<packed_pixel>::value == 2, "");
-        gil::at_c<0>(*this)=chan0; gil::at_c<1>(*this)=chan1;
+        gil::at_c<0>(*this) = chan0; gil::at_c<1>(*this) = chan1;
     }
-    packed_pixel(int chan0, int chan1, int chan2) : _bitfield(0) {
+
+    packed_pixel(int chan0, int chan1, int chan2)
+        : _bitfield(0)
+    {
         static_assert(num_channels<packed_pixel>::value == 3, "");
         gil::at_c<0>(*this) = chan0;
         gil::at_c<1>(*this) = chan1;
         gil::at_c<2>(*this) = chan2;
     }
-    packed_pixel(int chan0, int chan1, int chan2, int chan3) : _bitfield(0) {
+
+    packed_pixel(int chan0, int chan1, int chan2, int chan3)
+        : _bitfield(0)
+    {
         static_assert(num_channels<packed_pixel>::value == 4, "");
-        gil::at_c<0>(*this)=chan0; gil::at_c<1>(*this)=chan1; gil::at_c<2>(*this)=chan2; gil::at_c<3>(*this)=chan3;
+        gil::at_c<0>(*this) = chan0;
+        gil::at_c<1>(*this) = chan1;
+        gil::at_c<2>(*this) = chan2;
+        gil::at_c<3>(*this) = chan3;
     }
-    packed_pixel(int chan0, int chan1, int chan2, int chan3, int chan4) : _bitfield(0) {
+
+    packed_pixel(int chan0, int chan1, int chan2, int chan3, int chan4)
+        : _bitfield(0)
+    {
         static_assert(num_channels<packed_pixel>::value == 5, "");
-        gil::at_c<0>(*this)=chan0; gil::at_c<1>(*this)=chan1; gil::at_c<2>(*this)=chan2; gil::at_c<3>(*this)=chan3; gil::at_c<4>(*this)=chan4;
+        gil::at_c<0>(*this) = chan0;
+        gil::at_c<1>(*this) = chan1;
+        gil::at_c<2>(*this) = chan2;
+        gil::at_c<3>(*this) = chan3;
+        gil::at_c<4>(*this) = chan4;
     }
 
-    packed_pixel& operator=(const packed_pixel& p)     { _bitfield=p._bitfield; return *this; }
+    auto operator=(packed_pixel const& p) -> packed_pixel&
+    {
+        _bitfield = p._bitfield;
+        return *this;
+    }
 
-    template <typename P> packed_pixel& operator=(const P& p)        { assign(p, mpl::bool_<is_pixel<P>::value>()); return *this; }
-    template <typename P> bool          operator==(const P& p) const { return equal(p, mpl::bool_<is_pixel<P>::value>()); }
+    template <typename Pixel>
+    auto operator=(Pixel const& p) -> packed_pixel&
+    {
+        assign(p, is_pixel<Pixel>());
+        return *this;
+    }
 
-    template <typename P> bool operator!=(const P& p) const { return !(*this==p); }
+    template <typename Pixel>
+    bool operator==(Pixel const& p) const
+    {
+        return equal(p, is_pixel<Pixel>());
+    }
+
+    template <typename Pixel>
+    bool operator!=(Pixel const& p) const { return !(*this==p); }
 
 private:
-    template <typename Pixel> static void check_compatible() { gil_function_requires<PixelsCompatibleConcept<Pixel,packed_pixel> >(); }
-    template <typename Pixel> void assign(const Pixel& p, mpl::true_)       { check_compatible<Pixel>(); static_copy(p,*this); }
-    template <typename Pixel> bool  equal(const Pixel& p, mpl::true_) const { check_compatible<Pixel>(); return static_equal(*this,p); }
+    template <typename Pixel>
+    static void check_compatible()
+    {
+        gil_function_requires<PixelsCompatibleConcept<Pixel, packed_pixel>>();
+    }
 
-// Support for assignment/equality comparison of a channel with a grayscale pixel
+    template <typename Pixel>
+    void assign(Pixel const& p, std::true_type)
+    {
+        check_compatible<Pixel>();
+        static_copy(p, *this);
+    }
+
+    template <typename Pixel>
+    bool  equal(Pixel const& p, std::true_type) const
+    {
+        check_compatible<Pixel>();
+        return static_equal(*this, p);
+    }
+
+    // Support for assignment/equality comparison of a channel with a grayscale pixel
     static void check_gray()
     {
-        static_assert(is_same<typename Layout::color_space_t, gray_t>::value, "");
+        static_assert(std::is_same<typename Layout::color_space_t, gray_t>::value, "");
     }
-    template <typename Channel> void assign(const Channel& chan, mpl::false_)       { check_gray(); gil::at_c<0>(*this)=chan; }
-    template <typename Channel> bool equal (const Channel& chan, mpl::false_) const { check_gray(); return gil::at_c<0>(*this)==chan; }
+
+    template <typename Channel>
+    void assign(Channel const& channel, std::false_type)
+    {
+        check_gray();
+        gil::at_c<0>(*this) = channel;
+    }
+
+    template <typename Channel>
+    bool equal (Channel const& channel, std::false_type) const
+    {
+        check_gray();
+        return gil::at_c<0>(*this) == channel;
+    }
+
 public:
-    packed_pixel&  operator= (int chan)       { check_gray(); gil::at_c<0>(*this)=chan; return *this; }
-    bool           operator==(int chan) const { check_gray(); return gil::at_c<0>(*this)==chan; }
+    auto operator=(int channel) -> packed_pixel&
+    {
+        check_gray();
+        gil::at_c<0>(*this) = channel;
+        return *this;
+    }
+
+    bool operator==(int channel) const
+    {
+        check_gray();
+        return gil::at_c<0>(*this) == channel;
+    }
 };
 
 /////////////////////////////
 //  ColorBasedConcept
 /////////////////////////////
 
-template <typename BitField, typename ChannelRefVec, typename Layout, int K>
-struct kth_element_type<packed_pixel<BitField,ChannelRefVec,Layout>,K> : public mpl::at_c<ChannelRefVec,K> {};
-
-template <typename BitField, typename ChannelRefVec, typename Layout, int K>
-struct kth_element_reference_type<packed_pixel<BitField,ChannelRefVec,Layout>,K> : public mpl::at_c<ChannelRefVec,K> {};
-
-template <typename BitField, typename ChannelRefVec, typename Layout, int K>
-struct kth_element_const_reference_type<packed_pixel<BitField,ChannelRefVec,Layout>,K>
+template <typename BitField, typename ChannelRefs, typename Layout, int K>
+struct kth_element_type<packed_pixel<BitField, ChannelRefs, Layout>, K>
 {
-    using type = typename channel_traits<typename mpl::at_c<ChannelRefVec,K>::type>::const_reference;
+    using type = typename channel_traits<mp11::mp_at_c<ChannelRefs, K>>::value_type;
 };
 
-template <int K, typename P, typename C, typename L> inline
-typename kth_element_reference_type<packed_pixel<P,C,L>, K>::type
-at_c(packed_pixel<P,C,L>& p) {
-    return typename kth_element_reference_type<packed_pixel<P,C,L>, K>::type(&p._bitfield);
+template <typename BitField, typename ChannelRefs, typename Layout, int K>
+struct kth_element_reference_type<packed_pixel<BitField, ChannelRefs, Layout>, K>
+{
+    using type = typename channel_traits<mp11::mp_at_c<ChannelRefs, K>>::reference;
+};
+
+template <typename BitField, typename ChannelRefs, typename Layout, int K>
+struct kth_element_const_reference_type<packed_pixel<BitField, ChannelRefs, Layout>, K>
+{
+    using type = typename channel_traits<mp11::mp_at_c<ChannelRefs, K>>::const_reference;
+};
+
+template <int K, typename P, typename C, typename L>
+inline
+auto at_c(packed_pixel<P, C, L>& p)
+    -> typename kth_element_reference_type<packed_pixel<P, C, L>, K>::type
+{
+    return typename kth_element_reference_type
+        <
+            packed_pixel<P, C, L>,
+            K
+        >::type{&p._bitfield};
 }
 
-template <int K, typename P, typename C, typename L> inline
-typename kth_element_const_reference_type<packed_pixel<P,C,L>, K>::type
-at_c(const packed_pixel<P,C,L>& p) {
-    return typename kth_element_const_reference_type<packed_pixel<P,C,L>, K>::type(&p._bitfield);
+template <int K, typename P, typename C, typename L>
+inline
+auto at_c(const packed_pixel<P, C, L>& p)
+    -> typename kth_element_const_reference_type<packed_pixel<P, C, L>, K>::type
+{
+    return typename kth_element_const_reference_type
+        <
+            packed_pixel<P, C, L>,
+        K>::type{&p._bitfield};
 }
 
 /////////////////////////////
@@ -150,31 +237,30 @@ at_c(const packed_pixel<P,C,L>& p) {
 /////////////////////////////
 
 // Metafunction predicate that flags packed_pixel as a model of PixelConcept. Required by PixelConcept
-template <typename BitField, typename ChannelRefVec, typename Layout>
-struct is_pixel<packed_pixel<BitField,ChannelRefVec,Layout> > : public mpl::true_{};
+template <typename BitField, typename ChannelRefs, typename Layout>
+struct is_pixel<packed_pixel<BitField, ChannelRefs, Layout>> : std::true_type {};
 
 /////////////////////////////
 //  PixelBasedConcept
 /////////////////////////////
 
 template <typename P, typename C, typename Layout>
-struct color_space_type<packed_pixel<P,C,Layout> > {
+struct color_space_type<packed_pixel<P, C, Layout>>
+{
     using type = typename Layout::color_space_t;
 };
 
 template <typename P, typename C, typename Layout>
-struct channel_mapping_type<packed_pixel<P,C,Layout> > {
+struct channel_mapping_type<packed_pixel<P, C, Layout>>
+{
     using type = typename Layout::channel_mapping_t;
 };
 
 template <typename P, typename C, typename Layout>
-struct is_planar<packed_pixel<P,C,Layout> > : mpl::false_ {};
-
+struct is_planar<packed_pixel<P, C, Layout>> : std::false_type {};
 
 ////////////////////////////////////////////////////////////////////////////////
-///
 /// Support for interleaved iterators over packed pixel
-///
 ////////////////////////////////////////////////////////////////////////////////
 
 /// \defgroup PixelIteratorModelPackedInterleavedPtr Pointer to packed_pixel<P,CR,Layout>
@@ -183,16 +269,24 @@ struct is_planar<packed_pixel<P,C,Layout> > : mpl::false_ {};
 /// The pointer packed_pixel<P,CR,Layout>* is used as an iterator over interleaved pixels of packed format. Models PixelIteratorConcept, HasDynamicXStepTypeConcept, MemoryBasedIteratorConcept
 
 template <typename P, typename C, typename L>
-struct iterator_is_mutable<packed_pixel<P,C,L>*> : public mpl::bool_<packed_pixel<P,C,L>::is_mutable> {};
+struct iterator_is_mutable<packed_pixel<P, C, L>*>
+    : std::integral_constant<bool, packed_pixel<P, C, L>::is_mutable>
+{};
+
 template <typename P, typename C, typename L>
-struct iterator_is_mutable<const packed_pixel<P,C,L>*> : public mpl::false_ {};
+struct iterator_is_mutable<const packed_pixel<P, C, L>*> : std::false_type {};
 
+}}  // namespace boost::gil
 
+namespace std
+{
 
-} }  // namespace boost::gil
+// TODO: Avoid polluting std namespace?
+template <typename P, typename C, typename L>
+struct is_trivially_default_constructible<boost::gil::packed_pixel<P, C, L>>
+    : std::is_trivially_default_constructible<P>
+{};
 
-namespace boost {
-    template <typename P, typename C, typename L>
-    struct has_trivial_constructor<gil::packed_pixel<P,C,L> > : public has_trivial_constructor<P> {};
-}
+} // namespace std
+
 #endif

--- a/include/boost/gil/pixel.hpp
+++ b/include/boost/gil/pixel.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright 2005-2007 Adobe Systems Incorporated
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
 //
 // Distributed under the Boost Software License, Version 1.0
 // See accompanying file LICENSE_1_0.txt or copy at
@@ -14,11 +15,7 @@
 #include <boost/gil/concepts.hpp>
 #include <boost/gil/metafunctions.hpp>
 #include <boost/gil/utilities.hpp>
-
-#include <boost/core/ignore_unused.hpp>
-#include <boost/mpl/bool.hpp>
-#include <boost/mpl/front.hpp>
-#include <boost/type_traits.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <functional>
 #include <type_traits>
@@ -27,27 +24,34 @@ namespace boost { namespace gil {
 
 // Forward-declare gray_t
 struct gray_color_t;
-using gray_t = mpl::vector1<gray_color_t>;
+using gray_t = mp11::mp_list<gray_color_t>;
 template <typename PixelBased> struct color_space_type;
 template <typename PixelBased> struct channel_mapping_type;
 template <typename PixelBased> struct channel_type;
 template <typename PixelBased> struct is_planar;
 
-template <typename PixelBased> struct color_space_type<const PixelBased> : public color_space_type<PixelBased> {};
-template <typename PixelBased> struct channel_mapping_type<const PixelBased> : public channel_mapping_type<PixelBased> {};
-template <typename PixelBased> struct channel_type<const PixelBased> : public channel_type<PixelBased> {};
+template <typename PixelBased>
+struct color_space_type<PixelBased const> : color_space_type<PixelBased> {};
 
-template <typename PixelBased> struct is_planar : mpl::false_ {};
-template <typename PixelBased> struct is_planar<const PixelBased> : public is_planar<PixelBased> {};
+template <typename PixelBased>
+struct channel_mapping_type<PixelBased const> : channel_mapping_type<PixelBased> {};
 
+template <typename PixelBased>
+struct channel_type<PixelBased const> : channel_type<PixelBased> {};
 
-template <typename T> struct is_pixel : public mpl::false_{};
-template <typename T> struct is_pixel<const T> : public is_pixel<T> {};
+template <typename PixelBased>
+struct is_planar : std::false_type {};
+
+template <typename PixelBased>
+struct is_planar<PixelBased const> : is_planar<PixelBased> {};
+
+template <typename T> struct is_pixel : std::false_type {};
+template <typename T> struct is_pixel<T const> : is_pixel<T> {};
 
 /// \ingroup PixelBasedAlgorithm
 /// \brief Returns the number of channels of a pixel-based GIL construct
 template <typename PixelBased>
-struct num_channels : public mpl::size<typename color_space_type<PixelBased>::type> {};
+struct num_channels : mp11::mp_size<typename color_space_type<PixelBased>::type>::type {};
 
 /**
 \addtogroup PixelBasedAlgorithm
@@ -58,10 +62,10 @@ static_assert(num_channels<rgb8_view_t>::value == 3, "");
 static_assert(num_channels<cmyk16_planar_ptr_t>::value == 4, "");
 
 static_assert(is_planar<rgb16_planar_image_t>::value));
-static_assert(is_same<color_space_type<rgb8_planar_ref_t>::type, rgb_t>::value, "");
-static_assert(is_same<channel_mapping_type<cmyk8_pixel_t>::type,
+static_assert(std::is_same<color_space_type<rgb8_planar_ref_t>::type, rgb_t>::value, "");
+static_assert(std::is_same<channel_mapping_type<cmyk8_pixel_t>::type,
                              channel_mapping_type<rgba8_pixel_t>::type>::value, "");
-static_assert(is_same<channel_type<bgr8_pixel_t>::type, uint8_t>::value, "");
+static_assert(std::is_same<channel_type<bgr8_pixel_t>::type, uint8_t>::value, "");
 \endcode
 */
 
@@ -88,12 +92,26 @@ static_assert(is_same<channel_type<bgr8_pixel_t>::type, uint8_t>::value, "");
 /// The single-channel (grayscale) instantiation of the class pixel, (i.e. \p pixel<T,gray_layout_t>) is also convertible to/from a channel value.
 /// This allows grayscale pixels to be used in simpler expressions like *gray_pix1 = *gray_pix2  instead of more complicated at_c<0>(gray_pix1) = at_c<0>(gray_pix2)
 /// or get_color<gray_color_t>(gray_pix1) = get_color<gray_color_t>(gray_pix2)
-
-template <typename ChannelValue, typename Layout> // = mpl::range_c<int,0,ColorSpace::size> >
-struct pixel : public detail::homogeneous_color_base<ChannelValue,Layout,mpl::size<typename Layout::color_space_t>::value> {
+///
+/// \tparam ChannelValue TODO
+/// \tparam Layout mp11::make_integer_sequence<int, ColorSpace::size>
+template <typename ChannelValue, typename Layout>
+struct pixel :
+    detail::homogeneous_color_base
+    <
+        ChannelValue,
+        Layout,
+        mp11::mp_size<typename Layout::color_space_t>::value
+    >
+{
 private:
     using channel_t = ChannelValue;
-    using parent_t = detail::homogeneous_color_base<ChannelValue,Layout,mpl::size<typename Layout::color_space_t>::value>;
+    using parent_t = detail::homogeneous_color_base
+        <
+            ChannelValue,
+            Layout,
+            mp11::mp_size<typename Layout::color_space_t>::value
+        >;
 public:
     using value_type = pixel<ChannelValue, Layout>;
     using reference = value_type&;
@@ -102,14 +120,28 @@ public:
 
     pixel() = default;
     explicit pixel(channel_t v) : parent_t(v) {}  // sets all channels to v
-    pixel(channel_t v0, channel_t v1)                                                         : parent_t(v0,v1) {}
-    pixel(channel_t v0, channel_t v1, channel_t v2)                                           : parent_t(v0,v1,v2) {}
-    pixel(channel_t v0, channel_t v1, channel_t v2, channel_t v3)                             : parent_t(v0,v1,v2,v3) {}
-    pixel(channel_t v0, channel_t v1, channel_t v2, channel_t v3, channel_t v4)               : parent_t(v0,v1,v2,v3,v4) {}
-    pixel(channel_t v0, channel_t v1, channel_t v2, channel_t v3, channel_t v4, channel_t v5) : parent_t(v0,v1,v2,v3,v4,v5) {}
+    pixel(channel_t v0, channel_t v1) : parent_t(v0, v1) {}
+    pixel(channel_t v0, channel_t v1, channel_t v2) : parent_t(v0, v1, v2) {}
+
+    pixel(channel_t v0, channel_t v1, channel_t v2, channel_t v3)
+        : parent_t(v0, v1, v2, v3)
+    {}
+
+    pixel(channel_t v0, channel_t v1, channel_t v2, channel_t v3, channel_t v4)
+        : parent_t(v0, v1, v2, v3, v4)
+    {}
+
+    pixel(channel_t v0, channel_t v1, channel_t v2, channel_t v3, channel_t v4, channel_t v5)
+        : parent_t(v0, v1, v2, v3, v4, v5)
+    {}
 
     pixel(const pixel& p) : parent_t(p) {}
-    pixel&                       operator=(const pixel& p)       { static_copy(p,*this); return *this; }
+
+    pixel& operator=(pixel const& p)
+    {
+        static_copy(p,*this);
+        return *this;
+    }
 
     // Construct from another compatible pixel type
     template <typename Pixel>
@@ -120,32 +152,88 @@ public:
         check_compatible<Pixel>();
     }
 
-    template <typename P> pixel& operator=(const P& p)           { assign(p, mpl::bool_<is_pixel<P>::value>()); return *this; }
-    template <typename P> bool   operator==(const P& p)    const { return equal(p, mpl::bool_<is_pixel<P>::value>()); }
+    template <typename Pixel>
+    pixel& operator=(Pixel const& p)
+    {
+        assign(p, is_pixel<Pixel>());
+        return *this;
+    }
 
-    template <typename P> bool   operator!=(const P& p)    const { return !(*this==p); }
+    template <typename Pixel>
+    bool operator==(Pixel const& p) const { return equal(p, is_pixel<Pixel>()); }
+
+    template <typename Pixel>
+    bool operator!=(Pixel const& p) const { return !(*this == p); }
 
     // homogeneous pixels have operator[]
-    typename channel_traits<channel_t>::reference       operator[](std::size_t i)       { return dynamic_at_c(*this,i); }
-    typename channel_traits<channel_t>::const_reference operator[](std::size_t i) const { return dynamic_at_c(*this,i); }
-private:
-    template <typename Pixel> void assign(const Pixel& p, mpl::true_)       { check_compatible<Pixel>(); static_copy(p,*this); }
-    template <typename Pixel> bool  equal(const Pixel& p, mpl::true_) const { check_compatible<Pixel>(); return static_equal(*this,p); }
+    auto operator[](std::size_t index)
+        -> typename channel_traits<channel_t>::reference
+    {
+        return dynamic_at_c(*this, index);
+    }
 
-    template <typename Pixel> void check_compatible() const { gil_function_requires<PixelsCompatibleConcept<Pixel,pixel> >(); }
+    auto operator[](std::size_t index) const
+        -> typename channel_traits<channel_t>::const_reference 
+    {
+        return dynamic_at_c(*this, index);
+    }
+
+private:
+    template <typename Pixel>
+    void assign(Pixel const& p, std::true_type)
+    {
+        check_compatible<Pixel>();
+        static_copy(p, *this);
+    }
+
+    template <typename Pixel>
+    bool equal(Pixel const& p, std::true_type) const
+    {
+        check_compatible<Pixel>();
+        return static_equal(*this, p);
+    }
+
+    template <typename Pixel>
+    void check_compatible() const
+    {
+        gil_function_requires<PixelsCompatibleConcept<Pixel, pixel>>();
+    }
 
 // Support for assignment/equality comparison of a channel with a grayscale pixel
 
 private:
     static void check_gray()
     {
-        static_assert(is_same<typename Layout::color_space_t, gray_t>::value, "");
+        static_assert(std::is_same<typename Layout::color_space_t, gray_t>::value, "");
     }
-    template <typename Channel> void assign(const Channel& chan, mpl::false_)       { check_gray(); gil::at_c<0>(*this)=chan; }
-    template <typename Channel> bool equal (const Channel& chan, mpl::false_) const { check_gray(); return gil::at_c<0>(*this)==chan; }
+
+    template <typename Channel>
+    void assign(Channel const& channel, std::false_type)
+    {
+        check_gray();
+        gil::at_c<0>(*this) = channel;
+    }
+
+    template <typename Channel>
+    bool equal (Channel const& channel, std::false_type) const
+    {
+        check_gray();
+        return gil::at_c<0>(*this) == channel;
+    }
+
 public:
-    pixel&  operator= (channel_t chan)       { check_gray(); gil::at_c<0>(*this)=chan; return *this; }
-    bool    operator==(channel_t chan) const { check_gray(); return gil::at_c<0>(*this)==chan; }
+    pixel& operator= (channel_t channel)
+    {
+        check_gray();
+        gil::at_c<0>(*this) = channel;
+        return *this;
+    }
+
+    bool operator==(channel_t channel) const
+    {
+        check_gray();
+        return gil::at_c<0>(*this) == channel;
+    }
 };
 
 /////////////////////////////
@@ -153,22 +241,26 @@ public:
 /////////////////////////////
 
 template <typename ChannelValue, typename Layout, int K>
-struct kth_element_type<pixel<ChannelValue,Layout>, K> {
+struct kth_element_type<pixel<ChannelValue,Layout>, K>
+{
     using type = ChannelValue;
 };
 
 template <typename ChannelValue, typename Layout, int K>
-struct kth_element_reference_type<pixel<ChannelValue,Layout>, K> {
+struct kth_element_reference_type<pixel<ChannelValue,Layout>, K>
+{
     using type = typename channel_traits<ChannelValue>::reference;
 };
 
 template <typename ChannelValue, typename Layout, int K>
-struct kth_element_reference_type<const pixel<ChannelValue,Layout>, K> {
+struct kth_element_reference_type<const pixel<ChannelValue,Layout>, K>
+{
     using type = typename channel_traits<ChannelValue>::const_reference;
 };
 
 template <typename ChannelValue, typename Layout, int K>
-struct kth_element_const_reference_type<pixel<ChannelValue,Layout>, K> {
+struct kth_element_const_reference_type<pixel<ChannelValue,Layout>, K>
+{
     using type = typename channel_traits<ChannelValue>::const_reference;
 };
 
@@ -177,35 +269,43 @@ struct kth_element_const_reference_type<pixel<ChannelValue,Layout>, K> {
 /////////////////////////////
 
 template <typename ChannelValue, typename Layout>
-struct is_pixel<pixel<ChannelValue,Layout> > : public mpl::true_{};
+struct is_pixel<pixel<ChannelValue,Layout>> : std::true_type {};
 
 /////////////////////////////
 //  HomogeneousPixelBasedConcept
 /////////////////////////////
 
 template <typename ChannelValue, typename Layout>
-struct color_space_type<pixel<ChannelValue,Layout> > {
+struct color_space_type<pixel<ChannelValue, Layout>>
+{
     using type = typename Layout::color_space_t;
 };
 
 template <typename ChannelValue, typename Layout>
-struct channel_mapping_type<pixel<ChannelValue,Layout> > {
+struct channel_mapping_type<pixel<ChannelValue, Layout>>
+{
     using type = typename Layout::channel_mapping_t;
 };
 
 template <typename ChannelValue, typename Layout>
-struct is_planar<pixel<ChannelValue,Layout> > : public mpl::false_ {};
+struct is_planar<pixel<ChannelValue, Layout>> : std::false_type {};
 
 template <typename ChannelValue, typename Layout>
-struct channel_type<pixel<ChannelValue,Layout> > {
+struct channel_type<pixel<ChannelValue, Layout>>
+{
     using type = ChannelValue;
 };
 
 }}  // namespace boost::gil
 
-namespace boost {
-    template <typename ChannelValue, typename Layout>
-    struct has_trivial_constructor<gil::pixel<ChannelValue,Layout> > : public has_trivial_constructor<ChannelValue> {};
-}
+namespace std {
+
+// TODO: Avoid polluting std namespace
+template <typename ChannelValue, typename Layout>
+struct is_trivially_default_constructible<boost::gil::pixel<ChannelValue, Layout>>
+    : ::std::is_trivially_default_constructible<ChannelValue>
+{};
+
+} // namespace std
 
 #endif

--- a/include/boost/gil/pixel_iterator_adaptor.hpp
+++ b/include/boost/gil/pixel_iterator_adaptor.hpp
@@ -80,14 +80,17 @@ struct const_iterator_type<dereference_iterator_adaptor<I,DFn> > {
 };
 
 template <typename I, typename DFn>
-struct iterator_is_mutable<dereference_iterator_adaptor<I,DFn> > : public mpl::bool_<DFn::is_mutable> {};
+struct iterator_is_mutable<dereference_iterator_adaptor<I, DFn>>
+    : std::integral_constant<bool, DFn::is_mutable>
+{};
 
 
 template <typename I, typename DFn>
-struct is_iterator_adaptor<dereference_iterator_adaptor<I,DFn> > : public mpl::true_{};
+struct is_iterator_adaptor<dereference_iterator_adaptor<I, DFn>> : std::true_type {};
 
 template <typename I, typename DFn>
-struct iterator_adaptor_get_base<dereference_iterator_adaptor<I,DFn> > {
+struct iterator_adaptor_get_base<dereference_iterator_adaptor<I, DFn>>
+{
     using type = I;
 };
 

--- a/include/boost/gil/planar_pixel_iterator.hpp
+++ b/include/boost/gil/planar_pixel_iterator.hpp
@@ -10,12 +10,15 @@
 
 #include <boost/gil/pixel.hpp>
 #include <boost/gil/step_iterator.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <boost/iterator/iterator_facade.hpp>
 
 #include <iterator>
+#include <type_traits>
 
 namespace boost { namespace gil {
+
 //forward declaration (as this file is included in planar_pixel_reference.hpp)
 template <typename ChannelReference, typename ColorSpace>
 struct planar_pixel_reference;
@@ -37,18 +40,40 @@ struct planar_pixel_reference;
 ///
 /// \ingroup PixelIteratorModelPlanarPtr ColorBaseModelPlanarPtr PixelBasedModel
 template <typename ChannelPtr, typename ColorSpace>
-struct planar_pixel_iterator : public iterator_facade<planar_pixel_iterator<ChannelPtr,ColorSpace>,
-                                                      pixel<typename std::iterator_traits<ChannelPtr>::value_type,layout<ColorSpace> >,
-                                                      std::random_access_iterator_tag,
-                                                      const planar_pixel_reference<typename std::iterator_traits<ChannelPtr>::reference,ColorSpace> >,
-                               public detail::homogeneous_color_base<ChannelPtr,layout<ColorSpace>,mpl::size<ColorSpace>::value > {
+struct planar_pixel_iterator
+    :
+    iterator_facade
+    <
+        planar_pixel_iterator<ChannelPtr, ColorSpace>,
+        pixel<typename std::iterator_traits<ChannelPtr>::value_type,layout<ColorSpace>>,
+        std::random_access_iterator_tag,
+        planar_pixel_reference<typename std::iterator_traits<ChannelPtr>::reference, ColorSpace> const
+    >,
+    detail::homogeneous_color_base
+    <
+        ChannelPtr,
+        layout<ColorSpace>,
+        mp11::mp_size<ColorSpace>::value
+    >
+{
 private:
-    using parent_t = iterator_facade<planar_pixel_iterator<ChannelPtr,ColorSpace>,
-                            pixel<typename std::iterator_traits<ChannelPtr>::value_type,layout<ColorSpace>>,
-                            std::random_access_iterator_tag,
-                            const planar_pixel_reference<typename std::iterator_traits<ChannelPtr>::reference,ColorSpace>>;
-    using color_base_parent_t = detail::homogeneous_color_base<ChannelPtr,layout<ColorSpace>,mpl::size<ColorSpace>::value>;
+    using parent_t = iterator_facade
+        <
+            planar_pixel_iterator<ChannelPtr, ColorSpace>,
+            pixel<typename std::iterator_traits<ChannelPtr>::value_type,layout<ColorSpace>>,
+            std::random_access_iterator_tag,
+            planar_pixel_reference<typename std::iterator_traits<ChannelPtr>::reference, ColorSpace> const
+        >;
+
+    using color_base_parent_t = detail::homogeneous_color_base
+        <
+            ChannelPtr,
+            layout<ColorSpace>,
+            mp11::mp_size<ColorSpace>::value
+        >;
+
     using channel_t = typename std::iterator_traits<ChannelPtr>::value_type;
+
 public:
     using value_type = typename parent_t::value_type;
     using reference = typename parent_t::reference;
@@ -108,9 +133,13 @@ private:
 };
 
 namespace detail {
-    template <typename IC> struct channel_iterator_is_mutable : public mpl::true_ {};
-    template <typename T>  struct channel_iterator_is_mutable<const T*> : public mpl::false_ {};
-}
+template <typename I>
+struct channel_iterator_is_mutable : std::true_type {};
+
+template <typename I>
+struct channel_iterator_is_mutable<I const*> : std::false_type {};
+
+} // namespace detail
 
 template <typename IC, typename C>
 struct const_iterator_type<planar_pixel_iterator<IC,C> > {
@@ -129,33 +158,41 @@ struct iterator_is_mutable<planar_pixel_iterator<IC,C> > : public detail::channe
 /////////////////////////////
 
 template <typename IC, typename C, int K>
-struct kth_element_type<planar_pixel_iterator<IC,C>, K> {
+struct kth_element_type<planar_pixel_iterator<IC, C>, K>
+{
     using type = IC;
 };
 
 template <typename IC, typename C, int K>
-struct kth_element_reference_type<planar_pixel_iterator<IC,C>, K> : public add_reference<IC> {};
+struct kth_element_reference_type<planar_pixel_iterator<IC, C>, K>
+    : std::add_lvalue_reference<IC> {};
 
 template <typename IC, typename C, int K>
-struct kth_element_const_reference_type<planar_pixel_iterator<IC,C>, K> : public add_reference<typename add_const<IC>::type> {};
+struct kth_element_const_reference_type<planar_pixel_iterator<IC, C>, K>
+    : std::add_lvalue_reference<typename std::add_const<IC>::type>
+{};
 
 /////////////////////////////
 //  HomogeneousPixelBasedConcept
 /////////////////////////////
 
 template <typename IC, typename C>
-struct color_space_type<planar_pixel_iterator<IC,C> > {
+struct color_space_type<planar_pixel_iterator<IC,C>>
+{
     using type = C;
 };
 
 template <typename IC, typename C>
-struct channel_mapping_type<planar_pixel_iterator<IC,C> > : public channel_mapping_type<typename planar_pixel_iterator<IC,C>::value_type> {};
+struct channel_mapping_type<planar_pixel_iterator<IC, C>>
+    : channel_mapping_type<typename planar_pixel_iterator<IC,C>::value_type>
+{};
 
 template <typename IC, typename C>
-struct is_planar<planar_pixel_iterator<IC,C> > : public mpl::true_ {};
+struct is_planar<planar_pixel_iterator<IC, C>> : std::true_type {};
 
 template <typename IC, typename C>
-struct channel_type<planar_pixel_iterator<IC,C> > {
+struct channel_type<planar_pixel_iterator<IC, C>>
+{
     using type = typename std::iterator_traits<IC>::value_type;
 };
 

--- a/include/boost/gil/position_iterator.hpp
+++ b/include/boost/gil/position_iterator.hpp
@@ -12,18 +12,22 @@
 
 #include <boost/iterator/iterator_facade.hpp>
 
+#include <type_traits>
+
 namespace boost { namespace gil {
 
 /// \defgroup PixelIteratorModelVirtual position_iterator
 /// \ingroup PixelIteratorModel
-/// \brief An iterator that remembers its current X,Y position and invokes a function object with it upon dereferencing. Models PixelIteratorConcept, PixelBasedConcept, HasDynamicXStepTypeConcept. Used to create virtual image views.
+/// \brief An iterator that remembers its current X,Y position and invokes a function object with it upon dereferencing.
+/// Models PixelIteratorConcept, PixelBasedConcept, HasDynamicXStepTypeConcept. Used to create virtual image views.
 
-
-/// \brief An iterator that remembers its current X,Y position and invokes a function object with it upon dereferencing. Models PixelIteratorConcept. Used to create virtual image views.
-///    Models: StepIteratorConcept, PixelIteratorConcept, PixelBasedConcept, HasDynamicXStepTypeConcept
+/// \brief An iterator that remembers its current X,Y position and invokes a function object with it upon dereferencing.
+/// Used to create virtual image views.
+/// Models: StepIteratorConcept, PixelIteratorConcept, PixelBasedConcept, HasDynamicXStepTypeConcept
 /// \ingroup PixelIteratorModelVirtual PixelBasedModel
-template <typename Deref, // A function object that given a point returns a pixel reference. Models PixelDereferenceAdaptorConcept
-          int Dim>        // the dimension to advance along
+/// \tparam Deref A function object that given a point returns a pixel reference. Models PixelDereferenceAdaptorConcept
+/// \tparam Dim Dimension to advance along
+template <typename Deref, int Dim>
 struct position_iterator : public iterator_facade<position_iterator<Deref,Dim>,
                                                   typename Deref::value_type,
                                                   std::random_access_iterator_tag,
@@ -74,8 +78,10 @@ struct const_iterator_type<position_iterator<Deref,Dim> > {
     using type = position_iterator<typename Deref::const_t,Dim>;
 };
 
-template <typename Deref,int Dim>
-struct iterator_is_mutable<position_iterator<Deref,Dim> > : public mpl::bool_<Deref::is_mutable> {
+template <typename Deref, int Dim>
+struct iterator_is_mutable<position_iterator<Deref, Dim>>
+    : std::integral_constant<bool, Deref::is_mutable>
+{
 };
 
 /////////////////////////////
@@ -89,7 +95,7 @@ template <typename Deref,int Dim>
 struct channel_mapping_type<position_iterator<Deref,Dim> > : public channel_mapping_type<typename Deref::value_type> {};
 
 template <typename Deref,int Dim>
-struct is_planar<position_iterator<Deref,Dim> > : public mpl::false_ {};
+struct is_planar<position_iterator<Deref, Dim>> : std::false_type {};
 
 template <typename Deref,int Dim>
 struct channel_type<position_iterator<Deref,Dim> > : public channel_type<typename Deref::value_type> {};

--- a/include/boost/gil/rgb.hpp
+++ b/include/boost/gil/rgb.hpp
@@ -10,11 +10,10 @@
 
 #include <boost/gil/metafunctions.hpp>
 #include <boost/gil/planar_pixel_iterator.hpp>
-
-#include <boost/mpl/range_c.hpp>
-#include <boost/mpl/vector_c.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <cstddef>
+#include <type_traits>
 
 namespace boost { namespace gil {
 
@@ -32,26 +31,31 @@ struct blue_t {};
 /// \}
 
 /// \ingroup ColorSpaceModel
-using rgb_t = mpl::vector3<red_t,green_t,blue_t>;
+using rgb_t = mp11::mp_list<red_t, green_t, blue_t>;
 
 /// \ingroup LayoutModel
 using rgb_layout_t = layout<rgb_t>;
+
 /// \ingroup LayoutModel
-using bgr_layout_t = layout<rgb_t, mpl::vector3_c<int,2,1,0>>;
+using bgr_layout_t = layout<rgb_t, mp11::mp_list_c<int, 2, 1, 0>>;
 
 /// \ingroup ImageViewConstructors
 /// \brief from raw RGB planar data
 template <typename IC>
 inline
-typename type_from_x_iterator<planar_pixel_iterator<IC,rgb_t> >::view_t
-planar_rgb_view(std::size_t width, std::size_t height,
-                IC r, IC g, IC b,
-                std::ptrdiff_t rowsize_in_bytes)
+auto planar_rgb_view(
+    std::size_t width, std::size_t height,
+    IC r, IC g, IC b,
+    std::ptrdiff_t rowsize_in_bytes)
+    -> typename type_from_x_iterator<planar_pixel_iterator<IC, rgb_t> >::view_t
 {
-    using view_t = typename type_from_x_iterator<planar_pixel_iterator<IC,rgb_t>>::view_t;
-    return view_t(width, height,
-                 typename view_t::locator(planar_pixel_iterator<IC,rgb_t>(r,g,b),
-                                         rowsize_in_bytes));
+    using view_t = typename type_from_x_iterator<planar_pixel_iterator<IC, rgb_t>>::view_t;
+
+    return view_t(
+        width, height,
+        typename view_t::locator(
+            planar_pixel_iterator<IC, rgb_t>(r, g, b),
+            rowsize_in_bytes));
 }
 
 }}  // namespace boost::gil

--- a/include/boost/gil/rgba.hpp
+++ b/include/boost/gil/rgba.hpp
@@ -10,11 +10,10 @@
 
 #include <boost/gil/planar_pixel_iterator.hpp>
 #include <boost/gil/rgb.hpp>
-
-#include <boost/mpl/contains.hpp>
-#include <boost/mpl/vector.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <cstddef>
+#include <type_traits>
 
 namespace boost { namespace gil {
 
@@ -23,30 +22,37 @@ namespace boost { namespace gil {
 struct alpha_t {};
 
 /// \ingroup ColorSpaceModel
-using rgba_t = mpl::vector4<red_t,green_t,blue_t,alpha_t>;
+using rgba_t =mp11::mp_list<red_t, green_t, blue_t, alpha_t>;
 
 /// \ingroup LayoutModel
 using rgba_layout_t = layout<rgba_t>;
+
 /// \ingroup LayoutModel
-using bgra_layout_t = layout<rgba_t, mpl::vector4_c<int,2,1,0,3>>;
+using bgra_layout_t = layout<rgba_t, mp11::mp_list_c<int, 2, 1, 0, 3>>;
+
 /// \ingroup LayoutModel
-using argb_layout_t = layout<rgba_t, mpl::vector4_c<int,1,2,3,0>>;
+using argb_layout_t = layout<rgba_t, mp11::mp_list_c<int, 1, 2, 3, 0>>;
+
 /// \ingroup LayoutModel
-using abgr_layout_t = layout<rgba_t, mpl::vector4_c<int,3,2,1,0>>;
+using abgr_layout_t = layout<rgba_t, mp11::mp_list_c<int, 3, 2, 1, 0>>;
 
 /// \ingroup ImageViewConstructors
 /// \brief from raw RGBA planar data
 template <typename IC>
 inline
-typename type_from_x_iterator<planar_pixel_iterator<IC,rgba_t> >::view_t
-planar_rgba_view(std::size_t width, std::size_t height,
-                 IC r, IC g, IC b, IC a,
-                 std::ptrdiff_t rowsize_in_bytes)
+auto planar_rgba_view(
+    std::size_t width, std::size_t height,
+    IC r, IC g, IC b, IC a,
+    std::ptrdiff_t rowsize_in_bytes)
+    -> typename type_from_x_iterator<planar_pixel_iterator<IC, rgba_t> >::view_t
 {
-    using view_t = typename type_from_x_iterator<planar_pixel_iterator<IC,rgba_t> >::view_t;
-    return RView(width, height,
-                 typename view_t::locator(planar_pixel_iterator<IC,rgba_t>(r,g,b,a),
-                                         rowsize_in_bytes));
+    using view_t = typename type_from_x_iterator<planar_pixel_iterator<IC, rgba_t>>::view_t;
+
+    return RView(
+        width, height,
+        typename view_t::locator(
+            planar_pixel_iterator<IC, rgba_t>(r, g, b, a),
+            rowsize_in_bytes));
 }
 
 }} // namespace boost::gil

--- a/include/boost/gil/step_iterator.hpp
+++ b/include/boost/gil/step_iterator.hpp
@@ -17,6 +17,7 @@
 
 #include <cstddef>
 #include <iterator>
+#include <type_traits>
 
 namespace boost { namespace gil {
 
@@ -164,12 +165,12 @@ public:
 };
 
 template <typename Iterator>
-struct const_iterator_type<memory_based_step_iterator<Iterator> > {
+struct const_iterator_type<memory_based_step_iterator<Iterator>> {
     using type = memory_based_step_iterator<typename const_iterator_type<Iterator>::type>;
 };
 
 template <typename Iterator>
-struct iterator_is_mutable<memory_based_step_iterator<Iterator> > : public iterator_is_mutable<Iterator> {};
+struct iterator_is_mutable<memory_based_step_iterator<Iterator>> : public iterator_is_mutable<Iterator> {};
 
 
 /////////////////////////////
@@ -177,15 +178,17 @@ struct iterator_is_mutable<memory_based_step_iterator<Iterator> > : public itera
 /////////////////////////////
 
 template <typename Iterator>
-struct is_iterator_adaptor<memory_based_step_iterator<Iterator> > : public mpl::true_{};
+struct is_iterator_adaptor<memory_based_step_iterator<Iterator>> : std::true_type {};
 
 template <typename Iterator>
-struct iterator_adaptor_get_base<memory_based_step_iterator<Iterator> > {
+struct iterator_adaptor_get_base<memory_based_step_iterator<Iterator>>
+{
     using type = Iterator;
 };
 
 template <typename Iterator, typename NewBaseIterator>
-struct iterator_adaptor_rebind<memory_based_step_iterator<Iterator>,NewBaseIterator> {
+struct iterator_adaptor_rebind<memory_based_step_iterator<Iterator>, NewBaseIterator>
+{
     using type = memory_based_step_iterator<NewBaseIterator>;
 };
 
@@ -194,22 +197,22 @@ struct iterator_adaptor_rebind<memory_based_step_iterator<Iterator>,NewBaseItera
 /////////////////////////////
 
 template <typename Iterator>
-struct color_space_type<memory_based_step_iterator<Iterator> > : public color_space_type<Iterator> {};
+struct color_space_type<memory_based_step_iterator<Iterator>> : public color_space_type<Iterator> {};
 
 template <typename Iterator>
-struct channel_mapping_type<memory_based_step_iterator<Iterator> > : public channel_mapping_type<Iterator> {};
+struct channel_mapping_type<memory_based_step_iterator<Iterator>> : public channel_mapping_type<Iterator> {};
 
 template <typename Iterator>
-struct is_planar<memory_based_step_iterator<Iterator> > : public is_planar<Iterator> {};
+struct is_planar<memory_based_step_iterator<Iterator>> : public is_planar<Iterator> {};
 
 template <typename Iterator>
-struct channel_type<memory_based_step_iterator<Iterator> > : public channel_type<Iterator> {};
+struct channel_type<memory_based_step_iterator<Iterator>> : public channel_type<Iterator> {};
 
 /////////////////////////////
 //  MemoryBasedIteratorConcept
 /////////////////////////////
 template <typename Iterator>
-struct byte_to_memunit<memory_based_step_iterator<Iterator> > : public byte_to_memunit<Iterator> {};
+struct byte_to_memunit<memory_based_step_iterator<Iterator>> : public byte_to_memunit<Iterator> {};
 
 template <typename Iterator>
 inline std::ptrdiff_t memunit_step(const memory_based_step_iterator<Iterator>& p) { return p.step(); }
@@ -245,7 +248,7 @@ memunit_advanced_ref(const memory_based_step_iterator<Iterator>& p,
 /////////////////////////////
 
 template <typename Iterator>
-struct dynamic_x_step_type<memory_based_step_iterator<Iterator> > {
+struct dynamic_x_step_type<memory_based_step_iterator<Iterator>> {
     using type = memory_based_step_iterator<Iterator>;
 };
 
@@ -269,22 +272,32 @@ namespace detail {
 
 // if the iterator is a plain base iterator (non-adaptor), wraps it in memory_based_step_iterator
 template <typename I>
-typename dynamic_x_step_type<I>::type make_step_iterator_impl(const I& it, std::ptrdiff_t step, mpl::false_) {
+auto make_step_iterator_impl(I const& it, std::ptrdiff_t step, std::false_type)
+    -> typename dynamic_x_step_type<I>::type
+{
     return memory_based_step_iterator<I>(it, step);
 }
 
 // If the iterator is compound, put the step in its base
 template <typename I>
-typename dynamic_x_step_type<I>::type make_step_iterator_impl(const I& it, std::ptrdiff_t step, mpl::true_) {
+auto make_step_iterator_impl(I const& it, std::ptrdiff_t step, std::true_type)
+    -> typename dynamic_x_step_type<I>::type
+{
     return make_step_iterator(it.base(), step);
 }
 
 // If the iterator is memory_based_step_iterator, change the step
 template <typename BaseIt>
-memory_based_step_iterator<BaseIt> make_step_iterator_impl(const memory_based_step_iterator<BaseIt>& it, std::ptrdiff_t step, mpl::true_) {
+auto make_step_iterator_impl(
+    memory_based_step_iterator<BaseIt> const& it,
+    std::ptrdiff_t step,
+    std::true_type)
+    -> memory_based_step_iterator<BaseIt>
+{
     return memory_based_step_iterator<BaseIt>(it.base(), step);
 }
-}
+
+} // namespace detail
 
 /// \brief Constructs a step iterator from a base iterator and a step.
 ///

--- a/include/boost/gil/utilities.hpp
+++ b/include/boost/gil/utilities.hpp
@@ -8,15 +8,10 @@
 #ifndef BOOST_GIL_UTILITIES_HPP
 #define BOOST_GIL_UTILITIES_HPP
 
-#include <boost/mpl/begin.hpp>
-#include <boost/mpl/contains.hpp>
-#include <boost/mpl/distance.hpp>
-#include <boost/mpl/find.hpp>
-#include <boost/mpl/range_c.hpp>
-#include <boost/mpl/size.hpp>
+#include <boost/gil/detail/mp11.hpp>
+
 #include <boost/iterator/iterator_adaptor.hpp>
 #include <boost/iterator/iterator_facade.hpp>
-#include <boost/type_traits.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -24,6 +19,7 @@
 #include <functional>
 #include <iterator>
 #include <utility>
+#include <type_traits>
 
 namespace boost { namespace gil {
 
@@ -228,30 +224,37 @@ struct dec
 };
 
 /// \brief Returns the index corresponding to the first occurrance of a given given type in
-//         a given MPL RandomAccessSequence (or size if the type is not present)
+//         a given Boost.MP11-compatible list (or size if the type is not present)
 template <typename Types, typename T>
-struct type_to_index
-    : public mpl::distance
-        <
-            typename mpl::begin<Types>::type,
-            typename mpl::find<Types,T>::type
-        >::type
-    {
-        static_assert(mpl::contains<Types, T>::value, "T should be element of Types");
-    };
+struct type_to_index : mp11::mp_find<Types, T>
+{
+    static_assert(mp11::mp_contains<Types, T>::value, "T should be element of Types");
+};
+
 } // namespace detail
 
 /// \ingroup ColorSpaceAndLayoutModel
 /// \brief Represents a color space and ordering of channels in memory
-template <typename ColorSpace, typename ChannelMapping = mpl::range_c<int,0,mpl::size<ColorSpace>::value>>
+template
+<
+    typename ColorSpace,
+    typename ChannelMapping = mp11::mp_iota
+    <
+        std::integral_constant<int, mp11::mp_size<ColorSpace>::value>
+    >
+>
 struct layout
 {
     using color_space_t = ColorSpace;
     using channel_mapping_t = ChannelMapping;
+
+    static_assert(mp11::mp_size<ColorSpace>::value > 0,
+        "color space should not be empty sequence");
 };
 
 /// \brief A version of swap that also works with reference proxy objects
-template <typename Value, typename T1, typename T2> // where value_type<T1>  == value_type<T2> == Value
+/// Where value_type<T1>  == value_type<T2> == Value
+template <typename Value, typename T1, typename T2>
 void swap_proxy(T1& left, T2& right)
 {
     Value tmp = left;

--- a/io/test/bmp_old_test.cpp
+++ b/io/test/bmp_old_test.cpp
@@ -9,6 +9,7 @@
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/bmp/old.hpp>
 
+#include <boost/mp11.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "mandel_view.hpp"
@@ -73,7 +74,7 @@ BOOST_AUTO_TEST_CASE( old_write_view_test )
 
 BOOST_AUTO_TEST_CASE( old_dynamic_image_test )
 {
-    using my_img_types = mpl::vector
+    using my_img_types = mp11::mp_list
         <
             gray8_image_t,
             gray16_image_t,

--- a/io/test/bmp_read_test.cpp
+++ b/io/test/bmp_read_test.cpp
@@ -10,7 +10,6 @@
 #include <boost/gil/extension/io/bmp.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/type_traits/is_same.hpp>
 
 #include "paths.hpp"
 #include "scanline_read_test.hpp"

--- a/io/test/bmp_test.cpp
+++ b/io/test/bmp_test.cpp
@@ -11,6 +11,7 @@
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/bmp.hpp>
 
+#include <boost/mp11.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <fstream>
@@ -322,7 +323,7 @@ BOOST_AUTO_TEST_CASE( subimage_test )
 
 BOOST_AUTO_TEST_CASE( dynamic_image_test )
 {
-    using my_img_types = mpl::vector
+    using my_img_types = mp11::mp_list
         <
             gray8_image_t,
             gray16_image_t,

--- a/io/test/jpeg_old_test.cpp
+++ b/io/test/jpeg_old_test.cpp
@@ -9,6 +9,7 @@
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/jpeg/old.hpp>
 
+#include <boost/mp11.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "mandel_view.hpp"
@@ -73,7 +74,7 @@ BOOST_AUTO_TEST_CASE( old_write_view_test )
 
 BOOST_AUTO_TEST_CASE( old_dynamic_image_test )
 {
-    using my_img_types = mpl::vector
+    using my_img_types = mp11::mp_list
         <
             gray8_image_t,
             gray16_image_t,

--- a/io/test/jpeg_test.cpp
+++ b/io/test/jpeg_test.cpp
@@ -10,9 +10,9 @@
 #define BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 
 #include <boost/gil.hpp>
-
 #include <boost/gil/extension/io/jpeg.hpp>
 
+#include <boost/mp11.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <fstream>
@@ -308,7 +308,7 @@ BOOST_AUTO_TEST_CASE( subimage_test )
 
 BOOST_AUTO_TEST_CASE( dynamic_image_test )
 {
-    using my_img_types = mpl::vector
+    using my_img_types = mp11::mp_list
         <
             gray8_image_t,
             gray16_image_t,

--- a/io/test/make.cpp
+++ b/io/test/make.cpp
@@ -8,8 +8,10 @@
 #define BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 #define BOOST_FILESYSTEM_VERSION 3
 
-#include <boost/gil.hpp>
 #include <boost/gil/extension/io/bmp.hpp>
+
+#include <boost/gil.hpp>
+#include <boost/gil/detail/mp11.hpp>
 
 #include <boost/test/unit_test.hpp>
 
@@ -30,7 +32,7 @@ BOOST_AUTO_TEST_SUITE( gil_io_tests )
 BOOST_AUTO_TEST_CASE( make_reader_backend_test )
 {
     {
-        static_assert(std::is_same<gil::detail::is_supported_path_spec<char*>::type, mpl::true_>::value, "");
+        static_assert(std::is_same<gil::detail::is_supported_path_spec<char*>::type, std::true_type>::value, "");
 
         get_reader_backend< const char*, bmp_tag >::type backend_char   = make_reader_backend( bmp_filename.c_str(), bmp_tag() );
         get_reader_backend< std::string, bmp_tag >::type backend_string = make_reader_backend( bmp_filename, bmp_tag() );
@@ -133,7 +135,7 @@ BOOST_AUTO_TEST_CASE( make_writer_test )
     {
         using writer_t = get_writer<char const*, bmp_tag>::type;
 
-        static_assert(std::is_same<gil::detail::is_writer<writer_t>::type, boost::mpl::true_>::value, "");
+        static_assert(std::is_same<gil::detail::is_writer<writer_t>::type, std::true_type>::value, "");
     }
 
     {

--- a/io/test/png_old_test.cpp
+++ b/io/test/png_old_test.cpp
@@ -9,6 +9,7 @@
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/png/old.hpp>
 
+#include <boost/mp11.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "mandel_view.hpp"
@@ -73,7 +74,7 @@ BOOST_AUTO_TEST_CASE( old_write_view_test )
 
 BOOST_AUTO_TEST_CASE( old_dynamic_image_test )
 {
-    using my_img_types = mpl::vector
+    using my_img_types = mp11::mp_list
         <
             gray8_image_t,
             gray16_image_t,

--- a/io/test/png_test.cpp
+++ b/io/test/png_test.cpp
@@ -12,8 +12,8 @@
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/png.hpp>
 
+#include <boost/mp11.hpp>
 #include <boost/test/unit_test.hpp>
-#include <boost/type_traits/is_same.hpp>
 
 #include <fstream>
 
@@ -323,7 +323,7 @@ BOOST_AUTO_TEST_CASE( subimage_test )
 
 BOOST_AUTO_TEST_CASE( dynamic_image_test )
 {
-    using my_img_types = mpl::vector
+    using my_img_types = mp11::mp_list
         <
             gray8_image_t,
             gray16_image_t,

--- a/io/test/pnm_old_test.cpp
+++ b/io/test/pnm_old_test.cpp
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE( old_write_view_test )
 
 BOOST_AUTO_TEST_CASE( old_dynamic_image_test )
 {
-    using my_img_types = mpl::vector
+    using my_img_types = mp11::mp_list
         <
             gray8_image_t,
             gray16_image_t,

--- a/io/test/pnm_test.cpp
+++ b/io/test/pnm_test.cpp
@@ -10,8 +10,8 @@
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/pnm.hpp>
 
+#include <boost/mp11.hpp>
 #include <boost/test/unit_test.hpp>
-#include <boost/type_traits/is_same.hpp>
 
 #include <fstream>
 
@@ -301,7 +301,7 @@ BOOST_AUTO_TEST_CASE( subimage_test )
 
 BOOST_AUTO_TEST_CASE( dynamic_image_test )
 {
-    using my_img_types = mpl::vector
+    using my_img_types = mp11::mp_list
         <
             gray8_image_t,
             gray16_image_t,

--- a/io/test/raw_test.cpp
+++ b/io/test/raw_test.cpp
@@ -12,6 +12,7 @@
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/raw.hpp>
 
+#include <boost/mp11.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <fstream>
@@ -109,7 +110,7 @@ BOOST_AUTO_TEST_CASE( read_and_convert_view_test )
 
 BOOST_AUTO_TEST_CASE( dynamic_image_test )
 {
-  using my_img_types = mpl::vector
+  using my_img_types = mp11::mp_list
       <
           gray8_image_t,
           gray16_image_t,

--- a/io/test/targa_old_test.cpp
+++ b/io/test/targa_old_test.cpp
@@ -10,6 +10,7 @@
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/targa/old.hpp>
 
+#include <boost/mp11.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "mandel_view.hpp"
@@ -74,7 +75,7 @@ BOOST_AUTO_TEST_CASE( old_write_view_test )
 
 BOOST_AUTO_TEST_CASE( old_dynamic_image_test )
 {
-    using my_img_types = mpl::vector
+    using my_img_types = mp11::mp_list
         <
             gray8_image_t,
             gray16_image_t,

--- a/io/test/targa_read_test.cpp
+++ b/io/test/targa_read_test.cpp
@@ -11,7 +11,6 @@
 #include <boost/gil/extension/io/targa.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/type_traits/is_same.hpp>
 
 #include "paths.hpp"
 #include "scanline_read_test.hpp"

--- a/io/test/targa_test.cpp
+++ b/io/test/targa_test.cpp
@@ -11,6 +11,7 @@
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/targa.hpp>
 
+#include <boost/mp11.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <fstream>
@@ -303,7 +304,7 @@ BOOST_AUTO_TEST_CASE( subimage_test )
 
 BOOST_AUTO_TEST_CASE( dynamic_image_test )
 {
-    using my_img_types = mpl::vector
+    using my_img_types = mp11::mp_list
         <
             gray8_image_t,
             gray16_image_t,

--- a/io/test/tiff_old_test.cpp
+++ b/io/test/tiff_old_test.cpp
@@ -10,6 +10,7 @@
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/tiff/old.hpp>
 
+#include <boost/mp11.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "paths.hpp"
@@ -64,7 +65,7 @@ BOOST_AUTO_TEST_CASE( old_read_and_convert_view_test )
 
 BOOST_AUTO_TEST_CASE( old_dynamic_image_test )
 {
-    using my_img_types = mpl::vector
+    using my_img_types = mp11::mp_list
         <
             gray8_image_t,
             gray16_image_t,

--- a/io/test/tiff_test.cpp
+++ b/io/test/tiff_test.cpp
@@ -11,6 +11,7 @@
 
 #include <boost/gil/extension/io/tiff.hpp>
 
+#include <boost/mp11.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <fstream>
@@ -333,10 +334,9 @@ BOOST_AUTO_TEST_CASE( subimage_test )
 
 BOOST_AUTO_TEST_CASE( dynamic_image_test )
 {
-    // This test has been disabled for now because of
-    // compilation issues with MSVC10.
+    // FIXME: This test has been disabled for now because of compilation issues with MSVC10.
 
-    using my_img_types = mpl::vector
+    using my_img_types = mp11::mp_list
         <
             gray8_image_t,
             gray16_image_t,

--- a/io/test/tiff_tiled_read_macros.hpp
+++ b/io/test/tiff_tiled_read_macros.hpp
@@ -11,7 +11,6 @@
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/tiff/read.hpp>
 
-#include <boost/mpl/vector.hpp>
 #include <boost/preprocessor/cat.hpp>
 #include <boost/preprocessor/stringize.hpp>
 #include <boost/preprocessor/tuple/elem.hpp>
@@ -21,6 +20,8 @@
 #include "paths.hpp"
 
 using tag_t = boost::gil::tiff_tag;
+
+// TODO: Rename the macros to BOOST_GIL_*
 
 #define GENERATE_TILE_STRIP_COMPARISON_BIT_ALIGNED_RGB(z, n, data)\
     BOOST_AUTO_TEST_CASE( BOOST_PP_CAT( \

--- a/io/test/tiff_tiled_write_macros.hpp
+++ b/io/test/tiff_tiled_write_macros.hpp
@@ -11,7 +11,6 @@
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/tiff.hpp>
 
-#include <boost/mpl/vector.hpp>
 #include <boost/preprocessor/cat.hpp>
 #include <boost/preprocessor/stringize.hpp>
 #include <boost/preprocessor/tuple/elem.hpp>
@@ -21,6 +20,8 @@
 #include "paths.hpp"
 
 using tag_t = boost::gil::tiff_tag;
+
+// TODO: Rename the macros to BOOST_GIL_*
 
 #ifdef BOOST_GIL_IO_TEST_ALLOW_WRITING_IMAGES
 

--- a/test/channel/CMakeLists.txt
+++ b/test/channel/CMakeLists.txt
@@ -13,7 +13,7 @@ foreach(_name
   algorithm_channel_relation
   channel_traits
   concepts
-  is_integral
+  is_channel_integral
   packed_channel_value
   scoped_channel_value
   test_fixture)

--- a/test/channel/Jamfile
+++ b/test/channel/Jamfile
@@ -17,7 +17,7 @@ project
 
 compile concepts.cpp ;
 run test_fixture.cpp ;
-run is_integral.cpp ;
+run is_channel_integral.cpp ;
 run channel_traits.cpp ;
 run packed_channel_value.cpp ;
 run scoped_channel_value.cpp ;

--- a/test/channel/algorithm_channel_arithmetic.cpp
+++ b/test/channel/algorithm_channel_arithmetic.cpp
@@ -18,10 +18,10 @@ namespace gil = boost::gil;
 namespace fixture = boost::gil::test::fixture;
 
 template <typename ChannelFixtureBase>
-void test_channel_arithmetic_mutable(boost::mpl::false_)  {}
+void test_channel_arithmetic_mutable(std::false_type)  {}
 
 template <typename ChannelFixtureBase>
-void test_channel_arithmetic_mutable(boost::mpl::true_)
+void test_channel_arithmetic_mutable(std::true_type)
 {
     using fixture_t = fixture::channel<ChannelFixtureBase>;
     using channel_value_t = typename fixture_t::channel_value_t;
@@ -69,11 +69,12 @@ void test_channel_arithmetic()
     BOOST_TEST((f.min_v_ + 1) + 1 == f.min_v_ + 2);
     BOOST_TEST((f.max_v_ - 1) - 1 == f.max_v_ - 2);
 
-    using is_mutable_t = boost::mpl::bool_
+    using is_mutable_t = std::integral_constant
         <
-        gil::channel_traits<typename fixture_t::channel_t>::is_mutable
+            bool,
+            gil::channel_traits<typename fixture_t::channel_t>::is_mutable
         >;
-    test_channel_arithmetic_mutable<ChannelFixtureBase>(is_mutable_t());
+    test_channel_arithmetic_mutable<ChannelFixtureBase>(is_mutable_t{});
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(channel_value, Channel, fixture::channel_byte_types)

--- a/test/channel/is_channel_integral.cpp
+++ b/test/channel/is_channel_integral.cpp
@@ -7,18 +7,27 @@
 //
 #include <boost/gil/channel.hpp>
 #include <boost/gil/typedefs.hpp>
+#include <boost/gil/detail/is_channel_integral.hpp>
+
+#include <type_traits>
 
 namespace gil = boost::gil;
 
 int main()
 {
-    static_assert(boost::is_integral<gil::packed_channel_value<1>>::value,
+    static_assert(gil::detail::is_channel_integral
+        <
+            gil::packed_channel_value<1>
+        >::value,
         "1-bit packed_channel_value should be recognized as integral");
 
-    static_assert(boost::is_integral<gil::packed_channel_value<8>>::value,
+    static_assert(gil::detail::is_channel_integral
+        <
+            gil::packed_channel_value<8>
+        >::value,
         "8-bit packed_channel_value should be recognized as integral");
 
-    static_assert(boost::is_integral
+    static_assert(gil::detail::is_channel_integral
         <
             gil::packed_channel_reference
             <
@@ -27,7 +36,7 @@ int main()
         >::value,
         "3-bit packed_channel_reference should be recognized as integral");
 
-    static_assert(boost::is_integral
+    static_assert(gil::detail::is_channel_integral
         <
             gil::packed_dynamic_channel_reference
             <
@@ -36,7 +45,7 @@ int main()
         >::value,
         "2-bit packed_dynamic_channel_reference should be recognized as integral");
 
-    static_assert(boost::is_integral
+    static_assert(gil::detail::is_channel_integral
         <
             gil::packed_dynamic_channel_reference
             <
@@ -48,7 +57,7 @@ int main()
 
     struct int_minus_value  { static std::int8_t apply() { return -64; } };
     struct int_plus_value   { static std::int8_t apply() { return  64; } };
-    static_assert(boost::is_integral
+    static_assert(gil::detail::is_channel_integral
         <
             gil::scoped_channel_value
             <
@@ -57,9 +66,9 @@ int main()
         >::value,
         "integer-based scoped_channel_value should be recognized as integral");
 
-    static_assert(!boost::is_integral<gil::float32_t>::value,
+    static_assert(!gil::detail::is_channel_integral<gil::float32_t>::value,
         "float-based packed_channel_value should not be recognized as integral");
 
-    static_assert(!boost::is_integral<gil::float64_t>::value,
+    static_assert(!gil::detail::is_channel_integral<gil::float64_t>::value,
         "float-based packed_channel_value should not be recognized as integral");
 }

--- a/test/color_base/homogeneous_color_base.cpp
+++ b/test/color_base/homogeneous_color_base.cpp
@@ -9,25 +9,26 @@
 #include <boost/gil/gray.hpp>
 #include <boost/gil/rgb.hpp>
 #include <boost/gil/rgba.hpp>
-#include <boost/mpl/int.hpp>
+
 #include <boost/core/typeinfo.hpp>
+
+#include <type_traits>
 
 #define BOOST_TEST_MODULE test_channel_traits
 #include "unit_test.hpp"
 
 namespace gil = boost::gil;
-namespace mpl = boost::mpl;
 
 namespace {
 
 template <int N>
 using color_base = gil::detail::homogeneous_color_base<std::uint8_t, gil::gray_layout_t, N>;
 
-mpl::int_<0> e0;
-mpl::int_<1> e1;
-mpl::int_<2> e2;
-mpl::int_<3> e3;
-mpl::int_<4> e4;
+std::integral_constant<int, 0> e0;
+std::integral_constant<int, 1> e1;
+std::integral_constant<int, 2> e2;
+std::integral_constant<int, 3> e3;
+std::integral_constant<int, 4> e4;
 
 } // unnamed namespace
 
@@ -71,7 +72,6 @@ BOOST_AUTO_TEST_CASE(homogeneous_color_base_3_default_constructor)
     BOOST_TEST(f.at(e1) == std::uint8_t{0});
     BOOST_TEST(f.at(e2) == std::uint8_t{0});
 }
-
 
 BOOST_AUTO_TEST_CASE(homogeneous_color_base_3_value_constructor)
 {

--- a/test/legacy/CMakeLists.txt
+++ b/test/legacy/CMakeLists.txt
@@ -37,10 +37,13 @@ foreach(_name
 endforeach()
 
 # Add extra source files accompanying image.cpp
-target_sources(legacy_image
-  PRIVATE
+foreach(_name
+  image)
+  set(_target legacy_${_name})
+  target_sources(${_target} PRIVATE
     error_if.cpp
     sample_image.cpp)
-add_test(test.legacy.image
-  legacy_image
-  ${CMAKE_CURRENT_SOURCE_DIR}/gil_reference_checksums.txt)
+  add_test(test.legacy.${_name}
+    ${_target}
+    ${CMAKE_CURRENT_SOURCE_DIR}/gil_reference_checksums.txt)
+endforeach()

--- a/test/legacy/channel.cpp
+++ b/test/legacy/channel.cpp
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <exception>
 #include <iostream>
+#include <type_traits>
 
 #if defined(BOOST_CLANG)
 #pragma clang diagnostic push
@@ -62,8 +63,8 @@ struct do_test : public ChannelTestCore {
         test_channel_math();
     }
 
-    void test_mutable(boost::mpl::false_) {}
-    void test_mutable(boost::mpl::true_) {
+    void test_mutable(std::false_type) {}
+    void test_mutable(std::true_type) {
         channel_value_t mv=this->_min_v;
         ++this->_min_v; this->_min_v++;
         --this->_min_v; this->_min_v--;
@@ -107,7 +108,7 @@ struct do_test : public ChannelTestCore {
         error_if(this->_min_v != 1 && this->_min_v==1);  // comparable to integral
 
 
-        test_mutable(boost::mpl::bool_<channel_traits<channel_t>::is_mutable>());
+        test_mutable(std::integral_constant<bool, channel_traits<channel_t>::is_mutable>());
     }
 
 

--- a/test/legacy/image.cpp
+++ b/test/legacy/image.cpp
@@ -8,13 +8,15 @@
 #ifdef _MSC_VER
 #pragma warning(disable : 4244)     // conversion from 'gil::image<V,Alloc>::coord_t' to 'int', possible loss of data (visual studio compiler doesn't realize that the two types are the same)
 #pragma warning(disable : 4503)     // decorated name length exceeded, name was truncated
+#pragma warning(disable : 4701)     // potentially uninitialized local variable 'result' used in boost/crc.hpp
 #endif
 
+#include <boost/gil.hpp>
 #include <boost/gil/extension/dynamic_image/dynamic_image_all.hpp>
 
 #include <boost/core/ignore_unused.hpp>
 #include <boost/crc.hpp>
-#include <boost/mpl/vector.hpp>
+#include <boost/mp11.hpp>
 
 #include <ios>
 #include <iostream>
@@ -36,7 +38,6 @@ void error_if(bool condition);
 #pragma warning(push)
 #pragma warning(disable:4127) //conditional expression is constant
 #endif
-
 
 // When BOOST_GIL_GENERATE_REFERENCE_DATA is defined, the reference data is generated and saved.
 // When it is undefined, regression tests are checked against it
@@ -145,10 +146,10 @@ void x_gradient(const T& src, const gray8s_view_t& dst) {
 // A quick test whether a view is homogeneous
 
 template <typename Pixel>
-struct pixel_is_homogeneous : public mpl::true_ {};
+struct pixel_is_homogeneous : public std::true_type {};
 
 template <typename P, typename C, typename L>
-struct pixel_is_homogeneous<packed_pixel<P,C,L> > : public mpl::false_ {};
+struct pixel_is_homogeneous<packed_pixel<P,C,L> > : public std::false_type {};
 
 template <typename View>
 struct view_is_homogeneous : public pixel_is_homogeneous<typename View::value_type> {};
@@ -176,8 +177,8 @@ protected:
 private:
     template <typename Img> void basic_test(const string& prefix);
     template <typename View> void view_transformations_test(const View& img_view, const string& prefix);
-    template <typename View> void homogeneous_view_transformations_test(const View& img_view, const string& prefix, mpl::true_);
-    template <typename View> void homogeneous_view_transformations_test(const View& img_view, const string& prefix, mpl::false_)
+    template <typename View> void homogeneous_view_transformations_test(const View& img_view, const string& prefix, std::true_type);
+    template <typename View> void homogeneous_view_transformations_test(const View& img_view, const string& prefix, std::false_type)
     {
         boost::ignore_unused(img_view);
         boost::ignore_unused(prefix);
@@ -276,7 +277,7 @@ void image_test::view_transformations_test(const View& img_view, const string& p
 }
 
 template <typename View>
-void image_test::homogeneous_view_transformations_test(const View& img_view, const string& prefix, mpl::true_) {
+void image_test::homogeneous_view_transformations_test(const View& img_view, const string& prefix, std::true_type) {
     check_view(nth_channel_view(img_view,0),prefix+"0th_n_channel");
 }
 
@@ -325,7 +326,7 @@ void image_test::dynamic_image_test()
 {
     using any_image_t = any_image
         <
-            mpl::vector
+            mp11::mp_list
             <
                 gray8_image_t,
                 bgr8_image_t,
@@ -372,7 +373,7 @@ void image_test::run() {
     using bgr121_ref_t = bit_aligned_pixel_reference
         <
             boost::uint8_t,
-            mpl::vector3_c<int, 1, 2, 1>,
+            mp11::mp_list_c<int, 1, 2, 1>,
             bgr_layout_t,
             true
         > const;
@@ -540,7 +541,7 @@ void static_checks() {
         <
             derived_view_type
             <
-                cmyk8c_planar_step_view_t, use_default, rgb_layout_t, mpl::false_, use_default, mpl::false_
+                cmyk8c_planar_step_view_t, use_default, rgb_layout_t, std::false_type, use_default, std::false_type
             >::type,
             rgb8c_step_view_t
         >::value, "");

--- a/test/legacy/pixel.cpp
+++ b/test/legacy/pixel.cpp
@@ -8,15 +8,12 @@
 #include <boost/gil.hpp>
 
 #include <boost/core/ignore_unused.hpp>
-#include <boost/mpl/at.hpp>
-#include <boost/mpl/for_each.hpp>
-#include <boost/mpl/size.hpp>
-#include <boost/mpl/vector.hpp>
-#include <boost/type_traits.hpp>
+#include <boost/mp11.hpp>
 
 #include <exception>
 #include <iostream>
 #include <iterator>
+#include <type_traits>
 
 using namespace boost::gil;
 using std::swap;
@@ -106,15 +103,17 @@ struct do_basic_test : public C1, public C2
         // Test swap if both are mutable and if their value type is the same
         // (We know the second one is mutable)
         using p1_ref = typename boost::add_reference<typename C1::type>::type;
-        test_swap(boost::mpl::bool_
+        using is_swappable = std::integral_constant
             <
+                bool,
                 pixel_reference_is_mutable<p1_ref>::value &&
-                std::is_same<pixel1_value_t,pixel2_value_t>::value
-            >());
+                std::is_same<pixel1_value_t, pixel2_value_t>::value
+            >;
+        test_swap(is_swappable{});
     }
 
-    void test_swap(boost::mpl::false_) {}
-    void test_swap(boost::mpl::true_) {
+    void test_swap(std::false_type) {}
+    void test_swap(std::true_type) {
         // test swap
         static_fill(C1::_pixel, 0);
         static_fill(C2::_pixel, 1);
@@ -143,7 +142,7 @@ public:
 };
 
 template <typename PixelRef, int Tag=0>
-class reference_core : public value_core<typename boost::remove_reference<PixelRef>::type::value_type, Tag>
+class reference_core : public value_core<typename std::remove_reference<PixelRef>::type::value_type, Tag>
 {
 public:
     using type = PixelRef;
@@ -160,7 +159,7 @@ public:
 
 // Use a subset of pixel models that covers all color spaces, channel depths, reference/value, planar/interleaved, const/mutable
 // color conversion will be invoked on pairs of them. Having an exhaustive binary check would be too big/expensive.
-using representative_pixels_t = mpl::vector
+using representative_pixels_t = mp11::mp_list
 <
     value_core<gray8_pixel_t>,
     reference_core<gray16_pixel_t&>,
@@ -172,28 +171,10 @@ using representative_pixels_t = mpl::vector
     reference_core<rgb32fc_planar_ref_t>
 >;
 
-template <typename Vector, typename Fun, int K>
-struct for_each_impl {
-    static void apply(Fun fun) {
-        for_each_impl<Vector,Fun,K-1>::apply(fun);
-        fun(typename mpl::at_c<Vector,K>::type());
-    }
-};
-
-template <typename Vector, typename Fun>
-struct for_each_impl<Vector,Fun,-1> {
-    static void apply(Fun fun) { boost::ignore_unused(fun); }
-};
-
-template <typename Vector, typename Fun>
-void for_each(Fun fun) {
-    for_each_impl<Vector,Fun, mpl::size<Vector>::value-1>::apply(fun);
-}
-
 template <typename Pixel1>
 struct ccv2 {
     template <typename P1, typename P2>
-    void color_convert_compatible(const P1& p1, P2& p2, mpl::true_) {
+    void color_convert_compatible(const P1& p1, P2& p2, std::true_type) {
         using value_t = typename P1::value_type;
         p2 = p1;
         value_t converted;
@@ -202,23 +183,23 @@ struct ccv2 {
     }
 
     template <typename P1, typename P2>
-    void color_convert_compatible(const P1& p1, P2& p2, mpl::false_) {
+    void color_convert_compatible(const P1& p1, P2& p2, std::false_type) {
         color_convert(p1,p2);
     }
 
     template <typename P1, typename P2>
     void color_convert_impl(const P1& p1, P2& p2) {
-        color_convert_compatible(p1, p2, mpl::bool_<pixels_are_compatible<P1,P2>::value>());
+        using is_compatible = typename pixels_are_compatible<P1,P2>::type;
+        color_convert_compatible(p1, p2, is_compatible());
     }
-
 
     template <typename Pixel2>
     void operator()(Pixel2) {
         // convert from Pixel1 to Pixel2 (or, if Pixel2 is immutable, to its value type)
-        static const int p2_is_mutable = pixel_reference_is_mutable<typename Pixel2::type>::value;
-        using pixel_model_t = typename boost::remove_reference<typename Pixel2::type>::type;
+        using p2_is_mutable = pixel_reference_is_mutable<typename Pixel2::type>;
+        using pixel_model_t = typename std::remove_reference<typename Pixel2::type>::type;
         using p2_value_t = typename pixel_model_t::value_type;
-        using pixel2_mutable = typename mpl::if_c<p2_is_mutable, Pixel2, value_core<p2_value_t>>::type;
+        using pixel2_mutable = mp11::mp_if<p2_is_mutable, Pixel2, value_core<p2_value_t>>;
 
         Pixel1 p1;
         pixel2_mutable p2;
@@ -230,23 +211,22 @@ struct ccv2 {
 struct ccv1 {
     template <typename Pixel>
     void operator()(Pixel) {
-        mpl::for_each<representative_pixels_t>(ccv2<Pixel>());
+        mp11::mp_for_each<representative_pixels_t>(ccv2<Pixel>());
     }
 };
 
 void test_color_convert() {
-   for_each<representative_pixels_t>(ccv1());
+   mp11::mp_for_each<representative_pixels_t>(ccv1());
 }
 
 void test_packed_pixel()
 {
-    using rgb565_pixel_t = packed_pixel_type<uint16_t, mpl::vector3_c<unsigned,5,6,5>, rgb_layout_t>::type;
-
+    using rgb565_pixel_t = packed_pixel_type<uint16_t, mp11::mp_list_c<unsigned,5,6,5>, rgb_layout_t>::type;
     boost::function_requires<PixelValueConcept<rgb565_pixel_t> >();
     static_assert(sizeof(rgb565_pixel_t) == 2, "");
 
     // define a bgr556 pixel
-    using bgr556_pixel_t = packed_pixel_type<uint16_t, mpl::vector3_c<unsigned,5,6,5>, bgr_layout_t>::type;
+    using bgr556_pixel_t = packed_pixel_type<uint16_t, mp11::mp_list_c<unsigned,5,6,5>, bgr_layout_t>::type;
     boost::function_requires<PixelValueConcept<bgr556_pixel_t> >();
 
     // Create a zero packed pixel and a full regular unpacked pixel.
@@ -268,8 +248,8 @@ void test_packed_pixel()
     color_convert(rgb_full,r565);
 
     // Test bit-aligned pixel reference
-    using bgr121_ref_t = const bit_aligned_pixel_reference<std::uint8_t, boost::mpl::vector3_c<int,1,2,1>, bgr_layout_t, true>;
-    using rgb121_ref_t = const bit_aligned_pixel_reference<std::uint8_t, boost::mpl::vector3_c<int,1,2,1>, rgb_layout_t, true>;
+    using bgr121_ref_t = const bit_aligned_pixel_reference<std::uint8_t, mp11::mp_list_c<int,1,2,1>, bgr_layout_t, true>;
+    using rgb121_ref_t = const bit_aligned_pixel_reference<std::uint8_t, mp11::mp_list_c<int,1,2,1>, rgb_layout_t, true>;
     using rgb121_pixel_t = rgb121_ref_t::value_type;
     rgb121_pixel_t p121;
     do_basic_test<reference_core<bgr121_ref_t,0>, reference_core<rgb121_ref_t,1> >(p121).test_heterogeneous();
@@ -293,7 +273,6 @@ void test_packed_pixel()
 
     static_assert(pixel_reference_is_mutable<bgr121_ref_t>::value, "");
     static_assert(!pixel_reference_is_mutable<bgr121_ref_t::const_reference>::value, "");
-
 }
 
 void test_pixel() {
@@ -329,7 +308,6 @@ int main()
     try
     {
         test_pixel();
-
         return EXIT_SUCCESS;
     }
     catch (std::exception const& e)

--- a/test/legacy/pixel_iterator.cpp
+++ b/test/legacy/pixel_iterator.cpp
@@ -5,10 +5,14 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
+#ifdef _MSC_VER
+#pragma warning(disable : 4244) // 'argument': conversion from 'int' to 'unsigned char', possible loss of data
+#endif
+
 #include <boost/gil.hpp>
 
 #include <boost/assert.hpp>
-#include <boost/mpl/vector.hpp>
+#include <boost/mp11.hpp>
 
 #include <exception>
 #include <iostream>
@@ -38,7 +42,7 @@ void test_pixel_iterator()
     using bgr121_ref_t = bit_aligned_pixel_reference
         <
             std::uint8_t,
-            boost::mpl::vector3_c<int,1,2,1>,
+            boost::mp11::mp_list_c<int,1,2,1>,
             bgr_layout_t,
             true
         > const;
@@ -88,7 +92,7 @@ void test_pixel_iterator()
     using bgr232_ref_t = bit_aligned_pixel_reference
         <
             std::uint8_t,
-            boost::mpl::vector3_c<unsigned, 2, 3, 2>,
+            boost::mp11::mp_list_c<unsigned, 2, 3, 2>,
             bgr_layout_t,
             true
         > const;
@@ -203,9 +207,9 @@ void test_pixel_iterator() {
     rgb8_step_ptr_t stepIt3(&rgb8,5);
 
     rgb8_pixel_t& ref1=stepIt3[5];
-//  bool v=boost::is_POD<iterator_traits<memory_based_step_iterator<rgb8_ptr_t> >::value_type>::value;
-//  v=boost::is_POD<rgb8_pixel_t>::value;
-//  v=boost::is_POD<int>::value;
+//  bool v=std::is_pod<iterator_traits<memory_based_step_iterator<rgb8_ptr_t> >::value_type>::value;
+//  v=std::is_pod<rgb8_pixel_t>::value;
+//  v=std::is_pod<int>::value;
 
     rgb8_step_ptr_t rgb8StepIt(ptr1, 10);
     rgb8_step_ptr_t rgb8StepIt2=rgb8StepIt;

--- a/test/legacy/recreate_image.cpp
+++ b/test/legacy/recreate_image.cpp
@@ -12,7 +12,6 @@
 
 #include <boost/gil/extension/dynamic_image/dynamic_image_all.hpp>
 
-#include <boost/mpl/vector.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <ios>
@@ -20,6 +19,7 @@
 #include <fstream>
 #include <map>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 using namespace boost::gil;
@@ -30,7 +30,7 @@ using namespace boost;
 
 std::size_t is_planar_impl( const std::size_t size_in_units
                             , const std::size_t channels_in_image
-                            , mpl::true_
+                            , std::true_type
                             )
 {
     return size_in_units * channels_in_image;
@@ -38,7 +38,7 @@ std::size_t is_planar_impl( const std::size_t size_in_units
 
 std::size_t is_planar_impl( const std::size_t size_in_units
                           , const std::size_t
-                          , mpl::false_
+                          , std::false_type
                           )
 {
     return size_in_units;
@@ -62,14 +62,14 @@ std::size_t total_allocated_size_in_bytes( const typename View::point_t& dimensi
     using x_iterator = typename View::x_iterator;
 
     // when value_type is a non-pixel, like int or float, num_channels< ... > doesn't work.
-    const std::size_t _channels_in_image = mpl::eval_if< is_pixel< typename View::value_type >
+    const std::size_t _channels_in_image = mp11::mp_eval_if< is_pixel< typename View::value_type >
                                                         , num_channels< View >
-                                                        , mpl::int_< 1 >
+                                                        , std::integral_constant<int, 1>
                                                         >::type::value;
 
     std::size_t size_in_units = is_planar_impl( get_row_size_in_memunits< View >( dimensions.x ) * dimensions.y
                                                 , _channels_in_image
-                                                , typename boost::conditional< IsPlanar, mpl::true_, mpl::false_ >::type()
+                                                , typename std::conditional< IsPlanar, std::true_type, std::false_type >::type()
                                                 );
 
     // return the size rounded up to the nearest byte

--- a/test/pixel/bit_aligned_pixel_reference.cpp
+++ b/test/pixel/bit_aligned_pixel_reference.cpp
@@ -8,15 +8,15 @@
 #include <boost/gil/bit_aligned_pixel_reference.hpp>
 #include <boost/gil/packed_pixel.hpp>
 #include <boost/gil/rgb.hpp>
-#include <boost/mpl/vector_c.hpp>
+#include <boost/mp11.hpp>
 namespace gil = boost::gil;
-namespace mpl = boost::mpl;
+namespace mp11 = boost::mp11;
 
 int main()
 {
     using bgr121_ref_t = gil::bit_aligned_pixel_reference
         <
-            std::uint8_t, mpl::vector3_c<int, 1, 2, 1>, gil::bgr_layout_t, true
+            std::uint8_t, mp11::mp_list_c<int, 1, 2, 1>, gil::bgr_layout_t, true
         >;
 
     static_assert(bgr121_ref_t::bit_size == 4,
@@ -37,10 +37,10 @@ int main()
             std::uint8_t,
             typename gil::detail::packed_channel_references_vector_type
             <
-                std::uint8_t, mpl::vector3_c<int, 1, 2, 1>
+                std::uint8_t, mp11::mp_list_c<int, 1, 2, 1>
             >::type,
             gil::bgr_layout_t
         >;
-    static_assert(std::is_same<bgr121_ref_t::value_type, packed_pixel_t >::value,
+    static_assert(std::is_same<bgr121_ref_t::value_type, packed_pixel_t>::value,
         "value_type should be specialization of packed_pixel");
 }

--- a/test/pixel/concepts.cpp
+++ b/test/pixel/concepts.cpp
@@ -12,14 +12,12 @@
 
 #include <boost/concept_check.hpp>
 #include <boost/mp11.hpp>
-#include <boost/mpl/vector_c.hpp>
 
 #include "test_fixture.hpp"
 
-namespace mpl = boost::mpl;
 namespace gil = boost::gil;
+namespace mp11 = boost::mp11;
 using boost::function_requires;
-using namespace boost::mp11;
 
 template <template<typename> class Concept>
 struct assert_concept
@@ -34,7 +32,7 @@ struct assert_concept
 template <template<typename> class Concept, typename... Pixels>
 void test_concept()
 {
-    mp_for_each<Pixels...>(assert_concept<Concept>());
+    mp11::mp_for_each<Pixels...>(assert_concept<Concept>());
 }
 
 int main()
@@ -45,7 +43,7 @@ int main()
     using rgb565_pixel_t = gil::packed_pixel_type
         <
             std::uint16_t,
-            mpl::vector3_c<unsigned, 5, 6, 5>,
+            mp11::mp_list_c<unsigned, 5, 6, 5>,
             gil::rgb_layout_t
         >::type;
     function_requires<gil::PixelConcept<rgb565_pixel_t>>();
@@ -54,7 +52,7 @@ int main()
     using bgr556_pixel_t = gil::packed_pixel_type
         <
             std::uint16_t,
-            mpl::vector3_c<unsigned, 5, 6, 5>,
+            mp11::mp_list_c<unsigned, 5, 6, 5>,
             gil::bgr_layout_t>::type;
     function_requires<gil::PixelConcept<bgr556_pixel_t>>();
     function_requires<gil::PixelValueConcept<bgr556_pixel_t>>();

--- a/test/pixel/is_pixel.cpp
+++ b/test/pixel/is_pixel.cpp
@@ -59,14 +59,14 @@ int main()
 
     using bgr121_ref_t = gil::bit_aligned_pixel_reference
         <
-            std::uint8_t, boost::mpl::vector3_c<int, 1, 2, 1>, gil::bgr_layout_t, true
+            std::uint8_t, mp_list_c<int, 1, 2, 1>, gil::bgr_layout_t, true
         >;
     static_assert(gil::is_pixel<bgr121_ref_t>::value,
         "is_pixel does not yield true for bit_aligned_pixel_reference");
 
     using rgb121_ref_t = gil::bit_aligned_pixel_reference
         <
-            std::uint8_t, boost::mpl::vector3_c<int, 1, 2, 1>, gil::rgb_layout_t, true
+            std::uint8_t, mp_list_c<int, 1, 2, 1>, gil::rgb_layout_t, true
         >;
     static_assert(gil::is_pixel<bgr121_ref_t>::value,
         "is_pixel does not yield true for bit_aligned_pixel_reference");

--- a/test/pixel/packed_pixel.cpp
+++ b/test/pixel/packed_pixel.cpp
@@ -11,16 +11,13 @@
 #include <boost/gil/rgb.hpp>
 
 #include <boost/core/typeinfo.hpp>
-#include <boost/mpl/at.hpp>
-#include <boost/mpl/int.hpp>
-#include <boost/mpl/size.hpp>
-#include <boost/mpl/vector_c.hpp>
+#include <boost/mp11.hpp>
 
 #define BOOST_TEST_MODULE test_channel_traits
 #include "unit_test.hpp"
 
 namespace gil = boost::gil;
-namespace mpl = boost::mpl;
+namespace mp11 = boost::mp11;
 
 namespace boost { namespace gil {
 
@@ -40,7 +37,7 @@ std::ostream& operator<<(std::ostream& os, gil::packed_pixel<BitField, ChannelRe
 using packed_channel_references_3 = typename gil::detail::packed_channel_references_vector_type
 <
     std::uint8_t,
-    mpl::vector1_c<int, 3>
+    mp11::mp_list_c<int, 3>
 >::type;
 
 using packed_pixel_gray3 = gil::packed_pixel
@@ -72,12 +69,10 @@ BOOST_AUTO_TEST_CASE(packed_pixel_gray3_definition)
 
     // Verify metafunctions
 
-    using channel_references_t = packed_channel_references_3::type;
-
-    static_assert(mpl::size<channel_references_t>::value == 1,
+    static_assert(mp11::mp_size<packed_channel_references_3>::value == 1,
         "packed_channel_references_vector_type should define one reference to channel start bits");
 
-    using channel1_ref_t = mpl::at_c<channel_references_t, 0>::type;
+    using channel1_ref_t = mp11::mp_at_c<packed_channel_references_3, 0>;
     static_assert(channel1_ref_t::num_bits == 3,
         "1st channel of gray3 pixel should be of 3-bit size");
 
@@ -91,13 +86,23 @@ BOOST_AUTO_TEST_CASE(packed_pixel_gray3_definition)
     // double check intermediate metafunction packed_channel_reference_type
     static_assert(std::is_same
         <
-            gil::detail::packed_channel_reference_type<std::uint8_t, mpl::int_<0>, mpl::int_<3>>::type,
+            gil::detail::packed_channel_reference_type
+            <
+                std::uint8_t,
+                std::integral_constant<int, 0>,
+                std::integral_constant<int, 3>
+            >::type,
             channel1_ref_t
         >::value,
         "packed_channel_reference_type should return packed_channel_reference");
     static_assert(std::is_same
         <
-            gil::detail::packed_channel_reference_type<std::uint8_t, mpl::int_<0>, mpl::int_<3>>::type,
+            gil::detail::packed_channel_reference_type
+            <
+                std::uint8_t,
+                std::integral_constant<int, 0>,
+                std::integral_constant<int, 3>
+            >::type,
             gil::packed_channel_reference<std::uint8_t, 0, 3, true> const
         >::value,
         "packed_channel_reference_type should return packed_channel_reference");
@@ -145,7 +150,7 @@ BOOST_AUTO_TEST_CASE(packed_pixel_gray_equality_gray_channel)
 using packed_channel_references_121 = typename gil::detail::packed_channel_references_vector_type
 <
     std::uint8_t,
-    mpl::vector3_c<int, 1, 2, 1>
+    mp11::mp_list_c<int, 1, 2, 1>
 >::type;
 
 using packed_pixel_bgr121 = gil::packed_pixel
@@ -177,20 +182,18 @@ BOOST_AUTO_TEST_CASE(packed_pixel_bgr121_definition)
 
     // Verify metafunctions
 
-    using channel_references_t = packed_channel_references_121::type;
-
-    static_assert(mpl::size<channel_references_t>::value == 3,
+    static_assert(mp11::mp_size<packed_channel_references_121>::value == 3,
         "packed_channel_references_vector_type should define three references to channel start bits");
 
-    using channel1_ref_t = mpl::at_c<channel_references_t, 0>::type;
+    using channel1_ref_t = mp11::mp_at_c<packed_channel_references_121, 0>;
     static_assert(channel1_ref_t::num_bits == 1,
         "1st channel of bgr121 pixel should be of 1-bit size");
 
-    using channel2_ref_t = mpl::at_c<channel_references_t, 1>::type;
+    using channel2_ref_t = mp11::mp_at_c<packed_channel_references_121, 1>;
     static_assert(channel2_ref_t::num_bits == 2,
         "2nd channel of bgr121 pixel should be of 2-bit size");
 
-    using channel3_ref_t = mpl::at_c<channel_references_t, 2>::type;
+    using channel3_ref_t = mp11::mp_at_c<packed_channel_references_121, 2>;
     static_assert(channel3_ref_t::num_bits == 1,
         "3rd channel of bgr121 pixel should be of 1-bit size");
 
@@ -218,13 +221,19 @@ BOOST_AUTO_TEST_CASE(packed_pixel_bgr121_definition)
     // double check intermediate metafunction packed_channel_reference_type
     static_assert(std::is_same
         <
-            gil::detail::packed_channel_reference_type<std::uint8_t, mpl::int_<0>, mpl::int_<1>>::type,
+            gil::detail::packed_channel_reference_type
+            <
+                std::uint8_t, mp11::mp_int<0>, mp11::mp_int<1>
+            >::type,
             channel1_ref_t
         >::value,
         "packed_channel_reference_type should return packed_channel_reference");
     static_assert(std::is_same
         <
-            gil::detail::packed_channel_reference_type<std::uint8_t, mpl::int_<0>, mpl::int_<1>>::type,
+            gil::detail::packed_channel_reference_type
+            <
+                std::uint8_t, mp11::mp_int<0>, mp11::mp_int<1>
+            >::type,
             gil::packed_channel_reference<std::uint8_t, 0, 1, true> const
         >::value,
         "packed_channel_reference_type should return packed_channel_reference");
@@ -251,7 +260,7 @@ BOOST_AUTO_TEST_CASE(packed_pixel_bgr121_equality)
 using packed_channel_references_535 = typename gil::detail::packed_channel_references_vector_type
 <
     std::uint16_t,
-    mpl::vector3_c<int, 5, 3, 5>
+    mp11::mp_list_c<int, 5, 3, 5>
 >::type;
 
 using packed_pixel_rgb535 = gil::packed_pixel
@@ -283,20 +292,18 @@ BOOST_AUTO_TEST_CASE(packed_pixel_rgb535_definition)
 
     // Verify metafunctions
 
-    using channel_references_t = packed_channel_references_535::type;
-
-    static_assert(mpl::size<channel_references_t>::value == 3,
+    static_assert(mp11::mp_size<packed_channel_references_535>::value == 3,
         "packed_channel_references_vector_type should define three references to channel start bits");
 
-    using channel1_ref_t = mpl::at_c<channel_references_t, 0>::type;
+    using channel1_ref_t = mp11::mp_at_c<packed_channel_references_535, 0>;
     static_assert(channel1_ref_t::num_bits == 5,
         "1st channel of rgb535 pixel should be of 5-bit size");
 
-    using channel2_ref_t = mpl::at_c<channel_references_t, 1>::type;
+    using channel2_ref_t = mp11::mp_at_c<packed_channel_references_535, 1>;
     static_assert(channel2_ref_t::num_bits == 3,
         "2nd channel of rgb535 pixel should be of 3-bit size");
 
-    using channel3_ref_t = mpl::at_c<channel_references_t, 2>::type;
+    using channel3_ref_t = mp11::mp_at_c<packed_channel_references_535, 2>;
     static_assert(channel3_ref_t::num_bits == 5,
         "3rd channel of rgb535 pixel should be of 5-bit size");
 
@@ -324,13 +331,23 @@ BOOST_AUTO_TEST_CASE(packed_pixel_rgb535_definition)
     // double check intermediate metafunction packed_channel_reference_type
     static_assert(std::is_same
         <
-            gil::detail::packed_channel_reference_type<std::uint16_t, mpl::int_<0>, mpl::int_<5>>::type,
+            gil::detail::packed_channel_reference_type
+            <
+                std::uint16_t,
+                std::integral_constant<int, 0>,
+                std::integral_constant<int, 5>
+            >::type,
             channel1_ref_t
         >::value,
         "packed_channel_reference_type should return packed_channel_reference");
     static_assert(std::is_same
         <
-            gil::detail::packed_channel_reference_type<std::uint16_t, mpl::int_<0>, mpl::int_<5>>::type,
+            gil::detail::packed_channel_reference_type
+            <
+                std::uint16_t,
+                std::integral_constant<int, 0>,
+                std::integral_constant<int, 5>
+            >::type,
             gil::packed_channel_reference<std::uint16_t, 0, 5, true> const
         >::value,
         "packed_channel_reference_type should return packed_channel_reference");

--- a/test/pixel/pixel_reference_is_mutable.cpp
+++ b/test/pixel/pixel_reference_is_mutable.cpp
@@ -5,13 +5,8 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
-//#include <boost/gil/concepts/pixel.hpp>
-//#include <boost/gil/metafunctions.hpp>
-//#include <boost/gil/pixel.hpp>
-//#include <boost/gil/typedefs.hpp>
 #include <boost/gil.hpp>
 #include <boost/mp11.hpp>
-#include <boost/mp11/mpl.hpp>
 
 #include "test_fixture.hpp"
 

--- a/test/pixel/pixels_are_compatible.cpp
+++ b/test/pixel/pixels_are_compatible.cpp
@@ -27,8 +27,8 @@ struct assert_compatible
 
         // TODO: Refine after MPL -> MP11 switch
         static_assert(
-            !std::is_same<result_t, std::true_type>::value,
-            "pixels_are_compatible result type should no be std::true_type");
+            std::is_same<result_t, std::true_type>::value,
+            "pixels_are_compatible result type should be std::true_type");
 
         static_assert(
             !std::is_same<result_t, std::false_type>::value,

--- a/test/pixel/test_fixture.hpp
+++ b/test/pixel/test_fixture.hpp
@@ -14,6 +14,7 @@
 #include <boost/gil/promote_integral.hpp>
 #include <boost/gil/typedefs.hpp>
 
+#include <boost/core/ignore_unused.hpp>
 #include <boost/core/typeinfo.hpp>
 #include <boost/mp11.hpp>
 #include <boost/mp11/mpl.hpp> // for compatibility with Boost.Test
@@ -74,6 +75,7 @@ public:
         : pixel_(pixel) // test copy constructor
     {
         type temp_pixel; // test default constructor
+        boost::ignore_unused(temp_pixel);
         boost::function_requires<PixelValueConcept<pixel_t> >();
     }
 };

--- a/toolbox/test/channel_type.cpp
+++ b/toolbox/test/channel_type.cpp
@@ -8,7 +8,8 @@
 #include <boost/gil/extension/toolbox/metafunctions/channel_type.hpp>
 #include <boost/gil/extension/toolbox/metafunctions/is_bit_aligned.hpp>
 
-#include <boost/gil/channel.hpp> // boost::is_integral<packed_dynamic_channel_reference<...>>
+#include <boost/gil/channel.hpp>
+#include <boost/gil/detail/is_channel_integral.hpp>
 
 #include <boost/test/unit_test.hpp>
 
@@ -36,7 +37,7 @@ BOOST_AUTO_TEST_CASE(channel_type_test)
     // channel_type for bit_aligned images doesn't work with standard gil.
     using image_t = bg::bit_aligned_image4_type<4, 4, 4, 4, bg::rgb_layout_t>::type;
     using channel_t = bg::channel_type<image_t::view_t::reference>::type;
-    static_assert(boost::is_integral<channel_t>::value, "");
+    static_assert(bg::detail::is_channel_integral<channel_t>::value, "");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/toolbox/test/cmyka.cpp
+++ b/toolbox/test/cmyka.cpp
@@ -8,7 +8,6 @@
 #include <boost/gil/extension/toolbox/color_spaces/cmyka.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/type_traits/is_same.hpp>
 
 using namespace boost;
 using namespace gil;

--- a/toolbox/test/get_num_bits.cpp
+++ b/toolbox/test/get_num_bits.cpp
@@ -10,7 +10,6 @@
 #include <boost/gil/extension/toolbox/metafunctions/get_num_bits.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/type_traits/is_same.hpp>
 
 using namespace boost;
 using namespace gil;

--- a/toolbox/test/get_pixel_type.cpp
+++ b/toolbox/test/get_pixel_type.cpp
@@ -9,7 +9,8 @@
 #include <boost/gil/extension/toolbox/metafunctions/get_pixel_type.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/type_traits/is_same.hpp>
+
+#include <type_traits>
 
 using namespace boost;
 using namespace gil;
@@ -20,7 +21,7 @@ BOOST_AUTO_TEST_CASE( get_pixel_type_test )
 {
     {
         using image_t = bit_aligned_image3_type<4, 15, 4, rgb_layout_t>::type;
-        static_assert(is_same
+        static_assert(std::is_same
             <
                 get_pixel_type<image_t::view_t>::type,
                 image_t::view_t::reference
@@ -29,7 +30,7 @@ BOOST_AUTO_TEST_CASE( get_pixel_type_test )
 
     {
         using image_t = rgb8_image_t;
-        static_assert(is_same
+        static_assert(std::is_same
             <
                 get_pixel_type<image_t::view_t>::type,
                 image_t::view_t::value_type

--- a/toolbox/test/gray_alpha.cpp
+++ b/toolbox/test/gray_alpha.cpp
@@ -8,7 +8,6 @@
 #include <boost/gil/extension/toolbox/color_spaces/gray_alpha.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/type_traits/is_same.hpp>
 
 using namespace boost;
 using namespace gil;

--- a/toolbox/test/gray_to_rgba.cpp
+++ b/toolbox/test/gray_to_rgba.cpp
@@ -7,8 +7,6 @@
 //
 #include <boost/test/unit_test.hpp>
 
-#include <boost/type_traits/is_same.hpp>
-
 #include <boost/gil.hpp>
 #include <boost/gil/extension/toolbox/color_converters/gray_to_rgba.hpp>
 

--- a/toolbox/test/is_bit_aligned.cpp
+++ b/toolbox/test/is_bit_aligned.cpp
@@ -9,7 +9,6 @@
 #include <boost/gil/extension/toolbox/metafunctions/is_bit_aligned.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/type_traits/is_same.hpp>
 
 using namespace boost;
 using namespace gil;

--- a/toolbox/test/subchroma_image.cpp
+++ b/toolbox/test/subchroma_image.cpp
@@ -11,6 +11,8 @@
 #include <boost/gil/extension/toolbox/color_spaces/ycbcr.hpp>
 #include <boost/gil/extension/toolbox/image_types/subchroma_image.hpp>
 
+#include <boost/mp11.hpp>
+
 using namespace std;
 using namespace boost;
 using namespace gil;
@@ -57,17 +59,17 @@ BOOST_AUTO_TEST_CASE( subchroma_image_test )
     {
         using pixel_t = rgb8_pixel_t;
 
-        subchroma_image<pixel_t, mpl::vector_c<int, 4, 4, 4>> a(640, 480);
+        subchroma_image<pixel_t, mp11::mp_list_c<int, 4, 4, 4>> a(640, 480);
         static_assert(a.ss_X == 1 && a.ss_Y == 1, "");
-        subchroma_image<pixel_t, mpl::vector_c<int, 4, 4, 0>> b(640, 480);
+        subchroma_image<pixel_t, mp11::mp_list_c<int, 4, 4, 0>> b(640, 480);
         static_assert(b.ss_X == 1 && b.ss_Y == 2, "");
-        subchroma_image<pixel_t, mpl::vector_c<int, 4, 2, 2>> c(640, 480);
+        subchroma_image<pixel_t, mp11::mp_list_c<int, 4, 2, 2>> c(640, 480);
         static_assert(c.ss_X == 2 && c.ss_Y == 1, "");
-        subchroma_image<pixel_t, mpl::vector_c<int, 4, 2, 0>> d(640, 480);
+        subchroma_image<pixel_t, mp11::mp_list_c<int, 4, 2, 0>> d(640, 480);
         static_assert(d.ss_X == 2 && d.ss_Y == 2, "");
-        subchroma_image<pixel_t, mpl::vector_c<int, 4, 1, 1>> e(640, 480);
+        subchroma_image<pixel_t, mp11::mp_list_c<int, 4, 1, 1>> e(640, 480);
         static_assert(e.ss_X == 4 && e.ss_Y == 1, "");
-        subchroma_image<pixel_t, mpl::vector_c<int, 4, 1, 0>> f(640, 480);
+        subchroma_image<pixel_t, mp11::mp_list_c<int, 4, 1, 0>> f(640, 480);
         static_assert(f.ss_X == 4 && f.ss_Y == 2, "");
 
         fill_pixels( view( a ), pixel_t( 10, 20, 30 ) );
@@ -81,7 +83,7 @@ BOOST_AUTO_TEST_CASE( subchroma_image_test )
 
     {
         using pixel_t = ycbcr_601_8_pixel_t;
-        using factors_t = mpl::vector_c<int, 4, 2, 2>;
+        using factors_t = mp11::mp_list_c<int, 4, 2, 2>;
         using image_t = subchroma_image<pixel_t, factors_t>;
 
         std::size_t y_width     = 640;


### PR DESCRIPTION
### Description

- Use type traits and features of C++11, then use Boost.MP11.
- Remove unused and unnecessary metafunctions in `detail` namespace.
- Remove explicit access to ::type as no longer necessary with MP11.
- Replace `boost::is_integral` with `gil::detail::is_channel_integral` to avoid UB.
- Clean up and reformat code according to the current guidelines.

Legacy tests have been updated where necessary to accommodate switch to MP11.

### Status

Ready to start review process.

I will try make it easier to review/track changes and submit updates as new commits,
but sometimes I may need to rebase and force-push update. Sorry.

Two files have not been updated and it needs to be decided what to do:

- `promote_integral.hpp` which is external source borrowed from Boost.Geometry. 
- `extension/dynamic_image/reduce.hpp` which is compiled on demand by `#define BOOST_GIL_REDUCE_CODE_BLOAT=1`

### References

* Among others, implements #93
* Closes #229 

### Tasklist

- [x] Decide what to do with `promote_integral.hpp`. See #280
- [x] Decide what to do with `extension/dynamic_image/reduce.hpp`. See #281
- [x] Solve failing checksum test in `test/legacy/image.cpp` for `bgr121_*` (fixed in f45dd04aca1996ec8d1315cf495f9e5a78387f02)
- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed

