### PR TITLE
Compare float-pointing value to zero using <= operator

### DIFF
--- a/include/boost/gil/image_processing/numeric.hpp
+++ b/include/boost/gil/image_processing/numeric.hpp
@@ -38,7 +38,8 @@ inline double normalized_sinc(double x)
 /// otherwise: normalized_sinc(x) / normalized_sinc(x / a)
 inline double lanczos(double x, std::ptrdiff_t a)
 {
-    if (x == 0)
+    // means == but <= avoids compiler warning
+    if (0 <= x && x <= 0)
         return 1;
 
     if (-a < x && x < a)


### PR DESCRIPTION
### Description

Fixes `-Wfloat-equal` warning.

### Tasklist

- [x] Ensure all CI builds pass
- [x] Review and approve
