### PR TITLE
Add missing equal sign in interleaved_ptr.hpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ stdcerr
 # Python
 /.venv
 /.env
+
+# Conan
+conaninfo.txt
+graph_info.json

--- a/example/interleaved_ptr.hpp
+++ b/example/interleaved_ptr.hpp
@@ -42,7 +42,7 @@ struct interleaved_ptr : boost::iterator_facade
     >
 {
 private:
-    using parent_t boost::iterator_facade
+    using parent_t = boost::iterator_facade
         <
             interleaved_ptr<ChannelPtr, Layout>,
             pixel<typename std::iterator_traits<ChannelPtr>::value_type, Layout>,


### PR DESCRIPTION
### Description

Fixed a syntax error in examples, missing = sign.

### Environment

- Compiler version: VC++  19.16.27030.1
- Build settings: use_conan=true, others default
- GIL Version (Git ref or `<boost/version.hpp>`): https://github.com/boostorg/gil/commit/10f1efff5bbb86bc79341601e341fc9fa86cfdf5

### References

Mentioned in gitter

### Tasklist

- [X] Fix the bug
- [X] Add test case(s) (build attempt is a test, so no additional tests required)
- [x] Ensure all CI builds pass (examples are not used in CI yet)
- [x] Review and approve
