### PR TITLE
Add implementatin of box filter and blur

### DIFF
--- a/include/boost/gil/image_processing/filter.hpp
+++ b/include/boost/gil/image_processing/filter.hpp
@@ -1,0 +1,64 @@
+//
+// Copyright 2019 Miral Shah <miralshah2211@gmail.com>
+//
+// Use, modification and distribution are subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef BOOST_GIL_IMAGE_PROCESSING_FILTER_HPP
+#define BOOST_GIL_IMAGE_PROCESSING_FILTER_HPP
+
+#include <cstddef>
+#include <vector>
+
+#include <boost/gil/image.hpp>
+#include <boost/gil/image_view.hpp>
+#include <boost/gil/extension/numeric/kernel.hpp>
+#include <boost/gil/extension/numeric/convolve.hpp>
+
+namespace boost { namespace gil {
+
+template <typename SrcView, typename DstView>
+void box_filter(
+    SrcView const& src_view,
+    DstView const& dst_view,
+    std::size_t kernel_size,
+    long int anchor = -1,
+    bool normalize=true,
+    convolve_boundary_option option = convolve_option_extend_zero
+)
+{
+    gil_function_requires<ImageViewConcept<SrcView>>();
+    gil_function_requires<MutableImageViewConcept<DstView>>();
+    static_assert(color_spaces_are_compatible
+    <
+        typename color_space_type<SrcView>::type,
+        typename color_space_type<DstView>::type
+    >::value, "Source and destination views must have pixels with the same color space");
+
+    std::vector<float> kernel_values;
+    if (normalize) { kernel_values.resize(kernel_size, 1.0f / float(kernel_size)); }
+    else { kernel_values.resize(kernel_size, 1.0f); }
+
+    if (anchor == -1) anchor = static_cast<int>(kernel_size / 2);
+    kernel_1d<float> kernel(kernel_values.begin(), kernel_size, anchor);
+
+    convolve_1d<pixel<float, typename SrcView::value_type::layout_t>>(src_view, kernel, dst_view, option);
+}
+
+template <typename SrcView, typename DstView>
+void blur(
+    SrcView const& src_view,
+    DstView const& dst_view,
+    std::size_t kernel_size,
+    long int anchor = -1,
+    convolve_boundary_option option = convolve_option_extend_zero
+)
+{
+    box_filter(src_view, dst_view, kernel_size, anchor, true, option);
+}
+
+}} //namespace boost::gil
+
+#endif // !BOOST_GIL_IMAGE_PROCESSING_FILTER_HPP

--- a/test/core/image_processing/CMakeLists.txt
+++ b/test/core/image_processing/CMakeLists.txt
@@ -31,7 +31,8 @@ foreach(_name
   lanczos_scaling
   simple_kernels
   harris
-  hessian)
+  hessian
+  box_filter)
   set(_test t_core_image_processing_${_name})
   set(_target test_core_image_processing_${_name})
 

--- a/test/core/image_processing/Jamfile
+++ b/test/core/image_processing/Jamfile
@@ -21,3 +21,4 @@ run lanczos_scaling.cpp ;
 run simple_kernels.cpp ;
 run harris.cpp ;
 run hessian.cpp ;
+run box_filter.cpp /boost/test//boost_unit_test_framework : : : <link>shared:<define>BOOST_TEST_DYN_LINK=1 ;

--- a/test/core/image_processing/box_filter.cpp
+++ b/test/core/image_processing/box_filter.cpp
@@ -1,0 +1,66 @@
+//
+// Copyright 2019 Miral Shah <miralshah2211@gmail.com>
+//
+// Use, modification and distribution are subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#define BOOST_TEST_MODULE test_image_processing_box_filter
+#include "unit_test.hpp"
+
+#include <boost/gil/image_view.hpp>
+#include <boost/gil/algorithm.hpp>
+#include <boost/gil/gray.hpp>
+#include <boost/gil/image_processing/filter.hpp>
+
+
+namespace gil = boost::gil;
+
+std::uint8_t img[] =
+{
+    0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 255, 0, 0, 0, 255, 0, 0,
+    0, 0, 0, 255, 0, 255, 0, 0, 0,
+    0, 0, 0, 0, 255, 0, 0, 0, 0,
+    0, 0, 0, 255, 0, 255, 0, 0, 0,
+    0, 0, 255, 0, 0, 0, 255, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0
+};
+
+std::uint8_t output[] =
+{
+    0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 28, 28, 28, 0, 28, 28, 28, 0,
+    0, 28, 56, 56, 56, 56, 56, 28, 0,
+    0, 28, 56, 85, 85, 85, 56, 28, 0,
+    0, 0, 56, 85, 141, 85, 56, 0, 0,
+    0, 28, 56, 85, 85, 85, 56, 28, 0,
+    0, 28, 56, 56, 56, 56, 56, 28, 0,
+    0, 28, 28, 28, 0, 28, 28, 28, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0
+};
+
+BOOST_AUTO_TEST_SUITE(filter)
+
+BOOST_AUTO_TEST_CASE(box_filter_with_default_parameters)
+{
+    gil::gray8c_view_t src_view =
+        gil::interleaved_view(9, 9, reinterpret_cast<const gil::gray8_pixel_t*>(img), 9);
+
+    gil::image<gil::gray8_pixel_t> temp_img(src_view.width(), src_view.height());
+    typename gil::image<gil::gray8_pixel_t>::view_t temp_view = view(temp_img);
+    gil::gray8_view_t dst_view(temp_view);
+
+    gil::box_filter(src_view, dst_view, 3);
+
+    gil::gray8c_view_t out_view =
+        gil::interleaved_view(9, 9, reinterpret_cast<const gil::gray8_pixel_t*>(output), 9);
+
+
+    BOOST_TEST(gil::equal_pixels(out_view, dst_view));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION


<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description
implemented `blur` function

tests added for `box_filter`

This utility will provide a way to remove noise from the image using convolution with `average` kernel(normalized and unnormalized).

It also provides `blur` function which works only with normalized mean kernels

<!-- What does this pull request do? -->

### References
closes #382
<!-- Any links related to this PR: issues, other PRs, mailing list threads, StackOverflow questions, etc. -->

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Add test case(s)
- [x] Ensure all CI builds pass
- [x] Review and approve
