### PR TITLE
Tidy up headers in gil/image_processing/ directory

### DIFF
--- a/include/boost/gil/detail/math.hpp
+++ b/include/boost/gil/detail/math.hpp
@@ -1,3 +1,17 @@
-namespace boost{ namespace gil{
-    static constexpr double pi = 3.14159265358979323846;
-}}
+//
+// Copyright 2019 Olzhas Zhumabek <anonymous.from.applecity@gmail.com>
+//
+// Use, modification and distribution are subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+#ifndef BOOST_GIL_IMAGE_PROCESSING_DETAIL_MATH_HPP
+#define BOOST_GIL_IMAGE_PROCESSING_DETAIL_MATH_HPP
+
+namespace boost { namespace gil {
+
+static constexpr double pi = 3.14159265358979323846;
+
+}} // namespace boost::gil
+
+#endif

--- a/include/boost/gil/image_processing/numeric.hpp
+++ b/include/boost/gil/image_processing/numeric.hpp
@@ -1,20 +1,30 @@
+//
+// Copyright 2019 Olzhas Zhumabek <anonymous.from.applecity@gmail.com>
+//
+// Use, modification and distribution are subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+#ifndef BOOST_GIL_IMAGE_PROCESSING_NUMERIC_HPP
+#define BOOST_GIL_IMAGE_PROCESSING_NUMERIC_HPP
+
 #include <boost/gil/detail/math.hpp>
 #include <cmath>
 
-namespace boost{ namespace gil{
+namespace boost { namespace gil {
 
 /// \defgroup ImageProcessingMath
 /// \brief Math operations for IP algorithms
 ///
-/// This is mostly handful of mathemtical
-/// operations that are required by other
+/// This is mostly handful of mathemtical operations that are required by other
 /// image processing algorithms
-
+///
 /// \brief Normalized cardinal sine
 /// \ingroup ImageProcessingMath
 ///
 /// normalized_sinc(x) = sin(pi * x) / (pi * x)
-double normalized_sinc(double x)
+///
+inline double normalized_sinc(double x)
 {
     return std::sin(x * boost::gil::pi) / (x * boost::gil::pi);
 }
@@ -26,18 +36,17 @@ double normalized_sinc(double x)
 /// x == 0: 1
 /// -a < x && x < a: 0
 /// otherwise: normalized_sinc(x) / normalized_sinc(x / a)
-double lanczos(double x, std::ptrdiff_t a)
+inline double lanczos(double x, std::ptrdiff_t a)
 {
     if (x == 0)
-    {
         return 1;
-    }
+
     if (-a < x && x < a)
-    {
-        return normalized_sinc(x)
-               / normalized_sinc(x / static_cast<double>(a));
-    }
+        return normalized_sinc(x) / normalized_sinc(x / static_cast<double>(a));
 
     return 0;
 }
-}}
+
+}} // namespace boost::gil
+
+#endif

--- a/include/boost/gil/image_processing/scaling.hpp
+++ b/include/boost/gil/image_processing/scaling.hpp
@@ -1,31 +1,37 @@
+//
+// Copyright 2019 Olzhas Zhumabek <anonymous.from.applecity@gmail.com>
+//
+// Use, modification and distribution are subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+#ifndef BOOST_GIL_IMAGE_PROCESSING_SCALING_HPP
+#define BOOST_GIL_IMAGE_PROCESSING_SCALING_HPP
+
 #include <boost/gil/image_view.hpp>
 #include <boost/gil/rgb.hpp>
 #include <boost/gil/pixel.hpp>
 #include <boost/gil/image_processing/numeric.hpp>
 
-namespace boost{ namespace gil{
+namespace boost { namespace gil {
+
 /// \defgroup ScalingAlgorithms
 /// \brief Algorthims suitable for rescaling
 ///
-/// These algorithms are used to improve image
-/// quality after image resizing is made.
-
+/// These algorithms are used to improve image quality after image resizing is made.
+///
 /// \defgroup DownScalingAlgorithms
 /// \ingroup ScalingAlgorithms
 /// \brief Algorthims suitable for downscaling
 ///
-/// These algorithms provide best results when used
-/// for downscaling. Using for upscaling will probably
-/// provide less than good results.
-
-
+/// These algorithms provide best results when used for downscaling. Using for upscaling will
+/// probably provide less than good results.
+///
 /// \brief a single step of lanczos downscaling
 /// \ingroup DownScalingAlgorithms
 ///
-/// Use this algorithm to scale down source image
-/// into a smaller image with reasonable quality.
-/// Do note that having a look at the output once
-/// is a good idea, since it might have ringing
+/// Use this algorithm to scale down source image into a smaller image with reasonable quality.
+/// Do note that having a look at the output once is a good idea, since it might have ringing
 /// artifacts.
 template <typename ImageView>
 void lanczos_at(
@@ -39,20 +45,18 @@ void lanczos_at(
 {
     using x_coord_t = typename ImageView::x_coord_t;
     using y_coord_t = typename ImageView::y_coord_t;
-    using pixel_t = typename std::remove_reference<
-                      decltype(std::declval<ImageView>()(0, 0))
-                    >::type;
+    using pixel_t = typename std::remove_reference<decltype(std::declval<ImageView>()(0, 0))>::type;
+
     // C++11 doesn't allow auto in lambdas
-    using channel_t = typename std::remove_reference<
-                        decltype(
-                            std::declval<pixel_t>().at(
-                                std::integral_constant<int, 0>{}
-                            )
-                        )
-                       >::type;
+    using channel_t = typename std::remove_reference
+        <
+            decltype(std::declval<pixel_t>().at(std::integral_constant<int, 0>{}))
+        >::type;
+
     pixel_t result_pixel;
-    boost::gil::static_transform(result_pixel, result_pixel,
-        [](channel_t) { return static_cast<channel_t>(0); });
+    static_transform(result_pixel, result_pixel, [](channel_t) {
+        return static_cast<channel_t>(0);
+    });
     auto x_zero = static_cast<x_coord_t>(0);
     auto x_one = static_cast<x_coord_t>(1);
     auto y_zero = static_cast<y_coord_t>(0);
@@ -66,16 +70,12 @@ void lanczos_at(
              x_i <= std::min(source_x + static_cast<x_coord_t>(a), input_view.width() - x_one);
              ++x_i)
         {
-            double lanczos_response = boost::gil::lanczos(source_x - x_i, a)
-                                      * boost::gil::lanczos(source_y - y_i, a);
+            double lanczos_response = lanczos(source_x - x_i, a) * lanczos(source_y - y_i, a);
             auto op = [lanczos_response](channel_t prev, channel_t next)
             {
                 return static_cast<channel_t>(prev + next * lanczos_response);
             };
-            boost::gil::static_transform(result_pixel,
-                                         input_view(source_x, source_y),
-                                         result_pixel,
-                                         op);
+            static_transform(result_pixel, input_view(source_x, source_y), result_pixel, op);
         }
     }
 
@@ -85,11 +85,9 @@ void lanczos_at(
 /// \brief Complete Lanczos algorithm
 /// \ingroup DownScalingAlgorithms
 ///
-/// This algorithm does full pass over
-/// resulting image and convolves pixels from
-/// original image. Do note that it might be a good
-/// idea to have a look at test output as there
-/// might be ringing artifacts.
+/// This algorithm does full pass over resulting image and convolves pixels from
+/// original image. Do note that it might be a good idea to have a look at test
+/// output as there might be ringing artifacts.
 /// Based on wikipedia article:
 /// https://en.wikipedia.org/wiki/Lanczos_resampling
 /// with standardinzed cardinal sin (sinc)
@@ -107,15 +105,11 @@ void scale_lanczos(ImageView input_view, ImageView output_view, std::ptrdiff_t a
     {
         for (x_coord_t x = 0; x < output_view.width(); ++x)
         {
-            boost::gil::lanczos_at(
-                input_view,
-                output_view,
-                x / scale_x,
-                y / scale_y,
-                x,
-                y,
-                a);
+            lanczos_at(input_view, output_view, x / scale_x, y / scale_y, x, y, a);
         }
     }
 }
-}}
+
+}} // namespace boost::gil
+
+#endif


### PR DESCRIPTION
Add missing `inline` specifier for tiny functions.
Add missing include guards.
Add missing copyright notice.
Remove superfluous `boost::gil::` namespace qualifiers.
Make use of 100 characters line length limit:
 - Remove superfluous newlines to avoid too much of vertical stretch.
 - Tidy up Doxygen comments.

### Tasklist

- [x] Ensure all CI builds pass

------

FYI @simmplecoder 