### PR TITLE
Fix missing alignment default value in image constructor

### DIFF
--- a/include/boost/gil/image.hpp
+++ b/include/boost/gil/image.hpp
@@ -77,7 +77,7 @@ public:
 
     image(const point_t& dimensions,
           const Pixel& p_in,
-          std::size_t alignment,
+          std::size_t alignment = 0,
           const Alloc alloc_in = Alloc())  : _memory(nullptr), _align_in_bytes(alignment), _alloc(alloc_in)
                                            , _allocated_bytes( 0 ) {
         allocate_and_fill(dimensions, p_in);

--- a/test/core/image/CMakeLists.txt
+++ b/test/core/image/CMakeLists.txt
@@ -6,7 +6,8 @@
 # http://www.boost.org/LICENSE_1_0.txt)
 #
 foreach(_name
-  concepts)
+  concepts
+  image)
   set(_test t_core_image_${_name})
   set(_target test_core_image_${_name})
 

--- a/test/core/image/Jamfile
+++ b/test/core/image/Jamfile
@@ -9,3 +9,5 @@
 import testing ;
 
 compile concepts.cpp ;
+
+run image.cpp /boost/test//boost_unit_test_framework : : : <link>shared:<define>BOOST_TEST_DYN_LINK=1 ;

--- a/test/core/image/image.cpp
+++ b/test/core/image/image.cpp
@@ -1,0 +1,35 @@
+//
+// Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#define BOOST_TEST_MODULE gil/test/core/image/image
+#include "unit_test.hpp"
+
+#include <boost/gil.hpp>
+
+#include "test_fixture.hpp"
+#include "core/pixel/test_fixture.hpp"
+
+namespace gil = boost::gil;
+namespace fixture = boost::gil::test::fixture;
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(constructor_with_dimensions_pixel, Image, fixture::image_types)
+{
+    gil::point_t const dimensions{256, 128};
+    {
+        using pixel_t = typename Image::view_t::value_type;
+        pixel_t const rnd_pixel = fixture::pixel_generator<pixel_t>::random();
+
+        Image image(dimensions, rnd_pixel);
+        BOOST_TEST(image.width() == dimensions.x);
+        BOOST_TEST(image.height() == dimensions.y);
+
+        for (pixel_t const& p : gil::view(image))
+        {
+            BOOST_TEST(p == rnd_pixel);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

Fixes missing default value for `alignment` argument of one of the `image` constructor overloads.

### References

Fixes #424 blocking PR #423

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Add test case(s)
- [x] Ensure all CI builds pass

