### PR TITLE
Make b2 headers non-optional to simplify instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ The preparation involves the following steps:
     **TIP:** For more convenient path-less invocation, you can copy the `b2`
     program to a location in your `PATH`.
 
-4. Optionally, create full content of `/boost` virtual directory with
+4. Create full content of `/boost` virtual directory with
 all Boost headers linked from the individual modular Boost libraries.
 If you skip this step, executing `b2` to run tests will automatically
 create the directory with all headers required by Boost.GIL and tests.


### PR DESCRIPTION
There is a need to run 
```shell
./b2 -j8 headers
```
 otherwise, some other directory iterators do not create.

<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

<!-- What does this pull request do? -->

### References

<!-- Any links related to this PR: issues, other PRs, mailing list threads, StackOverflow questions, etc. -->

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Review and approve
