### PR TITLE
Add internal version of std::is_trivially_default_constructible

### DIFF
--- a/include/boost/gil/algorithm.hpp
+++ b/include/boost/gil/algorithm.hpp
@@ -14,6 +14,7 @@
 #include <boost/gil/image_view.hpp>
 #include <boost/gil/image_view_factory.hpp>
 #include <boost/gil/detail/mp11.hpp>
+#include <boost/gil/detail/type_traits.hpp>
 
 #include <boost/assert.hpp>
 #include <boost/config.hpp>
@@ -440,7 +441,7 @@ void destruct_range_impl(Iterator first, Iterator last,
             std::is_pointer<Iterator>,
             mp11::mp_not
             <
-                std::is_trivially_destructible<typename std::iterator_traits<Iterator>::value_type>
+                detail::is_trivially_destructible<typename std::iterator_traits<Iterator>::value_type>
             >
         >::value
     >::type* /*ptr*/ = 0)
@@ -460,7 +461,7 @@ void destruct_range_impl(Iterator /*first*/, Iterator /*last*/,
         mp11::mp_or
         <
             mp11::mp_not<std::is_pointer<Iterator>>,
-            std::is_trivially_destructible<typename std::iterator_traits<Iterator>::value_type>
+            detail::is_trivially_destructible<typename std::iterator_traits<Iterator>::value_type>
         >::value
     >::type* /* ptr */ = nullptr)
 {
@@ -664,12 +665,12 @@ void default_construct_aux(It first, It last, std::false_type)
 
 template <typename View, bool IsPlanar>
 struct has_trivial_pixel_constructor
-    : std::is_trivially_default_constructible<typename View::value_type>
+    : detail::is_trivially_default_constructible<typename View::value_type>
 {};
 
 template <typename View>
 struct has_trivial_pixel_constructor<View, true>
-    : std::is_trivially_default_constructible<typename channel_type<View>::type>
+    : detail::is_trivially_default_constructible<typename channel_type<View>::type>
 {};
 
 template<typename View, bool IsTriviallyConstructible>

--- a/include/boost/gil/detail/type_traits.hpp
+++ b/include/boost/gil/detail/type_traits.hpp
@@ -1,0 +1,49 @@
+//
+// Copyright 2017-2019 Peter Dimov.
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#ifndef BOOST_GIL_DETAIL_TYPE_TRAITS_HPP
+#define BOOST_GIL_DETAIL_TYPE_TRAITS_HPP
+
+#include <boost/config.hpp>
+
+#include <type_traits>
+
+namespace boost { namespace gil { namespace detail {
+
+#if defined(BOOST_LIBSTDCXX_VERSION) && BOOST_LIBSTDCXX_VERSION < 50000
+
+template<class T>
+struct is_trivially_default_constructible
+    : std::integral_constant
+    <
+        bool,
+        std::is_default_constructible<T>::value &&
+        std::has_trivial_default_constructor<T>::value
+    >
+{};
+
+
+template<class T>
+struct is_trivially_destructible
+    : std::integral_constant
+    <
+        bool,
+        std::is_destructible<T>::value &&
+        std::has_trivial_destructor<T>::value
+    >
+{};
+
+#else
+
+using std::is_trivially_default_constructible;
+using std::is_trivially_destructible;
+
+#endif
+
+}}} //namespace boost::gil::detail
+
+#endif


### PR DESCRIPTION
Add similar for `std::is_trivially_destructible`.
This should help to restore support for GCC<5 (credit to @pdimov).

### References

* Fixes #282

### Tasklist

- [x] Ensure all CI builds pass
- [x] Review and approve
