### PR TITLE
Define WIN32 macro to make LibRaw happy

### DIFF
--- a/include/boost/gil/extension/io/raw/tags.hpp
+++ b/include/boost/gil/extension/io/raw/tags.hpp
@@ -10,6 +10,15 @@
 
 #include <boost/gil/io/base.hpp>
 
+// Historically, LibRaw expects WIN32, not _WIN32 (see https://github.com/LibRaw/LibRaw/pull/206)
+#ifdef _MSC_VER
+#ifndef WIN32
+#define WIN32
+#endif
+#pragma warning(push)
+#pragma warning(disable:4251) // 'type' needs to have dll-interface to be used by clients of class
+#endif
+
 #include <libraw/libraw.h>
 
 namespace boost { namespace gil {
@@ -190,7 +199,10 @@ struct image_write_info< raw_tag >
 {
 };
 
-} // namespace gil
-} // namespace boost
+}} // namespace boost::gil
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif


### PR DESCRIPTION
Apparently, for some not entirely clear reasons, possibly historical use of `.vcproj`, LibRaw uses (not defines!) `WIN32` macro, instead of C standard compliant `_WIN32` common to majority of compilers on Windows.

This patch is required if GIL IO is used with Boost.Build or custom Makefile, without this custom `WIN32` hand-rolled in build configuration.

Hopefully, LibRaw may accept some clean up for this in near future: https://github.com/LibRaw/LibRaw/pull/206

### Tasklist

- [x] Ensure all CI builds pass
