### PR TITLE
Clean up BOOST_TEST_MODULE values for naming of test suites

### DIFF
--- a/test/core/Jamfile
+++ b/test/core/Jamfile
@@ -18,6 +18,8 @@ project
 alias headers_concepts : [ generate_self_contained_headers concepts ] ;
 alias headers : [ generate_self_contained_headers : concepts extension io ] ;
 
+run promote_integral.cpp /boost/test//boost_unit_test_framework : : : <link>shared:<define>BOOST_TEST_DYN_LINK=1 ;
+
 build-project point ;
 build-project channel ;
 build-project color ;
@@ -29,5 +31,3 @@ build-project image ;
 build-project image_view ;
 build-project algorithm ;
 build-project image_processing ;
-
-run promote_integral.cpp /boost/test//boost_unit_test_framework : : : <link>shared:<define>BOOST_TEST_DYN_LINK=1 ;

--- a/test/core/channel/Jamfile
+++ b/test/core/channel/Jamfile
@@ -8,21 +8,16 @@
 
 import testing ;
 
-project
-    : requirements
-    <include>..
-    <library>/boost/test//boost_unit_test_framework
-    <link>shared:<define>BOOST_TEST_DYN_LINK=1
-    ;
+compile is_channel_integral.cpp ;
 
-compile concepts.cpp ;
-run test_fixture.cpp ;
-run is_channel_integral.cpp ;
-run channel_traits.cpp ;
-run packed_channel_value.cpp ;
-run scoped_channel_value.cpp ;
-run algorithm_channel_arithmetic.cpp ;
-run algorithm_channel_convert.cpp ;
-run algorithm_channel_invert.cpp ;
-run algorithm_channel_multiply.cpp ;
-run algorithm_channel_relation.cpp ;
+run concepts.cpp /boost/test//boost_unit_test_framework : : : <link>shared:<define>BOOST_TEST_DYN_LINK=1 ;
+run channel_traits.cpp /boost/test//boost_unit_test_framework : : : <link>shared:<define>BOOST_TEST_DYN_LINK=1 ;
+run test_fixture.cpp /boost/test//boost_unit_test_framework : : : <link>shared:<define>BOOST_TEST_DYN_LINK=1 ;
+run packed_channel_value.cpp /boost/test//boost_unit_test_framework : : : <link>shared:<define>BOOST_TEST_DYN_LINK=1 ;
+run scoped_channel_value.cpp /boost/test//boost_unit_test_framework : : : <link>shared:<define>BOOST_TEST_DYN_LINK=1 ;
+
+run algorithm_channel_arithmetic.cpp /boost/test//boost_unit_test_framework : : : <link>shared:<define>BOOST_TEST_DYN_LINK=1 ;
+run algorithm_channel_convert.cpp /boost/test//boost_unit_test_framework : : : <link>shared:<define>BOOST_TEST_DYN_LINK=1 ;
+run algorithm_channel_invert.cpp /boost/test//boost_unit_test_framework : : : <link>shared:<define>BOOST_TEST_DYN_LINK=1 ;
+run algorithm_channel_multiply.cpp /boost/test//boost_unit_test_framework : : : <link>shared:<define>BOOST_TEST_DYN_LINK=1 ;
+run algorithm_channel_relation.cpp /boost/test//boost_unit_test_framework : : : <link>shared:<define>BOOST_TEST_DYN_LINK=1 ;

--- a/test/core/channel/algorithm_channel_arithmetic.cpp
+++ b/test/core/channel/algorithm_channel_arithmetic.cpp
@@ -6,12 +6,14 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
+#define BOOST_TEST_MODULE gil/test/core/channel/algorithm_channel_arithmetic
+#include "unit_test.hpp"
+
 #include <boost/gil/channel_algorithm.hpp>
+
 #include <type_traits>
 #include <utility>
 
-#define BOOST_TEST_MODULE test_algorithm_channel_arithmetic
-#include "unit_test.hpp"
 #include "test_fixture.hpp"
 
 namespace gil = boost::gil;

--- a/test/core/channel/algorithm_channel_convert.cpp
+++ b/test/core/channel/algorithm_channel_convert.cpp
@@ -6,11 +6,13 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
+#define BOOST_TEST_MODULE gil/test/core/channel/algorithm_channel_convert
+#include "unit_test.hpp"
+
 #include <boost/gil/channel_algorithm.hpp>
+
 #include <cstdint>
 
-#define BOOST_TEST_MODULE test_algorithm_channel_convert
-#include "unit_test.hpp"
 #include "test_fixture.hpp"
 
 namespace gil = boost::gil;

--- a/test/core/channel/algorithm_channel_invert.cpp
+++ b/test/core/channel/algorithm_channel_invert.cpp
@@ -6,10 +6,11 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
+#define BOOST_TEST_MODULE gil/test/core/channel/algorithm_channel_invert
+#include "unit_test.hpp"
+
 #include <boost/gil/channel_algorithm.hpp>
 
-#define BOOST_TEST_MODULE test_algorithm_channel_invert
-#include "unit_test.hpp"
 #include "test_fixture.hpp"
 
 namespace gil = boost::gil;

--- a/test/core/channel/algorithm_channel_multiply.cpp
+++ b/test/core/channel/algorithm_channel_multiply.cpp
@@ -6,10 +6,11 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
+#define BOOST_TEST_MODULE gil/test/core/channel/algorithm_channel_multiply
+#include "unit_test.hpp"
+
 #include <boost/gil/channel_algorithm.hpp>
 
-#define BOOST_TEST_MODULE test_algorithm_channel_multiply
-#include "unit_test.hpp"
 #include "test_fixture.hpp"
 
 namespace gil = boost::gil;

--- a/test/core/channel/algorithm_channel_relation.cpp
+++ b/test/core/channel/algorithm_channel_relation.cpp
@@ -6,10 +6,11 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
+#define BOOST_TEST_MODULE gil/test/core/channel/algorithm_channel_relation
+#include "unit_test.hpp"
+
 #include <boost/gil/channel_algorithm.hpp>
 
-#define BOOST_TEST_MODULE test_algorithm_channel_relation
-#include "unit_test.hpp"
 #include "test_fixture.hpp"
 
 namespace gil = boost::gil;

--- a/test/core/channel/channel_traits.cpp
+++ b/test/core/channel/channel_traits.cpp
@@ -5,13 +5,14 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
+#define BOOST_TEST_MODULE gil/test/core/channel/channel_traits
+#include "unit_test.hpp"
+
 #include <boost/gil/channel.hpp>
 #include <boost/gil/typedefs.hpp>
+
 #include <cstdint>
 #include <limits>
-
-#define BOOST_TEST_MODULE test_channel_traits
-#include "unit_test.hpp"
 
 namespace gil = boost::gil;
 

--- a/test/core/channel/concepts.cpp
+++ b/test/core/channel/concepts.cpp
@@ -6,7 +6,8 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
-#include <boost/config.hpp>
+#define BOOST_TEST_MODULE gil/test/core/channel/concepts
+#include "unit_test.hpp"
 
 #if defined(BOOST_CLANG)
 #pragma clang diagnostic push
@@ -19,10 +20,9 @@
 #endif
 
 #include <boost/gil/concepts.hpp>
+
 #include <cstdint>
 
-#define BOOST_TEST_MODULE test_channel_concepts
-#include "unit_test.hpp"
 #include "test_fixture.hpp"
 
 namespace gil = boost::gil;

--- a/test/core/channel/packed_channel_value.cpp
+++ b/test/core/channel/packed_channel_value.cpp
@@ -5,15 +5,15 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
+#define BOOST_TEST_MODULE gil/test/core/channel/packed_channel_value
+#include "unit_test.hpp"
+
 #include <boost/gil/channel.hpp>
 #include <boost/gil/typedefs.hpp>
+
 #include <cstdint>
 #include <limits>
 #include <type_traits>
-
-
-#define BOOST_TEST_MODULE test_channel_traits
-#include "unit_test.hpp"
 
 namespace gil = boost::gil;
 

--- a/test/core/channel/scoped_channel_value.cpp
+++ b/test/core/channel/scoped_channel_value.cpp
@@ -6,14 +6,15 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
+#define BOOST_TEST_MODULE gil/test/core/channel/scoped_channel_value
+#include "unit_test.hpp"
+
 #include <boost/gil/channel.hpp>
 #include <boost/gil/channel_algorithm.hpp>
 #include <boost/gil/typedefs.hpp>
+
 #include <cstdint>
 #include <limits>
-
-#define BOOST_TEST_MODULE test_scoped_channel_value
-#include "unit_test.hpp"
 
 namespace gil = boost::gil;
 

--- a/test/core/channel/test_fixture.cpp
+++ b/test/core/channel/test_fixture.cpp
@@ -5,11 +5,11 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
-#include <limits>
-
-#define BOOST_TEST_MODULE test_channel_test_fixture
+#define BOOST_TEST_MODULE gil/test/core/channel/test_fixture
 #include "unit_test.hpp"
 #include "test_fixture.hpp"
+
+#include <limits>
 
 namespace fixture = boost::gil::test::fixture;
 

--- a/test/core/color/Jamfile
+++ b/test/core/color/Jamfile
@@ -8,10 +8,5 @@
 
 import testing ;
 
-project
-    : requirements
-    <include>..
-    ;
-
 compile concepts.cpp ;
 compile color_spaces_are_compatible.cpp ;

--- a/test/core/color_base/Jamfile
+++ b/test/core/color_base/Jamfile
@@ -8,12 +8,9 @@
 
 import testing ;
 
-project
-    : requirements
-    <include>..
-    ;
-
 compile concepts.cpp ;
-compile homogeneous_color_base.cpp ;
 compile-fail static_transform_gray_to_rgb_fail.cpp ;
 compile-fail static_transform_rgb_to_cmyk_fail.cpp ;
+
+run homogeneous_color_base.cpp /boost/test//boost_unit_test_framework : : : <link>shared:<define>BOOST_TEST_DYN_LINK=1 ;
+run static_transform.cpp /boost/test//boost_unit_test_framework : : : <link>shared:<define>BOOST_TEST_DYN_LINK=1 ;

--- a/test/core/color_base/homogeneous_color_base.cpp
+++ b/test/core/color_base/homogeneous_color_base.cpp
@@ -5,6 +5,9 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
+#define BOOST_TEST_MODULE gil/test/core/color_base/homogeneous_color_base
+#include "unit_test.hpp"
+
 #include <boost/gil/color_base.hpp>
 #include <boost/gil/gray.hpp>
 #include <boost/gil/rgb.hpp>
@@ -13,9 +16,6 @@
 #include <boost/core/typeinfo.hpp>
 
 #include <type_traits>
-
-#define BOOST_TEST_MODULE test_channel_traits
-#include "unit_test.hpp"
 
 namespace gil = boost::gil;
 

--- a/test/core/color_base/static_transform.cpp
+++ b/test/core/color_base/static_transform.cpp
@@ -5,14 +5,14 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
+#define BOOST_TEST_MODULE gil/test/core/color_base/homogeneous_color_base
+#include "unit_test.hpp"
+
 #include <boost/gil/color_base.hpp>
 #include <boost/gil/pixel.hpp>
 #include <boost/gil/typedefs.hpp>
 
 #include <type_traits>
-
-#define BOOST_TEST_MODULE test_color_base_static_transform
-#include "unit_test.hpp"
 
 namespace gil = boost::gil;
 

--- a/test/core/image/Jamfile
+++ b/test/core/image/Jamfile
@@ -8,11 +8,6 @@
 
 import testing ;
 
-project
-    : requirements
-    <include>..
-    ;
-
 compile concepts.cpp ;
 
 run test_fixture.cpp /boost/test//boost_unit_test_framework : : : <link>shared:<define>BOOST_TEST_DYN_LINK=1 ;

--- a/test/core/image/test_fixture.cpp
+++ b/test/core/image/test_fixture.cpp
@@ -5,8 +5,8 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
-#include <boost/config.hpp>
-#include <boost/core/ignore_unused.hpp>
+#define BOOST_TEST_MODULE gil/test/core/image/test_fixture
+#include "unit_test.hpp"
 
 #if defined(BOOST_CLANG)
 #pragma clang diagnostic push
@@ -26,8 +26,6 @@
 #include <cstdint>
 #include <vector>
 
-#define BOOST_TEST_MODULE test_ext_numeric_test_fixture
-#include "unit_test.hpp"
 #include "test_fixture.hpp"
 
 namespace gil = boost::gil;

--- a/test/core/image_processing/Jamfile
+++ b/test/core/image_processing/Jamfile
@@ -8,11 +8,6 @@
 #
 import testing ;
 
-project
-    : requirements
-    <include>..
-    ;
-
 compile-fail threshold_color_spaces_not_compatible_fail.cpp ;
 run threshold_binary.cpp ;
 run threshold_truncate.cpp ;

--- a/test/core/image_processing/box_filter.cpp
+++ b/test/core/image_processing/box_filter.cpp
@@ -5,15 +5,13 @@
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
-
-#define BOOST_TEST_MODULE test_image_processing_box_filter
+#define BOOST_TEST_MODULE gil/test/core/image_processing/median_filter
 #include "unit_test.hpp"
 
-#include <boost/gil/image_view.hpp>
 #include <boost/gil/algorithm.hpp>
 #include <boost/gil/gray.hpp>
+#include <boost/gil/image_view.hpp>
 #include <boost/gil/image_processing/filter.hpp>
-
 
 namespace gil = boost::gil;
 

--- a/test/core/image_processing/harris.cpp
+++ b/test/core/image_processing/harris.cpp
@@ -5,11 +5,12 @@
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
-#include <boost/core/lightweight_test.hpp>
 #include <boost/gil/image.hpp>
 #include <boost/gil/image_view.hpp>
 #include <boost/gil/image_processing/numeric.hpp>
 #include <boost/gil/image_processing/harris.hpp>
+
+#include <boost/core/lightweight_test.hpp>
 
 namespace gil = boost::gil;
 

--- a/test/core/image_processing/hessian.cpp
+++ b/test/core/image_processing/hessian.cpp
@@ -5,11 +5,12 @@
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
-#include <boost/core/lightweight_test.hpp>
 #include <boost/gil/image.hpp>
 #include <boost/gil/image_view.hpp>
 #include <boost/gil/image_processing/numeric.hpp>
 #include <boost/gil/image_processing/hessian.hpp>
+
+#include <boost/core/lightweight_test.hpp>
 
 namespace gil = boost::gil;
 

--- a/test/core/image_processing/lanczos_scaling.cpp
+++ b/test/core/image_processing/lanczos_scaling.cpp
@@ -10,7 +10,6 @@
 
 #include <boost/core/lightweight_test.hpp>
 
-
 #include <iostream>
 
 namespace gil = boost::gil;

--- a/test/core/image_processing/median_filter.cpp
+++ b/test/core/image_processing/median_filter.cpp
@@ -5,15 +5,13 @@
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
-
-#define BOOST_TEST_MODULE test_image_processing_median_filter
+#define BOOST_TEST_MODULE gil/test/core/image_processing/median_filter
 #include "unit_test.hpp"
 
 #include <boost/gil/image_view.hpp>
 #include <boost/gil/algorithm.hpp>
 #include <boost/gil/gray.hpp>
 #include <boost/gil/image_processing/filter.hpp>
-
 
 namespace gil = boost::gil;
 

--- a/test/core/image_processing/simple_kernels.cpp
+++ b/test/core/image_processing/simple_kernels.cpp
@@ -5,10 +5,11 @@
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
-#include <boost/gil/image_processing/numeric.hpp>
 #include <boost/gil/image.hpp>
+#include <boost/gil/image_processing/numeric.hpp>
 #include <boost/gil/image_view.hpp>
 #include <boost/gil/typedefs.hpp>
+
 #include <boost/core/lightweight_test.hpp>
 
 namespace gil = boost::gil;

--- a/test/core/image_processing/sobel_scharr.cpp
+++ b/test/core/image_processing/sobel_scharr.cpp
@@ -1,5 +1,13 @@
-#include <boost/gil/image_processing/numeric.hpp>
+//
+// Copyright 2019 Olzhas Zhumabek <anonymous.from.applecity@gmail.com>
+//
+// Use, modification and distribution are subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
 #include <boost/gil/detail/math.hpp>
+#include <boost/gil/image_processing/numeric.hpp>
+
 #include <boost/core/lightweight_test.hpp>
 
 #include <algorithm>

--- a/test/core/image_processing/threshold_binary.cpp
+++ b/test/core/image_processing/threshold_binary.cpp
@@ -5,12 +5,12 @@
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
-#include <boost/gil/image_processing/threshold.hpp>
-#include <boost/gil/image_view.hpp>
-#include <boost/gil/algorithm.hpp>
 #include <boost/gil/gray.hpp>
-#include <boost/core/lightweight_test.hpp>
+#include <boost/gil/algorithm.hpp>
+#include <boost/gil/image_view.hpp>
+#include <boost/gil/image_processing/threshold.hpp>
 
+#include <boost/core/lightweight_test.hpp>
 
 namespace gil = boost::gil;
 

--- a/test/core/image_processing/threshold_otsu.cpp
+++ b/test/core/image_processing/threshold_otsu.cpp
@@ -5,12 +5,12 @@
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
-#include <boost/gil/image_processing/threshold.hpp>
-#include <boost/gil/image_view.hpp>
 #include <boost/gil/algorithm.hpp>
 #include <boost/gil/gray.hpp>
-#include <boost/core/lightweight_test.hpp>
+#include <boost/gil/image_view.hpp>
+#include <boost/gil/image_processing/threshold.hpp>
 
+#include <boost/core/lightweight_test.hpp>
 
 namespace gil = boost::gil;
 

--- a/test/core/image_processing/threshold_truncate.cpp
+++ b/test/core/image_processing/threshold_truncate.cpp
@@ -5,12 +5,12 @@
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
-#include <boost/gil/image_processing/threshold.hpp>
-#include <boost/gil/image_view.hpp>
 #include <boost/gil/algorithm.hpp>
 #include <boost/gil/gray.hpp>
-#include <boost/core/lightweight_test.hpp>
+#include <boost/gil/image_view.hpp>
+#include <boost/gil/image_processing/threshold.hpp>
 
+#include <boost/core/lightweight_test.hpp>
 
 namespace gil = boost::gil;
 

--- a/test/core/image_view/Jamfile
+++ b/test/core/image_view/Jamfile
@@ -8,11 +8,6 @@
 
 import testing ;
 
-project
-    : requirements
-    <include>..
-    ;
-
 compile concepts.cpp ;
 compile derived_view_type.cpp ;
 compile dynamic_step.cpp ;

--- a/test/core/image_view/subimage_view.cpp
+++ b/test/core/image_view/subimage_view.cpp
@@ -5,12 +5,13 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
+#define BOOST_TEST_MODULE gil/test/core/image_view/subimage_view
+#include "unit_test.hpp"
+
 #include <boost/gil.hpp>
 
-#define BOOST_TEST_MODULE test_image_view_subimage_view
-#include "unit_test.hpp"
-#include "unit_test_utility.hpp"
 #include "core/image/test_fixture.hpp"
+#include "unit_test_utility.hpp"
 
 namespace gil = boost::gil;
 namespace fixture = boost::gil::test::fixture;

--- a/test/core/iterator/Jamfile
+++ b/test/core/iterator/Jamfile
@@ -8,11 +8,6 @@
 
 import testing ;
 
-project
-    : requirements
-    <include>..
-    ;
-
 compile concepts.cpp ;
 compile dynamic_step.cpp ;
 compile is_planar.cpp ;

--- a/test/core/locator/Jamfile
+++ b/test/core/locator/Jamfile
@@ -8,10 +8,5 @@
 
 import testing ;
 
-project
-    : requirements
-    <include>..
-    ;
-
 compile concepts.cpp ;
 compile dynamic_step.cpp ;

--- a/test/core/pixel/Jamfile
+++ b/test/core/pixel/Jamfile
@@ -8,18 +8,13 @@
 
 import testing ;
 
-project
-    : requirements
-    <include>..
-    ;
-
 compile bit_aligned_pixel_reference.cpp ;
 compile concepts.cpp ;
 compile is_pixel.cpp ;
 compile is_planar.cpp ;
 compile num_channels.cpp ;
-compile packed_pixel.cpp ;
 compile pixel_reference_is_mutable.cpp ;
 compile pixels_are_compatible.cpp ;
 
+run packed_pixel.cpp /boost/test//boost_unit_test_framework : : : <link>shared:<define>BOOST_TEST_DYN_LINK=1 ;
 run test_fixture.cpp /boost/test//boost_unit_test_framework : : : <link>shared:<define>BOOST_TEST_DYN_LINK=1 ;

--- a/test/core/pixel/packed_pixel.cpp
+++ b/test/core/pixel/packed_pixel.cpp
@@ -5,16 +5,16 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
+#define BOOST_TEST_MODULE gil/test/core/pixel/packed_pixel
+#include "unit_test.hpp"
+
 #include <boost/gil/channel.hpp>
-#include <boost/gil/packed_pixel.hpp>
 #include <boost/gil/gray.hpp>
+#include <boost/gil/packed_pixel.hpp>
 #include <boost/gil/rgb.hpp>
 
 #include <boost/core/typeinfo.hpp>
 #include <boost/mp11.hpp>
-
-#define BOOST_TEST_MODULE test_channel_traits
-#include "unit_test.hpp"
 
 namespace gil = boost::gil;
 namespace mp11 = boost::mp11;

--- a/test/core/pixel/test_fixture.cpp
+++ b/test/core/pixel/test_fixture.cpp
@@ -5,8 +5,8 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
-#include <boost/config.hpp>
-#include <boost/core/ignore_unused.hpp>
+#define BOOST_TEST_MODULE gil/test/core/pixel/test_fixture
+#include "unit_test.hpp"
 
 #if defined(BOOST_CLANG)
 #pragma clang diagnostic push
@@ -25,10 +25,8 @@
 #include <limits>
 #include <ostream>
 
-#define BOOST_TEST_MODULE test_pixel_test_fixture
-#include "unit_test.hpp"
-#include "unit_test_utility.hpp"
 #include "test_fixture.hpp"
+#include "unit_test_utility.hpp"
 
 namespace gil = boost::gil;
 namespace fixture = boost::gil::test::fixture;

--- a/test/core/point/Jamfile
+++ b/test/core/point/Jamfile
@@ -8,11 +8,6 @@
 
 import testing ;
 
-project
-    : requirements
-    <include>..
-    ;
-
 compile concepts.cpp ;
 compile-fail multiply_by_non_arithmetic_fail.cpp ;
 run point.cpp ;

--- a/test/core/promote_integral.cpp
+++ b/test/core/promote_integral.cpp
@@ -18,6 +18,8 @@
 //
 // Uncomment to enable debugging output
 //#define BOOST_GIL_TEST_DEBUG 1
+#define BOOST_TEST_MODULE gil/test/promote_integral
+#include "unit_test.hpp"
 
 #include <boost/gil/promote_integral.hpp>
 
@@ -29,11 +31,6 @@
 #endif
 #include <limits>
 #include <string>
-
-#ifndef BOOST_TEST_MODULE
-#define BOOST_TEST_MODULE test_promote_integral
-#endif
-#include "unit_test.hpp"
 
 namespace bg = boost::gil;
 

--- a/test/extension/dynamic_image/subimage_view.cpp
+++ b/test/extension/dynamic_image/subimage_view.cpp
@@ -5,11 +5,12 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
+#define BOOST_TEST_MODULE gil/test/extension/dynamic_image/subimage_view
+#include "unit_test.hpp"
+
 #include <boost/gil.hpp>
 #include <boost/gil/extension/dynamic_image/dynamic_image_all.hpp>
 
-#define BOOST_TEST_MODULE test_ext_dynamic_image_subimage_view
-#include "unit_test.hpp"
 #include "unit_test_utility.hpp"
 #include "test_fixture.hpp"
 #include "core/image/test_fixture.hpp"

--- a/test/extension/io/all_formats_test.cpp
+++ b/test/extension/io/all_formats_test.cpp
@@ -5,15 +5,15 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
-#define BOOST_TEST_MODULE all_formats_test
+#define BOOST_TEST_MODULE gil/test/extension/io/all_formats_test
+#include "unit_test.hpp"
+
 #include <boost/gil/extension/io/png.hpp>
 #include <boost/gil/extension/io/bmp.hpp>
 #include <boost/gil/extension/io/jpeg.hpp>
 #include <boost/gil/extension/io/pnm.hpp>
 #include <boost/gil/extension/io/targa.hpp>
 #include <boost/gil/extension/io/tiff.hpp>
-
-#include <boost/test/unit_test.hpp>
 
 #include "paths.hpp"
 

--- a/test/extension/io/bmp_test.cpp
+++ b/test/extension/io/bmp_test.cpp
@@ -5,14 +5,15 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
-#define BOOST_TEST_MODULE bmp_test
+#define BOOST_TEST_MODULE gil/test/extension/io/bmp_test
+#include "unit_test.hpp"
+
 #define BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 #define BOOST_FILESYSTEM_VERSION 3
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/bmp.hpp>
 
 #include <boost/mp11.hpp>
-#include <boost/test/unit_test.hpp>
 
 #include <fstream>
 

--- a/test/extension/io/jpeg_test.cpp
+++ b/test/extension/io/jpeg_test.cpp
@@ -5,15 +5,15 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
-#define BOOST_TEST_MODULE jpeg_test
+#define BOOST_TEST_MODULE gil/test/extension/io/jpeg_test
+#include "unit_test.hpp"
+
 #define BOOST_FILESYSTEM_VERSION 3
 #define BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
-
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/jpeg.hpp>
 
 #include <boost/mp11.hpp>
-#include <boost/test/unit_test.hpp>
 
 #include <fstream>
 

--- a/test/extension/io/png_test.cpp
+++ b/test/extension/io/png_test.cpp
@@ -5,15 +5,15 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
-#define BOOST_TEST_MODULE png_test
+#define BOOST_TEST_MODULE gil/test/extension/io/png_test
+#include "unit_test.hpp"
+
 //#define BOOST_GIL_IO_PNG_FLOATING_POINT_SUPPORTED
 //#define BOOST_GIL_IO_PNG_FIXED_POINT_SUPPORTED
-
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/png.hpp>
 
 #include <boost/mp11.hpp>
-#include <boost/test/unit_test.hpp>
 
 #include <fstream>
 

--- a/test/extension/io/pnm_test.cpp
+++ b/test/extension/io/pnm_test.cpp
@@ -5,13 +5,13 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
-#define BOOST_TEST_MODULE pnm_test
+#define BOOST_TEST_MODULE gil/test/extension/io/pnm_test
+#include "unit_test.hpp"
 
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/pnm.hpp>
 
 #include <boost/mp11.hpp>
-#include <boost/test/unit_test.hpp>
 
 #include <fstream>
 

--- a/test/extension/io/raw_test.cpp
+++ b/test/extension/io/raw_test.cpp
@@ -5,15 +5,15 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
-#define BOOST_TEST_MODULE raw_test
+#define BOOST_TEST_MODULE gil/test/extension/io/raw_test
+#include "unit_test.hpp"
+
 #define BOOST_FILESYSTEM_VERSION 3
 #define BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
-
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/raw.hpp>
 
 #include <boost/mp11.hpp>
-#include <boost/test/unit_test.hpp>
 
 #include <fstream>
 

--- a/test/extension/io/targa_test.cpp
+++ b/test/extension/io/targa_test.cpp
@@ -5,14 +5,15 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
-#define BOOST_TEST_MODULE targa_test
+#define BOOST_TEST_MODULE gil/test/extension/io/targa_test
+#include "unit_test.hpp"
+
 #define BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/targa.hpp>
 
 #include <boost/mp11.hpp>
-#include <boost/test/unit_test.hpp>
 
 #include <fstream>
 

--- a/test/extension/io/tiff_test.cpp
+++ b/test/extension/io/tiff_test.cpp
@@ -5,14 +5,15 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
-#define BOOST_TEST_MODULE tiff_test
+#define BOOST_TEST_MODULE gil/test/extension/io/tiff_test
+#include "unit_test.hpp"
+
 #define BOOST_FILESYSTEM_VERSION 3
 #define BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 
 #include <boost/gil/extension/io/tiff.hpp>
 
 #include <boost/mp11.hpp>
-#include <boost/test/unit_test.hpp>
 
 #include <fstream>
 #include <sstream>

--- a/test/extension/numeric/channel_numeric_operations.cpp
+++ b/test/extension/numeric/channel_numeric_operations.cpp
@@ -5,14 +5,15 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
+#define BOOST_TEST_MODULE gil/test/extension/numeric/channel_numeric_operations
+#include "unit_test.hpp"
+
 #include <boost/gil.hpp>
 #include <boost/gil/extension/numeric/channel_numeric_operations.hpp>
 
 #include <tuple>
 #include <type_traits>
 
-#define BOOST_TEST_MODULE test_ext_numeric_pixel_numeric_operations
-#include "unit_test.hpp"
 #include "unit_test_utility.hpp"
 #include "core/channel/test_fixture.hpp"
 

--- a/test/extension/numeric/convolve.cpp
+++ b/test/extension/numeric/convolve.cpp
@@ -5,14 +5,15 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
+#define BOOST_TEST_MODULE gil/test/extension/numeric/convolve
+#include "unit_test.hpp"
+
 #include <boost/gil.hpp>
 #include <boost/gil/extension/numeric/convolve.hpp>
 
 #include <tuple>
 #include <type_traits>
 
-#define BOOST_TEST_MODULE test_ext_numeric_colvolve_2d
-#include "unit_test.hpp"
 #include "unit_test_utility.hpp"
 #include "test_fixture.hpp"
 #include "core/image/test_fixture.hpp"

--- a/test/extension/numeric/convolve_2d.cpp
+++ b/test/extension/numeric/convolve_2d.cpp
@@ -5,14 +5,13 @@
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
+#define BOOST_TEST_MODULE gil/test/extension/numeric/convolve_2d
+#include "unit_test.hpp"
 
 #include <cstddef>
 
 #include <boost/gil.hpp>
 #include <boost/gil/extension/numeric/convolve.hpp>
-
-#define BOOST_TEST_MODULE test_ext_convolve_2d
-#include "unit_test.hpp"
 
 namespace gil = boost::gil;
 

--- a/test/extension/numeric/convolve_cols.cpp
+++ b/test/extension/numeric/convolve_cols.cpp
@@ -5,14 +5,15 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
+#define BOOST_TEST_MODULE gil/test/extension/numeric/convolve_cols
+#include "unit_test.hpp"
+
 #include <boost/gil.hpp>
 #include <boost/gil/extension/numeric/convolve.hpp>
 
 #include <tuple>
 #include <type_traits>
 
-#define BOOST_TEST_MODULE test_ext_numeric_colvolve_cols
-#include "unit_test.hpp"
 #include "unit_test_utility.hpp"
 #include "test_fixture.hpp"
 #include "core/image/test_fixture.hpp"

--- a/test/extension/numeric/convolve_rows.cpp
+++ b/test/extension/numeric/convolve_rows.cpp
@@ -5,14 +5,15 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
+#define BOOST_TEST_MODULE gil/test/extension/numeric/convolve_rows
+#include "unit_test.hpp"
+
 #include <boost/gil.hpp>
 #include <boost/gil/extension/numeric/convolve.hpp>
 
 #include <tuple>
 #include <type_traits>
 
-#define BOOST_TEST_MODULE test_ext_numeric_colvolve_rows
-#include "unit_test.hpp"
 #include "unit_test_utility.hpp"
 #include "test_fixture.hpp"
 #include "core/image/test_fixture.hpp"

--- a/test/extension/numeric/extend_boundary.cpp
+++ b/test/extension/numeric/extend_boundary.cpp
@@ -5,14 +5,14 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
-
-#define BOOST_TEST_MODULE test_ext_numeric_extend_boundary
+#define BOOST_TEST_MODULE gil/test/extension/numeric/extend_boundary
 #include "unit_test.hpp"
-#include "unit_test_utility.hpp"
 
 #include <boost/gil.hpp>
 #include <boost/gil/extension/numeric/algorithm.hpp>
 #include <boost/gil/extension/numeric/convolve.hpp>
+
+#include "unit_test_utility.hpp"
 
 namespace gil = boost::gil;
 

--- a/test/extension/numeric/kernel.cpp
+++ b/test/extension/numeric/kernel.cpp
@@ -6,12 +6,12 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
+#define BOOST_TEST_MODULE gil/test/extension/numeric/kernel
+#include "unit_test.hpp"
+
 #define BOOST_DISABLE_ASSERTS 1 // kernel_1d_adaptor assertions are too strict
 #include <boost/gil/extension/numeric/kernel.hpp>
 #include <vector>
-
-#define BOOST_TEST_MODULE test_ext_numeric_kernel
-#include "unit_test.hpp"
 
 namespace gil = boost::gil;
 

--- a/test/extension/numeric/matrix3x2.cpp
+++ b/test/extension/numeric/matrix3x2.cpp
@@ -5,13 +5,13 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
+#define BOOST_TEST_MODULE gil/test/extension/numeric/matrix3x2
+#include "unit_test.hpp"
+
 #include <boost/gil/extension/numeric/affine.hpp>
 #include <boost/gil/extension/numeric/resample.hpp>
 #include <boost/gil/extension/numeric/sampler.hpp>
 #include <boost/gil.hpp>
-
-#define BOOST_TEST_MODULE test_ext_numeric_matrix3x2
-#include "unit_test.hpp"
 
 namespace gil = boost::gil;
 

--- a/test/extension/numeric/numeric.cpp
+++ b/test/extension/numeric/numeric.cpp
@@ -5,6 +5,9 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
+#define BOOST_TEST_MODULE gil/test/extension/numeric/numeric
+#include "unit_test.hpp"
+
 #include <boost/gil/image.hpp>
 #include <boost/gil/typedefs.hpp>
 
@@ -12,9 +15,6 @@
 #include <boost/gil/extension/numeric/sampler.hpp>
 
 #include <boost/assert.hpp>
-
-#define BOOST_TEST_MODULE test_ext_numeric_numeric
-#include "unit_test.hpp"
 
 using namespace boost;
 using namespace gil;

--- a/test/extension/numeric/pixel_numeric_operations.cpp
+++ b/test/extension/numeric/pixel_numeric_operations.cpp
@@ -5,14 +5,15 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
+#define BOOST_TEST_MODULE gil/test/extension/numeric/pixel_numeric_operations
+#include "unit_test.hpp"
+
 #include <boost/gil.hpp>
 #include <boost/gil/extension/numeric/pixel_numeric_operations.hpp>
 
 #include <tuple>
 #include <type_traits>
 
-#define BOOST_TEST_MODULE test_ext_numeric_pixel_numeric_operations
-#include "unit_test.hpp"
 #include "unit_test_utility.hpp"
 #include "core/image/test_fixture.hpp" // random_value
 #include "core/pixel/test_fixture.hpp"

--- a/test/unit_test.hpp
+++ b/test/unit_test.hpp
@@ -42,6 +42,8 @@
 #pragma GCC diagnostic pop
 #endif
 
+#include <boost/core/ignore_unused.hpp>
+
 namespace btt = boost::test_tools;
 namespace but = boost::unit_test;
 


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

Fix some Jamfile-s to not just `compile` some tests but also `run`, where applicable.

Remove redundant `project` definition from Jamfile-s.

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Ensure all CI builds pass
