### PR TITLE
[azp] Use pre-installed Boost 1.69

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -24,7 +24,6 @@ jobs:
       - script: |
           sudo apt-get install libjpeg-dev libpng16-dev libtiff5-dev libraw-dev
         displayName: 'Install dependencies'
-      - template: .ci/azure-pipelines/steps-install-boost.yml
       - template: .ci/azure-pipelines/steps-cmake-build-and-test.yml
 
   - job: 'ubuntu1604_gcc8_cxx14_cmake'
@@ -38,7 +37,6 @@ jobs:
       - script: |
           sudo apt-get install libjpeg-dev libpng16-dev libtiff5-dev libraw-dev
         displayName: 'Install dependencies'
-      - template: .ci/azure-pipelines/steps-install-boost.yml
       - template: .ci/azure-pipelines/steps-cmake-build-and-test.yml
         parameters:
           cxxver: '14'
@@ -55,10 +53,9 @@ jobs:
           architecture: 'x64'
       - template: .ci/azure-pipelines/steps-check-cmake.yml
       - template: .ci/azure-pipelines/steps-install-conan.yml
-      - template: .ci/azure-pipelines/steps-install-boost.yml
       - template: .ci/azure-pipelines/steps-cmake-build-and-test.yml
         parameters:
-          use_conan: 'yes'
+          use_conan: 'ON'
 
   - job: 'win2016_vs2017_cxx17_cmake'
     pool:
@@ -72,10 +69,9 @@ jobs:
           architecture: 'x64'
       - template: .ci/azure-pipelines/steps-check-cmake.yml
       - template: .ci/azure-pipelines/steps-install-conan.yml
-      - template: .ci/azure-pipelines/steps-install-boost.yml
       - template: .ci/azure-pipelines/steps-cmake-build-and-test.yml
         parameters:
-          use_conan: 'yes'
+          use_conan: 'ON'
           cxxver: '17'
 
   - job: 'win2012_vs2015_cmake'
@@ -101,7 +97,7 @@ jobs:
       - template: .ci/azure-pipelines/steps-install-boost.yml
       - template: .ci/azure-pipelines/steps-cmake-build-and-test.yml
         parameters:
-          use_conan: 'yes'
+          use_conan: 'ON'
 
   - job: 'macos1013_xcode91_cmake'
     pool:
@@ -118,4 +114,4 @@ jobs:
           toolset: darwin
       - template: .ci/azure-pipelines/steps-cmake-build-and-test.yml
         parameters:
-          use_conan: 'yes'
+          use_conan: 'ON'

--- a/.ci/azure-pipelines/steps-cmake-build-and-test.yml
+++ b/.ci/azure-pipelines/steps-cmake-build-and-test.yml
@@ -8,15 +8,29 @@ parameters:
   # defaults, if not specified
   configuration: 'Release'
   cxxver: '11'
-  get_findboost: 'no'
-  enable_ext_io: 'no'
-  enable_ext_numeric: 'yes'
-  enable_ext_toolbox: 'yes'
-  use_conan: 'no'
+  get_findboost: 'ON'
+  enable_ext_io: 'OFF'
+  enable_ext_numeric: 'ON'
+  enable_ext_toolbox: 'ON'
+  use_conan: 'OFF'
 
 steps:
   - script: |
-      cmake -H. -B_build -DCMAKE_BUILD_TYPE=${{ parameters.configuration }} -DCMAKE_CXX_STANDARD=${{ parameters.cxxver }} -DCMAKE_VERBOSE_MAKEFILE=ON -DGIL_DOWNLOAD_FINDBOOST=${{ parameters.get_findboost }} -DGIL_USE_CONAN=ON -DGIL_ENABLE_EXT_IO=${{ parameters.enable_ext_io }} -DGIL_ENABLE_EXT_NUMERIC=${{ parameters.enable_ext_numeric }} -DGIL_ENABLE_EXT_TOOLBOX=${{ parameters.enable_ext_toolbox }}
+      export BOOST_ROOT=/usr/local/share/boost/1.69.0
+      export BOOST_INCLUDEDIR=$BOOST_ROOT/include
+      export BOOST_LIBRARYDIR=$BOOST_ROOT/lib
+
+      cmake -H. -B_build -DCMAKE_BUILD_TYPE=${{ parameters.configuration }} -DCMAKE_CXX_STANDARD=${{ parameters.cxxver }} -DCMAKE_VERBOSE_MAKEFILE=ON -DBoost_DEBUG=ON -DBoost_ARCHITECTURE=-x64 -DGIL_DOWNLOAD_FINDBOOST=${{ parameters.get_findboost }} -DGIL_USE_CONAN=ON -DGIL_ENABLE_EXT_IO=${{ parameters.enable_ext_io }} -DGIL_ENABLE_EXT_NUMERIC=${{ parameters.enable_ext_numeric }} -DGIL_ENABLE_EXT_TOOLBOX=${{ parameters.enable_ext_toolbox }}
+    condition: ne(variables['Agent.OS'], 'Windows_NT')
+    displayName: 'Run CMake to configure build'
+
+  - script: |
+      set BOOST_ROOT="C:\Program Files\Boost\1.69.0"
+      set BOOST_INCLUDEDIR=%BOOST_ROOT%\include
+      set BOOST_LIBRARYDIR=%BOOST_ROOT%\lib
+
+      cmake -H. -B_build -A x64 -DCMAKE_BUILD_TYPE=${{ parameters.configuration }} -DCMAKE_CXX_STANDARD=${{ parameters.cxxver }} -DCMAKE_VERBOSE_MAKEFILE=ON -DBoost_DEBUG=ON -DBoost_ARCHITECTURE=-x64 -DGIL_DOWNLOAD_FINDBOOST=${{ parameters.get_findboost }} -DGIL_USE_CONAN=ON -DGIL_ENABLE_EXT_IO=${{ parameters.enable_ext_io }} -DGIL_ENABLE_EXT_NUMERIC=${{ parameters.enable_ext_numeric }} -DGIL_ENABLE_EXT_TOOLBOX=${{ parameters.enable_ext_toolbox }}
+    condition: eq(variables['Agent.OS'], 'Windows_NT')
     displayName: 'Run CMake to configure build'
 
   - script: cmake --build _build --config ${{ parameters.configuration }} -j 4


### PR DESCRIPTION
Apparently, Azure Pipelines images of Ubuntu and Windows (VS2017, VS2019) now come with pre-installed Boost. Since this update, our AzP builds on Ubuntu started failing due to mismatch between Boost 1.68 we deploy and pre-installed Boost 1.69, see https://developercommunity.visualstudio.com/content/problem/525582/ubuntu-1604-image-changed-and-comes-with-usrlocals.html

Let's try to avoid deploying of Boost 1.68 and use pre-installed Boost 1.69 where possible.

### References:

* C/C++: Add the latest 4 versions of Boost 1.66.0 - 1.69.0 (Linux, Windows)
  https://github.com/Microsoft/azure-pipelines-image-generation/pull/732

* Document available versions of Boost 1.66.0 - 1.69.0 following #732 update
  https://github.com/Microsoft/azure-pipelines-image-generation/issues/845

### Tasklist

- [ ] All CI builds and checks have passed
