### PR TITLE
Add SFINAE-friendly version of std::common_type

### DIFF
--- a/include/boost/gil/detail/std_common_type.hpp
+++ b/include/boost/gil/detail/std_common_type.hpp
@@ -1,0 +1,39 @@
+//
+// Copyright Louis Dionne 2013-2017
+//
+// Distributed under the Boost Software License, Version 1.0.
+//(See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+//
+#ifndef BOOST_GIL_DETAIL_STD_COMMON_TYPE_HPP
+#define BOOST_GIL_DETAIL_STD_COMMON_TYPE_HPP
+
+#include <type_traits>
+#include <utility>
+
+namespace boost { namespace gil { namespace detail {
+
+// Defines a SFINAE-friendly version of `std::common_type`.
+//
+// Based on boost/hana/detail/std_common_type.hpp
+// Equivalent to `std::common_type`, except it is SFINAE-friendly and
+// does not support custom specializations.
+
+template <typename T, typename U, typename = void>
+struct std_common_type {};
+
+template <typename T, typename U>
+struct std_common_type
+<
+    T, U,
+    decltype((void)(true ? std::declval<T>() : std::declval<U>()))
+>
+{
+    using type = typename std::decay
+        <
+            decltype(true ? std::declval<T>() : std::declval<U>())
+        >::type;
+};
+
+}}} // namespace boost::gil::detail
+
+#endif

--- a/include/boost/gil/point.hpp
+++ b/include/boost/gil/point.hpp
@@ -9,6 +9,7 @@
 #define BOOST_GIL_POINT_HPP
 
 #include <boost/gil/utilities.hpp>
+#include <boost/gil/detail/std_common_type.hpp>
 
 #include <boost/config.hpp>
 
@@ -165,10 +166,15 @@ point<T> operator-(const point<T>& p1, const point<T>& p2)
 /// \ingroup PointModel
 template <typename T, typename D>
 BOOST_FORCEINLINE
-auto operator/(point<T> const& p, D d) -> point<typename std::common_type<T, D>::type>
+auto operator/(point<T> const& p, D d)
+    -> typename std::enable_if
+    <
+        std::is_arithmetic<D>::value,
+        point<typename detail::std_common_type<T, D>::type>
+    >::type
 {
     static_assert(std::is_arithmetic<D>::value, "denominator is not arithmetic type");
-    using result_type = typename std::common_type<T, D>::type;
+    using result_type = typename detail::std_common_type<T, D>::type;
     if (d < 0 || 0 < d)
     {
         double const x = p.x / static_cast<double>(d);
@@ -188,13 +194,13 @@ template <typename T, typename M>
 BOOST_FORCEINLINE
 auto operator*(point<T> const& p, M m)
     -> typename std::enable_if
-        <
-            std::is_arithmetic<M>::value,
-            point<typename std::common_type<T, M>::type>
-        >::type
+    <
+        std::is_arithmetic<M>::value,
+        point<typename detail::std_common_type<T, M>::type>
+    >::type
 {
     static_assert(std::is_arithmetic<M>::value, "multiplier is not arithmetic type");
-    using result_type = typename std::common_type<T, M>::type;
+    using result_type = typename detail::std_common_type<T, M>::type;
     return point<result_type>{p.x * m, p.y * m};
 }
 
@@ -203,13 +209,13 @@ template <typename T, typename M>
 BOOST_FORCEINLINE
 auto operator*(M m, point<T> const& p)
     -> typename std::enable_if
-        <
-            std::is_arithmetic<M>::value,
-            point<typename std::common_type<T, M>::type>
-        >::type
+    <
+        std::is_arithmetic<M>::value,
+        point<typename detail::std_common_type<T, M>::type>
+    >::type
 {
     static_assert(std::is_arithmetic<M>::value, "multiplier is not arithmetic type");
-    using result_type = typename std::common_type<T, M>::type;
+    using result_type = typename detail::std_common_type<T, M>::type;
     return point<result_type>{p.x * m, p.y * m};
 }
 


### PR DESCRIPTION
It should help to improve uses of SFINAE like the one from #295 and fix #289 for MSVC 14.0 (VS2015) for good.

Copied from Boost.Hana.

### Rationale

Simply, SFINAE using `std::common_type` turned out to be insufficient, at least it was still not working well with VS2015. The issue was revealed by `matrix3x2` tests added in #293 for which VS2015 build jobs failed (e.g. https://ci.appveyor.com/project/mloskot/gil/build/job/c7xrfsikib6la83g).

Since the `std::common_type` is a very useful trait and it may be suitable in future cases where common type needs to be calculated, it is a good idea to have a solid SFINAE-friendly version available.

### References

* Refines #295 which was based on the idea from https://github.com/boostorg/gil/pull/294#issuecomment-486805343

### Tasklist

- [x] Ensure all CI builds pass
- [x] Review and approve

------

