### PR TITLE
Disable free operator* of point<T> for non-arithmetic operand

### DIFF
--- a/include/boost/gil/point.hpp
+++ b/include/boost/gil/point.hpp
@@ -186,7 +186,12 @@ auto operator/(point<T> const& p, D d) -> point<typename std::common_type<T, D>:
 /// \ingroup PointModel
 template <typename T, typename M>
 BOOST_FORCEINLINE
-auto operator*(point<T> const& p, M m) -> point<typename std::common_type<T, M>::type>
+auto operator*(point<T> const& p, M m)
+    -> typename std::enable_if
+        <
+            std::is_arithmetic<M>::value,
+            point<typename std::common_type<T, M>::type>
+        >::type
 {
     static_assert(std::is_arithmetic<M>::value, "multiplier is not arithmetic type");
     using result_type = typename std::common_type<T, M>::type;
@@ -196,7 +201,12 @@ auto operator*(point<T> const& p, M m) -> point<typename std::common_type<T, M>:
 /// \ingroup PointModel
 template <typename T, typename M>
 BOOST_FORCEINLINE
-auto operator*(M m, point<T> const& p) -> point<typename std::common_type<T, M>::type>
+auto operator*(M m, point<T> const& p)
+    -> typename std::enable_if
+        <
+            std::is_arithmetic<M>::value,
+            point<typename std::common_type<T, M>::type>
+        >::type
 {
     static_assert(std::is_arithmetic<M>::value, "multiplier is not arithmetic type");
     using result_type = typename std::common_type<T, M>::type;

--- a/test/point/Jamfile
+++ b/test/point/Jamfile
@@ -14,4 +14,5 @@ project
     ;
 
 compile concepts.cpp ;
+compile-fail multiply_by_non_arithmetic_fail.cpp ;
 run point.cpp ;

--- a/test/point/multiply_by_non_arithmetic_fail.cpp
+++ b/test/point/multiply_by_non_arithmetic_fail.cpp
@@ -1,0 +1,23 @@
+//
+// Copyright 2018 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/gil/point.hpp>
+
+#include <type_traits>
+
+namespace gil = boost::gil;
+
+struct FakeMatrix {};
+
+int main()
+{
+    gil::point<int> p1{2, 4};
+
+    FakeMatrix m1;
+    auto r1 = p1 * m1;
+    auto r2 = m1 * p1;
+}


### PR DESCRIPTION
Add Boost.Build-only test to verify compilation failure.

### References

Fixes #289 as better solution than #294 workaround.

### Tasklist

- [x] Add test case(s)
- [x] Ensure all CI builds pass
- [x] Review and approve

-----

This follows suggestion from @stefanseefeld in https://github.com/boostorg/gil/pull/294#issuecomment-486805343 