### PR TITLE
[CI] Rationalize deployment of Boost dependencies

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -96,75 +96,16 @@ install:
   - if "%APPVEYOR_REPO_BRANCH%" == "master" set BOOST_BRANCH=master
 
 before_build:
-  - git clone --quiet -b %BOOST_BRANCH% --depth 1 https://github.com/boostorg/boost.git c:\projects\boost
-  - cd c:\projects\boost
-  - git branch
-  # List all (recursive) dependencies explicitly to control any new additions
-  - git submodule --quiet update --init tools/build
-  - git submodule --quiet update --init tools/boost_install
-  - git submodule --quiet update --init tools/boostdep
-  - git submodule --quiet update --init libs/headers
-  ## Direct (of GIL headers only)
-  - git submodule --quiet update --init libs/algorithm
-  - git submodule --quiet update --init libs/array
-  - git submodule --quiet update --init libs/assert
-  - git submodule --quiet update --init libs/concept_check
-  - git submodule --quiet update --init libs/config
-  - git submodule --quiet update --init libs/core
-  - git submodule --quiet update --init libs/crc
-  - git submodule --quiet update --init libs/filesystem
-  - git submodule --quiet update --init libs/integer
-  - git submodule --quiet update --init libs/iterator
-  - git submodule --quiet update --init libs/mp11
-  - git submodule --quiet update --init libs/mpl
-  - git submodule --quiet update --init libs/numeric/conversion
-  - git submodule --quiet update --init libs/preprocessor
-  - git submodule --quiet update --init libs/test
-  - git submodule --quiet update --init libs/type_traits
-  - git submodule --quiet update --init libs/variant
-  ## Transitive (of GIL tests too)
-  - git submodule --quiet update --init libs/atomic
-  - git submodule --quiet update --init libs/bind
-  - git submodule --quiet update --init libs/chrono
-  - git submodule --quiet update --init libs/container
-  - git submodule --quiet update --init libs/container_hash
-  - git submodule --quiet update --init libs/conversion
-  - git submodule --quiet update --init libs/detail
-  - git submodule --quiet update --init libs/exception
-  - git submodule --quiet update --init libs/function
-  - git submodule --quiet update --init libs/function_types
-  - git submodule --quiet update --init libs/fusion
-  - git submodule --quiet update --init libs/intrusive
-  - git submodule --quiet update --init libs/io
-  - git submodule --quiet update --init libs/lambda
-  - git submodule --quiet update --init libs/math
-  - git submodule --quiet update --init libs/move
-  - git submodule --quiet update --init libs/optional
-  - git submodule --quiet update --init libs/predef
-  - git submodule --quiet update --init libs/range
-  - git submodule --quiet update --init libs/ratio
-  - git submodule --quiet update --init libs/rational
-  - git submodule --quiet update --init libs/regex
-  - git submodule --quiet update --init libs/static_assert
-  - git submodule --quiet update --init libs/smart_ptr
-  - git submodule --quiet update --init libs/system
-  - git submodule --quiet update --init libs/throw_exception
-  - git submodule --quiet update --init libs/timer
-  - git submodule --quiet update --init libs/tuple
-  - git submodule --quiet update --init libs/type_index
-  - git submodule --quiet update --init libs/typeof
-  - git submodule --quiet update --init libs/unordered
-  - git submodule --quiet update --init libs/utility
-  - git submodule --quiet update --init libs/winapi
-  - xcopy /s /e /q %APPVEYOR_BUILD_FOLDER% libs\gil
+  - cd ..
+  - bash -c '$APPVEYOR_BUILD_FOLDER/.ci/get-boost.sh $APPVEYOR_REPO_BRANCH $APPVEYOR_BUILD_FOLDER'
+  - cd boost-root
   - cmd /c bootstrap
-  - .\b2 headers
+  - .\b2 headers > NUL
   - if DEFINED GENERATOR .\b2 address-model=%AM% toolset=%TOOLSET% variant=%VARIANT% cxxstd=%CXXSTD% --with-filesystem --with-test stage
 
 build: off
 
 build_script:
-  - cd c:\projects\boost
   - if NOT DEFINED GENERATOR b2 address-model=%AM% toolset=%TOOLSET% variant=%VARIANT% cxxstd=%CXXSTD% libs/gil/test
   - if NOT DEFINED GENERATOR b2 address-model=%AM% toolset=%TOOLSET% variant=%VARIANT% cxxstd=%CXXSTD% libs/gil/toolbox/test
   - if NOT DEFINED GENERATOR b2 address-model=%AM% toolset=%TOOLSET% variant=%VARIANT% cxxstd=%CXXSTD% libs/gil/numeric/test

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -12,6 +12,7 @@ trigger:
   - master
   - develop
   - azure-pipelines
+  - ml/*
 
 jobs:
   - job: 'ubuntu1604_gcc5_cxx11_cmake'
@@ -58,7 +59,8 @@ jobs:
       - template: .ci/azure-pipelines/steps-install-boost.yml
       - template: .ci/azure-pipelines/steps-cmake-build-and-test.yml
         parameters:
-          use_conan: 'yes'
+          get_findboost: 'ON'
+          use_conan: 'ON'
 
   - job: 'win2016_vs2017_cxx17_cmake'
     pool:
@@ -75,8 +77,9 @@ jobs:
       - template: .ci/azure-pipelines/steps-install-boost.yml
       - template: .ci/azure-pipelines/steps-cmake-build-and-test.yml
         parameters:
-          use_conan: 'yes'
           cxxver: '17'
+          get_findboost: 'ON'
+          use_conan: 'ON'
 
   - job: 'win2012_vs2015_cmake'
     pool:
@@ -101,7 +104,8 @@ jobs:
       - template: .ci/azure-pipelines/steps-install-boost.yml
       - template: .ci/azure-pipelines/steps-cmake-build-and-test.yml
         parameters:
-          use_conan: 'yes'
+          get_findboost: 'ON'
+          use_conan: 'ON'
 
   - job: 'macos1013_xcode91_cmake'
     pool:
@@ -118,4 +122,4 @@ jobs:
           toolset: darwin
       - template: .ci/azure-pipelines/steps-cmake-build-and-test.yml
         parameters:
-          use_conan: 'yes'
+          use_conan: 'ON'

--- a/.ci/azure-pipelines/steps-cmake-build-and-test.yml
+++ b/.ci/azure-pipelines/steps-cmake-build-and-test.yml
@@ -16,23 +16,37 @@ parameters:
 
 steps:
   - script: |
-      export BOOST_ROOT=/usr/local
-      export BOOST_INCLUDEDIR=$BOOST_ROOT/include
+      export BOOST_ROOT=$(Build.SourcesDirectory)/boost-root
+      export BOOST_INCLUDEDIR=$BOOST_ROOT
       export BOOST_LIBRARYDIR=$BOOST_ROOT/lib
-      cmake -H. -B_build -DCMAKE_BUILD_TYPE=${{ parameters.configuration }} -DCMAKE_CXX_STANDARD=${{ parameters.cxxver }} -DCMAKE_VERBOSE_MAKEFILE=ON -DBoost_DEBUG=ON -DBoost_NO_SYSTEM_PATHS=ON -DGIL_DOWNLOAD_FINDBOOST=${{ parameters.get_findboost }} -DGIL_USE_CONAN=ON -DGIL_ENABLE_EXT_IO=${{ parameters.enable_ext_io }} -DGIL_ENABLE_EXT_NUMERIC=${{ parameters.enable_ext_numeric }} -DGIL_ENABLE_EXT_TOOLBOX=${{ parameters.enable_ext_toolbox }}
+      cmake -H. -B_build -DCMAKE_BUILD_TYPE=${{ parameters.configuration }} -DCMAKE_CXX_STANDARD=${{ parameters.cxxver }} -DCMAKE_VERBOSE_MAKEFILE=ON -DBoost_DEBUG=ON -DBoost_NO_SYSTEM_PATHS=ON -DGIL_DOWNLOAD_FINDBOOST=${{ parameters.get_findboost }} -DGIL_USE_CONAN=${{ parameters.use_conan }} -DGIL_ENABLE_EXT_IO=${{ parameters.enable_ext_io }} -DGIL_ENABLE_EXT_NUMERIC=${{ parameters.enable_ext_numeric }} -DGIL_ENABLE_EXT_TOOLBOX=${{ parameters.enable_ext_toolbox }}
+    workingDirectory: $(Build.SourcesDirectory)/boost-root/libs/gil
     displayName: 'Run CMake to configure build on Unix'
     condition: ne(variables['Agent.OS'], 'Windows_NT')
 
   - script: |
-      set BOOST_ROOT=C:\Boost
-      set BOOST_INCLUDEDIR=%BOOST_ROOT%\include\boost-1_68
+      set BOOST_ROOT=$(Build.SourcesDirectory)\boost-root
+      set BOOST_INCLUDEDIR=%BOOST_ROOT%
       set BOOST_LIBRARYDIR=%BOOST_ROOT%\lib
-      cmake -H. -B_build -DCMAKE_BUILD_TYPE=${{ parameters.configuration }} -DCMAKE_CXX_STANDARD=${{ parameters.cxxver }} -DCMAKE_VERBOSE_MAKEFILE=ON -DBoost_DEBUG=ON -DBoost_NO_SYSTEM_PATHS=ON -DGIL_DOWNLOAD_FINDBOOST=${{ parameters.get_findboost }} -DGIL_USE_CONAN=ON -DGIL_ENABLE_EXT_IO=${{ parameters.enable_ext_io }} -DGIL_ENABLE_EXT_NUMERIC=${{ parameters.enable_ext_numeric }} -DGIL_ENABLE_EXT_TOOLBOX=${{ parameters.enable_ext_toolbox }}
+      cmake -H. -B_build -DCMAKE_BUILD_TYPE=${{ parameters.configuration }} -DCMAKE_CXX_STANDARD=${{ parameters.cxxver }} -DCMAKE_VERBOSE_MAKEFILE=ON -DBoost_DEBUG=ON -DBoost_ADDITIONAL_VERSIONS="1.70;1.71" -DBoost_ARCHITECTURE=-x32 -DBoost_NO_SYSTEM_PATHS=ON -DGIL_DOWNLOAD_FINDBOOST=${{ parameters.get_findboost }} -DGIL_USE_CONAN=${{ parameters.use_conan }} -DGIL_ENABLE_EXT_IO=${{ parameters.enable_ext_io }} -DGIL_ENABLE_EXT_NUMERIC=${{ parameters.enable_ext_numeric }} -DGIL_ENABLE_EXT_TOOLBOX=${{ parameters.enable_ext_toolbox }}
+    workingDirectory: $(Build.SourcesDirectory)/boost-root/libs/gil
     displayName: 'Run CMake to configure build on Windows'
     condition: eq(variables['Agent.OS'], 'Windows_NT')
 
   - script: cmake --build _build --config ${{ parameters.configuration }} -j 4
+    workingDirectory: $(Build.SourcesDirectory)/boost-root/libs/gil
     displayName: 'Run CMake to build'
 
   - script: cd _build && ctest --build-config ${{ parameters.configuration }} -VV --output-on-failure
+    workingDirectory: $(Build.SourcesDirectory)/boost-root/libs/gil
     displayName: 'Run CTest to test'
+    condition: ne(variables['Agent.OS'], 'Darwin')
+
+  - script: |
+      # Set DYLD_FALLBACK_LIBRARY_PATH to avoid 'dyld: Library not loaded: libboost_*.dylib' error
+      export DYLD_FALLBACK_LIBRARY_PATH=$(Build.SourcesDirectory)/boost-root/stage/lib:$DYLD_FALLBACK_LIBRARY_PATH
+      echo "DYLD_FALLBACK_LIBRARY_PATH=$DYLD_FALLBACK_LIBRARY_PATH"
+      cd _build && ctest --build-config ${{ parameters.configuration }} -VV --output-on-failure
+    workingDirectory: $(Build.SourcesDirectory)/boost-root/libs/gil
+    displayName: 'Run CTest to test on macOS'
+    condition: eq(variables['Agent.OS'], 'Darwin')

--- a/.ci/azure-pipelines/steps-install-boost.yml
+++ b/.ci/azure-pipelines/steps-install-boost.yml
@@ -12,9 +12,6 @@ parameters:
 steps:
   # The $BSD_DIR is the same path as $(Build.SourcesDirectory)
   # but guaranteed in Unix format /a/b/c on every OS.
-  #
-  # FIXME: Replace 'master' below with $(Build.SourceBranchName) as soon as the C++
-  #        port of Boost.Build setup has been fixed in Boost 'develop' (boostrap is failing).
   - bash: |
       export BSD_DIR=$PWD
       cd ..
@@ -22,7 +19,7 @@ steps:
       echo "Copying $BSD_DIR to $GIL_DIR"
       cp -a $BSD_DIR $GIL_DIR
       cd $BSD_DIR
-      $GIL_DIR/.ci/get-boost.sh master $GIL_DIR
+      $GIL_DIR/.ci/get-boost.sh $(Build.SourceBranchName) $GIL_DIR
     displayName: 'Download Boost'
 
   - script: |

--- a/.ci/azure-pipelines/steps-install-boost.yml
+++ b/.ci/azure-pipelines/steps-install-boost.yml
@@ -10,27 +10,35 @@ parameters:
   toolset: 'gcc'
 
 steps:
+  # The $BSD_DIR is the same path as $(Build.SourcesDirectory)
+  # but guaranteed in Unix format /a/b/c on every OS.
+  #
+  # FIXME: Replace 'master' below with $(Build.SourceBranchName) as soon as the C++
+  #        port of Boost.Build setup has been fixed in Boost 'develop' (boostrap is failing).
   - bash: |
-      curl -L https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.gz -o boost.tar.gz
-      tar -xf boost.tar.gz
+      export BSD_DIR=$PWD
+      cd ..
+      export GIL_DIR=$PWD/gil
+      echo "Copying $BSD_DIR to $GIL_DIR"
+      cp -a $BSD_DIR $GIL_DIR
+      cd $BSD_DIR
+      $GIL_DIR/.ci/get-boost.sh master $GIL_DIR
     displayName: 'Download Boost'
 
-  - bash: |
-      cd boost_*
-      rm -r libs/gil
-      ls libs
-    displayName: 'Remove libs/gil from Boost 1.68'
-
   - script: |
-      cd boost_*
+      cd boost-root
       ./bootstrap.sh
-      sudo ./b2 -j4 variant=${{ parameters.variant }} toolset=${{ parameters.toolset }} --with-filesystem --with-test install
+      sudo ./b2 headers
+      sudo ./b2 -j4 toolset=${{ parameters.toolset }} variant=${{ parameters.variant }} --with-filesystem --with-system --with-test stage
+      ls stage/lib
     displayName: 'Install Boost on Unix'
     condition: ne(variables['Agent.OS'], 'Windows_NT')
 
   - script: |
-      cd boost_*
+      cd boost-root
       call .\bootstrap.bat
-      .\b2 -j4 variant=${{ parameters.variant }} --with-filesystem --with-test install
+      .\b2 headers
+      .\b2 -j4 address-model=32 variant=${{ parameters.variant }} --layout=system --with-filesystem --with-system --with-test stage
+      dir stage\lib
     displayName: 'Install Boost on Windows'
     condition: eq(variables['Agent.OS'], 'Windows_NT')

--- a/.ci/get-boost.sh
+++ b/.ci/get-boost.sh
@@ -1,0 +1,108 @@
+#!/bin/sh
+# Downloads Boost superproject from given Git branch
+# with all submodules required by Boost.GIL.
+set -e
+echo "get-boost: Downloading Boost superproject from Git"
+
+BOOST_BRANCH="master"
+if [ "$1" != "master" ]; then
+    BOOST_BRANCH="develop"
+fi
+BUILD_DIR=$2
+
+echo "BOOST_BRANCH=$BOOST_BRANCH"
+echo "BUILD_DIR=$BUILD_DIR"
+
+# Some (e.g. CircleCI) may have ancient version of Git installed.
+GIT_VERSION_MAJOR=$(git version | sed 's/git version //g' | cut -d. -f1)
+GIT_VERSION_MINOR=$(git version | sed 's/git version //g' | cut -d. -f2)
+if test $GIT_VERSION_MAJOR -gt 2 || test $GIT_VERSION_MAJOR -eq 2 -a $GIT_VERSION_MINOR -gt 8; then
+    GIT_SUBMODULE_OPTS="--jobs 4"
+fi
+
+# Use a reasonably large depth to prevent intermittent update failures due to
+# commits being on a submodule's master before the superproject is updated.
+git clone -b $BOOST_BRANCH --depth 10 https://github.com/boostorg/boost.git boost-root
+cd boost-root
+
+# List all (recursive) dependencies explicitly to control any new additions
+# Direct (of GIL headers only)
+git submodule --quiet update --init $GIT_SUBMODULE_OPTS \
+    tools/build \
+    tools/boost_install \
+    tools/boostdep \
+    libs/headers \
+    libs/algorithm \
+    libs/array \
+    libs/assert \
+    libs/concept_check \
+    libs/config \
+    libs/core \
+    libs/crc \
+    libs/filesystem \
+    libs/integer \
+    libs/iterator \
+    libs/mp11 \
+    libs/mpl \
+    libs/numeric/conversion \
+    libs/preprocessor \
+    libs/test \
+    libs/type_traits \
+    libs/variant
+# Transitive (of GIL tests too)
+git submodule --quiet update --init $GIT_SUBMODULE_OPTS \
+    libs/atomic \
+    libs/bind \
+    libs/chrono \
+    libs/container \
+    libs/container_hash \
+    libs/conversion \
+    libs/detail \
+    libs/exception \
+    libs/function \
+    libs/function_types \
+    libs/fusion \
+    libs/intrusive \
+    libs/io \
+    libs/lambda \
+    libs/math \
+    libs/move \
+    libs/optional \
+    libs/predef \
+    libs/range \
+    libs/ratio \
+    libs/rational \
+    libs/regex \
+    libs/static_assert \
+    libs/smart_ptr \
+    libs/system \
+    libs/throw_exception \
+    libs/timer \
+    libs/tuple \
+    libs/type_index \
+    libs/typeof \
+    libs/unordered \
+    libs/utility \
+    libs/winapi
+
+if [ -d ./.git ]; then
+    echo "get-boost: git log --stat -1"
+    git log --stat -1
+fi
+
+echo "get-boost: Deleting $PWD/libs/gil cloned with Boost superproject"
+rm -rf libs/gil
+
+echo "get-boost: Copying $BUILD_DIR to $PWD/libs"
+mkdir libs/gil
+cp -r $BUILD_DIR libs/
+
+if [ -d libs/gil/.git ]; then
+    current_pwd=`pwd`
+    cd libs/gil
+    echo "get-boost: git log --stat -1"
+    git log --stat -1
+    cd $current_pwd
+fi
+
+echo "get-boost: Done"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,41 +263,42 @@ steps_bootstrap: &steps_bootstrap
   steps:
     - *attach_workspace
     - *run_compiler_version
-    - run: cd boost && ./bootstrap.sh -with-toolset=$TOOLSET || cat ./bootstrap.log
-    - run: cd boost && ./b2 headers
+    - run: cd boost-root && ./bootstrap.sh -with-toolset=$TOOLSET || cat ./bootstrap.log
+    - run: cd boost-root && ./b2 headers > /dev/null
     - persist_to_workspace:
         root: ~/project
-        paths: boost
+        paths: boost-root
 
 steps_test_core: &steps_test_core
   steps:
     - *attach_workspace
     - *run_compiler_version
-    - run: cd boost && ./b2 toolset=$TOOLSET $VARIANT $OPTIMIZ cxxstd="$CXXSTD" libs/gil/test
+    - run: cd boost-root && ./b2 toolset=$TOOLSET $VARIANT $OPTIMIZ cxxstd="$CXXSTD" libs/gil/test
 
 steps_test_toolbox: &steps_test_toolbox
   steps:
     - *attach_workspace
     - *run_compiler_version
-    - run: cd boost && ./b2 toolset=$TOOLSET $VARIANT $OPTIMIZ cxxstd="$CXXSTD" libs/gil/toolbox/test
+    - run: cd boost-root && ./b2 toolset=$TOOLSET $VARIANT $OPTIMIZ cxxstd="$CXXSTD" libs/gil/toolbox/test
 
 steps_test_numeric: &steps_test_numeric
   steps:
     - *attach_workspace
     - *run_compiler_version
-    - run: cd boost && ./b2 toolset=$TOOLSET $VARIANT $OPTIMIZ cxxstd="$CXXSTD" libs/gil/numeric/test
+    - run: cd boost-root && ./b2 toolset=$TOOLSET $VARIANT $OPTIMIZ cxxstd="$CXXSTD" libs/gil/numeric/test
 
 steps_test_io: &steps_test_io
   steps:
     - *attach_workspace
     - *run_compiler_version
-    - run: cd boost && ./b2 toolset=$TOOLSET $VARIANT $OPTIMIZ cxxstd="$CXXSTD" libs/gil/io/test//simple
+    - run: cd boost-root && ./b2 toolset=$TOOLSET $VARIANT $OPTIMIZ cxxstd="$CXXSTD" libs/gil/io/test//simple
 
 ##############################################################################
 # Build jobs
 ##############################################################################
 jobs:
   bootstrap_checkout:
+    working_directory: ~/project/gil
     <<: *config_gcc48_cpp11_opt_speed
     steps:
       - checkout
@@ -307,20 +308,14 @@ jobs:
           # against other Boost libraries as defined by the Boost super-project master branch
           name: Checkout Boost superproject
           command: |
-            git clone -b master --depth 1 https://github.com/boostorg/boost.git
-            cd boost
-            git branch
-            git submodule --quiet update --init tools/build
-            git submodule --quiet update --init tools/boost_install
-            git submodule --quiet update --init tools/boostdep
-            git submodule --quiet update --init libs/headers
-            git submodule --quiet update --init libs/config
-            rm -rf libs/gil && mkdir -p libs/gil
-            mv -t libs/gil/ ../Jamfile ../example ../include ../io ../numeric ../test ../toolbox
-            python tools/boostdep/depinst/depinst.py gil
+            echo $PWD && ls -a $PWD
+            cd ..
+            echo $PWD && ls -a $PWD
+            ~/project/gil/.ci/get-boost.sh $CIRCLE_BRANCH ~/project/gil
+            cd boost-root
       - persist_to_workspace:
           root: ~/project
-          paths: boost
+          paths: boost-root
 
   bootstrap_gcc:
     <<: *config_gcc48_cpp11_opt_speed
@@ -483,7 +478,11 @@ jobs:
 
 ##############################################################################
 # Workflows
+#
+# Example of regex in filters:
+#   { branches: { only: [ develop, master, "/ml.*/" ] } }
 ##############################################################################
+
 workflows:
   version: 2
   build-and-test:
@@ -675,6 +674,9 @@ workflows:
 # Circle CI 1.0 notifications seem to work for Circle CI 2.0 (not 2.1!)
 # https://github.com/circleci/circleci-docs/issues/2411
 # https://discuss.circleci.com/t/circleci-2-0-notifications-webhooks/19075/9
-notify:
-  webhooks:
-    - url: https://webhooks.gitter.im/e/9538066016dc0f9b6511
+#
+# TODO: Disabled until CircleCI supports single notification per whole workflow.
+#       Currently, it floods the webhook with a notification per job.
+#notify:
+#  webhooks:
+#    - url: https://webhooks.gitter.im/e/9538066016dc0f9b6511

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,12 @@ os:
 env:
   global:
     - secure: "UHit2f6Hq2pkHvx8rfrQvFacYiQKVO3vrCbNuDi/VSAIzQjRnqCqE06y4vpXLMsXf62TvBeCBStIuI8g+HP8B+f39oGb/9Om+yIgN/yes47R4sLFKFbRiOS6sfCIefJp7Kx7GSFf81xWxStpIU4QaSsk8Dlt5xyurTWXFSde+lQ="
-    - BOOST_BRANCH=develop && [ "$TRAVIS_BRANCH" == "master" ] && BOOST_BRANCH=master || true
 
   matrix:
     - BOGUS_JOB=true
 
 matrix:
+  fast_finish: true
   exclude:
     - env: BOGUS_JOB=true
   include:
@@ -195,74 +195,10 @@ install:
       pip install --user sphinx==1.7.9
     fi
   - cd ..
-  # NOTE: Here switch between master or develop depending on against which branch of Boost
-  #       super-project we want to test GIL
-  - git clone -b $BOOST_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
+  - $TRAVIS_BUILD_DIR/.ci/get-boost.sh $TRAVIS_BRANCH $TRAVIS_BUILD_DIR
   - cd boost-root
-  - git branch
-  # List all (recursive) dependencies explicitly to control any new additions
-  - git submodule --quiet update --init tools/build
-  - git submodule --quiet update --init tools/boost_install
-  - git submodule --quiet update --init tools/boostdep
-  - git submodule --quiet update --init libs/headers
-  ## Direct (of GIL headers only)
-  - git submodule --quiet update --init libs/algorithm
-  - git submodule --quiet update --init libs/assert
-  - git submodule --quiet update --init libs/array
-  - git submodule --quiet update --init libs/concept_check
-  - git submodule --quiet update --init libs/config
-  - git submodule --quiet update --init libs/core
-  - git submodule --quiet update --init libs/crc
-  - git submodule --quiet update --init libs/filesystem
-  - git submodule --quiet update --init libs/integer
-  - git submodule --quiet update --init libs/iterator
-  - git submodule --quiet update --init libs/mp11
-  - git submodule --quiet update --init libs/mpl
-  - git submodule --quiet update --init libs/numeric/conversion
-  - git submodule --quiet update --init libs/preprocessor
-  - git submodule --quiet update --init libs/test
-  - git submodule --quiet update --init libs/type_traits
-  - git submodule --quiet update --init libs/variant
-  ## Transitive (of GIL tests too)
-  - git submodule --quiet update --init libs/atomic
-  - git submodule --quiet update --init libs/bind
-  - git submodule --quiet update --init libs/chrono
-  - git submodule --quiet update --init libs/container
-  - git submodule --quiet update --init libs/container_hash
-  - git submodule --quiet update --init libs/conversion
-  - git submodule --quiet update --init libs/detail
-  - git submodule --quiet update --init libs/exception
-  - git submodule --quiet update --init libs/function
-  - git submodule --quiet update --init libs/function_types
-  - git submodule --quiet update --init libs/fusion
-  - git submodule --quiet update --init libs/intrusive
-  - git submodule --quiet update --init libs/io
-  - git submodule --quiet update --init libs/lambda
-  - git submodule --quiet update --init libs/math
-  - git submodule --quiet update --init libs/move
-  - git submodule --quiet update --init libs/optional
-  - git submodule --quiet update --init libs/predef
-  - git submodule --quiet update --init libs/range
-  - git submodule --quiet update --init libs/ratio
-  - git submodule --quiet update --init libs/rational
-  - git submodule --quiet update --init libs/regex
-  - git submodule --quiet update --init libs/static_assert
-  - git submodule --quiet update --init libs/smart_ptr
-  - git submodule --quiet update --init libs/system
-  - git submodule --quiet update --init libs/throw_exception
-  - git submodule --quiet update --init libs/timer
-  - git submodule --quiet update --init libs/tuple
-  - git submodule --quiet update --init libs/type_index
-  - git submodule --quiet update --init libs/typeof
-  - git submodule --quiet update --init libs/unordered
-  - git submodule --quiet update --init libs/utility
-  - git submodule --quiet update --init libs/winapi
-  - rm -rf libs/gil
-  - mkdir libs/gil
-  - cp -r $TRAVIS_BUILD_DIR/* libs/gil
-  - cp -r $TRAVIS_BUILD_DIR/.ci libs/gil
+  - export BOOST_ROOT=$(pwd)
   - ./bootstrap.sh
-  - ./b2 headers
 
 script:
   - |-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,7 @@ endif()
 find_package(Boost 1.65.0 REQUIRED
   COMPONENTS
     filesystem
+    system
     unit_test_framework)
 message(STATUS "Boost.GIL: Using Boost_INCLUDE_DIRS=${Boost_INCLUDE_DIRS}")
 message(STATUS "Boost.GIL: Using Boost_LIBRARY_DIRS=${Boost_LIBRARY_DIRS}")


### PR DESCRIPTION
Introduce `get-boost.sh` as Boost downloader for all our CI services.

Credits for `get-boost.sh` idea go to @djarek and @boostorg/beast

### References

* Closes #276
* Solves issue explained in https://github.com/boostorg/gil/pull/274#issuecomment-482022037

### Tasklist

- [x] Review
- [x] Adjust for comments
- [x] All CI builds and checks have passed
