### PR TITLE
[numeric] std::extent not usable to obtain size of kernel_1d_fixed

### DIFF
--- a/include/boost/gil/extension/numeric/convolve.hpp
+++ b/include/boost/gil/extension/numeric/convolve.hpp
@@ -176,11 +176,7 @@ BOOST_FORCEINLINE
 void correlate_rows_fixed(const SrcView& src, const Kernel& kernel, const DstView& dst,
                           convolve_boundary_option option=convolve_option_extend_zero)
 {
-    using correlator = detail::correlator_k
-        <
-            std::extent<Kernel>::value,
-            PixelAccum
-        >;
+    using correlator = detail::correlator_k<Kernel::static_size, PixelAccum>;
     detail::correlate_rows_imp<PixelAccum>(
         src, kernel, dst, option, correlator{});
 }

--- a/include/boost/gil/extension/numeric/kernel.hpp
+++ b/include/boost/gil/extension/numeric/kernel.hpp
@@ -94,6 +94,10 @@ class kernel_1d_fixed : public detail::kernel_1d_adaptor<std::array<T,Size>>
 {
     using parent_t = detail::kernel_1d_adaptor<std::array<T,Size>>;
 public:
+    static constexpr std::size_t static_size = Size;
+    static_assert(static_size > 0, "kernel must have size greater than 0");
+    static_assert(static_size % 2 == 1, "kernel size must be odd to ensure validity at the center");
+
     kernel_1d_fixed() {}
     explicit kernel_1d_fixed(std::size_t center_in) : parent_t(center_in) {}
 
@@ -103,6 +107,11 @@ public:
     }
     kernel_1d_fixed(const kernel_1d_fixed& k_in)    : parent_t(k_in) {}
 };
+
+// TODO: This data member is odr-used and definition at namespace scope
+// is required by C++11. Redundant and deprecated in C++17.
+template <typename T,std::size_t Size>
+constexpr std::size_t kernel_1d_fixed<T, Size>::static_size;
 
 /// \brief reverse a kernel
 template <typename Kernel>

--- a/test/extension/numeric/Jamfile
+++ b/test/extension/numeric/Jamfile
@@ -18,5 +18,6 @@ project
 alias headers : [ generate_self_contained_headers extension/numeric ] ;
 
 run kernel.cpp ;
+compile-fail kernel_1d_fixed_even_size_fail.cpp ;
 run matrix3x2.cpp ;
 run numeric.cpp ;

--- a/test/extension/numeric/kernel.cpp
+++ b/test/extension/numeric/kernel.cpp
@@ -105,6 +105,7 @@ BOOST_AUTO_TEST_CASE(kernel_1d_fixed_parameterized_constructor_with_iterator)
     // FIXME: The constructor should throw if v.size() < k.size()
     std::vector<int> v(9);
     gil::kernel_1d_fixed<int, 9> k(v.cbegin(), 4);
+    BOOST_TEST((gil::kernel_1d_fixed<int, 9>::static_size) == 9);
     BOOST_TEST(k.center() == 4);
     BOOST_TEST(k.left_size() == 4);
     BOOST_TEST(k.right_size() == 4);
@@ -116,6 +117,7 @@ BOOST_AUTO_TEST_CASE(kernel_1d_fixed_copy_constructor)
 {
     gil::kernel_1d_fixed<int, 9> d(4);
     gil::kernel_1d_fixed<int, 9> k(d);
+    BOOST_TEST((gil::kernel_1d_fixed<int, 9>::static_size) == 9);
     BOOST_TEST(k.center() == 4);
     BOOST_TEST(k.center() == d.center());
     BOOST_TEST(k.left_size() == d.left_size());
@@ -129,6 +131,7 @@ BOOST_AUTO_TEST_CASE(kernel_1d_fixed_assignment_operator)
     gil::kernel_1d_fixed<int, 9> d(4);
     gil::kernel_1d_fixed<int, 9> k;
     k = d;
+    BOOST_TEST((gil::kernel_1d_fixed<int, 9>::static_size) == 9);
     BOOST_TEST(k.center() == 4);
     BOOST_TEST(k.center() == d.center());
     BOOST_TEST(k.left_size() == d.left_size());
@@ -139,10 +142,12 @@ BOOST_AUTO_TEST_CASE(kernel_1d_fixed_assignment_operator)
 
 BOOST_AUTO_TEST_CASE(kernel_1d_fixed_reverse_Kernel)
 {
-    gil::kernel_1d_fixed<int, 12> d(4);
-    BOOST_TEST(d.center() == 4);
+    std::array<int, 3> values = {1, 2, 3};
+    gil::kernel_1d_fixed<int, 3> d(values.begin(), 1);
+    BOOST_TEST((gil::kernel_1d_fixed<int, 3>::static_size) == 3);
+    BOOST_TEST(d == values);
+
+    std::array<int, 3> values_rev = {3, 2, 1};
     auto k = gil::reverse_kernel(d);
-    BOOST_TEST(k.center() == d.right_size());
-    // std::vector interface
-    BOOST_TEST(k.size() == d.size());
+    BOOST_TEST(k == values_rev);
 }

--- a/test/extension/numeric/kernel_1d_fixed_even_size_fail.cpp
+++ b/test/extension/numeric/kernel_1d_fixed_even_size_fail.cpp
@@ -1,0 +1,16 @@
+//
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/gil/extension/numeric/kernel.hpp>
+
+namespace gil = boost::gil;
+
+int main()
+{
+    gil::kernel_1d_fixed<int, 0> k0;
+    gil::kernel_1d_fixed<int, 4> k4;
+}


### PR DESCRIPTION
Use of `std::extent` was introduced in PR #200 but it turns out as not applicable for `std::array` or derived types (e.g. `kernel_1d_fixed`).
This led to obtaining invalid size of `kernel_1d_fixed` and erroneous results of the rows and columns convolution.
This change replaces `std::extent` with new public constant member `kernel_1d_fixed::static_size`.

Since `kernel_1d_fixed` is derived from `std::array`, the alternative could be to use `std::tuple_size` specialization for `std::array`.

Additionally, add static assertion to require that _kernel size must be odd to ensure validity at the center_.

### References

- #200 and related

### Tasklist

- [x] Add test case(s)
- [x] Ensure all CI builds pass
- [x] Review and approve
