### PR TITLE
Fix legacy test with workaround for MSVC++ 64-bit optimized build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -74,16 +74,6 @@ matrix:
   allow_failures:
     - TOOLSET: msvc-14.1
       ARCH: x86_64
-      VARIANT: release
-      CXXSTD: 17
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    - TOOLSET: msvc-14.1
-      ARCH: x86_64
-      VARIANT: release
-      CXXSTD: 14
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    - TOOLSET: msvc-14.1
-      ARCH: x86_64
       VARIANT: debug
       CXXSTD: 14
       GENERATOR: "Visual Studio 15 2017 Win64"

--- a/test/legacy/image.cpp
+++ b/test/legacy/image.cpp
@@ -370,6 +370,10 @@ void image_test::run() {
     image_all_test<rgb8_planar_image_t>("planarrgb8_");
     image_all_test<gray8_image_t>("gray8_");
 
+// FIXME: https://github.com/boostorg/gil/issues/447
+// Disable bgc121_image_t drawing as work around for a mysterious bug
+// revealing itself when using MSVC 64-bit optimized build.
+#if !(defined(NDEBUG) && defined (_MSC_VER) && defined(_WIN64))
     using bgr121_ref_t = bit_aligned_pixel_reference
         <
             boost::uint8_t,
@@ -379,6 +383,7 @@ void image_test::run() {
         > const;
     using bgr121_image_t = image<bgr121_ref_t, false>;
     image_all_test<bgr121_image_t>("bgr121_");
+#endif
 
     // TODO: Remove?
     view_transformations_test(subsampled_view(sample_view, point_t(1,2)), "subsampled_");


### PR DESCRIPTION
### Description

It is **not a fix** but workaround based on #447 applied in order to  avoid continuous failures of the checksum tests run by CI jobs.

Make related AppVeyor builds with MSVC++ no longer allowed to fail.

### References

- #447

### Tasklist

- [ ] Ensure all CI builds pass
