### PR TITLE
Replace Boost.MPL with Boost.MP11 in promote_integral.hpp

### DIFF
--- a/include/boost/gil/promote_integral.hpp
+++ b/include/boost/gil/promote_integral.hpp
@@ -46,13 +46,13 @@ struct bit_size<T, true> : std::integral_constant<std::size_t, (CHAR_BIT * sizeo
 template
 <
     typename T,
-    typename type_list,
+    typename IntegralTypes,
     std::size_t MinSize
 >
 struct promote_to_larger
 {
-    using current_type = boost::mp11::mp_first<type_list>;
-    using list_after_front = boost::mp11::mp_rest<type_list>;
+    using current_type = boost::mp11::mp_first<IntegralTypes>;
+    using list_after_front = boost::mp11::mp_rest<IntegralTypes>;
 
     using type = typename std::conditional
         <

--- a/include/boost/gil/promote_integral.hpp
+++ b/include/boost/gil/promote_integral.hpp
@@ -2,6 +2,8 @@
 //
 // Copyright (c) 2015, Oracle and/or its affiliates.
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+// 
+// Copyright (c) 2020, Debabrata Mandal <mandaldebabrata123@gmail.com>
 //
 // Licensed under the Boost Software License version 1.0.
 // http://www.boost.org/users/license.html
@@ -12,15 +14,12 @@
 //  - Rename include guards
 //  - Remove support for boost::multiprecision types
 //  - Remove support for 128-bit integer types
+//  - Replace mpl meta functions with mp11 equivalents
 //
 #ifndef BOOST_GIL_PROMOTE_INTEGRAL_HPP
 #define BOOST_GIL_PROMOTE_INTEGRAL_HPP
 
-#include <boost/mpl/begin.hpp>
-#include <boost/mpl/deref.hpp>
-#include <boost/mpl/end.hpp>
-#include <boost/mpl/list.hpp>
-#include <boost/mpl/next.hpp>
+#include <boost/mp11/list.hpp>
 
 #include <climits>
 #include <cstddef>
@@ -47,13 +46,13 @@ struct bit_size<T, true> : std::integral_constant<std::size_t, (CHAR_BIT * sizeo
 template
 <
     typename T,
-    typename Iterator,
-    typename EndIterator,
+    typename type_list,
     std::size_t MinSize
 >
 struct promote_to_larger
 {
-    using current_type = typename boost::mpl::deref<Iterator>::type;
+    using current_type = boost::mp11::mp_first<type_list>;
+    using list_after_front = boost::mp11::mp_rest<type_list>;
 
     using type = typename std::conditional
         <
@@ -62,8 +61,7 @@ struct promote_to_larger
             typename promote_to_larger
                 <
                     T,
-                    typename boost::mpl::next<Iterator>::type,
-                    EndIterator,
+                    list_after_front,
                     MinSize
                 >::type
         >::type;
@@ -71,8 +69,8 @@ struct promote_to_larger
 
 // The following specialization is required to finish the loop over
 // all list elements
-template <typename T, typename EndIterator, std::size_t MinSize>
-struct promote_to_larger<T, EndIterator, EndIterator, MinSize>
+template <typename T, std::size_t MinSize>
+struct promote_to_larger<T, boost::mp11::mp_list<>, MinSize>
 {
     // if promotion fails, keep the number T
     // (and cross fingers that overflow will not occur)
@@ -148,7 +146,7 @@ private:
 
     // Define the list of signed integral types we are going to use
     // for promotion
-    using signed_integral_types = boost::mpl::list
+    using signed_integral_types = boost::mp11::mp_list
         <
             short, int, long
 #if defined(BOOST_HAS_LONG_LONG)
@@ -158,7 +156,7 @@ private:
 
     // Define the list of unsigned integral types we are going to use
     // for promotion
-    using unsigned_integral_types = boost::mpl::list
+    using unsigned_integral_types = boost::mp11::mp_list
         <
             unsigned short, unsigned int, unsigned long, std::size_t
 #if defined(BOOST_HAS_LONG_LONG)
@@ -180,8 +178,7 @@ public:
     using type = typename detail::promote_integral::promote_to_larger
         <
             T,
-            typename boost::mpl::begin<integral_types>::type,
-            typename boost::mpl::end<integral_types>::type,
+            integral_types,
             min_bit_size_type::value
         >::type;
 };


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

This PR is to replace all occurrences of **Boost.mpl's** meta functions with equivalents from **Boost.mp11** as mentioned in #280. I have tried to make **minimal** number of changes to the source code while using only functionality from Boost.mp11 . I have also tried using other ways to do the replacement using mp_find_if or mp_cond from the mp11 docs but this PR proposes using mp_rest to recurse over the type list.

### References

https://www.boost.org/doc/libs/develop/libs/mp11/doc/html/mp11.html#mp_restl
https://www.boost.org/doc/libs/develop/libs/mp11/doc/html/mp11.html#mp_find_ifl_p
https://www.boost.org/doc/libs/develop/libs/mp11/doc/html/mp11.html#mp_condc_t_r

<!-- Any links related to this PR: issues, other PRs, mailing list threads, StackOverflow questions, etc. -->

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] <del>Add test case(s)</del> Check existing tests pass.
- [x] Ensure all CI builds pass
- [x] Review and approve
