### PR TITLE
Add basic test for color base algorithm: static_transform

### DIFF
--- a/test/core/color_base/CMakeLists.txt
+++ b/test/core/color_base/CMakeLists.txt
@@ -7,7 +7,8 @@
 #
 foreach(_name
   concepts
-  homogeneous_color_base)
+  homogeneous_color_base
+  static_transform)
   set(_test t_core_color_base_${_name})
   set(_target test_core_color_base_${_name})
 

--- a/test/core/color_base/Jamfile
+++ b/test/core/color_base/Jamfile
@@ -15,3 +15,5 @@ project
 
 compile concepts.cpp ;
 compile homogeneous_color_base.cpp ;
+compile-fail static_transform_gray_to_rgb_fail.cpp ;
+compile-fail static_transform_rgb_to_cmyk_fail.cpp ;

--- a/test/core/color_base/static_transform.cpp
+++ b/test/core/color_base/static_transform.cpp
@@ -1,0 +1,64 @@
+//
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/gil/color_base.hpp>
+#include <boost/gil/pixel.hpp>
+#include <boost/gil/typedefs.hpp>
+
+#include <type_traits>
+
+#define BOOST_TEST_MODULE test_color_base_static_transform
+#include "unit_test.hpp"
+
+namespace gil = boost::gil;
+
+BOOST_AUTO_TEST_CASE(single_source_gray8_to_gray8)
+{
+    gil::gray8_pixel_t src{128};
+    gil::gray8_pixel_t dst{0};
+    gil::static_transform(src, dst, [](std::uint8_t src_channel) {
+        return src_channel; // copy
+    });
+    BOOST_TEST(gil::at_c<0>(src) == gil::at_c<0>(dst));
+}
+
+BOOST_AUTO_TEST_CASE(single_source_rgb8_to_rgb8)
+{
+    gil::rgb8_pixel_t src{32, 64, 128};
+    gil::rgb8_pixel_t dst{0, 0, 0};
+    gil::static_transform(src, dst, [](std::uint8_t src_channel) {
+        return src_channel; // copy
+    });
+    BOOST_TEST(gil::at_c<0>(src) == gil::at_c<0>(dst));
+    BOOST_TEST(gil::at_c<1>(src) == gil::at_c<1>(dst));
+    BOOST_TEST(gil::at_c<2>(src) == gil::at_c<2>(dst));
+}
+
+BOOST_AUTO_TEST_CASE(single_source_rgb8_to_gray8)
+{
+    // Transformation of wider space to narrower space is a valid operation
+    gil::rgb8_pixel_t  src{32,64, 128};
+    gil::gray8_pixel_t dst{0};
+    gil::static_transform(src, dst, [](std::uint8_t src_channel) {
+        return src_channel; // copy
+    });
+    BOOST_TEST(gil::at_c<0>(dst) == std::uint8_t{32});
+}
+
+BOOST_AUTO_TEST_CASE(single_source_cmyk8_to_rgb8)
+{
+    // Transformation of wider space to narrower space is a valid operation
+    gil::cmyk8_pixel_t src{16, 32, 64, 128};
+    gil::rgb8_pixel_t dst{0, 0, 0};
+    gil::static_transform(src, dst, [](std::uint8_t src_channel) {
+        return src_channel; // copy
+    });
+    BOOST_TEST(gil::at_c<0>(dst) == std::uint8_t{16});
+    BOOST_TEST(gil::at_c<1>(dst) == std::uint8_t{32});
+    BOOST_TEST(gil::at_c<2>(dst) == std::uint8_t{64});
+}
+

--- a/test/core/color_base/static_transform_gray_to_rgb_fail.cpp
+++ b/test/core/color_base/static_transform_gray_to_rgb_fail.cpp
@@ -1,0 +1,40 @@
+//
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/gil/color_base_algorithm.hpp>
+#include <boost/gil/pixel.hpp>
+#include <boost/gil/typedefs.hpp>
+
+#include <cassert>
+#include <cstdint>
+
+namespace gil = boost::gil;
+
+int main()
+{
+    // K-element index must be less than size of channel_mapping_t sequence
+    // of the *destination* color base.
+
+    // RGB (wider space) transformation to Gray (narrower space) takes only R channel value
+    {
+        gil::rgb8_pixel_t src{ 32, 64, 128 };
+        gil::gray8_pixel_t dst{ 0 };
+        gil::static_transform(src, dst, [](std::uint8_t src_channel) {
+            return src_channel; // copy
+            });
+        assert(gil::at_c<0>(dst) == std::uint16_t{32});
+    }
+
+    // Gray (narrower space) to RGB (wider space) transformation FAILS to compile
+    {
+        gil::gray8_pixel_t src{32};
+        gil::rgb8_pixel_t dst{0, 0, 0};
+        gil::static_transform(src, dst, [](std::uint8_t src_channel) {
+            return src_channel; // copy
+        });
+    }
+}

--- a/test/core/color_base/static_transform_rgb_to_cmyk_fail.cpp
+++ b/test/core/color_base/static_transform_rgb_to_cmyk_fail.cpp
@@ -1,0 +1,42 @@
+//
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/gil/color_base_algorithm.hpp>
+#include <boost/gil/pixel.hpp>
+#include <boost/gil/typedefs.hpp>
+
+#include <cassert>
+#include <cstdint>
+
+namespace gil = boost::gil;
+
+int main()
+{
+    // K-element index must be less than size of channel_mapping_t sequence
+    // of the *destination* color base.
+
+    // RGB (wider space) transformation to Gray (narrower space) takes only R channel value
+    {
+        gil::cmyk8_pixel_t src{16, 32, 64, 128};
+        gil::rgb8_pixel_t  dst{0, 0, 0};
+        gil::static_transform(src, dst, [](std::uint8_t src_channel) {
+            return src_channel; // copy
+            });
+        assert(gil::at_c<0>(dst) == std::uint16_t{16});
+        assert(gil::at_c<0>(dst) == std::uint16_t{32});
+        assert(gil::at_c<0>(dst) == std::uint16_t{64});
+    }
+
+    // RGB (narrower space) to CMYK (wider space) transformation FAILS to compile
+    {
+        gil::rgb8_pixel_t  src{16, 32, 64};
+        gil::cmyk8_pixel_t dst{0, 0, 0, 0};
+        gil::static_transform(src, dst, [](std::uint8_t src_channel) {
+            return src_channel; // copy
+        });
+    }
+}


### PR DESCRIPTION
The test also illustrates and verifies that the `static_transform` is constrained by the size of destination color base.
That is, it is applicable if the source color base has number of elements equal-to or greater-than the destination color base.

------

I am not entirely sure if this behaviour is by design or by some sort of accident. For example, it is possible that some compile-time checks are simply missing e.g. refusing the case source of wider to narrower color base and requiring equal size of both color bases.
However, this test verifies (and documents) current behaviour w/o changing it.

### Tasklist

- [x] Add test case(s)
- [x] Ensure all CI builds pass
- [x] Review and approve
