### PR TITLE
[CMake] Remove GIL_DOWNLOAD_FINDBOOST option

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -61,7 +61,6 @@ jobs:
       - template: .ci/azure-pipelines/steps-install-boost.yml
       - template: .ci/azure-pipelines/steps-cmake-build-and-test.yml
         parameters:
-          get_findboost: 'ON'
           use_conan: 'ON'
 
   - job: 'win2016_vs2017_cxx17_cmake'
@@ -80,7 +79,6 @@ jobs:
       - template: .ci/azure-pipelines/steps-cmake-build-and-test.yml
         parameters:
           cxxver: '17'
-          get_findboost: 'ON'
           use_conan: 'ON'
 
   - job: 'win2012_vs2015_cmake'
@@ -106,7 +104,6 @@ jobs:
       - template: .ci/azure-pipelines/steps-install-boost.yml
       - template: .ci/azure-pipelines/steps-cmake-build-and-test.yml
         parameters:
-          get_findboost: 'ON'
           use_conan: 'ON'
 
   - job: 'macos1013_xcode91_cmake'

--- a/.ci/azure-pipelines/steps-cmake-build-and-test.yml
+++ b/.ci/azure-pipelines/steps-cmake-build-and-test.yml
@@ -8,7 +8,6 @@ parameters:
   # defaults, if not specified
   configuration: 'Release'
   cxxver: '11'
-  get_findboost: 'OFF'
   enable_ext_io: 'OFF'
   enable_ext_numeric: 'ON'
   enable_ext_toolbox: 'ON'
@@ -19,7 +18,7 @@ steps:
       export BOOST_ROOT=$(Build.SourcesDirectory)/boost-root
       export BOOST_INCLUDEDIR=$BOOST_ROOT
       export BOOST_LIBRARYDIR=$BOOST_ROOT/lib
-      cmake -H. -B_build -DCMAKE_BUILD_TYPE=${{ parameters.configuration }} -DCMAKE_CXX_STANDARD=${{ parameters.cxxver }} -DCMAKE_VERBOSE_MAKEFILE=ON -DBoost_DEBUG=ON -DBoost_NO_SYSTEM_PATHS=ON -DGIL_DOWNLOAD_FINDBOOST=${{ parameters.get_findboost }} -DGIL_USE_CONAN=${{ parameters.use_conan }} -DGIL_ENABLE_EXT_IO=${{ parameters.enable_ext_io }} -DGIL_ENABLE_EXT_NUMERIC=${{ parameters.enable_ext_numeric }} -DGIL_ENABLE_EXT_TOOLBOX=${{ parameters.enable_ext_toolbox }}
+      cmake -H. -B_build -DCMAKE_BUILD_TYPE=${{ parameters.configuration }} -DCMAKE_CXX_STANDARD=${{ parameters.cxxver }} -DCMAKE_VERBOSE_MAKEFILE=ON -DBoost_DEBUG=ON -DBoost_NO_SYSTEM_PATHS=ON -DGIL_USE_CONAN=${{ parameters.use_conan }} -DGIL_ENABLE_EXT_IO=${{ parameters.enable_ext_io }} -DGIL_ENABLE_EXT_NUMERIC=${{ parameters.enable_ext_numeric }} -DGIL_ENABLE_EXT_TOOLBOX=${{ parameters.enable_ext_toolbox }}
     workingDirectory: $(Build.SourcesDirectory)/boost-root/libs/gil
     displayName: 'Run CMake to configure build on Unix'
     condition: ne(variables['Agent.OS'], 'Windows_NT')
@@ -28,7 +27,7 @@ steps:
       set BOOST_ROOT=$(Build.SourcesDirectory)\boost-root
       set BOOST_INCLUDEDIR=%BOOST_ROOT%
       set BOOST_LIBRARYDIR=%BOOST_ROOT%\lib
-      cmake -H. -B_build -DCMAKE_BUILD_TYPE=${{ parameters.configuration }} -DCMAKE_CXX_STANDARD=${{ parameters.cxxver }} -DCMAKE_VERBOSE_MAKEFILE=ON -DBoost_DEBUG=ON -DBoost_ADDITIONAL_VERSIONS="1.70;1.71" -DBoost_ARCHITECTURE=-x32 -DBoost_NO_SYSTEM_PATHS=ON -DGIL_DOWNLOAD_FINDBOOST=${{ parameters.get_findboost }} -DGIL_USE_CONAN=${{ parameters.use_conan }} -DGIL_ENABLE_EXT_IO=${{ parameters.enable_ext_io }} -DGIL_ENABLE_EXT_NUMERIC=${{ parameters.enable_ext_numeric }} -DGIL_ENABLE_EXT_TOOLBOX=${{ parameters.enable_ext_toolbox }}
+      cmake -H. -B_build -DCMAKE_BUILD_TYPE=${{ parameters.configuration }} -DCMAKE_CXX_STANDARD=${{ parameters.cxxver }} -DCMAKE_VERBOSE_MAKEFILE=ON -DBoost_DEBUG=ON -DBoost_ADDITIONAL_VERSIONS="1.70;1.71" -DBoost_ARCHITECTURE=-x32 -DBoost_NO_SYSTEM_PATHS=ON -DGIL_USE_CONAN=${{ parameters.use_conan }} -DGIL_ENABLE_EXT_IO=${{ parameters.enable_ext_io }} -DGIL_ENABLE_EXT_NUMERIC=${{ parameters.enable_ext_numeric }} -DGIL_ENABLE_EXT_TOOLBOX=${{ parameters.enable_ext_toolbox }}
     workingDirectory: $(Build.SourcesDirectory)/boost-root/libs/gil
     displayName: 'Run CMake to configure build on Windows'
     condition: eq(variables['Agent.OS'], 'Windows_NT')

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,6 @@ option(GIL_ENABLE_EXT_NUMERIC "Enable Numeric extension, tests and examples" ON)
 option(GIL_ENABLE_EXT_TOOLBOX "Enable Toolbox extension, tests and examples" ON)
 option(GIL_USE_CONAN "Use Conan to install dependencies" OFF)
 option(GIL_USE_CLANG_TIDY "Set CMAKE_CXX_CLANG_TIDY property on targets to enable clang-tidy linting" OFF)
-option(GIL_DOWNLOAD_FINDBOOST "Download FindBoost.cmake from latest CMake release" OFF)
 set(CMAKE_CXX_STANDARD 11 CACHE STRING "C++ standard version to use (default is 11)")
 
 #-----------------------------------------------------------------------------
@@ -100,25 +99,6 @@ add_library(gil_dependencies INTERFACE)
 # - look for default installation location
 # - look for location specified with BOOST_ROOT
 #-----------------------------------------------------------------------------
-if(CMAKE_VERSION VERSION_LESS 3.13 AND NOT GIL_DOWNLOAD_FINDBOOST)
-  message(STATUS "Boost.GIL: You are using CMake older than 3.13")
-  message(STATUS "Boost.GIL: FindBoost.cmake has likely been updated to detect newer or even not yet released Boost")
-  message(STATUS "Boost.GIL: Run CMake with -DGIL_DOWNLOAD_FINDBOOST=ON to get latest version of FindBoost.cmake")
-  message(STATUS "Boost.GIL: WARNING:")
-  message(STATUS "Boost.GIL:    Newer FindBoost.cmake may fail to find your Boost for many reasons.")
-  message(STATUS "Boost.GIL:    For example, this may be due to unrecognised toolset eg. latest Visual Studio 2017.")
-  message(STATUS "Boost.GIL:    Try run CMake with -DBoost_COMPILER=\"-vc141\" or value for your toolset.")
-endif()
-
-if(GIL_DOWNLOAD_FINDBOOST)
-  if(NOT EXISTS "${CMAKE_BINARY_DIR}/cmake/FindBoost.cmake")
-    message(STATUS "Boost.GIL: Downloading FindBoost.cmake from https://gitlab.kitware.com/cmake/ release branch")
-    file(DOWNLOAD
-      "https://gitlab.kitware.com/cmake/cmake/raw/release/Modules/FindBoost.cmake"
-      "${CMAKE_BINARY_DIR}/cmake/FindBoost.cmake")
-  endif()
-endif()
-
 if(NOT DEFINED BOOST_ROOT AND NOT DEFINED ENV{BOOST_ROOT})
   message(STATUS "Boost.GIL: Looking for Boost from current source tree and libraries from stage.")
   message(STATUS "Boost.GIL: Disable stage look-up with passing -DBOOST_ROOT=/path/to/your/boost.")

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -443,9 +443,6 @@ Here is an example of such lightweight workflow in Linux environment (Debian-bas
     **TIP:** If CMake is failing to find Boost libraries, especially built with
         `--layout=versioned`, you can try a few hacks:
 
-     - `-DGIL_DOWNLOAD_FINDBOOST=ON` to use very latest version of
-       `FindBoost.cmake` without upgrading your CMake installation.
-
      - `-DBoost_ARCHITECTURE=-x64` to help CMake find Boost 1.66 and above
         add an architecture tag to the library file names in versioned build
         The option added in CMake 3.13.0.

--- a/example/cmake/CMakeSettings.json
+++ b/example/cmake/CMakeSettings.json
@@ -28,7 +28,6 @@
         { "name": "GIL_ENABLE_EXT_TOOLBOX", "value": "ON" },
         { "name": "GIL_BUILD_EXAMPLES", "value": "ON" },
         { "name": "GIL_BUILD_HEADER_TESTS", "value": "OFF" },
-        { "name": "GIL_DOWNLOAD_FINDBOOST", "value": "ON" },
         { "name": "GIL_USE_CONAN", "value": "ON" }
       ]
     },
@@ -52,7 +51,6 @@
         { "name": "GIL_ENABLE_EXT_TOOLBOX", "value": "ON" },
         { "name": "GIL_BUILD_EXAMPLES", "value": "OFF" },
         { "name": "GIL_BUILD_HEADER_TESTS", "value": "OFF" },
-        { "name": "GIL_DOWNLOAD_FINDBOOST", "value": "ON" },
         { "name": "GIL_USE_CONAN", "value": "OFF" }
       ]
     },
@@ -76,7 +74,6 @@
         { "name": "GIL_ENABLE_EXT_TOOLBOX", "value": "ON" },
         { "name": "GIL_BUILD_EXAMPLES", "value": "ON" },
         { "name": "GIL_BUILD_HEADER_TESTS", "value": "ON" },
-        { "name": "GIL_DOWNLOAD_FINDBOOST", "value": "ON" },
         { "name": "GIL_USE_CONAN", "value": "ON" }
       ]
     },
@@ -100,7 +97,6 @@
         { "name": "GIL_ENABLE_EXT_TOOLBOX", "value": "ON" },
         { "name": "GIL_BUILD_EXAMPLES", "value": "ON" },
         { "name": "GIL_BUILD_HEADER_TESTS", "value": "ON" },
-        { "name": "GIL_DOWNLOAD_FINDBOOST", "value": "ON" },
         { "name": "GIL_USE_CONAN", "value": "ON" }
       ]
     },


### PR DESCRIPTION
Upcoming [CMake 3.15](https://cmake.org/pipermail/cmake/2019-June/069548.html) introduced more dependencies in FindBoost.cmake what makes the downloading impractical.

### Tasklist

- [x] Ensure all CI builds pass
