### PR TITLE
Always build test/extension/io//simple if format libraries are available

### DIFF
--- a/test/extension/io/Jamfile
+++ b/test/extension/io/Jamfile
@@ -38,8 +38,6 @@ alias simple
       : # input files
       : # requirements
         <library>/boost/filesystem//boost_filesystem
-        <define>BOOST_GIL_IO_TEST_ALLOW_READING_IMAGES
-        <define>BOOST_GIL_IO_TEST_ALLOW_WRITING_IMAGES
         [ ac.check-library /libjpeg//libjpeg : <library>/libjpeg//libjpeg : <build>no ]
         [ ac.check-library /zlib//zlib : <library>/zlib//zlib : <build>no ]
         [ ac.check-library /libpng//libpng : <library>/libpng//libpng : <build>no ]

--- a/test/extension/io/paths.hpp
+++ b/test/extension/io/paths.hpp
@@ -5,8 +5,8 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
-#ifndef BOOST_GIL_IO_TEST_PATHS_HPP
-#define BOOST_GIL_IO_TEST_PATHS_HPP
+#ifndef BOOST_GIL_TEST_EXTENSION_IO_PATHS_HPP
+#define BOOST_GIL_TEST_EXTENSION_IO_PATHS_HPP
 
 // Disable warning: conversion to 'std::atomic<int>::__integral_type {aka int}' from 'long int' may alter its value
 #if defined(BOOST_CLANG)
@@ -66,4 +66,4 @@ static const std::string raw_filename(raw_in + "RAW_CANON_D30_SRGB.CRW");
 static const std::string targa_filename(targa_in + "24BPP_compressed.tga");
 static const std::string tiff_filename(tiff_in + "test.tif");
 
-#endif // BOOST_GIL_IO_TEST_PATHS_HPP
+#endif // BOOST_GIL_TEST_EXTENSION_IO_PATHS_HPP

--- a/test/extension/io/simple_all_formats.cpp
+++ b/test/extension/io/simple_all_formats.cpp
@@ -21,66 +21,57 @@ namespace fs = boost::filesystem;
 
 // Test will include all format's headers and load and write some images.
 // This test is more of a compilation test.
-#ifdef BOOST_GIL_IO_TEST_ALLOW_READING_IMAGES
 
 void test_bmp()
 {
     gil::rgb8_image_t img;
     gil::read_image(bmp_filename, img, gil::bmp_tag());
-#ifdef BOOST_GIL_IO_TEST_ALLOW_WRITING_IMAGES
+
     fs::create_directories(fs::path(bmp_out));
-    gil::write_view(bmp_out + "all_formats_test.bmp", gil::view(img), gil::bmp_tag());
-#endif // BOOST_GIL_IO_TEST_ALLOW_WRITING_IMAGES
+    gil::write_view(bmp_out + "simple_all_format.bmp", gil::view(img), gil::bmp_tag());
 }
 
 void test_jpeg()
 {
     gil::rgb8_image_t img;
     gil::read_image(jpeg_filename, img, gil::jpeg_tag());
-#ifdef BOOST_GIL_IO_TEST_ALLOW_WRITING_IMAGES
     fs::create_directories(fs::path(jpeg_out));
-    gil::write_view(jpeg_out + "all_formats_test.jpg", gil::view(img), gil::jpeg_tag());
-#endif // BOOST_GIL_IO_TEST_ALLOW_WRITING_IMAGES
+    gil::write_view(jpeg_out + "simple_all_format.jpg", gil::view(img), gil::jpeg_tag());
 }
 
 void test_png()
 {
     gil::rgba8_image_t img;
     gil::read_image(png_filename, img, gil::png_tag());
-#ifdef BOOST_GIL_IO_TEST_ALLOW_WRITING_IMAGES
     fs::create_directories(fs::path(png_out));
-    gil::write_view(png_out + "all_formats_test.png", gil::view(img), gil::png_tag());
-#endif // BOOST_GIL_IO_TEST_ALLOW_WRITING_IMAGES
+    gil::write_view(png_out + "simple_all_format.png", gil::view(img), gil::png_tag());
 }
 
 void test_pnm()
 {
     gil::rgb8_image_t img;
     gil::read_image(pnm_filename, img, gil::pnm_tag());
-#ifdef BOOST_GIL_IO_TEST_ALLOW_WRITING_IMAGES
+
     fs::create_directories(fs::path(pnm_out));
-    gil::write_view(pnm_out + "all_formats_test.pnm", gil::view(img), gil::pnm_tag());
-#endif // BOOST_GIL_IO_TEST_ALLOW_WRITING_IMAGES
+    gil::write_view(pnm_out + "simple_all_format.pnm", gil::view(img), gil::pnm_tag());
 }
 
 void test_targa()
 {
     gil::rgb8_image_t img;
     gil::read_image(targa_filename, img, gil::targa_tag());
-#ifdef BOOST_GIL_IO_TEST_ALLOW_WRITING_IMAGES
+
     fs::create_directories(fs::path(targa_out));
-    gil::write_view(targa_out + "all_formats_test.tga", gil::view(img), gil::targa_tag());
-#endif // BOOST_GIL_IO_TEST_ALLOW_WRITING_IMAGES
+    gil::write_view(targa_out + "simple_all_format.tga", gil::view(img), gil::targa_tag());
 }
 
 void test_tiff()
 {
     gil::rgba8_image_t img;
     gil::read_image(tiff_filename, img, gil::tiff_tag());
-#ifdef BOOST_GIL_IO_TEST_ALLOW_WRITING_IMAGES
+
     fs::create_directories(fs::path(tiff_out));
-    gil::write_view(tiff_out + "all_formats_test.tif", gil::view(img), gil::tiff_tag());
-#endif // BOOST_GIL_IO_TEST_ALLOW_WRITING_IMAGES
+    gil::write_view(tiff_out + "simple_all_format.tif", gil::view(img), gil::tiff_tag());
 }
 
 int main()
@@ -89,12 +80,9 @@ int main()
     test_jpeg();
     test_png();
     test_pnm();
+    // TODO: test_raw()
     test_targa();
     test_tiff();
 
     return boost::report_errors();
 }
-
-#else
-int main() {}
-#endif // BOOST_GIL_IO_TEST_ALLOW_READING_IMAGES


### PR DESCRIPTION
### Description

This is part of efforts removing use of compile-time configuration macros
  - `BOOST_GIL_IO_TEST_ALLOW_READING_IMAGES`
  - `BOOST_GIL_IO_TEST_ALLOW_WRITING_IMAGES`

### References

The idea of getting rid of the macros was introduce here https://lists.boost.org/boost-gil//2019/07/0279.php

### Tasklist

- [x] Ensure all CI builds pass
