### PR TITLE
[appveyor] Add C++17 builds with VS2017

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,28 +20,39 @@ environment:
     - TOOLSET: msvc-14.1
       ARCH: x86_64
       VARIANT: debug
-      CXXSTD: 11
+      CXXSTD: 17
       TEST_HEADERS: 1
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     - TOOLSET: msvc-14.1
       ARCH: x86_64
       VARIANT: release
-      CXXSTD: 11
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    - TOOLSET: msvc-14.1
-      ARCH: x86
-      VARIANT: debug
-      CXXSTD: 11
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    - TOOLSET: msvc-14.1
-      ARCH: x86
-      VARIANT: release
-      CXXSTD: 11
+      CXXSTD: 17
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     - TOOLSET: msvc-14.1
       ARCH: x86_64
       VARIANT: debug
-      CXXSTD: 11
+      CXXSTD: 14
+      TEST_HEADERS: 1
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - TOOLSET: msvc-14.1
+      ARCH: x86_64
+      VARIANT: release
+      CXXSTD: 14
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - TOOLSET: msvc-14.1
+      ARCH: x86
+      VARIANT: debug
+      CXXSTD: 14
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - TOOLSET: msvc-14.1
+      ARCH: x86
+      VARIANT: release
+      CXXSTD: 14
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - TOOLSET: msvc-14.1
+      ARCH: x86_64
+      VARIANT: debug
+      CXXSTD: 14
       GENERATOR: "Visual Studio 15 2017 Win64"
       CMAKE_CONFIG: Debug
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
@@ -52,12 +63,17 @@ matrix:
     - TOOLSET: msvc-14.1
       ARCH: x86_64
       VARIANT: release
-      CXXSTD: 11
+      CXXSTD: 17
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - TOOLSET: msvc-14.1
+      ARCH: x86_64
+      VARIANT: release
+      CXXSTD: 14
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     - TOOLSET: msvc-14.1
       ARCH: x86_64
       VARIANT: debug
-      CXXSTD: 11
+      CXXSTD: 14
       GENERATOR: "Visual Studio 15 2017 Win64"
       CMAKE_CONFIG: Debug
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
  msvc++    | VS2017 | VS2017, VS2015 |   |   |
  clang     |   | Xcode 9.4.1 | 3.9, 5.0, Xcode 9.4.1 | 3.9, 4.0, 5.0 |
  gcc       |   | 5.4, 8.1 | 5.5, 6.5, 7.4 | 4.8-9, 5.1-5, 6.1-4, 7.1-3, 8.2 |
- C++       | 14 | 11, 14, 17 | 11 | 11 |
+ C++       | 14, 17 | 11, 14, 17 | 11 | 11 |
  <br />    | Boost.Build, CMake | CMake, Boost 1.68 | Boost.Build, UBSan | Boost.Build |
 
 # Boost.GIL


### PR DESCRIPTION
For existing builds, bump C++ version to 14 which [lowest effective version (and default)](https://docs.microsoft.com/en-us/cpp/build/reference/std-specify-language-standard-version?view=vs-2017) supported by compiler from VS2017.

### References

* Since added C++17 builds use Boost `develop` and not older 1.68, if they pass, it means there indeed is MP11 issue in Boost 1.68 (see https://github.com/boostorg/gil/pull/274#issuecomment-482022037).

### Tasklist

- [x] All CI builds and checks have passed
