### PR TITLE
Fix UB due is_trivially_default_constructible specializations

### DIFF
--- a/include/boost/gil/packed_pixel.hpp
+++ b/include/boost/gil/packed_pixel.hpp
@@ -278,15 +278,4 @@ struct iterator_is_mutable<const packed_pixel<P, C, L>*> : std::false_type {};
 
 }}  // namespace boost::gil
 
-namespace std
-{
-
-// TODO: Avoid polluting std namespace?
-template <typename P, typename C, typename L>
-struct is_trivially_default_constructible<boost::gil::packed_pixel<P, C, L>>
-    : std::is_trivially_default_constructible<P>
-{};
-
-} // namespace std
-
 #endif

--- a/include/boost/gil/pixel.hpp
+++ b/include/boost/gil/pixel.hpp
@@ -173,7 +173,7 @@ public:
     }
 
     auto operator[](std::size_t index) const
-        -> typename channel_traits<channel_t>::const_reference 
+        -> typename channel_traits<channel_t>::const_reference
     {
         return dynamic_at_c(*this, index);
     }
@@ -297,15 +297,5 @@ struct channel_type<pixel<ChannelValue, Layout>>
 };
 
 }}  // namespace boost::gil
-
-namespace std {
-
-// TODO: Avoid polluting std namespace
-template <typename ChannelValue, typename Layout>
-struct is_trivially_default_constructible<boost::gil::pixel<ChannelValue, Layout>>
-    : ::std::is_trivially_default_constructible<ChannelValue>
-{};
-
-} // namespace std
 
 #endif


### PR DESCRIPTION
>   C++11 / 20.11.2 Header <type_traits> synopsis
>   1 The behavior of a program that adds specializations for any
>   of the class templates defined in this subclause is undefined
>   unless otherwise specified.

The specializations are not used anywhere, so they are safe to remove
without providing a replacement.

### References

Fixes #283

### Tasklist

- [x] Review
- [x] All CI builds and checks have passed
