### PR TITLE
Adding Gaussian Smoothening for images

### DIFF
--- a/example/gaussian_blur.cpp
+++ b/example/gaussian_blur.cpp
@@ -1,0 +1,18 @@
+#include <boost/gil/extension/io/jpeg.hpp>
+#include <boost/gil/image_processing/filter.hpp>
+
+using namespace boost::gil;
+
+int main()
+{
+    rgb8_image_t img;
+    read_image("test.jpg",img, jpeg_tag{});
+    rgb8_image_t img_out(img.dimensions());
+
+//    performing binary threshold on each channel of the image
+//    if the pixel value is more than 150 than it will be set to 255 else to 0
+    boost::gil::gaussian_filter(const_view(img), view(img_out), 5, 1.0f);
+    write_view("gaussian_blur.jpg", view(img_out), jpeg_tag{});
+
+    return 0;
+}

--- a/example/gaussian_blur.cpp
+++ b/example/gaussian_blur.cpp
@@ -1,3 +1,11 @@
+//
+// Copyright 2020 Laxmikant Suryavanshi <laxmikantsuryavanshi@hotmail.com>
+//
+// Use, modification and distribution are subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
 #include <boost/gil/extension/io/jpeg.hpp>
 #include <boost/gil/image_processing/filter.hpp>
 

--- a/example/gaussian_blur.cpp
+++ b/example/gaussian_blur.cpp
@@ -9,8 +9,8 @@ int main()
     read_image("test.jpg",img, jpeg_tag{});
     rgb8_image_t img_out(img.dimensions());
 
-//    performing binary threshold on each channel of the image
-//    if the pixel value is more than 150 than it will be set to 255 else to 0
+//    performing Gaussian Blur on image
+//    here kernel size is 5 and sigma is taken as 1
     boost::gil::gaussian_filter(const_view(img), view(img_out), 5, 1.0f);
     write_view("gaussian_blur.jpg", view(img_out), jpeg_tag{});
 

--- a/include/boost/gil/image_processing/filter.hpp
+++ b/include/boost/gil/image_processing/filter.hpp
@@ -155,7 +155,7 @@ void getGaussianKernel(KernelT& kernel,
         const auto delta_x = center - x;
         const double power = (delta_x * delta_x) / exp_denom;
         const double numerator = std::exp(-power);
-        const float value = static_cast<float>(numerator/std::sqrt(boost::gil::pi * exp_denom));
+        const float value = static_cast<float>(numerator/std::sqrt(M_PI * exp_denom));
         kernel[x] = value;
         kernel[kernel_size-1-x] = value;
     }

--- a/include/boost/gil/image_processing/filter.hpp
+++ b/include/boost/gil/image_processing/filter.hpp
@@ -16,11 +16,11 @@
 #include <boost/gil/image.hpp>
 #include <boost/gil/image_view.hpp>
 
-#include <cstddef>
-#include <vector>
-#include <utility>
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
+#include <utility>
+#include <vector>
 
 
 
@@ -140,12 +140,12 @@ void median_filter(SrcView const& src_view, DstView const& dst_view, std::size_t
 namespace detail {
 
 template<typename KernelT>
-void getGaussianKernel(KernelT& kernel,
-                       long int kernel_size,
-                       double sigma,
-                       bool normalize = true)
+void get_gaussian_kernel(
+    KernelT& kernel,
+    long int kernel_size,
+    double sigma)
 {
-    if (!(kernel_size & 0x1))
+    if (!(kernel_size%2))
         throw std::invalid_argument("kernel dimensions should be odd");
 
     const double exp_denom = 2 * sigma * sigma;
@@ -164,12 +164,12 @@ void getGaussianKernel(KernelT& kernel,
 } // namespace detail
 
 template <typename SrcView, typename DstView>
-void gaussian_filter(SrcView src_view,
-                     DstView dst_view,
-                     long int kernel_size,
-                     double sigma,
-                     bool normalize = true,
-                     boundary_option option = boundary_option::extend_zero)
+void gaussian_filter(
+    SrcView src_view,
+    DstView dst_view,
+    long int kernel_size,
+    double sigma,
+    boundary_option option = boundary_option::extend_zero)
 {
     gil_function_requires<ImageViewConcept<SrcView>>();
     gil_function_requires<MutableImageViewConcept<DstView>>();

--- a/include/boost/gil/image_processing/filter.hpp
+++ b/include/boost/gil/image_processing/filter.hpp
@@ -145,7 +145,7 @@ void get_gaussian_kernel(
     long int kernel_size,
     double sigma)
 {
-    if (!(kernel_size%2))
+    if ((kernel_size%2) == 0)
         throw std::invalid_argument("kernel dimensions should be odd");
 
     const double exp_denom = 2 * sigma * sigma;

--- a/include/boost/gil/image_processing/filter.hpp
+++ b/include/boost/gil/image_processing/filter.hpp
@@ -18,7 +18,9 @@
 
 #include <cstddef>
 #include <vector>
-
+#include <utility>
+#include <algorithm>
+#include <cmath>
 
 
 

--- a/include/boost/gil/image_processing/filter.hpp
+++ b/include/boost/gil/image_processing/filter.hpp
@@ -140,7 +140,7 @@ void median_filter(SrcView const& src_view, DstView const& dst_view, std::size_t
 namespace detail {
 
 template<typename KernelT>
-void get_gaussian_kernel(
+void get_1d_gaussian_kernel(
     KernelT& kernel,
     long int kernel_size,
     double sigma)

--- a/include/boost/gil/image_processing/filter.hpp
+++ b/include/boost/gil/image_processing/filter.hpp
@@ -145,7 +145,7 @@ void getGaussianKernel(KernelT& kernel,
 {
     if (kernel_size & 0x1)
         throw std::invalid_argument("kernel dimensions should be odd");
-    
+
     const double exp_denom = 2 * sigma * sigma;
     auto center = kernel_size / 2;
     for (long int x = 0; x <= center; x++)
@@ -153,7 +153,7 @@ void getGaussianKernel(KernelT& kernel,
         const auto delta_x = center - x;
         const double power = (delta_x * delta_x) / exp_denom;
         const double numerator = std::exp(-power);
-        const float value = static_cast<float>(numerator/(boost::gil::pi * exp_denom));
+        const float value = static_cast<float>(numerator/std::sqrt(boost::gil::pi * exp_denom));
         kernel[x] = value;
         kernel[kernel_size-1-x] = value;
     }

--- a/include/boost/gil/image_processing/filter.hpp
+++ b/include/boost/gil/image_processing/filter.hpp
@@ -143,7 +143,7 @@ void getGaussianKernel(KernelT& kernel,
                        double sigma,
                        bool normalize = true)
 {
-    if (kernel_size & 0x1)
+    if (!(kernel_size & 0x1))
         throw std::invalid_argument("kernel dimensions should be odd");
 
     const double exp_denom = 2 * sigma * sigma;

--- a/include/boost/gil/image_processing/filter.hpp
+++ b/include/boost/gil/image_processing/filter.hpp
@@ -159,11 +159,6 @@ void getGaussianKernel(KernelT& kernel,
         kernel[x] = value;
         kernel[kernel_size-1-x] = value;
     }
-    if (normalize)
-    {
-        auto sum = std::accumulate(kernel.begin(), kernel.end(), 0.0f);
-        std::for_each(kernel.begin(), kernel.end(), [&sum](float x) { return x/sum; });
-    }
 }
 
 } // namespace detail

--- a/include/boost/gil/image_processing/threshold.hpp
+++ b/include/boost/gil/image_processing/threshold.hpp
@@ -45,7 +45,7 @@ void threshold_impl(SrcView const& src_view, DstView const& dst_view, Operator c
         typename color_space_type<DstView>::type
     >::value, "Source and destination views must have pixels with the same color space");
 
-    //iterate over the image chaecking each pixel value for the threshold
+    //iterate over the image checking each pixel value for the threshold
     for (std::ptrdiff_t y = 0; y < src_view.height(); y++)
     {
         typename SrcView::x_iterator src_it = src_view.row_begin(y);
@@ -64,7 +64,7 @@ void threshold_impl(SrcView const& src_view, DstView const& dst_view, Operator c
 /// @{
 ///
 /// \brief Direction of image segmentation.
-/// The direction specifieds which pixels are considered as corresponding to object
+/// The direction specifies which pixels are considered as corresponding to object
 /// and which pixels correspond to background.
 enum class threshold_direction
 {

--- a/test/core/image_processing/gaussian_filter.cpp
+++ b/test/core/image_processing/gaussian_filter.cpp
@@ -1,0 +1,54 @@
+#define BOOST_TEST_MODULE gil/test/core/image_processing/gaussian_filter
+#include "unit_test.hpp"
+
+#include <boost/gil/algorithm.hpp>
+#include <boost/gil/gray.hpp>
+#include <boost/gil/image_view.hpp>
+#include <boost/gil/image_processing/filter.hpp>
+
+namespace gil = boost::gil;
+
+const float kernel[] =
+{
+  0.241971, 0.398942, 0.241971
+};
+
+std::uint8_t img[] =
+{
+  0, 0,   0,   0,   0,
+  0, 100, 100, 100, 0,
+  0, 100, 100, 100, 0,
+  0, 100, 100, 100, 0,
+  0, 0,   0,   0,   0
+};
+
+std::uint8 output[] =
+{
+  5, 15, 21, 15, 5,
+  15, 41, 56, 41, 15,
+  21, 56, 77, 56, 21,
+  15, 41, 56, 41, 15,
+  5, 15, 21, 15, 5
+};
+
+BOOST_AUTO_TEST_SUITE(filter)
+
+BOOST_AUTO_TEST_CASE(box_filter_with_default_parameters)
+{
+    gil::gray8c_view_t src_view =
+        gil::interleaved_view(5, 5, reinterpret_cast<const gil::gray8_pixel_t*>(img), 5);
+
+    gil::image<gil::gray8_pixel_t> temp_img(src_view.width(), src_view.height());
+    typename gil::image<gil::gray8_pixel_t>::view_t temp_view = view(temp_img);
+    gil::gray8_view_t dst_view(temp_view);
+
+    gil::gaussian_filter(src_view, dst_view, 3, 1.0f);
+
+    gil::gray8c_view_t out_view =
+        gil::interleaved_view(5, 5, reinterpret_cast<const gil::gray8_pixel_t*>(output), 5);
+
+
+    BOOST_TEST(gil::equal_pixels(out_view, dst_view));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/core/image_processing/gaussian_filter.cpp
+++ b/test/core/image_processing/gaussian_filter.cpp
@@ -33,7 +33,7 @@ std::uint8 output[] =
 
 BOOST_AUTO_TEST_SUITE(filter)
 
-BOOST_AUTO_TEST_CASE(box_filter_with_default_parameters)
+BOOST_AUTO_TEST_CASE(gaussian_filter_with_default_parameters)
 {
     gil::gray8c_view_t src_view =
         gil::interleaved_view(5, 5, reinterpret_cast<const gil::gray8_pixel_t*>(img), 5);

--- a/test/core/image_processing/gaussian_filter.cpp
+++ b/test/core/image_processing/gaussian_filter.cpp
@@ -1,3 +1,11 @@
+//
+// Copyright 2020 Laxmikant Suryavanshi <laxmikantsuryavanshi@hotmail.com>
+//
+// Use, modification and distribution are subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
 #define BOOST_TEST_MODULE gil/test/core/image_processing/gaussian_filter
 #include "unit_test.hpp"
 


### PR DESCRIPTION
**Description**
Gaussian smoothening is the result of blurring an image with a Gaussian function.
The implementation here takes advantage of the separable property of the Gaussian filter by dividing the process into two passes.

**Motivation**
This PR is proposed as a solution to the competency test for GSoC 2020. I chose the project proposed in the ideas list "Image Processing Algorithms". If accepted, I could start implementing more algorithms like Wiener filter, Median filter, Histogram (even though proposed separately)

**Reference**
https://en.wikipedia.org/wiki/Gaussian_filter
http://rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/