### PR TITLE
Apply the rule of three in memory_based_2d_locator and iterator_from_2d

### DIFF
--- a/include/boost/gil/image_view.hpp
+++ b/include/boost/gil/image_view.hpp
@@ -89,6 +89,7 @@ public:
     };
 
     image_view() : _dimensions(0,0) {}
+    image_view(image_view const& img_view) : _dimensions(img_view.dimensions()),  _pixels(img_view.pixels()) {}
     template <typename View> image_view(const View& iv)                                    : _dimensions(iv.dimensions()), _pixels(iv.pixels()) {}
 
     template <typename L2> image_view(const point_t& sz            , const L2& loc)        : _dimensions(sz),          _pixels(loc) {}

--- a/include/boost/gil/iterator_from_2d.hpp
+++ b/include/boost/gil/iterator_from_2d.hpp
@@ -67,10 +67,11 @@ public:
     bool            is_1d_traversable() const { return _p.is_1d_traversable(width()); }   // is there no gap at the end of each row?
     x_iterator&     x()                   { return _p.x(); }
 
-    iterator_from_2d(){}
+    iterator_from_2d() = default;
     iterator_from_2d(const Loc2& p, std::ptrdiff_t width, std::ptrdiff_t x=0, std::ptrdiff_t y=0) : _coords(x,y), _width(width), _p(p) {}
     iterator_from_2d(const iterator_from_2d& pit) : _coords(pit._coords), _width(pit._width), _p(pit._p) {}
     template <typename Loc> iterator_from_2d(const iterator_from_2d<Loc>& pit) : _coords(pit._coords), _width(pit._width), _p(pit._p) {}
+    iterator_from_2d& operator=(iterator_from_2d const& other) = default;
 
 private:
     template <typename Loc> friend class iterator_from_2d;

--- a/include/boost/gil/locator.hpp
+++ b/include/boost/gil/locator.hpp
@@ -261,6 +261,7 @@ public:
     memory_based_2d_locator(x_iterator xit, std::ptrdiff_t row_bytes) : _p(xit,row_bytes) {}
     template <typename X> memory_based_2d_locator(const memory_based_2d_locator<X>& pl) : _p(pl._p) {}
     memory_based_2d_locator(const memory_based_2d_locator& pl) : _p(pl._p) {}
+    memory_based_2d_locator& operator=(memory_based_2d_locator const& other) = default;
 
     bool                  operator==(const this_t& p)  const { return _p==p._p; }
 


### PR DESCRIPTION
Add copy assignment operator to `memory_based_2d_locator` and `iterator_from_2d`.
Add copy constructor to `image_view` which already has copy assignment operator.

Fix GCC 9 warning [-Wdeprecated-copy](https://gcc.gnu.org/onlinedocs/gcc-9.1.0/gcc/C_002b_002b-Dialect-Options.html#index-Wdeprecated-copy) that:

> implicit declaration of a copy constructor or copy assignment operator
> is deprecated if the class has a user-provided copy constructor or
> copy assignment operator, in C++11 and up."

### References

- https://en.wikipedia.org/wiki/Rule_of_three_(C%2B%2B_programming)

### Tasklist

- [x] Ensure all CI builds pass
- [ ] Review and approve
