### PR TITLE
[numeric] Add gil::transform multiplication workaround for MSVC=1900

### DIFF
--- a/include/boost/gil/extension/numeric/affine.hpp
+++ b/include/boost/gil/extension/numeric/affine.hpp
@@ -10,6 +10,8 @@
 
 #include <boost/gil/point.hpp>
 
+#include <boost/config/workaround.hpp>
+
 namespace boost { namespace gil {
 
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -86,7 +88,14 @@ template <typename F, typename F2>
 BOOST_FORCEINLINE
 point<F> transform(matrix3x2<F> const& mat, point<F2> const& src)
 {
+#if BOOST_WORKAROUND(BOOST_MSVC, > 1900)
     return src * mat;
+#else
+    point<F> p;
+    p.x = mat.a*src.x + mat.c*src.y + mat.e;
+    p.y = mat.b*src.x + mat.d*src.y + mat.f;
+    return p;
+#endif
 }
 
 }} // namespace boost::gil


### PR DESCRIPTION
For some reason, MSVC, for this `point<F2> * matrix3x2<F>` instead of calling

```
template <typename T, typename F>
point<F> operator*(point<T> const& p, matrix3x2<F> const& m)
```
calls

```
template <typename T, typename M>
auto operator*(point<T> const& p, M m)
```

There is no ambiguity reported by any other compiler/version (~20) that is currently CI-tested.

### References

- Fixes #289
- Test added in #293

### Tasklist

- [x] Add test case(s)
- [ ] Ensure all CI builds pass
- [ ] Review and approve
