### PR TITLE
Comparison operator changed to `>` from `>=` for threshold

### DIFF
--- a/include/boost/gil/image_processing/threshold.hpp
+++ b/include/boost/gil/image_processing/threshold.hpp
@@ -84,14 +84,16 @@ void threshold_binary
     if (direction == threshold_direction::regular)
     {
         detail::threshold_impl<source_channel_t, result_channel_t>(src_view, dst_view,
-            [threshold_value, max_value](source_channel_t px) ->
-                result_channel_t { return px >= threshold_value ? max_value : 0; });
+            [threshold_value, max_value](source_channel_t px) -> result_channel_t {
+                return px > threshold_value ? max_value : 0;
+            });
     }
     else
     {
         detail::threshold_impl<source_channel_t, result_channel_t>(src_view, dst_view,
-            [threshold_value, max_value](source_channel_t px) ->
-                result_channel_t { return px >= threshold_value ? 0 : max_value; });
+            [threshold_value, max_value](source_channel_t px) -> result_channel_t {
+                return px > threshold_value ? 0 : max_value;
+            });
     }
 }
 
@@ -152,14 +154,16 @@ void threshold_truncate
         if (direction == threshold_direction::regular)
         {
             detail::threshold_impl<source_channel_t, result_channel_t>(src_view, dst_view,
-                [threshold_value](source_channel_t px) -> result_channel_t
-                    { return px >= threshold_value ? threshold_value : px; });
+                [threshold_value](source_channel_t px) -> result_channel_t {
+                    return px > threshold_value ? threshold_value : px;
+                });
         }
         else
         {
             detail::threshold_impl<source_channel_t, result_channel_t>(src_view, dst_view,
-                [threshold_value](source_channel_t px) -> result_channel_t
-                    { return px >= threshold_value ? px : threshold_value; });
+                [threshold_value](source_channel_t px) -> result_channel_t {
+                    return px > threshold_value ? px : threshold_value;
+                });
         }
     }
     else
@@ -167,14 +171,16 @@ void threshold_truncate
         if (direction == threshold_direction::regular)
         {
             detail::threshold_impl<source_channel_t, result_channel_t>(src_view, dst_view,
-                [threshold_value](source_channel_t px) -> result_channel_t
-                    { return px >= threshold_value ? px : 0; });
+                [threshold_value](source_channel_t px) -> result_channel_t {
+                    return px > threshold_value ? px : 0;
+                });
         }
         else
         {
             detail::threshold_impl<source_channel_t, result_channel_t>(src_view, dst_view,
-                [threshold_value](source_channel_t px) -> result_channel_t
-                    { return px >= threshold_value ? 0 : px; });
+                [threshold_value](source_channel_t px) -> result_channel_t {
+                    return px > threshold_value ? 0 : px;
+                });
         }
     }
 }


### PR DESCRIPTION
### Description

*Changed comparison operator in all the lambda function in `threshold.hpp` from `>=` to `>`.*

### Reasons for the changes:
1. To provide uniform behavior with other image processing libraries.
2. Thresholds are boundary and boundaries are not included in the threshold values.
3. See https://github.com/boostorg/gil/pull/321#issuecomment-508844056


### Tasklist
- [x] Add test case(s)
- [x] Ensure all CI builds pass
- [x] Review and approve
