### PR TITLE
[gsoc2019] Add color_spaces_are_compatible requirement as static_assert to threshold

### DIFF
--- a/include/boost/gil/image_processing/threshold.hpp
+++ b/include/boost/gil/image_processing/threshold.hpp
@@ -24,14 +24,8 @@ template
     typename DstView,
     typename Operator
 >
-void threshold_impl
-(
-    SrcView const& src_view,
-    DstView const& dst_view,
-    Operator const& threshold_op
-)
+void threshold_impl(SrcView const& src_view, DstView const& dst_view, Operator const& threshold_op)
 {
-    //template argument validation
     gil_function_requires<ImageViewConcept<SrcView>>();
     gil_function_requires<MutableImageViewConcept<DstView>>();
     gil_function_requires<ColorSpacesCompatibleConcept
@@ -39,6 +33,11 @@ void threshold_impl
         typename color_space_type<SrcView>::type,
         typename color_space_type<DstView>::type>
     >();
+    static_assert(color_spaces_are_compatible
+    <
+        typename color_space_type<SrcView>::type,
+        typename color_space_type<DstView>::type
+    >::value, "Source and destination views must have pixels with the same color space");
 
     //iterate over the image chaecking each pixel value for the threshold
     for (std::ptrdiff_t y = 0; y < src_view.height(); y++)
@@ -79,7 +78,6 @@ void threshold_binary
     //deciding output channel type and creating functor
     typedef typename channel_type<SrcView>::type source_channel_t;
     typedef typename channel_type<DstView>::type result_channel_t;
-
 
     if (direction == threshold_direction::regular)
     {

--- a/test/core/image_processing/Jamfile
+++ b/test/core/image_processing/Jamfile
@@ -13,6 +13,7 @@ project
     <include>..
     ;
 
+compile-fail threshold_color_spaces_not_compatible_fail.cpp ;
 run threshold_binary.cpp ;
 run threshold_truncate.cpp ;
 run lanczos_scaling.cpp ;

--- a/test/core/image_processing/threshold_color_spaces_not_compatible_fail.cpp
+++ b/test/core/image_processing/threshold_color_spaces_not_compatible_fail.cpp
@@ -1,0 +1,25 @@
+//
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/gil/image_processing/threshold.hpp>
+
+namespace gil = boost::gil;
+
+int main()
+{
+    // Source and destination views must have pixels with the same (compatible) color space
+    {
+        gil::rgb8_image_t src;
+        gil::gray8_image_t dst;
+        gil::threshold_binary(const_view(src), view(dst), 0, 255);
+    }
+    {
+        gil::gray8_image_t src;
+        gil::rgb8_image_t dst;
+        gil::threshold_binary(const_view(src), view(dst), 0, 255);
+    }
+}


### PR DESCRIPTION
Since use of `gil_function_requires` check is optional, it can be disabled by not defining `BOOST_GIL_USE_CONCEPT_CHECK`, we need a mandatory form of the check.

Closes #323

### Tasklist

- [x] Add compile-time tests
- [x] Ensure all CI builds pass

------

/cc @miralshah365 