### PR TITLE
Add any_image_view::size()

### DIFF
--- a/doc/design/dynamic_image.rst
+++ b/doc/design/dynamic_image.rst
@@ -120,6 +120,7 @@ GIL ``any_image_view`` and ``any_image`` are subclasses of ``variant``:
     typedef std::ptrdiff_t x_coord_t;
     typedef std::ptrdiff_t y_coord_t;
     typedef point<std::ptrdiff_t> point_t;
+    using size_type = std::size_t;
 
     any_image_view();
     template <typename T> explicit any_image_view(const T& obj);
@@ -131,6 +132,7 @@ GIL ``any_image_view`` and ``any_image`` are subclasses of ``variant``:
     // parameters of the currently instantiated view
     std::size_t num_channels()  const;
     point_t     dimensions()    const;
+    size_type   size()          const;
     x_coord_t   width()         const;
     y_coord_t   height()        const;
   };

--- a/include/boost/gil/extension/dynamic_image/any_image_view.hpp
+++ b/include/boost/gil/extension/dynamic_image/any_image_view.hpp
@@ -45,6 +45,14 @@ struct any_type_get_dimensions
     result_type operator()(const T& v) const { return v.dimensions(); }
 };
 
+// works for image_view
+struct any_type_get_size
+{
+    using result_type = std::size_t;
+    template <typename T>
+    result_type operator()(const T& v) const { return v.size(); }
+};
+
 } // namespace detail
 
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -71,6 +79,7 @@ public:
     using x_coord_t = std::ptrdiff_t;
     using y_coord_t = std::ptrdiff_t;
     using point_t = point<std::ptrdiff_t>;
+    using size_type = std::size_t;
 
     any_image_view() = default;
     any_image_view(any_image_view const& view) : parent_t((parent_t const&)view) {}
@@ -105,6 +114,7 @@ public:
 
     std::size_t num_channels()  const { return apply_operation(*this, detail::any_type_get_num_channels()); }
     point_t     dimensions()    const { return apply_operation(*this, detail::any_type_get_dimensions()); }
+    size_type   size()          const { return apply_operation(*this, detail::any_type_get_size()); }
     x_coord_t   width()         const { return dimensions().x; }
     y_coord_t   height()        const { return dimensions().y; }
 };

--- a/test/extension/dynamic_image/subimage_view.cpp
+++ b/test/extension/dynamic_image/subimage_view.cpp
@@ -25,17 +25,20 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(subimage_equals_image, Image, fixture::image_types
     auto const v0 = gil::const_view(i0);
     BOOST_TEST(v0.dimensions().x == 4);
     BOOST_TEST(v0.dimensions().y == 4);
+    BOOST_TEST(v0.size() == 4 * 4);
 
     // request with 2 x point_t values
     {
         auto v1 = gil::subimage_view(gil::view(i0), {0, 0}, i0.dimensions());
         BOOST_TEST(v0.dimensions() == v1.dimensions());
+        BOOST_TEST(v0.size() == v1.size());
         BOOST_TEST(gil::equal_pixels(v0, v1));
     }
     // request with 4 x dimension values
     {
         auto v1 = gil::subimage_view(gil::view(i0), 0, 0, i0.dimensions().x, i0.dimensions().y);
         BOOST_TEST(v0.dimensions() == v1.dimensions());
+        BOOST_TEST(v0.size() == v1.size());
         BOOST_TEST(gil::equal_pixels(v0, v1));
     }
 }


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

<!-- What does this pull request do? -->

Adds `any_image_view::size()` that returns the size of the underlying `image_view`.

```
size_type        View::size()       const; // total number of elements
```

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Add test case(s)
- [x] Update doc(s)
- [x] Ensure all CI builds pass
- [x] Review and approve
