### PR TITLE
[azp] Avoid pre-installed Boost 1.69

### DIFF
--- a/.ci/azure-pipelines/steps-cmake-build-and-test.yml
+++ b/.ci/azure-pipelines/steps-cmake-build-and-test.yml
@@ -8,16 +8,28 @@ parameters:
   # defaults, if not specified
   configuration: 'Release'
   cxxver: '11'
-  get_findboost: 'no'
-  enable_ext_io: 'no'
-  enable_ext_numeric: 'yes'
-  enable_ext_toolbox: 'yes'
-  use_conan: 'no'
+  get_findboost: 'OFF'
+  enable_ext_io: 'OFF'
+  enable_ext_numeric: 'ON'
+  enable_ext_toolbox: 'ON'
+  use_conan: 'OFF'
 
 steps:
   - script: |
-      cmake -H. -B_build -DCMAKE_BUILD_TYPE=${{ parameters.configuration }} -DCMAKE_CXX_STANDARD=${{ parameters.cxxver }} -DCMAKE_VERBOSE_MAKEFILE=ON -DGIL_DOWNLOAD_FINDBOOST=${{ parameters.get_findboost }} -DGIL_USE_CONAN=ON -DGIL_ENABLE_EXT_IO=${{ parameters.enable_ext_io }} -DGIL_ENABLE_EXT_NUMERIC=${{ parameters.enable_ext_numeric }} -DGIL_ENABLE_EXT_TOOLBOX=${{ parameters.enable_ext_toolbox }}
-    displayName: 'Run CMake to configure build'
+      export BOOST_ROOT=/usr/local
+      export BOOST_INCLUDEDIR=$BOOST_ROOT/include
+      export BOOST_LIBRARYDIR=$BOOST_ROOT/lib
+      cmake -H. -B_build -DCMAKE_BUILD_TYPE=${{ parameters.configuration }} -DCMAKE_CXX_STANDARD=${{ parameters.cxxver }} -DCMAKE_VERBOSE_MAKEFILE=ON -DBoost_DEBUG=ON -DBoost_NO_SYSTEM_PATHS=ON -DGIL_DOWNLOAD_FINDBOOST=${{ parameters.get_findboost }} -DGIL_USE_CONAN=ON -DGIL_ENABLE_EXT_IO=${{ parameters.enable_ext_io }} -DGIL_ENABLE_EXT_NUMERIC=${{ parameters.enable_ext_numeric }} -DGIL_ENABLE_EXT_TOOLBOX=${{ parameters.enable_ext_toolbox }}
+    displayName: 'Run CMake to configure build on Unix'
+    condition: ne(variables['Agent.OS'], 'Windows_NT')
+
+  - script: |
+      set BOOST_ROOT=C:\Boost
+      set BOOST_INCLUDEDIR=%BOOST_ROOT%\include\boost-1_68
+      set BOOST_LIBRARYDIR=%BOOST_ROOT%\lib
+      cmake -H. -B_build -DCMAKE_BUILD_TYPE=${{ parameters.configuration }} -DCMAKE_CXX_STANDARD=${{ parameters.cxxver }} -DCMAKE_VERBOSE_MAKEFILE=ON -DBoost_DEBUG=ON -DBoost_NO_SYSTEM_PATHS=ON -DGIL_DOWNLOAD_FINDBOOST=${{ parameters.get_findboost }} -DGIL_USE_CONAN=ON -DGIL_ENABLE_EXT_IO=${{ parameters.enable_ext_io }} -DGIL_ENABLE_EXT_NUMERIC=${{ parameters.enable_ext_numeric }} -DGIL_ENABLE_EXT_TOOLBOX=${{ parameters.enable_ext_toolbox }}
+    displayName: 'Run CMake to configure build on Windows'
+    condition: eq(variables['Agent.OS'], 'Windows_NT')
 
   - script: cmake --build _build --config ${{ parameters.configuration }} -j 4
     displayName: 'Run CMake to build'


### PR DESCRIPTION
Linux and Windows images now come with pre-installed Boost 1.69.
Since it is not possible to remove GIL headers from it, we should
prefer our deployment of Boost.

### References

* #276
* C/C++: Add the latest 4 versions of Boost 1.66.0 - 1.69.0 (Linux, Windows)
  Microsoft/azure-pipelines-image-generation#732
* Document available versions of Boost 1.66.0 - 1.69.0 following #732 update
  Microsoft/azure-pipelines-image-generation#845

### Tasklist

- [x] All CI builds and checks have passed (https://dev.azure.com/boostorg/gil/_build/results?buildId=332)
