### PR TITLE
Fix #401: segmentation fault when reading purposely corrupted png image

### DIFF
--- a/include/boost/gil/extension/io/png/detail/read.hpp
+++ b/include/boost/gil/extension/io/png/detail/read.hpp
@@ -17,6 +17,7 @@
 #include <boost/gil/io/conversion_policies.hpp>
 #include <boost/gil/io/device.hpp>
 #include <boost/gil/io/dynamic_io_new.hpp>
+#include <boost/gil/io/error.hpp>
 #include <boost/gil/io/reader_base.hpp>
 #include <boost/gil/io/row_buffer_helper.hpp>
 #include <boost/gil/io/typedefs.hpp>
@@ -83,6 +84,12 @@ public:
     template< typename View >
     void apply( const View& view )
     {
+        // guard from errors in the following functions
+        if (setjmp( png_jmpbuf( this->get_struct() )))
+        {
+            io_error("png is invalid");
+        }
+
         // The info structures are filled at this point.
 
         // Now it's time for some transformations.
@@ -230,6 +237,12 @@ private:
             >
     void read_rows( const View& view )
     {
+        // guard from errors in the following functions
+        if (setjmp( png_jmpbuf( this->get_struct() )))
+        {
+            io_error("png is invalid");
+        }
+
         using row_buffer_helper_t = detail::row_buffer_helper_view<ImagePixel>;
 
         using it_t = typename row_buffer_helper_t::iterator_t;

--- a/test/extension/io/png_read_test.cpp
+++ b/test/extension/io/png_read_test.cpp
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE(read_with_trns_chunk_color_type_2)
 {
     // PNG 1.2: For color type 2 (truecolor), the tRNS chunk contains a single RGB color value,
     // stored in the format:
-    // 
+    //
     // Red:   2 bytes, range 0 .. (2^bitdepth)-1
     // Green: 2 bytes, range 0 .. (2^bitdepth)-1
     // Blue:  2 bytes, range 0 .. (2^bitdepth)-1
@@ -257,7 +257,7 @@ BOOST_AUTO_TEST_CASE(read_with_trns_chunk_color_type_3)
 {
     // PNG 1.2: For color type 3 (indexed color), the tRNS chunk contains a series of one-byte
     // alpha values, corresponding to entries in the PLTE chunk:
-    // 
+    //
     // Alpha for palette index 0:  1 byte
     // Alpha for palette index 1:  1 byte
     // ...etc...
@@ -726,5 +726,30 @@ BOOST_AUTO_TEST_CASE( gamma_test )
 }
 
 #endif // BOOST_GIL_IO_USE_PNG_TEST_SUITE_IMAGES
+
+
+BOOST_AUTO_TEST_CASE( corrupted_png_read_test ) {
+// taken from https://github.com/boostorg/gil/issues/401#issue-518615480
+// author: https://github.com/misos1
+
+	std::initializer_list<unsigned char> corrupt_png = {
+		0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A,
+		0x00, 0x00, 0x00, 0x0D,
+		'I', 'H', 'D', 'R',
+		0x00, 0x00, 0x04, 0x00,
+		0x00, 0x00, 0x05, 0xA9,
+		0x08, 0x02, 0x00, 0x00, 0x00,
+		0x68, 0x1B, 0xF7, 0x46,
+		0x00, 0x00, 0x00, 0x00,
+		'I', 'D', 'A', 'T',
+		0x35, 0xAF, 0x06, 0x1E,
+		0x00, 0x00, 0x00, 0x00,
+		'I', 'E', 'N', 'D',
+		0xAE, 0x42, 0x60, 0x82
+	};
+	std::stringstream ss(std::string(corrupt_png.begin(), corrupt_png.end()), std::ios_base::in | std::ios_base::binary);
+	boost::gil::rgb8_image_t img;
+	boost::gil::read_image(ss, img, boost::gil::png_tag{});
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/extension/io/png_read_test.cpp
+++ b/test/extension/io/png_read_test.cpp
@@ -749,7 +749,20 @@ BOOST_AUTO_TEST_CASE( corrupted_png_read_test ) {
 	};
 	std::stringstream ss(std::string(corrupt_png.begin(), corrupt_png.end()), std::ios_base::in | std::ios_base::binary);
 	boost::gil::rgb8_image_t img;
-	boost::gil::read_image(ss, img, boost::gil::png_tag{});
+    try
+    {
+	    boost::gil::read_image(ss, img, boost::gil::png_tag{});
+    } catch (std::ios_base::failure& exception)
+    {
+        // the exception message is "png is invalid: iostream error"
+        // is the error portable throughout stdlib implementations,
+        // or is it native to this one?
+        // the description passd is "png_is_invalid"
+        // the exact error message is thus not checked
+        return;
+    }
+
+    BOOST_FAIL("no exception was thrown, which is an error");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### Description

This pull request fixes https://github.com/boostorg/gil/issues/401#issue-518615480 by replicating the mechanism used in jpeg reader. Since on initialization the error handling mechanism is not selected, libpng uses default one, which is through setjmp/longjmp (the same as in jpeg). There is also a test that confirms the case is covered.

### References

https://github.com/boostorg/gil/issues/401#issue-518615480

### Tasklist

- [X] Fix erratic behavior
- [X] Add test case(s)
- [x] Ensure all CI builds pass
- [x] Review and approve
