### PR TITLE
[WIP] Added Gaussian Filter

### DIFF
--- a/example/gaussian_filter.cpp
+++ b/example/gaussian_filter.cpp
@@ -1,0 +1,26 @@
+//
+// Copyright 2020 Laxmikant Suryavanshi <laxmikantsuryavanshi@hotmail.com>
+//
+// Use, modification and distribution are subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/gil/extension/io/jpeg.hpp>
+#include <boost/gil/image_processing/filter.hpp>
+
+using namespace boost::gil;
+
+int main()
+{
+    rgb8_image_t img;
+    read_image("test.jpg",img, jpeg_tag{});
+    rgb8_image_t img_out(img.dimensions());
+
+//    performing Gaussian Blur on image
+//    here kernel size is 5 and sigma is taken as 1
+    boost::gil::gaussian_filter(const_view(img), view(img_out), 5, 1.0f);
+    write_view("gaussian_blur.jpg", view(img_out), jpeg_tag{});
+
+    return 0;
+}

--- a/include/boost/gil/concepts/channel.hpp
+++ b/include/boost/gil/concepts/channel.hpp
@@ -66,7 +66,7 @@ auto channel_convert(SrcT const& val)
 ///     static const bool is_mutable;        // use channel_traits<T>::is_mutable to access it
 ///
 ///     static T min_value();                // use channel_traits<T>::min_value to access it
-///     static T max_value();                // use channel_traits<T>::min_value to access it
+///     static T max_value();                // use channel_traits<T>::max_value to access it
 /// };
 /// \endcode
 template <typename T>

--- a/include/boost/gil/concepts/image_view.hpp
+++ b/include/boost/gil/concepts/image_view.hpp
@@ -39,7 +39,7 @@ namespace boost { namespace gil {
 /// \ingroup ImageViewConcept
 /// \brief N-dimensional range
 
-/// \defgroup ImageView2DConcept ImageView2DConcept
+/// \defgroup ImageView2DConcept ImageView2DLocatorConcept
 /// \ingroup ImageViewConcept
 /// \brief 2-dimensional range
 

--- a/include/boost/gil/image_processing/filter.hpp
+++ b/include/boost/gil/image_processing/filter.hpp
@@ -135,6 +135,26 @@ void median_filter(SrcView const& src_view, DstView const& dst_view, std::size_t
     }
 }
 
+template <typename SrcView, typename DstView>
+void gaussian_filter(
+    SrcView const& src_view,
+    DstView const& dst_view,
+    std::size_t kernel_size,
+    double sigma)
+{
+    gil_function_requires<ImageViewConcept<SrcView>>();
+    gil_function_requires<MutableImageViewConcept<DstView>>();
+    static_assert(color_spaces_are_compatible
+    <
+        typename color_space_type<SrcView>::type,
+        typename color_space_type<DstView>::type
+    >::value, "Source and destination views must have pixels with the same color space");
+
+    auto gaussian_kernel = generate_gaussian_kernel(kernel_size, sigma);
+    detail::convolve_2d(src_view, gaussian_kernel, dst_view);
+}
+
+
 }} //namespace boost::gil
 
 #endif // !BOOST_GIL_IMAGE_PROCESSING_FILTER_HPP

--- a/include/boost/gil/image_processing/filter.hpp
+++ b/include/boost/gil/image_processing/filter.hpp
@@ -12,6 +12,7 @@
 #include <boost/gil/extension/numeric/algorithm.hpp>
 #include <boost/gil/extension/numeric/kernel.hpp>
 #include <boost/gil/extension/numeric/convolve.hpp>
+#include <boost/gil/extension/image_processing/numeric.hpp>
 
 #include <boost/gil/image.hpp>
 #include <boost/gil/image_view.hpp>
@@ -153,7 +154,6 @@ void gaussian_filter(
     auto gaussian_kernel = generate_gaussian_kernel(kernel_size, sigma);
     detail::convolve_2d(src_view, gaussian_kernel, dst_view);
 }
-
 
 }} //namespace boost::gil
 

--- a/include/boost/gil/image_processing/threshold.hpp
+++ b/include/boost/gil/image_processing/threshold.hpp
@@ -45,7 +45,7 @@ void threshold_impl(SrcView const& src_view, DstView const& dst_view, Operator c
         typename color_space_type<DstView>::type
     >::value, "Source and destination views must have pixels with the same color space");
 
-    //iterate over the image chaecking each pixel value for the threshold
+    //iterate over the image checking each pixel value for the threshold
     for (std::ptrdiff_t y = 0; y < src_view.height(); y++)
     {
         typename SrcView::x_iterator src_it = src_view.row_begin(y);
@@ -64,7 +64,7 @@ void threshold_impl(SrcView const& src_view, DstView const& dst_view, Operator c
 /// @{
 ///
 /// \brief Direction of image segmentation.
-/// The direction specifieds which pixels are considered as corresponding to object
+/// The direction specifies which pixels are considered as corresponding to object
 /// and which pixels correspond to background.
 enum class threshold_direction
 {
@@ -160,13 +160,13 @@ void threshold_binary(
 
 /// \ingroup ImageProcessing
 /// \brief Applies truncating threshold to each pixel of image view.
-/// Takes an image view and performes truncating threshold operation on each chennel.
+/// Takes an image view and performs truncating threshold operation on each chennel.
 /// If mode is threshold and direction is regular:
 /// values greater than threshold_value will be set to threshold_value else no change
 /// If mode is threshold and direction is inverse:
-/// values less than threshold_value will be set to threshold_value else no change
+/// values less than or equal to threshold_value will be set to threshold_value else no change
 /// If mode is zero and direction is regular:
-/// values less than threshold_value will be set to 0 else no change
+/// values less than or equal to threshold_value will be set to 0 else no change
 /// If mode is zero and direction is inverse:
 /// values more than threshold_value will be set to 0 else no change
 template <typename SrcView, typename DstView>
@@ -372,7 +372,7 @@ void adaptive_impl
         typename color_space_type<DstView>::type
     >::value, "Source and destination views must have pixels with the same color space");
 
-    //iterate over the image chaecking each pixel value for the threshold
+    //iterate over the image checking each pixel value for the threshold
     for (std::ptrdiff_t y = 0; y < src_view.height(); y++)
     {
         typename SrcView::x_iterator src_it = src_view.row_begin(y);

--- a/test/core/image_processing/gaussian_filter.cpp
+++ b/test/core/image_processing/gaussian_filter.cpp
@@ -1,0 +1,56 @@
+//
+// Copyright 2020 Laxmikant Suryavanshi <laxmikantsuryavanshi@hotmail.com>
+//
+// Use, modification and distribution are subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+#define BOOST_TEST_MODULE gil/test/core/image_processing/gaussian_filter
+#include "unit_test.hpp"
+
+#include <boost/gil/algorithm.hpp>
+#include <boost/gil/gray.hpp>
+#include <boost/gil/image_view.hpp>
+#include <boost/gil/image_processing/filter.hpp>
+
+namespace gil = boost::gil;
+
+std::uint8_t img[] =
+{
+  0, 0,   0,   0,   0,
+  0, 100, 100, 100, 0,
+  0, 100, 100, 100, 0,
+  0, 100, 100, 100, 0,
+  0, 0,   0,   0,   0
+};
+
+std::uint8 output[] =
+{
+  5, 15, 21, 15, 5,
+  15, 41, 56, 41, 15,
+  21, 56, 77, 56, 21,
+  15, 41, 56, 41, 15,
+  5, 15, 21, 15, 5
+};
+
+BOOST_AUTO_TEST_SUITE(filter)
+
+BOOST_AUTO_TEST_CASE(gaussian_filter_with_default_parameters)
+{
+    gil::gray8c_view_t src_view =
+        gil::interleaved_view(5, 5, reinterpret_cast<const gil::gray8_pixel_t*>(img), 5);
+
+    gil::image<gil::gray8_pixel_t> temp_img(src_view.width(), src_view.height());
+    typename gil::image<gil::gray8_pixel_t>::view_t temp_view = view(temp_img);
+    gil::gray8_view_t dst_view(temp_view);
+
+    gil::gaussian_filter(src_view, dst_view, 3, 1.0f);
+
+    gil::gray8c_view_t out_view =
+        gil::interleaved_view(5, 5, reinterpret_cast<const gil::gray8_pixel_t*>(output), 5);
+
+
+    BOOST_TEST(gil::equal_pixels(out_view, dst_view));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description
A Gaussian filter is a linear filter. It's usually used to blur the image or to reduce Gaussian noise. Current implementation relies on boost::gil functions. Builtin convolve_2d can only use convolve_option_extend_zero as convolve_boundary_option. In the future, the implementation will be improved by using the Gaussian filter's property of being separable.

### References

https://homepages.inf.ed.ac.uk/rbf/HIPR2/gsmooth.htm
https://en.wikipedia.org/wiki/Gaussian_blur

### Tasklist

- [ ] Add test case(s)
- [ ] Ensure all CI builds pass
- [ ] Review and approve
- [ ] Improve algorithm
- [ ] Add more de-noising algorithm