### PR TITLE
Fix error: RView identifier not found in planar_rgba_view

### DIFF
--- a/include/boost/gil/concepts/pixel_locator.hpp
+++ b/include/boost/gil/concepts/pixel_locator.hpp
@@ -11,6 +11,7 @@
 #include <boost/gil/concepts/basic.hpp>
 #include <boost/gil/concepts/concept_check.hpp>
 #include <boost/gil/concepts/fwd.hpp>
+#include <boost/gil/concepts/pixel.hpp>
 #include <boost/gil/concepts/pixel_dereference.hpp>
 #include <boost/gil/concepts/pixel_iterator.hpp>
 #include <boost/gil/concepts/point.hpp>

--- a/include/boost/gil/rgba.hpp
+++ b/include/boost/gil/rgba.hpp
@@ -38,21 +38,19 @@ using abgr_layout_t = layout<rgba_t, mp11::mp_list_c<int, 3, 2, 1, 0>>;
 
 /// \ingroup ImageViewConstructors
 /// \brief from raw RGBA planar data
-template <typename IC>
+template <typename ChannelPtr>
 inline
-auto planar_rgba_view(
-    std::size_t width, std::size_t height,
-    IC r, IC g, IC b, IC a,
+auto planar_rgba_view(std::size_t width, std::size_t height,
+    ChannelPtr r, ChannelPtr g, ChannelPtr b, ChannelPtr a,
     std::ptrdiff_t rowsize_in_bytes)
-    -> typename type_from_x_iterator<planar_pixel_iterator<IC, rgba_t> >::view_t
+    -> typename type_from_x_iterator<planar_pixel_iterator<ChannelPtr, rgba_t> >::view_t
 {
-    using view_t = typename type_from_x_iterator<planar_pixel_iterator<IC, rgba_t>>::view_t;
+    using pixel_iterator_t = planar_pixel_iterator<ChannelPtr, rgba_t>;
+    using view_t = typename type_from_x_iterator<pixel_iterator_t>::view_t;
+    using locator_t = typename view_t::locator;
 
-    return RView(
-        width, height,
-        typename view_t::locator(
-            planar_pixel_iterator<IC, rgba_t>(r, g, b, a),
-            rowsize_in_bytes));
+    locator_t loc(pixel_iterator_t(r, g, b, a), rowsize_in_bytes);
+    return view_t(width, height, loc);
 }
 
 }} // namespace boost::gil

--- a/test/core/image_view/CMakeLists.txt
+++ b/test/core/image_view/CMakeLists.txt
@@ -11,6 +11,7 @@ foreach(_name
   derived_view_type
   dynamic_step
   is_planar
+  planar_rgba_view
   view_is_basic
   view_is_mutable
   view_is_step

--- a/test/core/image_view/Jamfile
+++ b/test/core/image_view/Jamfile
@@ -24,3 +24,4 @@ compile view_type.cpp ;
 compile view_type_from_pixel.cpp ;
 
 run collection.cpp ;
+run planar_rgba_view.cpp ;

--- a/test/core/image_view/planar_rgba_view.cpp
+++ b/test/core/image_view/planar_rgba_view.cpp
@@ -1,0 +1,43 @@
+//
+// Copyright 2018 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/gil.hpp>
+
+#include <boost/core/lightweight_test.hpp>
+
+#include <cstdint>
+
+namespace gil = boost::gil;
+
+int main()
+{
+    gil::point_t d{2, 2};
+    std::uint8_t r[] = { 1, 2, 3, 4 };
+    std::uint8_t g[] = { 10, 20, 30, 40 };
+    std::uint8_t b[] = { 110, 120, 130, 140 };
+    std::uint8_t a[] = { 251, 252, 253, 254 };
+
+    auto v = gil::planar_rgba_view(d.x, d.y, r, g, b, a, sizeof(std::uint8_t) * 2);
+    BOOST_TEST(!v.empty());
+    BOOST_TEST(v.dimensions() == d);
+    BOOST_TEST(v.num_channels() == 4u);
+    BOOST_TEST(v.size() == static_cast<std::size_t>(d.x * d.y));
+
+    gil::rgba8_pixel_t const pf{1, 10, 110, 251};
+    BOOST_TEST(v.front() == pf);
+
+    gil::rgba8_pixel_t const pb{4, 40, 140, 254};
+    BOOST_TEST(v.back() == pb);
+
+    for (std::ptrdiff_t i = 0; i < v.size(); i++)
+    {
+        gil::rgba8_pixel_t const p{r[i], g[i], b[i], a[i]};
+        BOOST_TEST(v[i] == p);
+    }
+
+    return boost::report_errors();
+}


### PR DESCRIPTION
Add basic run-time test of `planar_rgba_view` function.
Add missing include of `planar_pixel_reference.hpp` also required
for successful compilation.

### References

- Fixes #331

### Tasklist

- [x] Ensure all CI builds pass
