### PR TITLE
Add suppressive parentheses for function-like macro

### DIFF
--- a/include/boost/gil/channel_algorithm.hpp
+++ b/include/boost/gil/channel_algorithm.hpp
@@ -44,7 +44,7 @@ struct unsigned_integral_max_value
     : std::integral_constant
     <
         UnsignedIntegralChannel,
-        std::numeric_limits<UnsignedIntegralChannel>::max()
+        (std::numeric_limits<UnsignedIntegralChannel>::max)()
     >
 {};
 


### PR DESCRIPTION
### Description

This PR adds suppressing parentheses to the std::numeric_limits<UnsignedIntegralChannel>::max to avoid windows.h redefinition issues that may arise when boost/gil is used in large projects with other libraries.

### Environment

All relevant information like:

- Compiler version: Boost.Build 4.0-git
- Build settings:
- GIL Version (Git ref or `<boost/version.hpp>`): 107100

### References

*Link related issues, pull requests here, mailing list, stackoverflow, etc.*

### Tasklist

- [x] Ensure all CI builds pass
- [x] Review and approve
