### PR TITLE
Hide convolve_1d, convolve_2d and kernel_2 in namespace detail

### DIFF
--- a/example/convolve2d.cpp
+++ b/example/convolve2d.cpp
@@ -19,7 +19,7 @@ int main()
 
     std::vector<float> v(9, 1.0f / 9.0f);
     kernel_2d<float> kernel(v.begin(), v.size(), 1, 1);
-    convolve_2d(view(img), kernel, view(img_out1));
+    detail::convolve_2d(view(img), kernel, view(img_out1));
 
     //write_view("out-convolve2d.png", view(img_out), png_tag{});
     write_view("out-convolve2d.png", view(img_out1), jpeg_tag{});
@@ -29,7 +29,7 @@ int main()
     std::vector<float> v1(3, 1.0f / 3.0f);
     kernel_1d<float> kernel1(v1.begin(), v1.size(), 1);
 
-    convolve_1d<gray32f_pixel_t>(const_view(img), kernel1, view(img_out), boundary_option::extend_zero);
+    detail::convolve_1d<gray32f_pixel_t>(const_view(img), kernel1, view(img_out), boundary_option::extend_zero);
     write_view("out-convolve_option_extend_zero.png", view(img_out), png_tag{});
 
     if (equal_pixels(view(img_out1), view(img_out)))cout << "convolve_option_extend_zero" << endl;

--- a/example/convolve2d.cpp
+++ b/example/convolve2d.cpp
@@ -18,7 +18,7 @@ int main()
     gray8_image_t img_out(img.dimensions()), img_out1(img.dimensions());
 
     std::vector<float> v(9, 1.0f / 9.0f);
-    kernel_2d<float> kernel(v.begin(), v.size(), 1, 1);
+    detail::kernel_2d<float> kernel(v.begin(), v.size(), 1, 1);
     detail::convolve_2d(view(img), kernel, view(img_out1));
 
     //write_view("out-convolve2d.png", view(img_out), png_tag{});

--- a/include/boost/gil/extension/numeric/convolve.hpp
+++ b/include/boost/gil/extension/numeric/convolve.hpp
@@ -255,24 +255,6 @@ void convolve_cols(
 }
 
 /// \ingroup ImageAlgorithms
-/// \brief Convolve 1D variable-size kernel along both rows and columns of image
-/// \tparam PixelAccum TODO
-/// \tparam SrcView Models ImageViewConcept
-/// \tparam Kernel TODO
-/// \tparam DstView Models MutableImageViewConcept
-template <typename PixelAccum, typename SrcView, typename Kernel, typename DstView>
-BOOST_FORCEINLINE
-void convolve_1d(
-    SrcView const& src_view,
-    Kernel const& kernel,
-    DstView const& dst_view,
-    boundary_option option = boundary_option::extend_zero)
-{
-    convolve_rows<PixelAccum>(src_view, kernel, dst_view, option);
-    convolve_cols<PixelAccum>(dst_view, kernel, dst_view, option);
-}
-
-/// \ingroup ImageAlgorithms
 /// \brief Correlate 1D fixed-size kernel along the rows of image
 /// \tparam PixelAccum TODO
 /// \tparam SrcView Models ImageViewConcept
@@ -346,6 +328,24 @@ void convolve_cols_fixed(
 namespace detail
 {
 
+/// \ingroup ImageAlgorithms
+/// \brief Convolve 1D variable-size kernel along both rows and columns of image
+/// \tparam PixelAccum TODO
+/// \tparam SrcView Models ImageViewConcept
+/// \tparam Kernel TODO
+/// \tparam DstView Models MutableImageViewConcept
+template <typename PixelAccum, typename SrcView, typename Kernel, typename DstView>
+BOOST_FORCEINLINE
+void convolve_1d(
+    SrcView const& src_view,
+    Kernel const& kernel,
+    DstView const& dst_view,
+    boundary_option option = boundary_option::extend_zero)
+{
+    convolve_rows<PixelAccum>(src_view, kernel, dst_view, option);
+    convolve_cols<PixelAccum>(dst_view, kernel, dst_view, option);
+}
+
 template <typename SrcView, typename DstView, typename Kernel>
 void convolve_2d_impl(SrcView const& src_view, DstView const& dst_view, Kernel const& kernel)
 {
@@ -383,9 +383,6 @@ void convolve_2d_impl(SrcView const& src_view, DstView const& dst_view, Kernel c
     }
 }
 
-} //namespace detail
-
-
 /// \ingroup ImageAlgorithms
 /// \brief convolve_2d can only use convolve_option_extend_zero as convolve_boundary_option
 ///  this is the default option and cannot be changed for now
@@ -417,6 +414,6 @@ void convolve_2d(SrcView const& src_view, Kernel const& kernel, DstView const& d
     }
 }
 
-}} // namespace boost::gil
+}}} // namespace boost::gil::detail
 
 #endif

--- a/include/boost/gil/extension/numeric/convolve.hpp
+++ b/include/boost/gil/extension/numeric/convolve.hpp
@@ -365,8 +365,8 @@ void convolve_2d_impl(SrcView const& src_view, DstView const& dst_view, Kernel c
                     flip_ker_col = kernel.size() - 1 - kernel_col; // column index of flipped kernel
 
                     // index of input signal, used for checking boundary
-                    row_boundary = view_row + (kernel.center_vertical() - flip_ker_row);
-                    col_boundary = view_col + (kernel.center_horizontal() - flip_ker_col);
+                    row_boundary = view_row + (kernel.center_y() - flip_ker_row);
+                    col_boundary = view_col + (kernel.center_x() - flip_ker_col);
 
                     // ignore input samples which are out of bound
                     if (row_boundary >= 0 && row_boundary < src_view.height() &&

--- a/include/boost/gil/extension/numeric/kernel.hpp
+++ b/include/boost/gil/extension/numeric/kernel.hpp
@@ -44,8 +44,7 @@ public:
     }
 
     kernel_1d_adaptor(std::size_t size, std::size_t center)
-        : Core(size)
-        , center_(center)
+        : Core(size) , center_(center)
     {
         BOOST_ASSERT(this->size() > 0);
         BOOST_ASSERT(center_ < this->size()); // also implies `size() > 0`
@@ -164,28 +163,24 @@ class kernel_2d_adaptor : public Core
 public:
     kernel_2d_adaptor() = default;
 
-    explicit kernel_2d_adaptor(std::size_t center_vertical, std::size_t center_horizontal)
-        : center_(center_horizontal, center_vertical)
+    explicit kernel_2d_adaptor(std::size_t center_y, std::size_t center_x)
+        : center_(center_x, center_y)
     {
         BOOST_ASSERT(center_.y < this->size() && center_.x < this->size());
     }
 
-    kernel_2d_adaptor(std::size_t size, std::size_t center_vertical, std::size_t center_horizontal)
-        : Core(size * size),
-        square_size(size),
-        center_(center_horizontal, center_vertical)
+    kernel_2d_adaptor(std::size_t size, std::size_t center_y, std::size_t center_x)
+        : Core(size * size), square_size(size), center_(center_x, center_y)
     {
         BOOST_ASSERT(this->size() > 0);
-        BOOST_ASSERT(center_.y < this->size() && center_.x < this->size()); // also implies `size() > 0`
+        BOOST_ASSERT(center_.y < this->size() && center_.x < this->size()); // implies `size() > 0`
     }
 
     kernel_2d_adaptor(kernel_2d_adaptor const& other)
-        : Core(other),
-        square_size(other.square_size),
-        center_(other.center_.x, other.center_.y)
+        : Core(other), square_size(other.square_size), center_(other.center_.x, other.center_.y)
     {
         BOOST_ASSERT(this->size() > 0);
-        BOOST_ASSERT(center_.y < this->size() && center_.x < this->size()); // also implies `size() > 0`
+        BOOST_ASSERT(center_.y < this->size() && center_.x < this->size()); // implies `size() > 0`
     }
 
     kernel_2d_adaptor& operator=(kernel_2d_adaptor const& other)
@@ -221,25 +216,25 @@ public:
         return this->size() - center_.x - 1;
     }
 
-    auto center_vertical() -> std::size_t&
+    auto center_y() -> std::size_t&
     {
         BOOST_ASSERT(center_.y < this->size());
         return center_.y;
     }
 
-    auto center_vertical() const -> std::size_t const&
+    auto center_y() const -> std::size_t const&
     {
         BOOST_ASSERT(center_.y < this->size());
         return center_.y;
     }
 
-    auto center_horizontal() -> std::size_t&
+    auto center_x() -> std::size_t&
     {
         BOOST_ASSERT(center_.x < this->size());
         return center_.x;
     }
 
-    auto center_horizontal() const -> std::size_t const&
+    auto center_x() const -> std::size_t const&
     {
         BOOST_ASSERT(center_.x < this->size());
         return center_.x;
@@ -256,18 +251,15 @@ public:
         {
             throw std::out_of_range("Index out of range");
         }
-        
         return this->begin()[y * this->size() + x];
     }
 
-private:
-    using center_t = point<std::size_t>;
-    center_t center_{ 0, 0 };
-
 protected:
-    std::size_t square_size{ 0 };
+    std::size_t square_size{0};
+
+private:
+    point<std::size_t> center_{0, 0};
 };
-} //namespace detail
 
 /// \brief variable-size kernel
 template
@@ -282,19 +274,13 @@ class kernel_2d : public detail::kernel_2d_adaptor<std::vector<T, Allocator>>
 public:
 
     kernel_2d() = default;
-    kernel_2d(
-        std::size_t size,
-        std::size_t vertical_center,
-        std::size_t center_horizontal
-    ) : parent_t(size, vertical_center, center_horizontal){}
+    kernel_2d(std::size_t size,std::size_t center_y, std::size_t center_x)
+        : parent_t(size, center_y, center_x)
+    {}
 
     template <typename FwdIterator>
-    kernel_2d(
-        FwdIterator elements,
-        std::size_t size,
-        std::size_t vertical_center,
-        std::size_t center_horizontal
-    ) : parent_t(static_cast<int>(std::sqrt(size)), vertical_center, center_horizontal)
+    kernel_2d(FwdIterator elements, std::size_t size, std::size_t center_y, std::size_t center_x)
+        : parent_t(static_cast<int>(std::sqrt(size)), center_y, center_x)
     {
         detail::copy_n(elements, size, this->begin());
     }
@@ -319,18 +305,15 @@ public:
         this->square_size = Size;
     }
 
-    explicit kernel_2d_fixed(std::size_t center_vertical, std::size_t center_horizontal) :
-        parent_t(center_vertical, center_horizontal)
+    explicit kernel_2d_fixed(std::size_t center_y, std::size_t center_x) :
+        parent_t(center_y, center_x)
     {
         this->square_size = Size;
     }
 
     template <typename FwdIterator>
-    explicit kernel_2d_fixed(
-        FwdIterator elements,
-        std::size_t center_vertical,
-        std::size_t center_horizontal
-    ) : parent_t(center_vertical, center_horizontal)
+    explicit kernel_2d_fixed(FwdIterator elements, std::size_t center_y, std::size_t center_x)
+        : parent_t(center_y, center_x)
     {
         this->square_size = Size;
         detail::copy_n(elements, Size * Size, this->begin());
@@ -344,6 +327,8 @@ public:
 // is required by C++11. Redundant and deprecated in C++17.
 template <typename T, std::size_t Size>
 constexpr std::size_t kernel_2d_fixed<T, Size>::static_size;
+
+} //namespace detail
 
 /// \brief reverse a kernel
 //template <typename Kernel>

--- a/include/boost/gil/image_processing/filter.hpp
+++ b/include/boost/gil/image_processing/filter.hpp
@@ -49,12 +49,10 @@ void box_filter(
     if (anchor == -1) anchor = static_cast<int>(kernel_size / 2);
     kernel_1d<float> kernel(kernel_values.begin(), kernel_size, anchor);
 
-    convolve_1d<pixel<float, typename SrcView::value_type::layout_t>>(
-        src_view,
-        kernel,
-        dst_view,
-        option
-        );
+    detail::convolve_1d
+    <
+        pixel<float, typename SrcView::value_type::layout_t>
+    >(src_view, kernel, dst_view, option);
 }
 
 template <typename SrcView, typename DstView>

--- a/include/boost/gil/image_processing/threshold.hpp
+++ b/include/boost/gil/image_processing/threshold.hpp
@@ -424,14 +424,12 @@ void threshold_adaptive
         generate_gaussian_kernel(view(gaussian_kernel_values), 1.0);
 
         gray32f_view_t gaussian_kernel_view = view(gaussian_kernel_values);
-        kernel_2d<float> kernel(
-            kernel_size,
-            kernel_size / 2,
-            kernel_size / 2
-        );
+        detail::kernel_2d<float> kernel(kernel_size, kernel_size / 2, kernel_size / 2);
 
         std::transform(gaussian_kernel_view.begin(), gaussian_kernel_view.end(), kernel.begin(),
-            [](gray32f_pixel_t pixel) -> float {return pixel.at(std::integral_constant<int, 0>{}); }
+            [](gray32f_pixel_t pixel) -> float {
+                return pixel.at(std::integral_constant<int, 0>{});
+            }
         );
 
         detail::convolve_2d(src_view, kernel, temp_view);

--- a/include/boost/gil/image_processing/threshold.hpp
+++ b/include/boost/gil/image_processing/threshold.hpp
@@ -413,9 +413,10 @@ void threshold_adaptive
         std::vector<float> mean_kernel_values(kernel_size, 1.0f/kernel_size);
         kernel_1d<float> kernel(mean_kernel_values.begin(), kernel_size, kernel_size/2);
 
-        convolve_1d<pixel<float, typename SrcView::value_type::layout_t>>(
-            src_view, kernel, temp_view
-        );
+        detail::convolve_1d
+        <
+            pixel<float, typename SrcView::value_type::layout_t>
+        >(src_view, kernel, temp_view);
     }
     else if (method == threshold_adaptive_method::gaussian)
     {
@@ -433,7 +434,7 @@ void threshold_adaptive
             [](gray32f_pixel_t pixel) -> float {return pixel.at(std::integral_constant<int, 0>{}); }
         );
 
-        convolve_2d(src_view, kernel, temp_view);
+        detail::convolve_2d(src_view, kernel, temp_view);
     }
 
     if (direction == threshold_direction::regular)

--- a/test/extension/numeric/convolve.cpp
+++ b/test/extension/numeric/convolve.cpp
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(image_1x1_kernel_1x1_identity, Image, fixture::ima
     using pixel_t = typename Image::value_type;
     using channel_t = typename gil::channel_type<pixel_t>::type;
     auto const kernel = fixture::create_kernel<channel_t>({1});
-    gil::convolve_1d<pixel_t>(const_view(img_out), kernel, view(img_out));
+    gil::detail::convolve_1d<pixel_t>(const_view(img_out), kernel, view(img_out));
 
     // 1x1 kernel reduces convolution to multiplication
     BOOST_TEST(gil::const_view(img).front() == gil::const_view(img_out).front());
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(image_1x1_kernel_3x3_identity, Image, fixture::ima
     using pixel_t = typename Image::value_type;
     using channel_t = typename gil::channel_type<pixel_t>::type;
     auto const kernel = fixture::create_kernel<channel_t>({0, 0, 0, 0, 1, 0, 0, 0, 0});
-    gil::convolve_1d<pixel_t>(const_view(img_out), kernel, view(img_out));
+    gil::detail::convolve_1d<pixel_t>(const_view(img_out), kernel, view(img_out));
 
     BOOST_TEST(gil::const_view(img).front() == gil::const_view(img_out).front());
 }
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(image_3x3_kernel_3x3_identity, Image, fixture::ima
     Image img_out(img);
 
     auto const kernel = fixture::create_kernel<channel_t>({0, 0, 0, 0, 1, 0, 0, 0, 0});
-    gil::convolve_1d<pixel_t>(const_view(img_out), kernel, view(img_out));
+    gil::detail::convolve_1d<pixel_t>(const_view(img_out), kernel, view(img_out));
 
     BOOST_TEST(gil::equal_pixels(gil::const_view(img), gil::const_view(img_out)));
 }
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(image_5x5_kernel_3x3_identity, Image, fixture::ima
     Image img_out(img);
 
     auto const kernel = fixture::create_kernel<channel_t>({0, 0, 0, 0, 1, 0, 0, 0, 0});
-    gil::convolve_1d<pixel_t>(const_view(img_out), kernel, view(img_out));
+    gil::detail::convolve_1d<pixel_t>(const_view(img_out), kernel, view(img_out));
     // TODO: Test different boundary options
 
     BOOST_TEST(gil::equal_pixels(gil::const_view(img), gil::const_view(img_out)));

--- a/test/extension/numeric/convolve_2d.cpp
+++ b/test/extension/numeric/convolve_2d.cpp
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE(convolve_2d_with_normalized_mean_filter)
     std::vector<float> v(9, 1.0f / 9.0f);
     gil::kernel_2d<float> kernel(v.begin(), v.size(), 1, 1);
 
-    gil::convolve_2d(src_view, kernel, dst_view);
+    gil::detail::convolve_2d(src_view, kernel, dst_view);
 
     gil::gray8c_view_t out_view =
         gil::interleaved_view(9, 9, reinterpret_cast<const gil::gray8_pixel_t*>(output), 9);

--- a/test/extension/numeric/convolve_2d.cpp
+++ b/test/extension/numeric/convolve_2d.cpp
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(convolve_2d_with_normalized_mean_filter)
     gil::gray8_view_t dst_view(temp_view);
 
     std::vector<float> v(9, 1.0f / 9.0f);
-    gil::kernel_2d<float> kernel(v.begin(), v.size(), 1, 1);
+    gil::detail::kernel_2d<float> kernel(v.begin(), v.size(), 1, 1);
 
     gil::detail::convolve_2d(src_view, kernel, dst_view);
 

--- a/test/extension/numeric/kernel.cpp
+++ b/test/extension/numeric/kernel.cpp
@@ -27,12 +27,12 @@ BOOST_AUTO_TEST_CASE(kernel_1d_default_constructor)
 
 BOOST_AUTO_TEST_CASE(kernel_2d_default_constructor)
 {
-    gil::kernel_2d<int> k;
-    BOOST_TEST(k.center_vertical() == 0);
-    BOOST_TEST(k.center_horizontal() == 0);
+    gil::detail::kernel_2d<int> k;
+    BOOST_TEST(k.center_y() == 0);
+    BOOST_TEST(k.center_x() == 0);
 
     //BOOST_TEST(k.left_size() == 0);
-    //BOOST_TEST(k.right_size() == -1); 
+    //BOOST_TEST(k.right_size() == -1);
     BOOST_TEST(k.upper_size() == 0);
     BOOST_TEST(k.lower_size() == -1);
     // std::vector interface
@@ -51,9 +51,9 @@ BOOST_AUTO_TEST_CASE(kernel_1d_parameterized_constructor)
 
 BOOST_AUTO_TEST_CASE(kernel_2d_parameterized_constructor)
 {
-    gil::kernel_2d<int> k(9, 4, 4);
-    BOOST_TEST(k.center_vertical() == 4);
-    BOOST_TEST(k.center_horizontal() == 4);
+    gil::detail::kernel_2d<int> k(9, 4, 4);
+    BOOST_TEST(k.center_y() == 4);
+    BOOST_TEST(k.center_x() == 4);
     BOOST_TEST(k.left_size() == 4);
     BOOST_TEST(k.right_size() == 4);
     BOOST_TEST(k.upper_size() == 4);
@@ -76,9 +76,9 @@ BOOST_AUTO_TEST_CASE(kernel_1d_parameterized_constructor_with_iterator)
 BOOST_AUTO_TEST_CASE(kernel_2d_parameterized_constructor_with_iterator)
 {
     std::vector<int> v(81);
-    gil::kernel_2d<int> k(v.cbegin(), v.size(), 4, 4);
-    BOOST_TEST(k.center_vertical() == 4);
-    BOOST_TEST(k.center_horizontal() == 4);
+    gil::detail::kernel_2d<int> k(v.cbegin(), v.size(), 4, 4);
+    BOOST_TEST(k.center_y() == 4);
+    BOOST_TEST(k.center_x() == 4);
     BOOST_TEST(k.left_size() == 4);
     BOOST_TEST(k.right_size() == 4);
     BOOST_TEST(k.upper_size() == 4);
@@ -101,12 +101,12 @@ BOOST_AUTO_TEST_CASE(kernel_1d_copy_constructor)
 
 BOOST_AUTO_TEST_CASE(kernel_2d_copy_constructor)
 {
-    gil::kernel_2d<int> d(9, 4, 4);
-    gil::kernel_2d<int> k(d);
-    BOOST_TEST(k.center_vertical() == 4);
-    BOOST_TEST(k.center_horizontal() == 4);
-    BOOST_TEST(k.center_vertical() == d.center_vertical());
-    BOOST_TEST(k.center_horizontal() == d.center_horizontal());
+    gil::detail::kernel_2d<int> d(9, 4, 4);
+    gil::detail::kernel_2d<int> k(d);
+    BOOST_TEST(k.center_y() == 4);
+    BOOST_TEST(k.center_x() == 4);
+    BOOST_TEST(k.center_y() == d.center_y());
+    BOOST_TEST(k.center_x() == d.center_x());
     BOOST_TEST(k.left_size() == d.left_size());
     BOOST_TEST(k.right_size() == d.right_size());
     BOOST_TEST(k.lower_size() == d.lower_size());
@@ -130,13 +130,13 @@ BOOST_AUTO_TEST_CASE(kernel_1d_assignment_operator)
 
 BOOST_AUTO_TEST_CASE(kernel_2d_assignment_operator)
 {
-    gil::kernel_2d<int> d(9, 4, 4);
-    gil::kernel_2d<int> k;
+    gil::detail::kernel_2d<int> d(9, 4, 4);
+    gil::detail::kernel_2d<int> k;
     k = d;
-    BOOST_TEST(k.center_vertical() == 4);
-    BOOST_TEST(k.center_horizontal() == 4);
-    BOOST_TEST(k.center_vertical() == d.center_vertical());
-    BOOST_TEST(k.center_horizontal() == d.center_horizontal());
+    BOOST_TEST(k.center_y() == 4);
+    BOOST_TEST(k.center_x() == 4);
+    BOOST_TEST(k.center_y() == d.center_y());
+    BOOST_TEST(k.center_x() == d.center_x());
     BOOST_TEST(k.left_size() == d.left_size());
     BOOST_TEST(k.right_size() == d.right_size());
     BOOST_TEST(k.lower_size() == d.lower_size());
@@ -167,9 +167,9 @@ BOOST_AUTO_TEST_CASE(kernel_1d_fixed_default_constructor)
 
 BOOST_AUTO_TEST_CASE(kernel_2d_fixed_default_constructor)
 {
-    gil::kernel_2d_fixed<int, 9> k;
-    BOOST_TEST(k.center_horizontal() == 0);
-    BOOST_TEST(k.center_vertical() == 0);
+    gil::detail::kernel_2d_fixed<int, 9> k;
+    BOOST_TEST(k.center_x() == 0);
+    BOOST_TEST(k.center_y() == 0);
     BOOST_TEST(k.left_size() == 0);
     BOOST_TEST(k.right_size() == 8); // TODO: Why not 0 or -1 if not set?
     BOOST_TEST(k.upper_size() == 0);
@@ -190,9 +190,9 @@ BOOST_AUTO_TEST_CASE(kernel_1d_fixed_parameterized_constructor)
 
 BOOST_AUTO_TEST_CASE(kernel_2d_fixed_parameterized_constructor)
 {
-    gil::kernel_2d_fixed<int, 9> k(4, 4);
-    BOOST_TEST(k.center_horizontal() == 4);
-    BOOST_TEST(k.center_vertical() == 4);
+    gil::detail::kernel_2d_fixed<int, 9> k(4, 4);
+    BOOST_TEST(k.center_x() == 4);
+    BOOST_TEST(k.center_y() == 4);
     BOOST_TEST(k.left_size() == 4);
     BOOST_TEST(k.right_size() == 4);
     BOOST_TEST(k.upper_size() == 4);
@@ -218,10 +218,10 @@ BOOST_AUTO_TEST_CASE(kernel_2d_fixed_parameterized_constructor_with_iterator)
 {
 //    // FIXME: The constructor should throw if v.size() < k.size()
     std::array<int, 81> v;
-    gil::kernel_2d_fixed<int, 9> k(v.cbegin(), 4, 4);
-    BOOST_TEST((gil::kernel_2d_fixed<int, 9>::static_size) == 9);
-    BOOST_TEST(k.center_vertical() == 4);
-    BOOST_TEST(k.center_horizontal() == 4);
+    gil::detail::kernel_2d_fixed<int, 9> k(v.cbegin(), 4, 4);
+    BOOST_TEST((gil::detail::kernel_2d_fixed<int, 9>::static_size) == 9);
+    BOOST_TEST(k.center_y() == 4);
+    BOOST_TEST(k.center_x() == 4);
     BOOST_TEST(k.left_size() == 4);
     BOOST_TEST(k.right_size() == 4);
     BOOST_TEST(k.upper_size() == 4);
@@ -245,13 +245,13 @@ BOOST_AUTO_TEST_CASE(kernel_1d_fixed_copy_constructor)
 
 BOOST_AUTO_TEST_CASE(kernel_2d_fixed_copy_constructor)
 {
-    gil::kernel_2d_fixed<int, 9> d(4, 4);
-    gil::kernel_2d_fixed<int, 9> k(d);
-    BOOST_TEST((gil::kernel_2d_fixed<int, 9>::static_size) == 9);
-    BOOST_TEST(k.center_horizontal() == 4);
-    BOOST_TEST(k.center_vertical() == 4);
-    BOOST_TEST(k.center_horizontal() == d.center_horizontal());
-    BOOST_TEST(k.center_vertical() == d.center_vertical());
+    gil::detail::kernel_2d_fixed<int, 9> d(4, 4);
+    gil::detail::kernel_2d_fixed<int, 9> k(d);
+    BOOST_TEST((gil::detail::kernel_2d_fixed<int, 9>::static_size) == 9);
+    BOOST_TEST(k.center_x() == 4);
+    BOOST_TEST(k.center_y() == 4);
+    BOOST_TEST(k.center_x() == d.center_x());
+    BOOST_TEST(k.center_y() == d.center_y());
     BOOST_TEST(k.left_size() == d.left_size());
     BOOST_TEST(k.right_size() == d.right_size());
     BOOST_TEST(k.lower_size() == d.lower_size());
@@ -276,14 +276,14 @@ BOOST_AUTO_TEST_CASE(kernel_1d_fixed_assignment_operator)
 
 BOOST_AUTO_TEST_CASE(kernel_2d_fixed_assignment_operator)
 {
-    gil::kernel_2d_fixed<int, 9> d(4, 4);
-    gil::kernel_2d_fixed<int, 9> k;
+    gil::detail::kernel_2d_fixed<int, 9> d(4, 4);
+    gil::detail::kernel_2d_fixed<int, 9> k;
     k = d;
-    BOOST_TEST((gil::kernel_2d_fixed<int, 9>::static_size) == 9);
-    BOOST_TEST(k.center_horizontal() == 4);
-    BOOST_TEST(k.center_vertical() == 4);
-    BOOST_TEST(k.center_horizontal() == d.center_horizontal());
-    BOOST_TEST(k.center_vertical() == d.center_vertical());
+    BOOST_TEST((gil::detail::kernel_2d_fixed<int, 9>::static_size) == 9);
+    BOOST_TEST(k.center_x() == 4);
+    BOOST_TEST(k.center_y() == 4);
+    BOOST_TEST(k.center_x() == d.center_x());
+    BOOST_TEST(k.center_y() == d.center_y());
     BOOST_TEST(k.left_size() == d.left_size());
     BOOST_TEST(k.right_size() == d.right_size());
     BOOST_TEST(k.lower_size() == d.lower_size());


### PR DESCRIPTION
## Description

Following @lpranam comments on planned changes to `convolve_2d`, which will not be ready for Boost 1.72, @mloskot proposed to hide the function as implementation detail, https://lists.boost.org/boost-gil/2019/10/0316.php, until it is ready and @stefanseefeld agreed on the proposal, https://lists.boost.org/boost-gil/2019/10/0320.php.

### References

<!-- Any links related to this PR: issues, other PRs, mailing list threads, StackOverflow questions, etc. -->

- PR #347
- PR #367
- Issue #381 with planned changes by @lpranam too, https://lists.boost.org/boost-gil/2019/10/0315.php

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Ensure all CI builds pass (see https://github.com/boostorg/gil/pull/397#issuecomment-545861855)
