### PR TITLE
`convolve` function added

### DIFF
--- a/include/boost/gil/extension/numeric/convolve.hpp
+++ b/include/boost/gil/extension/numeric/convolve.hpp
@@ -170,6 +170,16 @@ void convolve_cols(const SrcView& src, const Kernel& ker, const DstView& dst,
 }
 
 /// \ingroup ImageAlgorithms
+///convolve a 1D variable-size kernel along both rows and columns of an image
+template <typename PixelAccum,typename SrcView,typename Kernel,typename DstView>
+BOOST_FORCEINLINE
+void convolve(const SrcView& src, const Kernel& ker, const DstView& dst,
+                   convolve_boundary_option option=convolve_option_extend_zero) {
+    convolve_rows<PixelAccum>(src, ker, dst, option);
+    convolve_cols<PixelAccum>(dst, ker, dst, option);
+}
+
+/// \ingroup ImageAlgorithms
 ///correlate a 1D fixed-size kernel along the rows of an image
 template <typename PixelAccum, typename SrcView, typename Kernel, typename DstView>
 BOOST_FORCEINLINE


### PR DESCRIPTION
### Description
This function combines both `convolve_rows` and `convolve_cols` into a single call for user convenience.

The need for such function came into the sight when @miralshah365 was implementing `adaptive_threshold` and encountered error due to multiple calls to convolve function with the same source instead of using the result of the first convolution as the source for other. 


### Tasklist
- [ ] Add test case(s)
- [x] Ensure all CI builds pass
- [x] Review and approve
