### PR TITLE
Fix invalid conversion from RGB8 to CMYK32 due to overflow

### DIFF
--- a/include/boost/gil/color_convert.hpp
+++ b/include/boost/gil/color_convert.hpp
@@ -105,6 +105,8 @@ struct default_color_converter_impl<gray_t,rgb_t> {
 
 /// \ingroup ColorConvert
 /// \brief Gray to CMYK
+/// \todo FIXME: Where does this calculation come from? Shouldn't gray be inverted?
+///              Currently, white becomes black and black becomes white.
 template <>
 struct default_color_converter_impl<gray_t,cmyk_t> {
     template <typename P1, typename P2>
@@ -141,26 +143,51 @@ struct default_color_converter_impl<rgb_t,gray_t> {
 /// c = (1 - r - k) / (1 - k)
 /// m = (1 - g - k) / (1 - k)
 /// y = (1 - b - k) / (1 - k)
+/// where `1` denotes max value of channel type of destination pixel.
+///
+/// The conversion from RGB to CMYK is based on CMY->CMYK (Version 2)
+/// from the Principles of Digital Image Processing - Fundamental Techniques
+/// by Burger, Wilhelm, Burge, Mark J.
+/// and it is a gross approximation not precise enough for professional work.
+///
+/// \todo FIXME: The original implementation did not handle properly signed CMYK pixels as destination
+///
 template <>
-struct default_color_converter_impl<rgb_t,cmyk_t> {
-    template <typename P1, typename P2>
-    void operator()(const P1& src, P2& dst) const {
-        using T2 = typename channel_type<P2>::type;
-        get_color(dst,cyan_t())    = channel_invert(channel_convert<T2>(get_color(src,red_t())));          // c = 1 - r
-        get_color(dst,magenta_t()) = channel_invert(channel_convert<T2>(get_color(src,green_t())));        // m = 1 - g
-        get_color(dst,yellow_t())  = channel_invert(channel_convert<T2>(get_color(src,blue_t())));         // y = 1 - b
-        get_color(dst,black_t())   = (std::min)(get_color(dst,cyan_t()),
-                                                (std::min)(get_color(dst,magenta_t()),
-                                                           get_color(dst,yellow_t())));   // k = minimum(c, m, y)
-        T2 x = channel_traits<T2>::max_value()-get_color(dst,black_t());                  // x = 1 - k
-        if (x>0.0001f) {
-            float x1 = channel_traits<T2>::max_value()/float(x);
-            get_color(dst,cyan_t())    = (T2)((get_color(dst,cyan_t())    - get_color(dst,black_t()))*x1);                // c = (c - k) / x
-            get_color(dst,magenta_t()) = (T2)((get_color(dst,magenta_t()) - get_color(dst,black_t()))*x1);                // m = (m - k) / x
-            get_color(dst,yellow_t())  = (T2)((get_color(dst,yellow_t())  - get_color(dst,black_t()))*x1);                // y = (y - k) / x
-        } else {
-            get_color(dst,cyan_t())=get_color(dst,magenta_t())=get_color(dst,yellow_t())=0;
+struct default_color_converter_impl<rgb_t, cmyk_t>
+{
+    template <typename SrcPixel, typename DstPixel>
+    void operator()(SrcPixel const& src, DstPixel& dst) const
+    {
+        using src_t = typename channel_type<SrcPixel>::type;
+        src_t const r = get_color(src, red_t());  
+        src_t const g = get_color(src, green_t());
+        src_t const b = get_color(src, blue_t());
+
+        using dst_t   = typename channel_type<DstPixel>::type;
+        dst_t const c = channel_invert(channel_convert<dst_t>(r)); // c = 1 - r
+        dst_t const m = channel_invert(channel_convert<dst_t>(g)); // m = 1 - g
+        dst_t const y = channel_invert(channel_convert<dst_t>(b)); // y = 1 - b
+        dst_t const k = (std::min)(c, (std::min)(m, y));           // k = minimum(c, m, y)
+
+        // Apply color correction, strengthening, reducing non-zero components by
+        // s = 1 / (1 - k) for k < 1, where 1 denotes dst_t max, otherwise s = 1 (literal).
+        dst_t const dst_max = channel_traits<dst_t>::max_value();
+        dst_t const s_div   = dst_max - k;
+        if (s_div != 0)
+        {
+            double const s              = dst_max / static_cast<double>(s_div);
+            get_color(dst, cyan_t())    = static_cast<dst_t>((c - k) * s);
+            get_color(dst, magenta_t()) = static_cast<dst_t>((m - k) * s);
+            get_color(dst, yellow_t())  = static_cast<dst_t>((y - k) * s);
         }
+        else
+        {
+            // Black only for k = 1 (max of dst_t)
+            get_color(dst, cyan_t())    = channel_traits<dst_t>::min_value();
+            get_color(dst, magenta_t()) = channel_traits<dst_t>::min_value();
+            get_color(dst, yellow_t())  = channel_traits<dst_t>::min_value();
+        }
+        get_color(dst, black_t()) = k; 
     }
 };
 

--- a/test/core/pixel/CMakeLists.txt
+++ b/test/core/pixel/CMakeLists.txt
@@ -6,8 +6,9 @@
 # http://www.boost.org/LICENSE_1_0.txt)
 #
 foreach(_name
-  concepts
   bit_aligned_pixel_reference
+  color_convert_cmyk
+  concepts
   is_pixel
   is_planar
   num_channels

--- a/test/core/pixel/Jamfile
+++ b/test/core/pixel/Jamfile
@@ -16,5 +16,6 @@ compile num_channels.cpp ;
 compile pixel_reference_is_mutable.cpp ;
 compile pixels_are_compatible.cpp ;
 
+run color_convert_cmyk.cpp ;
 run packed_pixel.cpp ;
 run test_fixture.cpp ;

--- a/test/core/pixel/color_convert_cmyk.cpp
+++ b/test/core/pixel/color_convert_cmyk.cpp
@@ -1,0 +1,218 @@
+//
+// Copyright 2020 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/gil/cmyk.hpp>
+#include <boost/gil/gray.hpp>
+#include <boost/gil/pixel.hpp>
+#include <boost/gil/rgb.hpp>
+
+#include <boost/mp11.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+#include "test_fixture.hpp"
+#include "core/channel/test_fixture.hpp"
+
+namespace gil = boost::gil;
+namespace fixture = boost::gil::test::fixture;
+namespace mp11 = boost::mp11;
+
+// Test color_convert from any pixel to CMYK pixel types
+
+template <typename SrcPixel>
+struct test_cmyk_from_gray
+{
+    template<typename DstPixel>
+    void operator()(DstPixel const&)
+    {
+        using pixel_src_t = SrcPixel;
+        using pixel_dst_t = DstPixel;
+        fixture::channel_value<typename gil::channel_type<pixel_src_t>::type> f_src;
+        fixture::channel_value<typename gil::channel_type<pixel_dst_t>::type> f_dst;
+
+        // FIXME: Where does this calculation come from? Shouldn't gray be inverted?
+        //        Currently, white becomes black and black becomes white.
+        {
+            pixel_src_t const src{f_src.min_v_};
+            pixel_dst_t dst;
+            gil::color_convert(src, dst);
+
+            BOOST_TEST_EQ(gil::get_color(dst, gil::cyan_t{}), f_dst.min_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::magenta_t{}), f_dst.min_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::yellow_t{}), f_dst.min_v_);
+        }
+        {
+            pixel_src_t const src{f_src.max_v_};
+            pixel_dst_t dst;
+            gil::color_convert(src, dst);
+
+            BOOST_TEST_EQ(gil::get_color(dst, gil::cyan_t{}), f_dst.min_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::magenta_t{}), f_dst.min_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::yellow_t{}), f_dst.min_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::black_t{}), f_dst.max_v_);
+        }
+    }
+    static void run()
+    {
+        boost::mp11::mp_for_each
+        <
+            mp11::mp_list
+            <
+                gil::cmyk8_pixel_t,
+                gil::cmyk8s_pixel_t,
+                gil::cmyk16_pixel_t,
+                gil::cmyk16s_pixel_t,
+                gil::cmyk32_pixel_t,
+                gil::cmyk32s_pixel_t,
+                gil::cmyk32f_pixel_t
+            >
+        >(test_cmyk_from_gray<SrcPixel>{});
+    }
+};
+
+struct test_cmyk_from_rgb
+{
+    template <typename SrcPixel, typename DstPixel>
+    void operator()(mp11::mp_list<SrcPixel, DstPixel> const&) const
+    {
+        using pixel_src_t = SrcPixel;
+        using pixel_dst_t = DstPixel;
+        fixture::channel_value<typename gil::channel_type<pixel_src_t>::type> f_src;
+        fixture::channel_value<typename gil::channel_type<pixel_dst_t>::type> f_dst;
+
+        // black
+        {
+            pixel_src_t const src(f_src.min_v_, f_src.min_v_, f_src.min_v_);
+            pixel_dst_t dst;
+            gil::color_convert(src, dst);
+
+            BOOST_TEST_EQ(gil::get_color(dst, gil::cyan_t{}), f_dst.min_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::magenta_t{}), f_dst.min_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::yellow_t{}), f_dst.min_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::black_t{}), f_dst.max_v_);
+        }
+        // white
+        {
+            pixel_src_t const src(f_src.max_v_, f_src.max_v_, f_src.max_v_);
+            pixel_dst_t dst;
+            gil::color_convert(src, dst);
+
+            BOOST_TEST_EQ(gil::get_color(dst, gil::cyan_t{}), f_dst.min_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::magenta_t{}), f_dst.min_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::yellow_t{}), f_dst.min_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::black_t{}), f_dst.min_v_);
+        }
+        // red
+        {
+            pixel_src_t const src(f_src.max_v_, f_src.min_v_, f_src.min_v_);
+            pixel_dst_t dst;
+            gil::color_convert(src, dst);
+
+            BOOST_TEST_EQ(gil::get_color(dst, gil::cyan_t{}), f_dst.min_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::magenta_t{}), f_dst.max_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::yellow_t{}), f_dst.max_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::black_t{}), f_dst.min_v_);
+        }
+        // green
+        {
+            pixel_src_t const src(f_src.min_v_, f_src.max_v_, f_src.min_v_);
+            pixel_dst_t dst;
+            gil::color_convert(src, dst);
+
+            BOOST_TEST_EQ(gil::get_color(dst, gil::cyan_t{}), f_dst.max_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::magenta_t{}), f_dst.min_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::yellow_t{}), f_dst.max_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::black_t{}), f_dst.min_v_);
+        }
+        // blue
+        {
+            pixel_src_t const src(f_src.min_v_, f_src.min_v_, f_src.max_v_);
+            pixel_dst_t dst;
+            gil::color_convert(src, dst);
+
+            BOOST_TEST_EQ(gil::get_color(dst, gil::cyan_t{}), f_dst.max_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::magenta_t{}), f_dst.max_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::yellow_t{}), f_dst.min_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::black_t{}), f_dst.min_v_);
+        }
+        // yellow
+        {
+            pixel_src_t const src(f_src.max_v_, f_src.max_v_, f_src.min_v_);
+            pixel_dst_t dst;
+            gil::color_convert(src, dst);
+
+            BOOST_TEST_EQ(gil::get_color(dst, gil::cyan_t{}), f_dst.min_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::magenta_t{}), f_dst.min_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::yellow_t{}), f_dst.max_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::black_t{}), f_dst.min_v_);
+        }
+        // cyan
+        {
+            pixel_src_t const src(f_src.min_v_, f_src.max_v_, f_src.max_v_);
+            pixel_dst_t dst;
+            gil::color_convert(src, dst);
+
+            BOOST_TEST_EQ(gil::get_color(dst, gil::cyan_t{}), f_dst.max_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::magenta_t{}), f_dst.min_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::yellow_t{}), f_dst.min_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::black_t{}), f_dst.min_v_);
+        }
+        // magenta
+        {
+            pixel_src_t const src(f_src.max_v_, f_src.min_v_, f_src.max_v_);
+            pixel_dst_t dst;
+            gil::color_convert(src, dst);
+
+            BOOST_TEST_EQ(gil::get_color(dst, gil::cyan_t{}), f_dst.min_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::magenta_t{}), f_dst.max_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::yellow_t{}), f_dst.min_v_);
+            BOOST_TEST_EQ(gil::get_color(dst, gil::black_t{}), f_dst.min_v_);
+        }
+    }
+    static void run()
+    {
+        boost::mp11::mp_for_each
+        <
+            mp11::mp_product
+            <
+                mp11::mp_list,
+                mp11::mp_list
+                <
+                    gil::rgb8_pixel_t,
+                    gil::rgb8s_pixel_t,
+                    gil::rgb16_pixel_t,
+                    gil::rgb16s_pixel_t,
+                    gil::rgb32_pixel_t,
+                    gil::rgb32s_pixel_t,
+                    gil::rgb32f_pixel_t
+                >,
+                mp11::mp_list
+                <
+                    gil::cmyk8_pixel_t,
+                    gil::cmyk16_pixel_t,
+                    gil::cmyk32_pixel_t,
+                    gil::cmyk32f_pixel_t
+                    // FIXME: Conversion not handle properly signed CMYK pixels as destination
+                >
+            >
+        >(test_cmyk_from_rgb{});
+    }
+};
+
+int main()
+{
+    test_cmyk_from_gray<gil::gray8_pixel_t>::run();
+    test_cmyk_from_gray<gil::gray8s_pixel_t>::run();
+    test_cmyk_from_gray<gil::gray16_pixel_t>::run();
+    test_cmyk_from_gray<gil::gray16s_pixel_t>::run();
+    test_cmyk_from_gray<gil::gray32_pixel_t>::run();
+    test_cmyk_from_gray<gil::gray32s_pixel_t>::run();
+    test_cmyk_from_gray<gil::gray32f_pixel_t>::run();
+
+    test_cmyk_from_rgb::run();
+
+    return ::boost::report_errors();
+}


### PR DESCRIPTION
### Description

Correct calculation to correctly map CMYK 0 to minimum and 1 to maximum of input and output channel types.

If float-point division is necessary, use double instead of float which may be too narrow for large operands. `cmyk32_pixel_t` is based on `uint32_t` which multiplication by its maximum may yield result too large to fit 32-bit float.

For example, `(uint32_t(c) -  uint32_t(k)) * float(s)` for`c = 4294967295, k = 0, s = 1.0`
results in `4294967300` value which does not fit `uint32_t`.

**FIXME:** The original calculation was broken for signed CMYK target types. This has not been corrected yet.

### References

- Fixes #406
- https://web.archive.org/web/20061119141350/www.neuro.sfc.keio.ac.jp/~aly/polygon/info/color-space-faq.html

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Add test case(s) - ~currently there are no related tests, to be added~
- [x] Ensure all CI builds pass
- [ ] Review and approve
