### PR TITLE
Include <boost/gil.hpp> in examples

### DIFF
--- a/example/adaptive_threshold.cpp
+++ b/example/adaptive_threshold.cpp
@@ -5,8 +5,8 @@
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
+#include <boost/gil.hpp>
 #include <boost/gil/extension/io/png.hpp>
-#include <boost/gil/image_processing/threshold.hpp>
 
 using namespace boost::gil;
 

--- a/example/convolution.cpp
+++ b/example/convolution.cpp
@@ -4,8 +4,7 @@
 // Distributed under the Boost Software License, Version 1.0
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
-#include <boost/gil/image.hpp>
-#include <boost/gil/typedefs.hpp>
+#include <boost/gil.hpp>
 #include <boost/gil/extension/io/jpeg.hpp>
 #include <boost/gil/extension/numeric/kernel.hpp>
 #include <boost/gil/extension/numeric/convolve.hpp>

--- a/example/interleaved_ptr.cpp
+++ b/example/interleaved_ptr.cpp
@@ -23,6 +23,7 @@ namespace boost { namespace gil {
     at_c(const interleaved_ref<ChannelReference,Layout>& p);
 } }
 
+#include <boost/gil.hpp>
 #include <boost/gil/extension/io/jpeg.hpp>
 
 #include <iostream>

--- a/example/interleaved_ptr.hpp
+++ b/example/interleaved_ptr.hpp
@@ -8,7 +8,7 @@
 #ifndef BOOST_GIL_EXAMPLE_INTERLEAVED_PTR_HPP
 #define BOOST_GIL_EXAMPLE_INTERLEAVED_PTR_HPP
 
-#include <boost/gil/pixel_iterator.hpp>
+#include <boost/gil.hpp>
 #include <boost/mp11.hpp>
 
 #include <type_traits>

--- a/example/interleaved_ref.hpp
+++ b/example/interleaved_ref.hpp
@@ -8,6 +8,7 @@
 #ifndef BOOST_GIL_EXAMPLE_INTERLEAVED_REF_HPP
 #define BOOST_GIL_EXAMPLE_INTERLEAVED_REF_HPP
 
+#include <boost/gil.hpp>
 #include <boost/gil/extension/dynamic_image/dynamic_image_all.hpp>
 
 #include <type_traits>


### PR DESCRIPTION
### Description

A typical user is supposed to include the main header and to not know the library enough to include headers selectively.

### Tasklist

- [x] Ensure all CI builds pass
