### PR TITLE
CI: Avoid huge logs due to compilation warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,15 @@ message(STATUS "Boost.GIL: Require C++${CMAKE_CXX_STANDARD}")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# Avoid warnings flood on Travis CI, AppVeyor, CircleCI, Azure Pipelines
+if(DEFINED ENV{CI} OR DEFINED ENV{AGENT_JOBSTATUS} OR DEFINED ENV{GITHUB_ACTIONS})
+  set(BOOST_GIL_BUILD_CI ON)
+  message(STATUS "Boost.GIL: Turning off detailed compiler warnings for CI build short log")
+else()
+  set(BOOST_GIL_BUILD_CI OFF)
+  message(STATUS "Boost.GIL: Turning on detailed compiler warnings")
+endif()
+
 add_library(gil_compile_options INTERFACE)
 
 # See https://cmake.org/pipermail/cmake/2018-December/068716.html
@@ -50,20 +59,14 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 endif()
 
 # See https://svn.boost.org/trac10/wiki/Guidelines/WarningsGuidelines
-
 target_compile_options(gil_compile_options
   INTERFACE
-    $<$<CXX_COMPILER_ID:MSVC>:-W4>
+    $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<BOOL:${BOOST_GIL_BUILD_CI}>>:-W1>
+    $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<NOT:$<BOOL:${BOOST_GIL_BUILD_CI}>>>:-W4>
     $<$<CXX_COMPILER_ID:MSVC>:-bigobj>
     $<$<CXX_COMPILER_ID:MSVC>:-FC> # Need absolute path for __FILE__ used in tests
-    $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-fstrict-aliasing -pedantic>)
-
-# Do not mix warnings due to strict compilation level with linter warnings
-if(NOT CMAKE_CXX_CLANG_TIDY)
-  target_compile_options(gil_compile_options
-    INTERFACE
-      $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wall -Wconversion -Wextra -Wfloat-equal -Wshadow -Wsign-promo -Wstrict-aliasing -Wunused-parameter>)
-endif()
+    $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-fstrict-aliasing>
+    $<$<AND:$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>,$<NOT:$<BOOL:${BOOST_GIL_BUILD_CI}>>>:-Wall -Wconversion -Wextra -Wfloat-equal -Wshadow -Wsign-promo -Wstrict-aliasing -Wunused-parameter -pedantic>)
 
 target_compile_definitions(gil_compile_options
   INTERFACE

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -16,16 +16,22 @@ import regex ;
 import sequence ;
 import testing ;
 
-# Avoid warnings flood on Travis CI, AppVeyor, CircleCI, Azure Pipelines
-if ! [ os.environ CI ] && ! [ os.environ AGENT_JOBSTATUS ]
+# Avoid warnings flood on Travis CI, AppVeyor, CircleCI, Azure Pipelines, GitHub Actions
+if ! [ os.environ CI ] && ! [ os.environ AGENT_JOBSTATUS ] && ! [ os.environ GITHUB_ACTIONS ]
 {
-    DEVELOPMENT_EXTRA_WARNINGS =
-      <toolset>msvc:<cxxflags>/W4
-      <toolset>gcc:<cxxflags>"-pedantic -Wextra -Wcast-align -Wconversion -Wfloat-equal -Wshadow -Wsign-promo -Wstrict-aliasing -Wunused-parameter"
-      <toolset>clang,<variant>debug:<cxxflags>"-pedantic -Wextra -Wcast-align -Wconversion -Wfloat-equal -Wshadow -Wsign-promo -Wstrict-aliasing -Wunused-parameter -Wsign-conversion"
-      <toolset>clang,<variant>release:<cxxflags>"-pedantic -Wextra -Wcast-align -Wconversion -Wfloat-equal -Wshadow -Wsign-promo -Wstrict-aliasing -Wunused-parameter -Wsign-conversion"
-      <toolset>darwin:<cxxflags>"-pedantic -Wextra -Wcast-align -Wconversion -Wfloat-equal -Wshadow -Wsign-promo -Wstrict-aliasing -Wunused-parameter"
-      ;
+  DEVELOPMENT_EXTRA_WARNINGS =
+    <toolset>msvc:<cxxflags>"-W4"
+    <toolset>gcc:<cxxflags>"-pedantic -Wextra -Wcast-align -Wconversion -Wfloat-equal -Wshadow -Wsign-promo -Wstrict-aliasing -Wunused-parameter"
+    <toolset>clang,<variant>debug:<cxxflags>"-pedantic -Wextra -Wcast-align -Wconversion -Wfloat-equal -Wshadow -Wsign-promo -Wstrict-aliasing -Wunused-parameter -Wsign-conversion"
+    <toolset>clang,<variant>release:<cxxflags>"-pedantic -Wextra -Wcast-align -Wconversion -Wfloat-equal -Wshadow -Wsign-promo -Wstrict-aliasing -Wunused-parameter -Wsign-conversion"
+    <toolset>darwin:<cxxflags>"-pedantic -Wextra -Wcast-align -Wconversion -Wfloat-equal -Wshadow -Wsign-promo -Wstrict-aliasing -Wunused-parameter"
+    ;
+}
+else
+{
+  DEVELOPMENT_EXTRA_WARNINGS =
+    <toolset>msvc:<cxxflags>"-W1"
+    ;
 }
 
 project
@@ -34,8 +40,8 @@ project
     <include>.
     # TODO: Enable concepts check for all, not just test/core
     #<define>BOOST_GIL_USE_CONCEPT_CHECK=1
+    <toolset>msvc:<cxxflags>"-bigobj"
     <toolset>msvc:<asynch-exceptions>on
-    <toolset>msvc:<cxxflags>/bigobj
     <toolset>msvc:<define>_SCL_SECURE_NO_DEPRECATE
     <toolset>msvc:<define>_CRT_SECURE_NO_WARNINGS
     <toolset>msvc:<define>_CRT_NONSTDC_NO_DEPRECATE


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

Remove setting flags specific to `CMAKE_CXX_CLANG_TIDY` as likely not necessary
- restore if it causes issues.

If `CI` (Travis CI, AppVeyor, CircleCI) or `AGENT_JOBSTATUS` (Azure Pipelines) or `GITHUB_ACTIONS` (GitHub Actions) environment variable is defined, then do not set high compiler warning levels.

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Ensure all CI builds pass
