### PR TITLE
Move jpeg_finish_compress out of destructor

### DIFF
--- a/include/boost/gil/extension/io/jpeg/detail/write.hpp
+++ b/include/boost/gil/extension/io/jpeg/detail/write.hpp
@@ -132,6 +132,9 @@ private:
                                 , 1
                                 );
         }
+
+        jpeg_finish_compress ( this->get() );
+
     }
 };
 

--- a/include/boost/gil/extension/io/jpeg/detail/write.hpp
+++ b/include/boost/gil/extension/io/jpeg/detail/write.hpp
@@ -134,7 +134,6 @@ private:
         }
 
         jpeg_finish_compress ( this->get() );
-
     }
 };
 

--- a/include/boost/gil/extension/io/jpeg/detail/writer_backend.hpp
+++ b/include/boost/gil/extension/io/jpeg/detail/writer_backend.hpp
@@ -113,6 +113,9 @@ public:
 
     ~writer_backend()
     {
+        // JPEG compression object destruction does not signal errors,
+        // unlike jpeg_finish_compress called elsewhere,
+        // so there is no need for the setjmp bookmark here.
         jpeg_destroy_compress( get() );
     }
 

--- a/include/boost/gil/extension/io/jpeg/detail/writer_backend.hpp
+++ b/include/boost/gil/extension/io/jpeg/detail/writer_backend.hpp
@@ -113,7 +113,6 @@ public:
 
     ~writer_backend()
     {
-        jpeg_finish_compress ( get() );
         jpeg_destroy_compress( get() );
     }
 


### PR DESCRIPTION
### Description

This pull request removes the `jpeg_finish_compress` call from destructor, which will ensure no erroring function can be called when an exception is in flight or the destructor can fail. If we would throw out of destructor some time in the future, we will have to put `noexcept(false)`, as destructors are `noexcept` by default.

Thanks a lot to [@misos1](https://github.com/misos1) for having productive discussion about the `setjmp` and `longjmp` in the [original issue](https://github.com/boostorg/gil/issues/416).

### References

#416 

### Tasklist

- [ ] Add test case(s) - not applicable ?
- [ ] Ensure all CI builds pass
- [ ] Review and approve
