### PR TITLE
Fixed typo(T y->U y) in concepts.rst

### DIFF
--- a/doc/design/concepts.rst
+++ b/doc/design/concepts.rst
@@ -40,8 +40,8 @@ Most of them are defined at the
 
   auto concept EqualityComparable<typename T, typename U = T>
   {
-      bool operator==(T x, T y);
-      bool operator!=(T x, T y) { return !(x==y); }
+      bool operator==(T x, U y);
+      bool operator!=(T x, U y) { return !(x==y); }
   };
 
   concept SameType<typename T, typename U> { /* unspecified */ };


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description
Fixed typo in Boost.Gil's design guide [concepts](https://boostorg.github.io/gil/html/design/concepts.html) page as mentioned in the comments of #272 . 
<!-- What does this pull request do? -->

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Review and approve
