### PR TITLE
Extract GIL-specific Boost.Test utilities from test/unit_test.hpp

### DIFF
--- a/test/core/image_view/subimage_view.cpp
+++ b/test/core/image_view/subimage_view.cpp
@@ -9,6 +9,7 @@
 
 #define BOOST_TEST_MODULE test_image_view_subimage_view
 #include "unit_test.hpp"
+#include "unit_test_utility.hpp"
 #include "core/image/test_fixture.hpp"
 
 namespace gil = boost::gil;

--- a/test/core/pixel/test_fixture.cpp
+++ b/test/core/pixel/test_fixture.cpp
@@ -27,6 +27,7 @@
 
 #define BOOST_TEST_MODULE test_pixel_test_fixture
 #include "unit_test.hpp"
+#include "unit_test_utility.hpp"
 #include "test_fixture.hpp"
 
 namespace gil = boost::gil;

--- a/test/extension/dynamic_image/subimage_view.cpp
+++ b/test/extension/dynamic_image/subimage_view.cpp
@@ -10,6 +10,7 @@
 
 #define BOOST_TEST_MODULE test_ext_dynamic_image_subimage_view
 #include "unit_test.hpp"
+#include "unit_test_utility.hpp"
 #include "test_fixture.hpp"
 #include "core/image/test_fixture.hpp"
 

--- a/test/extension/numeric/convolve_2d.cpp
+++ b/test/extension/numeric/convolve_2d.cpp
@@ -13,6 +13,7 @@
 
 #define BOOST_TEST_MODULE test_ext_numeric_colvolve_2d
 #include "unit_test.hpp"
+#include "unit_test_utility.hpp"
 #include "test_fixture.hpp"
 #include "core/image/test_fixture.hpp"
 

--- a/test/extension/numeric/convolve_cols.cpp
+++ b/test/extension/numeric/convolve_cols.cpp
@@ -13,8 +13,9 @@
 
 #define BOOST_TEST_MODULE test_ext_numeric_colvolve_cols
 #include "unit_test.hpp"
-#include "core/image/test_fixture.hpp"
+#include "unit_test_utility.hpp"
 #include "test_fixture.hpp"
+#include "core/image/test_fixture.hpp"
 
 namespace gil = boost::gil;
 namespace fixture = boost::gil::test::fixture;

--- a/test/extension/numeric/convolve_rows.cpp
+++ b/test/extension/numeric/convolve_rows.cpp
@@ -13,8 +13,9 @@
 
 #define BOOST_TEST_MODULE test_ext_numeric_colvolve_rows
 #include "unit_test.hpp"
-#include "core/image/test_fixture.hpp"
+#include "unit_test_utility.hpp"
 #include "test_fixture.hpp"
+#include "core/image/test_fixture.hpp"
 
 namespace gil = boost::gil;
 namespace fixture = boost::gil::test::fixture;

--- a/test/unit_test.hpp
+++ b/test/unit_test.hpp
@@ -31,10 +31,6 @@
 #include <boost/core/typeinfo.hpp>
 #include <boost/test/unit_test.hpp>
 
-#include <boost/gil/color_base_algorithm.hpp> // static_for_each
-#include <boost/gil/pixel.hpp>
-#include <boost/gil/promote_integral.hpp>
-
 #if defined(_MSC_VER)
 #pragma warning(pop)
 #endif
@@ -49,53 +45,5 @@
 
 namespace btt = boost::test_tools;
 namespace but = boost::unit_test;
-
-namespace boost { namespace gil {
-
-namespace detail {
-
-struct print_color_base
-{
-    std::ostream& os_;
-    std::size_t element_index_{0};
-    print_color_base(std::ostream& os) : os_(os) {}
-
-    template <typename Element>
-    void operator()(Element& c)
-    {
-        typename ::boost::gil::promote_integral<Element>::type const v(c);
-        if (element_index_ > 0) os_ << ", ";
-        os_ << "v" << element_index_ << "=" << v;
-        ++element_index_;
-    }
-};
-
-} // namespace detail
-
-// Make `point` printable for BOOST_TEST()
-
-template <typename T>
-std::ostream& operator<<(std::ostream& os, point<T> const& p)
-{
-    os << "point<" << boost::core::demangled_name(typeid(T)) << ">";
-    os << "(" << p.x << ", " << p.y << ")" << std::endl;
-    return os;
-}
-
-// Make `pixel` printable for BOOST_TEST()
-template <typename ChannelValue, typename Layout>
-std::ostream& operator<<(std::ostream& os, pixel<ChannelValue, Layout> const& p)
-{
-    os << "pixel<"
-       << "Channel=" << boost::core::demangled_name(typeid(ChannelValue))
-       << ", Layout=" << boost::core::demangled_name(typeid(Layout))
-       << ">(";
-
-    static_for_each(p, detail::print_color_base{os});
-    os << ")" << std::endl;
-    return os;
-}
-
-}} // namespace boost::gil
 
 #endif

--- a/test/unit_test_utility.hpp
+++ b/test/unit_test_utility.hpp
@@ -1,0 +1,65 @@
+//
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distribtted under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#ifndef BOOST_GIL_TEST_UNIT_TEST_UTILITY_HPP
+#define BOOST_GIL_TEST_UNIT_TEST_UTILITY_HPP
+
+#include <boost/gil/color_base_algorithm.hpp> // static_for_each
+#include <boost/gil/pixel.hpp>
+#include <boost/gil/promote_integral.hpp>
+
+#include <cstdint>
+#include <ostream>
+
+namespace boost { namespace gil {
+
+namespace detail {
+
+struct print_color_base
+{
+    std::ostream& os_;
+    std::size_t element_index_{0};
+    print_color_base(std::ostream& os) : os_(os) {}
+
+    template <typename Element>
+    void operator()(Element& c)
+    {
+        typename ::boost::gil::promote_integral<Element>::type const v(c);
+        if (element_index_ > 0) os_ << ", ";
+        os_ << "v" << element_index_ << "=" << v;
+        ++element_index_;
+    }
+};
+
+} // namespace detail
+
+// Make `point` printable for BOOST_TEST()
+template <typename T>
+std::ostream& operator<<(std::ostream& os, point<T> const& p)
+{
+    os << "point<" << boost::core::demangled_name(typeid(T)) << ">";
+    os << "(" << p.x << ", " << p.y << ")" << std::endl;
+    return os;
+}
+
+// Make `pixel` printable for BOOST_TEST()
+template <typename ChannelValue, typename Layout>
+std::ostream& operator<<(std::ostream& os, pixel<ChannelValue, Layout> const& p)
+{
+    os << "pixel<"
+       << "Channel=" << boost::core::demangled_name(typeid(ChannelValue))
+       << ", Layout=" << boost::core::demangled_name(typeid(Layout))
+       << ">(";
+
+    static_for_each(p, detail::print_color_base{os});
+    os << ")" << std::endl;
+    return os;
+}
+
+}} // namespace boost::gil
+
+#endif


### PR DESCRIPTION
_Refactoring only, no functional changes._

### Description

<!-- What does this pull request do? -->

Add separate header `test/unit_test_utility.hpp` for printers and
other utilities for better integration of GIL types with Boost.Test.

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Ensure all CI builds pass
