### PR TITLE
Add first tests for convolve functions from Numeric extension

### DIFF
--- a/test/core/pixel/test_fixture.hpp
+++ b/test/core/pixel/test_fixture.hpp
@@ -15,7 +15,6 @@
 #include <boost/gil/typedefs.hpp>
 
 #include <boost/core/ignore_unused.hpp>
-#include <boost/core/typeinfo.hpp>
 #include <boost/mp11.hpp>
 #include <boost/mp11/mpl.hpp> // for compatibility with Boost.Test
 
@@ -25,40 +24,6 @@
 #include <type_traits>
 
 namespace boost { namespace gil {
-
-namespace detail {
-
-struct print_color_base
-{
-    std::ostream& os_;
-    std::size_t element_index_{0};
-    print_color_base(std::ostream& os) : os_(os) {}
-
-    template <typename Element>
-    void operator()(Element& c)
-    {
-        typename gil::promote_integral<Element>::type const v(c);
-        if (element_index_ > 0) os_ << ", ";
-        os_ << "v" << element_index_ << "=" << v;
-        ++element_index_;
-    }
-};
-
-} // namespace detail
-
-// Pixel has to implement operator<< to be printable for BOOST_TEST()
-template <typename ChannelValue, typename Layout>
-std::ostream& operator<<(std::ostream& os, pixel<ChannelValue, Layout> const& p)
-{
-    os << "pixel<"
-       << "Channel=" << boost::core::demangled_name(typeid(ChannelValue))
-       << ", Layout=" << boost::core::demangled_name(typeid(Layout))
-       << ">(";
-
-    gil::static_for_each(p, detail::print_color_base{os});
-    os << ")" << std::endl;
-    return os;
-}
 
 namespace test { namespace fixture {
 

--- a/test/extension/numeric/CMakeLists.txt
+++ b/test/extension/numeric/CMakeLists.txt
@@ -9,9 +9,13 @@
 message(STATUS "Boost.GIL: Configuring tests in test/extension/numeric")
 
 foreach(_name
+  convolve_cols
+  convolve_rows
+  convolve_2d
   kernel
   matrix3x2
-  numeric)
+  numeric
+  test_fixture)
   set(_test t_ext_numeric_${_name})
   set(_target test_ext_numeric_${_name})
 

--- a/test/extension/numeric/Jamfile
+++ b/test/extension/numeric/Jamfile
@@ -17,7 +17,12 @@ project
 
 alias headers : [ generate_self_contained_headers extension/numeric ] ;
 
+run convolve_cols.cpp ;
+run convolve_rows.cpp ;
+run convolve_2d.cpp ;
 run kernel.cpp ;
 compile-fail kernel_1d_fixed_even_size_fail.cpp ;
 run matrix3x2.cpp ;
 run numeric.cpp ;
+
+run test_fixture.cpp /boost/test//boost_unit_test_framework : : : <link>shared:<define>BOOST_TEST_DYN_LINK=1 ;

--- a/test/extension/numeric/convolve_2d.cpp
+++ b/test/extension/numeric/convolve_2d.cpp
@@ -1,0 +1,88 @@
+//
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/gil.hpp>
+#include <boost/gil/extension/numeric/convolve.hpp>
+
+#include <tuple>
+#include <type_traits>
+
+#define BOOST_TEST_MODULE test_ext_numeric_colvolve_cols
+#include "unit_test.hpp"
+#include "test_fixture.hpp"
+
+namespace gil = boost::gil;
+namespace fixture = boost::gil::test::fixture;
+
+namespace {
+
+template <typename Pixel, typename SrcView, typename Kernel, typename DstView>
+void convolve2d(SrcView const& src_view, Kernel const& kernel, DstView const& dst_view)
+{
+    gil::convolve_rows<Pixel>(src_view, kernel, dst_view);
+    gil::convolve_cols<Pixel>(src_view, kernel, dst_view);
+}
+
+} // unnamed namespace
+
+BOOST_AUTO_TEST_SUITE(convolve_2d)
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(image_1x1_kernel_1x1_identity, Image, fixture::image_types)
+{
+    auto const img = fixture::create_image<Image>(1, 1, 7);
+    Image img_out(img);
+
+    using pixel_t = typename Image::value_type;
+    using channel_t = typename gil::channel_type<pixel_t>::type;
+    auto const kernel = fixture::create_kernel<channel_t>({1});
+    convolve2d<pixel_t>(const_view(img_out), kernel, view(img_out));
+
+    // 1x1 kernel reduces convolution to multiplication
+    BOOST_TEST(gil::const_view(img).front() == gil::const_view(img_out).front());
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(image_1x1_kernel_3x3_identity, Image, fixture::image_types)
+{
+    auto const img = fixture::create_image<Image>(1, 1, 7);
+    Image img_out(img);
+
+    using pixel_t = typename Image::value_type;
+    using channel_t = typename gil::channel_type<pixel_t>::type;
+    auto const kernel = fixture::create_kernel<channel_t>({0, 0, 0, 0, 1, 0, 0, 0, 0});
+    convolve2d<pixel_t>(const_view(img_out), kernel, view(img_out));
+
+    BOOST_TEST(gil::const_view(img).front() == gil::const_view(img_out).front());
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(image_3x3_kernel_3x3_identity, Image, fixture::image_types)
+{
+    using pixel_t = typename Image::value_type;
+    using channel_t = typename gil::channel_type<pixel_t>::type;
+    auto const img = fixture::generate_image<Image>(3, 3, fixture::random_value<channel_t>{});
+    Image img_out(img);
+
+    auto const kernel = fixture::create_kernel<channel_t>({0, 0, 0, 0, 1, 0, 0, 0, 0});
+    convolve2d<pixel_t>(const_view(img_out), kernel, view(img_out));
+
+    BOOST_TEST(gil::equal_pixels(gil::const_view(img), gil::const_view(img_out)));
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(image_5x5_kernel_3x3_identity, Image, fixture::image_types)
+{
+    using pixel_t = typename Image::value_type;
+    using channel_t = typename gil::channel_type<pixel_t>::type;
+    auto const img = fixture::generate_image<Image>(5, 5, fixture::random_value<channel_t>{});
+    Image img_out(img);
+
+    auto const kernel = fixture::create_kernel<channel_t>({0, 0, 0, 0, 1, 0, 0, 0, 0});
+    convolve2d<pixel_t>(const_view(img_out), kernel, view(img_out));
+    // TODO: Test different boundary options
+
+    BOOST_TEST(gil::equal_pixels(gil::const_view(img), gil::const_view(img_out)));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/extension/numeric/convolve_cols.cpp
+++ b/test/extension/numeric/convolve_cols.cpp
@@ -1,0 +1,50 @@
+//
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/gil.hpp>
+#include <boost/gil/extension/numeric/convolve.hpp>
+
+#include <tuple>
+#include <type_traits>
+
+#define BOOST_TEST_MODULE test_ext_numeric_colvolve_cols
+#include "unit_test.hpp"
+#include "test_fixture.hpp"
+
+namespace gil = boost::gil;
+namespace fixture = boost::gil::test::fixture;
+
+BOOST_AUTO_TEST_SUITE(convolve_cols)
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(image_1x1_kernel_1x1_identity, Image, fixture::image_types)
+{
+    auto const img = fixture::create_image<Image>(1, 1, 7);
+    auto img_out = fixture::create_image<Image>(1, 1, 0);
+
+    using pixel_t = typename Image::value_type;
+    using channel_t = typename gil::channel_type<pixel_t>::type;
+    auto const kernel = fixture::create_kernel<channel_t>({1});
+    gil::convolve_cols<pixel_t>(const_view(img), kernel, view(img_out));
+
+    // 1x1 kernel reduces convolution to multiplication
+    BOOST_TEST(gil::const_view(img).front() == gil::const_view(img_out).front());
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(image_1x1_kernel_3x3_identity, Image, fixture::image_types)
+{
+    auto const img = fixture::create_image<Image>(1, 1, 7);
+    auto img_out = fixture::create_image<Image>(1, 1, 0);
+
+    using pixel_t = typename Image::value_type;
+    using channel_t = typename gil::channel_type<pixel_t>::type;
+    auto const kernel = fixture::create_kernel<channel_t>({0, 0, 0, 0, 1, 0, 0, 0, 0});
+    gil::convolve_cols<pixel_t>(const_view(img), kernel, view(img_out));
+
+    BOOST_TEST(gil::const_view(img).front() == gil::const_view(img_out).front());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/extension/numeric/convolve_rows.cpp
+++ b/test/extension/numeric/convolve_rows.cpp
@@ -1,0 +1,50 @@
+//
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/gil.hpp>
+#include <boost/gil/extension/numeric/convolve.hpp>
+
+#include <tuple>
+#include <type_traits>
+
+#define BOOST_TEST_MODULE test_ext_numeric_colvolve_rows
+#include "unit_test.hpp"
+#include "test_fixture.hpp"
+
+namespace gil = boost::gil;
+namespace fixture = boost::gil::test::fixture;
+
+BOOST_AUTO_TEST_SUITE(convolve_rows)
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(image_1x1_kernel_1x1_identity, Image, fixture::image_types)
+{
+    auto const img = fixture::create_image<Image>(1, 1, 7);
+    auto img_out = fixture::create_image<Image>(1, 1, 0);
+
+    using pixel_t = typename Image::value_type;
+    using channel_t = typename gil::channel_type<pixel_t>::type;
+    auto const kernel = fixture::create_kernel<channel_t>({1});
+    gil::convolve_rows<pixel_t>(const_view(img), kernel, view(img_out));
+
+    // 1x1 kernel reduces convolution to multiplication
+    BOOST_TEST(gil::const_view(img).front() == gil::const_view(img_out).front());
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(image_1x1_kernel_3x3_identity, Image, fixture::image_types)
+{
+    auto const img = fixture::create_image<Image>(1, 1, 7);
+    auto img_out = fixture::create_image<Image>(1, 1, 0);
+
+    using pixel_t = typename Image::value_type;
+    using channel_t = typename gil::channel_type<pixel_t>::type;
+    auto const kernel = fixture::create_kernel<channel_t>({0, 0, 0, 0, 1, 0, 0, 0, 0});
+    gil::convolve_rows<pixel_t>(const_view(img), kernel, view(img_out));
+
+    BOOST_TEST(gil::const_view(img).front() == gil::const_view(img_out).front());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/extension/numeric/test_fixture.cpp
+++ b/test/extension/numeric/test_fixture.cpp
@@ -1,0 +1,56 @@
+//
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/config.hpp>
+#include <boost/core/ignore_unused.hpp>
+
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wconversion"
+#pragma clang diagnostic ignored "-Wfloat-equal"
+#pragma clang diagnostic ignored "-Wsign-conversion"
+#elif BOOST_GCC >= 40700
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
+
+#include <boost/gil.hpp>
+
+#include <cstdint>
+
+#define BOOST_TEST_MODULE test_ext_numeric_test_fixture
+#include "unit_test.hpp"
+#include "test_fixture.hpp"
+
+namespace gil = boost::gil;
+namespace fixture = boost::gil::test::fixture;
+
+BOOST_AUTO_TEST_CASE(consecutive_value)
+{
+    fixture::consecutive_value<std::uint8_t> v(10);
+    BOOST_TEST(v() = std::uint8_t{11});
+    BOOST_TEST(v() = std::uint8_t{12});
+    BOOST_TEST(v() = std::uint8_t{13});
+}
+
+BOOST_AUTO_TEST_CASE(reverse_consecutive_value)
+{
+    fixture::reverse_consecutive_value<std::uint8_t> v(10);
+    BOOST_TEST(v() = std::uint8_t{9});
+    BOOST_TEST(v() = std::uint8_t{8});
+    BOOST_TEST(v() = std::uint8_t{7});
+}
+
+BOOST_AUTO_TEST_CASE(random_value)
+{
+    fixture::random_value<std::uint8_t> v;
+    BOOST_TEST(v() != v());
+    BOOST_TEST(v() != v());
+    BOOST_TEST(v() != v());
+}

--- a/test/extension/numeric/test_fixture.hpp
+++ b/test/extension/numeric/test_fixture.hpp
@@ -1,0 +1,132 @@
+//
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/gil.hpp>
+#include <boost/gil/extension/numeric/kernel.hpp>
+#include <boost/assert.hpp>
+
+#include <cstdint>
+#include <limits>
+#include <random>
+#include <tuple>
+#include <type_traits>
+
+namespace boost { namespace gil {
+
+namespace test { namespace fixture {
+
+using image_types = std::tuple
+<
+    gil::gray8_image_t,
+    gil::gray16_image_t,
+    gil::gray32_image_t,
+    gil::bgr8_image_t,
+    gil::bgr16_image_t,
+    gil::bgr32_image_t,
+    gil::rgb8_image_t,
+    gil::rgb16_image_t,
+    gil::rgb32_image_t,
+    gil::rgba8_image_t,
+    gil::rgba16_image_t,
+    gil::rgba32_image_t
+>;
+
+template <typename T>
+struct consecutive_value
+{
+    consecutive_value(T start) : current_(start)
+    {
+        BOOST_TEST(current_ >= 0);
+    }
+
+    T operator()()
+    {
+        BOOST_ASSERT(current_ + 1 > 0);
+        return current_++;
+    }
+
+    T current_;
+};
+
+template <typename T>
+struct reverse_consecutive_value
+{
+    reverse_consecutive_value(T start) : current_(start)
+    {
+        BOOST_ASSERT(current_ > 0);
+    }
+
+    T operator()()
+    {
+        BOOST_ASSERT(static_cast<int>(current_) + 1 >= 0);
+        return current_--;
+    }
+
+    T current_;
+};
+
+template <typename T>
+struct random_value
+{
+    static_assert(std::is_integral<T>::value, "T must be integral type");
+    static constexpr auto range_min = std::numeric_limits<T>::min();
+    static constexpr auto range_max = std::numeric_limits<T>::max();
+
+    random_value() : rng_(rd_()), uid_(range_min, range_max) {}
+
+    T operator()()
+    {
+        auto random_value = uid_(rng_);
+        BOOST_ASSERT(range_min <= random_value && random_value <= range_max);
+        return static_cast<T>(random_value);
+    }
+
+    std::random_device rd_;
+    std::mt19937 rng_;
+    std::uniform_int_distribution<typename gil::promote_integral<T>::type> uid_;
+};
+
+template <typename Image, typename Generator>
+auto generate_image(std::ptrdiff_t size_x, std::ptrdiff_t size_y, Generator&& generate) -> Image
+{
+    using pixel_t = typename Image::value_type;
+
+    Image out(size_x, size_y);
+    gil::for_each_pixel(view(out), [&generate](pixel_t& p) {
+        gil::static_generate(p, [&generate]() { return generate(); });
+    });
+
+    return out;
+}
+
+template <typename Image>
+auto create_image(std::ptrdiff_t size_x, std::ptrdiff_t size_y, int channel_value) -> Image
+{
+    using pixel_t = typename Image::value_type;
+    using channel_t = typename gil::channel_type<pixel_t>::type;
+    static_assert(std::is_integral<channel_t>::value, "channel must be integral type");
+
+    Image out(size_x, size_y);
+    gil::for_each_pixel(view(out), [&channel_value](pixel_t& p) {
+        gil::static_fill(p, static_cast<channel_t>(channel_value));
+    });
+
+    return out;
+}
+
+template <typename T>
+auto create_kernel(std::initializer_list<T> const& values)
+    -> gil::kernel_1d<T>
+{
+    static_assert(std::is_arithmetic<T>::value,
+        "kernel value type should be integral or floating-point type");
+    BOOST_ASSERT_MSG((values.size() - 1) % 2 == 0, "expected odd number of kernel values");
+    gil::kernel_1d<T> kernel(values.begin(), values.size(), (values.size() - 1) / 2);
+    return kernel;
+}
+
+}}}} // namespace boost::gil::test::fixture


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

First stab at convolution tests includes cases with the identity kernel.

Move `pixel`-s streaming facility used by Boost.Test (required  by `BOOST_TEST` macro) to the common header for re-use in other tests.

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Ensure all CI builds pass
- [x] Review and approve

------

/cc @miralshah365 