### PR TITLE
Remove llvm-toolchain-trusty-6.0 from APT sources as unused

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -144,7 +144,6 @@ matrix:
             - libraw-dev
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-6.0
 
     - os: linux
       env: COMPILER=clang++-6.0 VARIANT=gil_ubsan_nullability TOOLSET=clang CXXSTD=11 B2_OPTIONS="visibility=global" UBSAN_OPTIONS='print_stacktrace=1'
@@ -188,9 +187,6 @@ matrix:
             - python3
             - python3-pip
             - python3-setuptools
-
-  allow_failures:
-    - env: COMPILER=clang++-6.0 VARIANT=gil_ubsan_integer TOOLSET=clang CXXSTD=11 B2_OPTIONS="visibility=global" UBSAN_OPTIONS='print_stacktrace=1'
 
 install:
   - |-


### PR DESCRIPTION
This just fixes CI infrastructure issue, APT conflict.
We no longer need to allow `VARIANT=gil_ubsan_integer` job to fail.

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Ensure all CI builds pass
