### PR TITLE
Prefer ptrdiff_t to express image dimensions instead of int

### DIFF
--- a/include/boost/gil/extension/dynamic_image/image_view_factory.hpp
+++ b/include/boost/gil/extension/dynamic_image/image_view_factory.hpp
@@ -249,11 +249,11 @@ template <typename Views>
 inline
 auto subimage_view(
     any_image_view<Views> const& src,
-    int xMin, int yMin, int width, int height)
+    std::ptrdiff_t x, std::ptrdiff_t y, std::ptrdiff_t width, std::ptrdiff_t height)
     -> any_image_view<Views>
 {
     using subimage_view_fn = detail::subimage_view_fn<any_image_view<Views>>;
-    return apply_operation(src, subimage_view_fn(point_t(xMin, yMin),point_t(width, height)));
+    return apply_operation(src, subimage_view_fn(point_t{x, y}, point_t{width, height}));
 }
 
 /// \ingroup ImageViewTransformationsSubsampled
@@ -272,7 +272,7 @@ auto subsampled_view(any_image_view<Views> const& src, point_t const& step)
 /// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
 template <typename Views>
 inline
-auto subsampled_view(any_image_view<Views> const& src, int xStep, int yStep)
+auto subsampled_view(any_image_view<Views> const& src, std::ptrdiff_t xStep, std::ptrdiff_t yStep)
     -> typename dynamic_xy_step_type<any_image_view<Views>>::type
 {
     using step_type = typename dynamic_xy_step_type<any_image_view<Views>>::type;

--- a/include/boost/gil/extension/io/bmp/detail/write.hpp
+++ b/include/boost/gil/extension/io/bmp/detail/write.hpp
@@ -154,20 +154,12 @@ private:
                                        , spn
                                        );
 
-        for( typename View::y_coord_t y = view.height() - 1; y > -1; --y  )
+        for (typename View::y_coord_t y = view.height() - 1; y > -1; --y)
         {
-            copy_pixels( subimage_view( view
-                                      , 0
-                                      , (int) y
-                                      , (int) view.width()
-                                      , 1
-                                      )
-                       , row
-                       );
+            copy_pixels(subimage_view(view, 0, y, view.width(), 1), row);
 
             this->_io_dev.write( &buffer.front(), spn );
         }
-
     }
 };
 

--- a/include/boost/gil/extension/io/jpeg/detail/read.hpp
+++ b/include/boost/gil/extension/io/jpeg/detail/read.hpp
@@ -188,7 +188,7 @@ private:
         }
 
         // Read data.
-        for( int y = 0; y < view.height(); ++y )
+        for (typename View::y_coord_t y = 0; y < view.height(); ++y)
         {
             io_error_if( jpeg_read_scanlines( this->get()
                                             , &row_adr

--- a/include/boost/gil/extension/io/jpeg/detail/write.hpp
+++ b/include/boost/gil/extension/io/jpeg/detail/write.hpp
@@ -120,17 +120,10 @@ private:
 
         JSAMPLE* row_addr = reinterpret_cast< JSAMPLE* >( &row_buffer[0] );
 
-        for( int y =0; y != view.height(); ++ y )
+        for (typename View::y_coord_t y =0; y != view.height(); ++ y)
         {
-            std::copy( view.row_begin( y )
-                     , view.row_end  ( y )
-                     , row_buffer.begin()
-                     );
-
-            jpeg_write_scanlines( this->get()
-                                , &row_addr
-                                , 1
-                                );
+            std::copy(view.row_begin(y), view.row_end(y), row_buffer.begin());
+            jpeg_write_scanlines(this->get(), &row_addr, 1);
         }
     }
 };

--- a/include/boost/gil/extension/io/png/detail/write.hpp
+++ b/include/boost/gil/extension/io/png/detail/write.hpp
@@ -102,16 +102,10 @@ private:
                           >
                    > row_buffer( view.width() );
 
-        for( int y = 0; y != view.height(); ++ y)
+        for (typename View::y_coord_t y = 0; y != view.height(); ++ y)
         {
-            std::copy( view.row_begin( y )
-                     , view.row_end  ( y )
-                     , row_buffer.begin()
-                     );
-
-            png_write_row( this->get_struct()
-                         , reinterpret_cast< png_bytep >( row_buffer.data() )
-                         );
+            std::copy(view.row_begin(y), view.row_end(y), row_buffer.begin());
+            png_write_row(this->get_struct(), reinterpret_cast<png_bytep>(row_buffer.data()));
         }
 
         png_write_end( this->get_struct()

--- a/include/boost/gil/image_view_factory.hpp
+++ b/include/boost/gil/image_view_factory.hpp
@@ -19,6 +19,7 @@
 #include <boost/assert.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <type_traits>
 
 /// Methods for creating shallow image views from raw pixel data or from other image views -
@@ -257,8 +258,12 @@ inline View subimage_view(const View& src, const typename View::point_t& topleft
 
 /// \ingroup ImageViewTransformationsSubimage
 template <typename View>
-inline View subimage_view(const View& src, int xMin, int yMin, int width, int height) {
-    return View(width,height,src.xy_at(xMin,yMin));
+inline
+View subimage_view(View const& src,
+    std::ptrdiff_t x, std::ptrdiff_t y,
+    std::ptrdiff_t width, std::ptrdiff_t height)
+{
+    return View(width, height, src.xy_at(x, y));
 }
 
 /// \defgroup ImageViewTransformationsSubsampled subsampled_view


### PR DESCRIPTION
The ptrdiff_t is de-facto standard convention used across GIL and any uses of int or size_t should be unified using ptrdiff_t.

### Tasklist

- [x] Ensure all CI builds pass
- [ ] Review and approve
