### PR TITLE
[numeric] Add unit test for matrix3x2<T> class

### DIFF
--- a/numeric/test/CMakeLists.txt
+++ b/numeric/test/CMakeLists.txt
@@ -9,9 +9,10 @@
 message(STATUS "Boost.GIL: Configuring Numeric extension tests")
 
 foreach(_name
+  matrix3x2
   numeric)
 
-  set(_target test_ext_${_name})
+  set(_target test_ext_numeric_${_name})
   add_executable(${_target} "")
   target_sources(${_target} PRIVATE ${_name}.cpp)
   target_link_libraries(${_target}

--- a/numeric/test/Jamfile
+++ b/numeric/test/Jamfile
@@ -10,9 +10,10 @@ import testing ;
 
 project
     : requirements
-    <include>$(BOOST_ROOT)
+    <include>../../test
     <library>/boost/test//boost_unit_test_framework
     <link>shared:<define>BOOST_TEST_DYN_LINK=1
     ;
 
+run matrix3x2.cpp ;
 run numeric.cpp ;

--- a/numeric/test/matrix3x2.cpp
+++ b/numeric/test/matrix3x2.cpp
@@ -1,0 +1,170 @@
+//
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/gil/extension/numeric/affine.hpp>
+#include <boost/gil/extension/numeric/resample.hpp>
+#include <boost/gil/extension/numeric/sampler.hpp>
+#include <boost/gil.hpp>
+
+#define BOOST_TEST_MODULE test_ext_numeric_matrix3x2
+#include "unit_test.hpp"
+
+namespace gil = boost::gil;
+
+namespace {
+constexpr double HALF_PI = 1.57079632679489661923;
+}
+
+BOOST_AUTO_TEST_CASE(matrix3x2_default_constructor)
+{
+    gil::matrix3x2<int> m1;
+    BOOST_TEST(m1.a == 1);
+    BOOST_TEST(m1.b == 0);
+    BOOST_TEST(m1.c == 0);
+    BOOST_TEST(m1.d == 1);
+    BOOST_TEST(m1.e == 0);
+    BOOST_TEST(m1.f == 0);
+}
+
+BOOST_AUTO_TEST_CASE(matrix3x2_parameterized_constructor)
+{
+    gil::matrix3x2<int> m1(1, 2, 3, 4, 5, 6);
+    BOOST_TEST(m1.a == 1);
+    BOOST_TEST(m1.b == 2);
+    BOOST_TEST(m1.c == 3);
+    BOOST_TEST(m1.d == 4);
+    BOOST_TEST(m1.e == 5);
+    BOOST_TEST(m1.f == 6);
+}
+
+BOOST_AUTO_TEST_CASE(matrix3x2_copy_constructor)
+{
+    gil::matrix3x2<int> m1(1, 2, 3, 4, 5, 6);
+    gil::matrix3x2<int> m2(m1);
+    BOOST_TEST(m2.a == 1);
+    BOOST_TEST(m2.b == 2);
+    BOOST_TEST(m2.c == 3);
+    BOOST_TEST(m2.d == 4);
+    BOOST_TEST(m2.e == 5);
+    BOOST_TEST(m2.f == 6);
+}
+
+BOOST_AUTO_TEST_CASE(matrix3x2_assignment_operator)
+{
+    gil::matrix3x2<int> m1(1, 2, 3, 4, 5, 6);
+    gil::matrix3x2<int> m2;
+    m2 = m1;
+    BOOST_TEST(m2.a == 1);
+    BOOST_TEST(m2.b == 2);
+    BOOST_TEST(m2.c == 3);
+    BOOST_TEST(m2.d == 4);
+    BOOST_TEST(m2.e == 5);
+    BOOST_TEST(m2.f == 6);
+}
+
+BOOST_AUTO_TEST_CASE(matrix3x2_multiplication_assignment)
+{
+    gil::matrix3x2<int> m1;
+    gil::matrix3x2<int> m2;
+    m2 *= m1;
+    BOOST_TEST(m2.a == 1);
+    BOOST_TEST(m2.b == 0);
+    BOOST_TEST(m2.c == 0);
+    BOOST_TEST(m2.d == 1);
+    BOOST_TEST(m2.e == 0);
+    BOOST_TEST(m2.f == 0);
+
+    gil::matrix3x2<int> m3(0, 0, 0, 0, 0, 0);
+    m2 *= m3;
+    BOOST_TEST(m2.a == 0);
+    BOOST_TEST(m2.b == 0);
+    BOOST_TEST(m2.c == 0);
+    BOOST_TEST(m2.d == 0);
+    BOOST_TEST(m2.e == 0);
+    BOOST_TEST(m2.f == 0);
+}
+
+BOOST_AUTO_TEST_CASE(matrix3x2_matrix3x2_multiplication)
+{
+    gil::matrix3x2<int> m1;
+    gil::matrix3x2<int> m2(0, 0, 0, 0, 0, 0);
+    gil::matrix3x2<int> m3;
+    m3 = m1 * m2;
+    BOOST_TEST(m3.a == 0);
+    BOOST_TEST(m3.b == 0);
+    BOOST_TEST(m3.c == 0);
+    BOOST_TEST(m3.d == 0);
+    BOOST_TEST(m3.e == 0);
+    BOOST_TEST(m3.f == 0);
+}
+
+BOOST_AUTO_TEST_CASE(matrix3x2_vector_multiplication)
+{
+    gil::matrix3x2<int> m1;
+    gil::point<int> v1{2, 4};
+
+    gil::point<int> v2 = v1 * m1;
+    BOOST_TEST(v2.x == 2);
+    BOOST_TEST(v2.y == 4);
+
+    gil::point<int> v3 = gil::transform(m1, v1);
+    BOOST_TEST(v3.x == 2);
+    BOOST_TEST(v3.y == 4);
+}
+
+BOOST_AUTO_TEST_CASE(matrix3x2_get_rotate)
+{
+    auto m1 = gil::matrix3x2<double>::get_rotate(HALF_PI);
+    BOOST_TEST(m1.a == std::cos(HALF_PI), btt::tolerance(0.03));
+    BOOST_TEST(m1.b == 1);
+    BOOST_TEST(m1.c == -1);
+    BOOST_TEST(m1.d == std::cos(HALF_PI), btt::tolerance(0.03));
+    BOOST_TEST(m1.e == 0);
+    BOOST_TEST(m1.f == 0);
+}
+
+BOOST_AUTO_TEST_CASE(matrix3x2_get_scale)
+{
+    gil::matrix3x2<int> m1;
+    m1 = gil::matrix3x2<int>::get_scale(2);
+    BOOST_TEST(m1.a == 2);
+    BOOST_TEST(m1.b == 0);
+    BOOST_TEST(m1.c == 0);
+    BOOST_TEST(m1.d == 2);
+    BOOST_TEST(m1.e == 0);
+    BOOST_TEST(m1.f == 0);
+    m1 = gil::matrix3x2<int>::get_scale(2, 4);
+    BOOST_TEST(m1.a == 2);
+    BOOST_TEST(m1.d == 4);
+    m1 = gil::matrix3x2<int>::get_scale(gil::point<int>{4, 8});
+    BOOST_TEST(m1.a == 4);
+    BOOST_TEST(m1.d == 8);
+}
+
+BOOST_AUTO_TEST_CASE(matrix3x2_get_translate)
+{
+    gil::matrix3x2<int> m1;
+    m1 = gil::matrix3x2<int>::get_translate(2, 4);
+    BOOST_TEST(m1.a == 1);
+    BOOST_TEST(m1.b == 0);
+    BOOST_TEST(m1.c == 0);
+    BOOST_TEST(m1.d == 1);
+    BOOST_TEST(m1.e == 2);
+    BOOST_TEST(m1.f == 4);
+    m1 = gil::matrix3x2<int>::get_translate(gil::point<int>{4, 8});
+    BOOST_TEST(m1.e == 4);
+    BOOST_TEST(m1.f == 8);
+}
+
+BOOST_AUTO_TEST_CASE(matrix3x2_transform)
+{
+    gil::matrix3x2<int> m1;
+    gil::point<int> v1{2, 4};
+    gil::point<int> v2 = gil::transform(m1, v1);
+    BOOST_TEST(v2.x == 2);
+    BOOST_TEST(v2.y == 4);
+}

--- a/numeric/test/numeric.cpp
+++ b/numeric/test/numeric.cpp
@@ -1,12 +1,10 @@
+//
 // Copyright 2013 Krzysztof Czainski
-// Distributed under the Boost Software License, Version 1.0. (See
-// accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
-
-/// \file numeric.cpp
-
-/// \brief Unit test for Numeric extension
-
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
 #include <boost/gil/image.hpp>
 #include <boost/gil/typedefs.hpp>
 
@@ -15,18 +13,8 @@
 
 #include <boost/assert.hpp>
 
-#if defined(BOOST_CLANG)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wfloat-equal"
-#endif
-
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wfloat-equal"
-#endif
-
-#define BOOST_TEST_MAIN
-#include <boost/test/unit_test.hpp>
+#define BOOST_TEST_MODULE test_ext_numeric_numeric
+#include "unit_test.hpp"
 
 using namespace boost;
 using namespace gil;


### PR DESCRIPTION
Additionally, in numeric.cpp:
- Add `#include "unit_test.hpp"` - proxy header common to all GIL tests.
- Tidy up copyright notice.

### Tasklist

- [x] Approve #294 or #295
- [x] Ensure all CI builds pass
- [x] Review and approve
