### PR TITLE
Add move semantics to image class

### DIFF
--- a/include/boost/gil/image.hpp
+++ b/include/boost/gil/image.hpp
@@ -37,7 +37,8 @@ namespace boost { namespace gil {
 ////////////////////////////////////////////////////////////////////////////////////////
 
 template< typename Pixel, bool IsPlanar = false, typename Alloc=std::allocator<unsigned char> >
-class image {
+class image
+{
 public:
 #if defined(BOOST_NO_CXX11_ALLOCATOR)
     using allocator_type = typename Alloc::template rebind<unsigned char>::other;
@@ -64,14 +65,16 @@ public:
     image(const point_t& dimensions,
           std::size_t alignment=0,
           const Alloc alloc_in = Alloc()) : _memory(nullptr), _align_in_bytes(alignment), _alloc(alloc_in)
-                                          , _allocated_bytes( 0 ) {
+                                          , _allocated_bytes( 0 )
+    {
         allocate_and_default_construct(dimensions);
     }
 
     image(x_coord_t width, y_coord_t height,
           std::size_t alignment=0,
           const Alloc alloc_in = Alloc()) : _memory(nullptr), _align_in_bytes(alignment), _alloc(alloc_in)
-                                          , _allocated_bytes( 0 ) {
+                                          , _allocated_bytes( 0 )
+    {
         allocate_and_default_construct(point_t(width,height));
     }
 
@@ -79,25 +82,30 @@ public:
           const Pixel& p_in,
           std::size_t alignment = 0,
           const Alloc alloc_in = Alloc())  : _memory(nullptr), _align_in_bytes(alignment), _alloc(alloc_in)
-                                           , _allocated_bytes( 0 ) {
+                                           , _allocated_bytes( 0 )
+    {
         allocate_and_fill(dimensions, p_in);
     }
+    
     image(x_coord_t width, y_coord_t height,
           const Pixel& p_in,
           std::size_t alignment = 0,
           const Alloc alloc_in = Alloc())  : _memory(nullptr), _align_in_bytes(alignment), _alloc(alloc_in)
-                                           , _allocated_bytes ( 0 ) {
+                                           , _allocated_bytes ( 0 )
+    {
         allocate_and_fill(point_t(width,height),p_in);
     }
 
     image(const image& img) : _memory(nullptr), _align_in_bytes(img._align_in_bytes), _alloc(img._alloc)
-                            , _allocated_bytes( img._allocated_bytes ) {
+                            , _allocated_bytes( img._allocated_bytes )
+    {
         allocate_and_copy(img.dimensions(),img._view);
     }
 
     template <typename P2, bool IP2, typename Alloc2>
     image(const image<P2,IP2,Alloc2>& img) : _memory(nullptr), _align_in_bytes(img._align_in_bytes), _alloc(img._alloc)
-                                           , _allocated_bytes( img._allocated_bytes ) {
+                                           , _allocated_bytes( img._allocated_bytes )
+    {
        allocate_and_copy(img.dimensions(),img._view);
     }
 
@@ -107,17 +115,20 @@ public:
       _memory(img._memory),
       _align_in_bytes(img._align_in_bytes),
       _alloc(std::move(img._alloc)),
-      _allocated_bytes(img._allocated_bytes)  {
+      _allocated_bytes(img._allocated_bytes)
+    {
         img._view = view_t();
         img._memory = nullptr;
         img._align_in_bytes = 0;
         img._allocated_bytes = 0;
     }
 
-    image& operator=(const image& img) {
+    image& operator=(const image& img)
+    {
         if (dimensions() == img.dimensions())
             copy_pixels(img._view,_view);
-        else {
+        else
+        {
             image tmp(img);
             swap(tmp);
         }
@@ -125,10 +136,12 @@ public:
     }
 
     template <typename Img>
-    image& operator=(const Img& img) {
+    image& operator=(const Img& img)
+    {
         if (dimensions() == img.dimensions())
             copy_pixels(img._view,_view);
-        else {
+        else
+        {
             image tmp(img);
             swap(tmp);
         }
@@ -143,7 +156,8 @@ private:
     // TODO: Use std::allocator_traits<Allocator>::is_always_equal if available
     using move_policy = typename std::is_empty<Allocator>::type;
 
-    void move_assign(image& img, equal_allocators) {
+    void move_assign(image& img, equal_allocators)
+    {
         destruct_pixels(_view);
         deallocate();
 
@@ -159,10 +173,12 @@ private:
         img._allocated_bytes = 0;
     }
 
-    void move_assign(image& img, no_propagate_allocators) {
-        if (_alloc == img._alloc) {
+    void move_assign(image& img, no_propagate_allocators)
+    {
+        if (_alloc == img._alloc)
             move_assign(img, equal_allocators{});
-        } else {
+        else
+        {
             // Fallback to copy
             image tmp(img);
             swap(tmp);
@@ -170,14 +186,16 @@ private:
     }
   
 public:
-    image& operator=(image&& img) {
+    image& operator=(image&& img)
+    {
         if (this != std::addressof(img))
             move_assign(img, move_policy<Alloc>{});
 
         return *this;
     }
 
-    ~image() {
+    ~image()
+    {
         destruct_pixels(_view);
         deallocate();
     }
@@ -185,7 +203,8 @@ public:
     Alloc&       allocator() { return _alloc; }
     Alloc const& allocator() const { return _alloc; }
 
-    void swap(image& img) { // required by MutableContainerConcept
+    void swap(image& img) // required by MutableContainerConcept
+    {
         using std::swap;
         swap(_align_in_bytes,  img._align_in_bytes);
         swap(_memory,          img._memory);
@@ -474,12 +493,14 @@ private:
 };
 
 template <typename Pixel, bool IsPlanar, typename Alloc>
-void swap(image<Pixel, IsPlanar, Alloc>& im1,image<Pixel, IsPlanar, Alloc>& im2) {
+void swap(image<Pixel, IsPlanar, Alloc>& im1,image<Pixel, IsPlanar, Alloc>& im2)
+{
     im1.swap(im2);
 }
 
 template <typename Pixel1, bool IsPlanar1, typename Alloc1, typename Pixel2, bool IsPlanar2, typename Alloc2>
-bool operator==(const image<Pixel1,IsPlanar1,Alloc1>& im1,const image<Pixel2,IsPlanar2,Alloc2>& im2) {
+bool operator==(const image<Pixel1,IsPlanar1,Alloc1>& im1,const image<Pixel2,IsPlanar2,Alloc2>& im2)
+{
     if ((void*)(&im1)==(void*)(&im2)) return true;
     if (const_view(im1).dimensions()!=const_view(im2).dimensions()) return false;
     return equal_pixels(const_view(im1),const_view(im2));
@@ -499,7 +520,8 @@ const typename image<Pixel,IsPlanar,Alloc>::view_t& view(image<Pixel,IsPlanar,Al
 
 /// \brief Returns the constant-pixel view of an image
 template <typename Pixel, bool IsPlanar, typename Alloc> inline
-const typename image<Pixel,IsPlanar,Alloc>::const_view_t const_view(const image<Pixel,IsPlanar,Alloc>& img) {
+const typename image<Pixel,IsPlanar,Alloc>::const_view_t const_view(const image<Pixel,IsPlanar,Alloc>& img)
+{
     return static_cast<const typename image<Pixel,IsPlanar,Alloc>::const_view_t>(img._view);
 }
 ///@}

--- a/include/boost/gil/image.hpp
+++ b/include/boost/gil/image.hpp
@@ -14,6 +14,7 @@
 #include <boost/gil/detail/mp11.hpp>
 
 #include <boost/assert.hpp>
+#include <boost/core/exchange.hpp>
 
 #include <cstddef>
 #include <memory>
@@ -148,48 +149,52 @@ public:
         return *this;
     }
 
-private:
-    using equal_allocators = std::true_type;
-    using no_propagate_allocators = std::false_type;
-
-    template <class Allocator>
-    // TODO: Use std::allocator_traits<Allocator>::is_always_equal if available
-    using move_policy = typename std::is_empty<Allocator>::type;
-
-    void move_assign(image& img, equal_allocators)
-    {
-        destruct_pixels(_view);
-        deallocate();
-
-        // TODO Use std::exchange
-        _view = img._view;
-        _memory = img._memory;
-        _align_in_bytes = img._align_in_bytes;
-        _allocated_bytes = img._allocated_bytes;
-        
-        img._view = view_t();
-        img._memory = nullptr;
-        img._align_in_bytes = 0;
-        img._allocated_bytes = 0;
-    }
-
-    void move_assign(image& img, no_propagate_allocators)
-    {
-        if (_alloc == img._alloc)
-            move_assign(img, equal_allocators{});
-        else
-        {
-            // Fallback to copy
-            image tmp(img);
-            swap(tmp);
-        }
-    }
-  
-public:
     image& operator=(image&& img)
     {
         if (this != std::addressof(img))
-            move_assign(img, move_policy<Alloc>{});
+        {
+            auto const exchange_memory = [](image& lhs, image& rhs)
+            {
+                lhs._memory = boost::exchange(rhs._memory, nullptr);
+                lhs._align_in_bytes = boost::exchange(rhs._align_in_bytes, 0);
+                lhs._allocated_bytes = boost::exchange(rhs._allocated_bytes, 0);
+                lhs._view = boost::exchange(rhs._view, image::view_t{});
+            };
+
+            constexpr bool pocma = std::allocator_traits<Alloc>::propagate_on_container_move_assignment::value;
+            if (pocma)
+            {
+                // non-sticky allocator, can adopt the memory, fast
+                destruct_pixels(this->_view);
+                this->deallocate();
+                this->_alloc = img._alloc;
+                exchange_memory(*this, img);
+            }
+            else if (_alloc == img._alloc)
+            {
+                // allocator stuck to the rhs, but it's equivalent of ours, we can still adopt the memory
+                destruct_pixels(_view);
+                this->deallocate();
+                exchange_memory(*this, img);
+            }
+            else
+            {
+                // cannot propagate the allocator and cannot adopt the memory
+                if (img._memory)
+                {
+                    allocate_and_copy(img.dimensions(), img._view);
+                    destruct_pixels(img._view);
+                    img.deallocate();
+                    img._view = image::view_t{};
+                }
+                else
+                {
+                    destruct_pixels(this->_view);
+                    this->deallocate();
+                    this->_view = view_t{};
+                }
+            }
+        }
 
         return *this;
     }

--- a/test/core/image/image.cpp
+++ b/test/core/image/image.cpp
@@ -44,3 +44,26 @@ int main()
 
     return ::boost::report_errors();
 }
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(move_constructor, Image, fixture::image_types)
+{
+    gil::point_t const dimensions{256, 128};
+    {
+        Image image(fixture::create_image<Image>(dimensions.x, dimensions.y, 0));
+
+        Image image2(std::move(image));
+        BOOST_CHECK_EQUAL(image2.dimensions(), dimensions);
+        BOOST_CHECK_EQUAL(image.dimensions(), gil::point_t{});
+    }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(move_assignement, Image, fixture::image_types)
+{
+    gil::point_t const dimensions{256, 128};
+    {
+        Image image = fixture::create_image<Image>(dimensions.x, dimensions.y, 0);
+        Image image2 = std::move(image);
+        BOOST_CHECK_EQUAL(image2.dimensions(), dimensions);
+        BOOST_CHECK_EQUAL(image.dimensions(), gil::point_t{});
+    }
+}

--- a/test/core/image/image.cpp
+++ b/test/core/image/image.cpp
@@ -68,7 +68,8 @@ struct test_move_assignement
         gil::point_t const dimensions{256, 128};
         {
             image_t image = fixture::create_image<image_t>(dimensions.x, dimensions.y, 0);
-            image_t image2 = std::move(image);
+            image_t image2 = fixture::create_image<image_t>(dimensions.x * 2, dimensions.y * 2, 1);
+            image2 = std::move(image);
             BOOST_TEST_EQ(image2.dimensions(), dimensions);
             BOOST_TEST_EQ(image.dimensions(), gil::point_t{});
         }

--- a/test/core/image/image.cpp
+++ b/test/core/image/image.cpp
@@ -38,32 +38,53 @@ struct test_constructor_with_dimensions_pixel
     }
 };
 
+struct test_move_constructor
+{
+    template <typename Image>
+    void operator()(Image const&)
+    {
+        using image_t = Image;
+        gil::point_t const dimensions{256, 128};
+        {
+            image_t image(fixture::create_image<image_t>(dimensions.x, dimensions.y, 0));
+
+            image_t image2(std::move(image));
+            BOOST_TEST_EQ(image2.dimensions(), dimensions);
+            BOOST_TEST_EQ(image.dimensions(), gil::point_t{});
+        }
+    }
+    static void run()
+    {
+        boost::mp11::mp_for_each<fixture::image_types>(test_move_constructor{});
+    }
+};
+
+struct test_move_assignement
+{
+    template <typename Image>
+    void operator()(Image const&)
+    {
+        using image_t = Image;
+        gil::point_t const dimensions{256, 128};
+        {
+            image_t image = fixture::create_image<image_t>(dimensions.x, dimensions.y, 0);
+            image_t image2 = std::move(image);
+            BOOST_TEST_EQ(image2.dimensions(), dimensions);
+            BOOST_TEST_EQ(image.dimensions(), gil::point_t{});
+        }
+    }
+    static void run()
+    {
+        boost::mp11::mp_for_each<fixture::image_types>(test_move_assignement{});
+    }
+};
+
 int main()
 {
     test_constructor_with_dimensions_pixel::run();
 
+    test_move_constructor::run();
+    test_move_assignement::run();
+
     return ::boost::report_errors();
-}
-
-BOOST_AUTO_TEST_CASE_TEMPLATE(move_constructor, Image, fixture::image_types)
-{
-    gil::point_t const dimensions{256, 128};
-    {
-        Image image(fixture::create_image<Image>(dimensions.x, dimensions.y, 0));
-
-        Image image2(std::move(image));
-        BOOST_CHECK_EQUAL(image2.dimensions(), dimensions);
-        BOOST_CHECK_EQUAL(image.dimensions(), gil::point_t{});
-    }
-}
-
-BOOST_AUTO_TEST_CASE_TEMPLATE(move_assignement, Image, fixture::image_types)
-{
-    gil::point_t const dimensions{256, 128};
-    {
-        Image image = fixture::create_image<Image>(dimensions.x, dimensions.y, 0);
-        Image image2 = std::move(image);
-        BOOST_CHECK_EQUAL(image2.dimensions(), dimensions);
-        BOOST_CHECK_EQUAL(image.dimensions(), gil::point_t{});
-    }
 }


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

Add move semantic to `image`.

### References

- Fix part of #438
- [[gil] Review of move assignment operator for image class](https://lists.boost.org/Archives/boost/2020/03/248582.php)

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Add test case(s)
- [ ] Update doc(s)
- [x] Ensure all CI builds pass
- [x] Review and approve
