### PR TITLE
Officially drop support for GCC <= 4.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,6 @@ version: 2.0
 ##############################################################################
 # Docker images
 ##############################################################################
-docker_gcc48: &docker_gcc48
-  docker:
-    - image: gcc:4.8
 docker_gcc49: &docker_gcc49
   docker:
     - image: gcc:4.9
@@ -112,13 +109,6 @@ env_clang_cpp11_opt_speed: &env_clang_cpp11_opt_speed
 ##############################################################################
 # Build configurations
 ##############################################################################
-config_gcc48_cpp11_dbg: &config_gcc48_cpp11_dbg
-  <<: *docker_gcc48
-  <<: *env_gcc_cpp11_dbg
-config_gcc48_cpp11_opt_speed: &config_gcc48_cpp11_opt_speed
-  <<: *docker_gcc48
-  <<: *env_gcc_cpp11_opt_speed
-
 config_gcc49_cpp11_dbg: &config_gcc49_cpp11_dbg
   <<: *docker_gcc49
   <<: *env_gcc_cpp11_dbg
@@ -299,7 +289,7 @@ steps_test_io: &steps_test_io
 jobs:
   bootstrap_checkout:
     working_directory: ~/project/gil
-    <<: *config_gcc48_cpp11_opt_speed
+    <<: *config_gcc49_cpp11_opt_speed
     steps:
       - checkout
       - run:
@@ -318,7 +308,7 @@ jobs:
           paths: boost-root
 
   bootstrap_gcc:
-    <<: *config_gcc48_cpp11_opt_speed
+    <<: *config_gcc49_cpp11_opt_speed
     <<: *steps_bootstrap
 
   bootstrap_clang:
@@ -326,14 +316,6 @@ jobs:
     <<: *steps_bootstrap
 
   ### GCC 4.x ################################################################
-  gcc48_11_core:
-    <<: *config_gcc48_cpp11_dbg
-    <<: *steps_test_core
-
-  gcc48_11_core_speed:
-    <<: *config_gcc48_cpp11_opt_speed
-    <<: *steps_test_core
-
   gcc49_11_core:
     <<: *config_gcc49_cpp11_dbg
     <<: *steps_test_core
@@ -492,13 +474,6 @@ workflows:
             - bootstrap_checkout
 
       ### GCC 4.x ############################################################
-      - gcc48_11_core:
-          requires:
-            - bootstrap_gcc
-      - gcc48_11_core_speed:
-          requires:
-            - gcc48_11_core
-
       - gcc49_11_core:
           requires:
             - bootstrap_gcc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ version: 2.0
 ##############################################################################
 # Docker images
 ##############################################################################
+docker_gcc48: &docker_gcc48
+  docker:
+    - image: gcc:4.8
 docker_gcc49: &docker_gcc49
   docker:
     - image: gcc:4.9
@@ -109,6 +112,11 @@ env_clang_cpp11_opt_speed: &env_clang_cpp11_opt_speed
 ##############################################################################
 # Build configurations
 ##############################################################################
+# GCC 4.8 is used to build `b2` driver
+config_gcc48_cpp11_opt_speed: &config_gcc48_cpp11_opt_speed
+  <<: *docker_gcc48
+  <<: *env_gcc_cpp11_opt_speed
+
 config_gcc49_cpp11_dbg: &config_gcc49_cpp11_dbg
   <<: *docker_gcc49
   <<: *env_gcc_cpp11_dbg
@@ -289,7 +297,9 @@ steps_test_io: &steps_test_io
 jobs:
   bootstrap_checkout:
     working_directory: ~/project/gil
-    <<: *config_gcc49_cpp11_opt_speed
+    # Build `b2` using the ancient compiler to hopefully avoid run-time failures:
+    # ./b2: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.14' not found (required by ./b2)
+    <<: *config_gcc48_cpp11_opt_speed
     steps:
       - checkout
       - run:
@@ -308,7 +318,7 @@ jobs:
           paths: boost-root
 
   bootstrap_gcc:
-    <<: *config_gcc49_cpp11_opt_speed
+    <<: *config_gcc48_cpp11_opt_speed
     <<: *steps_bootstrap
 
   bootstrap_clang:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
  **C++/compilers:** | 11, 14, 17 | 11, 14, 17 | 11 | 11 |
  msvc++    | VS2015, VS2017 | VS2015, VS2017 |   |   |
  clang++   |   | Xcode 9.4.1 | 3.9, 5.0, Xcode 9.4.1 | 3.9, 4.0, 5.0 |
- g++       |   | 5.4, 8.1 | 5.5, 6.5, 7.4 | 4.8-9, 5.1-5, 6.1-4, 7.1-3, 8.2 |
+ g++       |   | 5.4, 8.1 | 5.5, 6.5, 7.4 | 4.9, 5.1-5, 6.1-4, 7.1-3, 8.2 |
  **tests coverage:** |
 core + concepts | Y | Y | Y | Y |
 headers    | core + ext | core + ext | core + ext | core + ext |
@@ -61,7 +61,7 @@ See [example/README.md](example/README.md) for available GIL examples.
 
 The Boost Generic Image Library (GIL) requires:
 
-- C++11 compiler
+- C++11 compiler (GCC 4.9, clang 3.3, MSVC++ 14.0 (1900) or any later version)
 - Boost header-only libraries
 
 Optionally, in order to build and run tests and examples:

--- a/include/boost/gil/color_base_algorithm.hpp
+++ b/include/boost/gil/color_base_algorithm.hpp
@@ -238,7 +238,7 @@ template <int N>
 struct element_recursion
 {
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Wfloat-equal"
@@ -272,7 +272,7 @@ struct element_recursion
         semantic_at_c<N-1>(dst)=op();
     }
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/concepts/basic.hpp
+++ b/include/boost/gil/concepts/basic.hpp
@@ -16,7 +16,7 @@
 #pragma clang diagnostic ignored "-Wuninitialized"
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #pragma GCC diagnostic ignored "-Wuninitialized"
@@ -188,7 +188,7 @@ struct SameType
 #pragma clang diagnostic pop
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/concepts/channel.hpp
+++ b/include/boost/gil/concepts/channel.hpp
@@ -22,7 +22,7 @@
 #pragma clang diagnostic ignored "-Wunused-local-typedefs"
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
@@ -208,7 +208,7 @@ struct ChannelConvertibleConcept
 #pragma clang diagnostic pop
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/concepts/color.hpp
+++ b/include/boost/gil/concepts/color.hpp
@@ -17,7 +17,7 @@
 #pragma clang diagnostic ignored "-Wunused-local-typedefs"
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
@@ -91,7 +91,7 @@ struct ChannelMappingConcept
 #pragma clang diagnostic pop
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/concepts/color_base.hpp
+++ b/include/boost/gil/concepts/color_base.hpp
@@ -21,7 +21,7 @@
 #pragma clang diagnostic ignored "-Wunused-local-typedefs"
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
@@ -321,7 +321,7 @@ struct ColorBasesCompatibleConcept
 #pragma clang diagnostic pop
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/concepts/concept_check.hpp
+++ b/include/boost/gil/concepts/concept_check.hpp
@@ -16,7 +16,7 @@
 #pragma clang diagnostic ignored "-Wuninitialized"
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfloat-equal"
 #pragma GCC diagnostic ignored "-Wuninitialized"
@@ -28,7 +28,7 @@
 #pragma clang diagnostic pop
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/concepts/dynamic_step.hpp
+++ b/include/boost/gil/concepts/dynamic_step.hpp
@@ -16,7 +16,7 @@
 #pragma clang diagnostic ignored "-Wunused-local-typedefs"
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
@@ -70,7 +70,7 @@ struct HasDynamicYStepTypeConcept
 #pragma clang diagnostic pop
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/concepts/image.hpp
+++ b/include/boost/gil/concepts/image.hpp
@@ -22,7 +22,7 @@
 #pragma clang diagnostic ignored "-Wunused-local-typedefs"
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
@@ -161,7 +161,7 @@ struct ImageConcept
 #pragma clang diagnostic pop
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/concepts/image_view.hpp
+++ b/include/boost/gil/concepts/image_view.hpp
@@ -27,7 +27,7 @@
 #pragma clang diagnostic ignored "-Wunused-local-typedefs"
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
@@ -549,7 +549,7 @@ struct ViewsCompatibleConcept
 #pragma clang diagnostic pop
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/concepts/pixel.hpp
+++ b/include/boost/gil/concepts/pixel.hpp
@@ -26,7 +26,7 @@
 #pragma clang diagnostic ignored "-Wunused-local-typedefs"
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
@@ -291,7 +291,7 @@ struct PixelConvertibleConcept
 #pragma clang diagnostic pop
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/concepts/pixel_based.hpp
+++ b/include/boost/gil/concepts/pixel_based.hpp
@@ -21,7 +21,7 @@
 #pragma clang diagnostic ignored "-Wunused-local-typedefs"
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
@@ -96,7 +96,7 @@ struct HomogeneousPixelBasedConcept
 #pragma clang diagnostic pop
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/concepts/pixel_dereference.hpp
+++ b/include/boost/gil/concepts/pixel_dereference.hpp
@@ -24,7 +24,7 @@
 #pragma clang diagnostic ignored "-Wunused-local-typedefs"
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
@@ -107,7 +107,7 @@ struct PixelDereferenceAdaptorArchetype
 #pragma clang diagnostic pop
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/concepts/pixel_iterator.hpp
+++ b/include/boost/gil/concepts/pixel_iterator.hpp
@@ -26,7 +26,7 @@
 #pragma clang diagnostic ignored "-Wunused-local-typedefs"
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
@@ -353,7 +353,7 @@ struct MutableIteratorAdaptorConcept
 #pragma clang diagnostic pop
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/concepts/pixel_locator.hpp
+++ b/include/boost/gil/concepts/pixel_locator.hpp
@@ -25,7 +25,7 @@
 #pragma clang diagnostic ignored "-Wunused-local-typedefs"
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
@@ -402,7 +402,7 @@ struct MutablePixelLocatorConcept
 #pragma clang diagnostic pop
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/concepts/point.hpp
+++ b/include/boost/gil/concepts/point.hpp
@@ -18,7 +18,7 @@
 #pragma clang diagnostic ignored "-Wunused-local-typedefs"
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
@@ -117,7 +117,7 @@ struct Point2DConcept
 #pragma clang diagnostic pop
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic pop
 #endif
 

--- a/include/boost/gil/io/path_spec.hpp
+++ b/include/boost/gil/io/path_spec.hpp
@@ -15,7 +15,7 @@
 #pragma clang diagnostic ignored "-Wshorten-64-to-32"
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #endif
@@ -27,7 +27,7 @@
 #pragma clang diagnostic pop
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic pop
 #endif
 #endif // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT

--- a/io/test/paths.hpp
+++ b/io/test/paths.hpp
@@ -14,7 +14,7 @@
 #pragma clang diagnostic ignored "-Wshorten-64-to-32"
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #endif
@@ -26,7 +26,7 @@
 #pragma clang diagnostic pop
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic pop
 #endif
 

--- a/numeric/test/numeric.cpp
+++ b/numeric/test/numeric.cpp
@@ -20,7 +20,7 @@
 #pragma clang diagnostic ignored "-Wfloat-equal"
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfloat-equal"
 #endif

--- a/test/channel/concepts.cpp
+++ b/test/channel/concepts.cpp
@@ -13,7 +13,7 @@
 #pragma GCC diagnostic ignored "-Wuninitialized"
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wuninitialized"
 #endif

--- a/test/unit_test.hpp
+++ b/test/unit_test.hpp
@@ -20,7 +20,7 @@
 #pragma clang diagnostic ignored "-Wfloat-equal"
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Wfloat-equal"
@@ -37,7 +37,7 @@
 #pragma clang diagnostic pop
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic pop
 #endif
 

--- a/toolbox/test/lab_test.cpp
+++ b/toolbox/test/lab_test.cpp
@@ -14,7 +14,7 @@
 #pragma clang diagnostic ignored "-Wfloat-equal"
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfloat-equal"
 #endif
@@ -25,7 +25,7 @@
 #pragma clang diagnostic pop
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
 #pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
Although GCC 4.8 is labelled as C++11 compatible, the reasons are:

* GCC 4.8 is buggy enough to prevent reasonable use of Boost.MP11
* GCC 4.8 is dying

### References

* Closes #282

### Tasklist

- [x] Ensure all CI builds pass
- [x] Review and approve
