### PR TITLE
[gsoc2019] Add image_processing/scaling.hpp to boost/gil.hpp

### DIFF
--- a/include/boost/gil.hpp
+++ b/include/boost/gil.hpp
@@ -44,6 +44,7 @@
 #include <boost/gil/utilities.hpp>
 #include <boost/gil/version.hpp>
 #include <boost/gil/virtual_locator.hpp>
+#include <boost/gil/image_processing/scaling.hpp>
 #include <boost/gil/image_processing/threshold.hpp>
 
 #endif


### PR DESCRIPTION
Header missing from the all-in-one `gil.hpp`

### Tasklist

- [x] Ensure all CI builds pass
