### PR TITLE
Custom PNG error handler

### DIFF
--- a/include/boost/gil/extension/io/png/detail/read.hpp
+++ b/include/boost/gil/extension/io/png/detail/read.hpp
@@ -84,12 +84,6 @@ public:
     template< typename View >
     void apply( const View& view )
     {
-        // guard from errors in the following functions
-        if (setjmp( png_jmpbuf( this->get_struct() )))
-        {
-            io_error("png is invalid");
-        }
-
         // The info structures are filled at this point.
 
         // Now it's time for some transformations.
@@ -237,12 +231,6 @@ private:
             >
     void read_rows( const View& view )
     {
-        // guard from errors in the following functions
-        if (setjmp( png_jmpbuf( this->get_struct() )))
-        {
-            io_error("png is invalid");
-        }
-
         using row_buffer_helper_t = detail::row_buffer_helper_view<ImagePixel>;
 
         using it_t = typename row_buffer_helper_t::iterator_t;

--- a/include/boost/gil/extension/io/png/detail/reader_backend.hpp
+++ b/include/boost/gil/extension/io/png/detail/reader_backend.hpp
@@ -91,6 +91,9 @@ public:
         // you can supply NULL for the last three parameters.  We also supply the
         // the compiler header file version, so that we know if the application
         // was compiled with a compatible version of the library.  REQUIRED
+        // Please read http://www.libpng.org/pub/png/book/chapter13.html
+        // and http://www.libpng.org/pub/png/book/chapter14.html
+        // on why using default handler is dangerous
         get()->_struct = png_create_read_struct( PNG_LIBPNG_VER_STRING
                                              , nullptr  // user_error_ptr
                                              , &error_handler  // user_error_fn
@@ -127,7 +130,6 @@ public:
         // Set error handling if you are using the setjmp/longjmp method (this is
         // the normal method of doing things with libpng).  REQUIRED unless you
         // set up your own error handlers in the png_create_read_struct() earlier.
-
         png_set_read_fn( get_struct()
                        , static_cast< png_voidp >( &this->_io_dev )
                        , this_t::read_data


### PR DESCRIPTION
### Description

This pull request sets custom error handler function to avoid all of the problems stated in the referenced pages, and also hopefully deals with the resource leak that happens when objects with non-trivial destructors are declared after `setjmp` part.

### References

http://www.libpng.org/pub/png/book/chapter13.html

http://www.libpng.org/pub/png/book/chapter14.html

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [ ] Find some way to bypass C ABI
- <s>Add test case(s)</s> not applicable
- [ ] Ensure all CI builds pass
- [ ] Review and approve
