### PR TITLE
Mark all non-simple build targets of extension/io as explicit

### DIFF
--- a/test/extension/io/Jamfile
+++ b/test/extension/io/Jamfile
@@ -26,7 +26,11 @@ project
     ;
 
 alias headers : [ generate_self_contained_headers extension/io ] ;
+explicit headers ;
 
+# The `simple` in names of targets, somewhat misleading, means two things:
+# - minimal set of tests
+# - set of tests that require third-party libraries which are de-facto ubiquitous
 alias simple
   : [ run all_formats_test.cpp
       : # args
@@ -96,3 +100,5 @@ alias full :
           : [ ac.check-library /libtiff//libtiff : <library>/libtiff//libtiff : <build>no ]
     ]
     ;
+
+explicit full ;


### PR DESCRIPTION
### Description

This addresses issues during the Boost regression runs, where builders only provide popular third-party libraries (i.e. libraw is missing).

### References

<!-- Any links related to this PR: issues, other PRs, mailing list threads, StackOverflow questions, etc. -->
- @mjcaisse pointed out the problem https://cpplang.slack.com/archives/C27KZLB0X/p1565130435280100

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Ensure all CI builds pass
- [ ] Review and approve
