### PR TITLE
Fix incorrect assert caught in image_view::col_end 

### DIFF
--- a/include/boost/gil/image_view.hpp
+++ b/include/boost/gil/image_view.hpp
@@ -292,7 +292,7 @@ public:
     {
         // TODO: Are relative locations of neighbors with negative offsets valid? Sampling?
         BOOST_ASSERT(x < width());
-        BOOST_ASSERT(y < height());
+        BOOST_ASSERT(y <= height());
         return _pixels + point_t(x, y);
     }
 

--- a/test/core/image_view/CMakeLists.txt
+++ b/test/core/image_view/CMakeLists.txt
@@ -11,6 +11,7 @@ foreach(_name
   derived_view_type
   dynamic_step
   is_planar
+  iteration
   planar_rgba_view
   subimage_view
   view_is_basic

--- a/test/core/image_view/Jamfile
+++ b/test/core/image_view/Jamfile
@@ -21,3 +21,4 @@ compile view_type_from_pixel.cpp ;
 run collection.cpp /boost/test//boost_unit_test_framework : : : <link>shared:<define>BOOST_TEST_DYN_LINK=1 ;
 run planar_rgba_view.cpp /boost/test//boost_unit_test_framework : : : <link>shared:<define>BOOST_TEST_DYN_LINK=1 ;
 run subimage_view.cpp /boost/test//boost_unit_test_framework : : : <link>shared:<define>BOOST_TEST_DYN_LINK=1 ;
+run iteration.cpp ;

--- a/test/core/image_view/iteration.cpp
+++ b/test/core/image_view/iteration.cpp
@@ -1,0 +1,34 @@
+// the tests were adapted from contribution of evansds
+// https://github.com/evansds
+// link to original: https://github.com/boostorg/gil/issues/432#issue-561546949
+
+#include <boost/gil/typedefs.hpp>
+#include <boost/gil/image_view.hpp>
+#include <boost/gil/image_view_factory.hpp>
+
+#include <boost/core/lightweight_test.hpp>
+
+#include <vector>
+
+using pixel_type = boost::gil::rgb8_pixel_t;
+
+void test_col_end()
+{
+    std::vector<pixel_type> v(50);
+    auto view = boost::gil::interleaved_view(10, 5, v.data(), 10 * sizeof(pixel_type));
+    view.col_end(0);  // asserts
+}
+
+void test_row_end()
+{
+    std::vector<pixel_type> v(50);
+    auto view = boost::gil::interleaved_view(10, 5, v.data(), 10 * sizeof(pixel_type));
+    auto it = view.row_end(0);  // asserts
+}
+
+int main()
+{
+    test_col_end();
+    test_row_end();
+    return boost::report_errors();
+}


### PR DESCRIPTION
### Description

The commit changes assert condition
to temporary fix the problem. There are
also very basic tests that will check
for regression.

Fix for #432 

### References

#432 

### Tasklist

- [X] Change assert condition
- [x] Add test case(s)
- [x] Ensure all CI builds pass
- [x] Review and approve
