### PR TITLE
Move Pixel Locator out of Pixel Iterator section

### DIFF
--- a/doc/design_guide.rst
+++ b/doc/design_guide.rst
@@ -1165,7 +1165,7 @@ of the pixel upon dereferencing. It models ``PixelIteratorConcept``
 and ``StepIteratorConcept`` but not ``MemoryBasedIteratorConcept``.
 
 Pixel Locator
-~~~~~~~~~~~~~
+-------------
 
 A Locator allows for navigation in two or more dimensions. Locators
 are N-dimensional iterators in spirit, but we use a different name


### PR DESCRIPTION
The "Pixel Locator" was missing from the ToC.