### PR TITLE
Fix setup logic to also work with differently named GIL forks.

### DIFF
--- a/.ci/get-boost.sh
+++ b/.ci/get-boost.sh
@@ -93,9 +93,8 @@ fi
 echo "get-boost: Deleting $PWD/libs/gil cloned with Boost superproject"
 rm -rf libs/gil
 
-echo "get-boost: Copying $BUILD_DIR to $PWD/libs"
-mkdir libs/gil
-cp -r $BUILD_DIR libs/
+echo "get-boost: Copying $BUILD_DIR to $PWD/libs/gil"
+cp -r $BUILD_DIR libs/gil
 
 if [ -d libs/gil/.git ]; then
     current_pwd=`pwd`


### PR DESCRIPTION
This PR fixes the CI logic that assumed the fork was named "gil". (Failures to be observed i.e. 
https://travis-ci.org/BoostGSoC19/gil-olzhas/jobs/540510185).