### PR TITLE
GCC 4.8/4.9 define std::is_trivially_destructible

### DIFF
--- a/include/boost/gil/detail/type_traits.hpp
+++ b/include/boost/gil/detail/type_traits.hpp
@@ -14,7 +14,7 @@
 
 namespace boost { namespace gil { namespace detail {
 
-#if defined(BOOST_LIBSTDCXX_VERSION) && BOOST_LIBSTDCXX_VERSION < 50000
+#if defined(BOOST_LIBSTDCXX_VERSION) && BOOST_LIBSTDCXX_VERSION < 50100
 
 template<class T>
 struct is_trivially_default_constructible
@@ -26,23 +26,13 @@ struct is_trivially_default_constructible
     >
 {};
 
-
-template<class T>
-struct is_trivially_destructible
-    : std::integral_constant
-    <
-        bool,
-        std::is_destructible<T>::value &&
-        std::has_trivial_destructor<T>::value
-    >
-{};
-
 #else
 
 using std::is_trivially_default_constructible;
-using std::is_trivially_destructible;
 
 #endif
+
+using std::is_trivially_destructible;
 
 }}} //namespace boost::gil::detail
 


### PR DESCRIPTION
### Description

Part of restoring/improving support for GCC 4.8 and 4.9.

### References

* #282 

### Tasklist

- [x] Ensure all CI builds pass (see https://github.com/boostorg/gil/pull/292#issuecomment-485101606) 
- [x] Review and approve
