### PR TITLE
Move math.hpp constants to detail namespace

### DIFF
--- a/include/boost/gil/detail/math.hpp
+++ b/include/boost/gil/detail/math.hpp
@@ -11,7 +11,7 @@
 #include <array>
 #include <boost/gil/extension/numeric/kernel.hpp>
 
-namespace boost { namespace gil {
+namespace boost { namespace gil { namespace detail {
 
 static constexpr double pi = 3.14159265358979323846;
 
@@ -29,6 +29,6 @@ inline detail::kernel_2d<T, Allocator> get_identity_kernel()
     return kernel;
 }
 
-}} // namespace boost::gil
+}}} // namespace boost::gil::detail
 
 #endif

--- a/include/boost/gil/image_processing/numeric.hpp
+++ b/include/boost/gil/image_processing/numeric.hpp
@@ -32,7 +32,7 @@ namespace boost { namespace gil {
 ///
 inline double normalized_sinc(double x)
 {
-    return std::sin(x * boost::gil::pi) / (x * boost::gil::pi);
+    return std::sin(x * boost::gil::detail::pi) / (x * boost::gil::detail::pi);
 }
 
 /// \brief Lanczos response at point x
@@ -132,7 +132,7 @@ inline detail::kernel_2d<T, Allocator> generate_gaussian_kernel(std::size_t side
         throw std::invalid_argument("kernel dimensions should be odd and equal");
 
 
-    const double denominator = 2 * boost::gil::pi * sigma * sigma;
+    const double denominator = 2 * boost::gil::detail::pi * sigma * sigma;
     auto middle = side_length / 2;
     std::vector<T, Allocator> values(side_length * side_length);
     for (std::size_t y = 0; y < side_length; ++y)
@@ -165,12 +165,12 @@ inline detail::kernel_2d<T, Allocator> generate_dx_sobel(unsigned int degree = 1
     {
         case 0:
         {
-            return get_identity_kernel<T, Allocator>();
+            return detail::get_identity_kernel<T, Allocator>();
         }
         case 1:
         {
             detail::kernel_2d<T, Allocator> result(3, 1, 1);
-            std::copy(dx_sobel.begin(), dx_sobel.end(), result.begin());
+            std::copy(detail::dx_sobel.begin(), detail::dx_sobel.end(), result.begin());
             return result;
         }
         default:
@@ -195,12 +195,12 @@ inline detail::kernel_2d<T, Allocator> generate_dx_scharr(unsigned int degree = 
     {
         case 0:
         {
-            return get_identity_kernel<T, Allocator>();
+            return detail::get_identity_kernel<T, Allocator>();
         }
         case 1:
         {
             detail::kernel_2d<T, Allocator> result(3, 1, 1);
-            std::copy(dx_scharr.begin(), dx_scharr.end(), result.begin());
+            std::copy(detail::dx_scharr.begin(), detail::dx_scharr.end(), result.begin());
             return result;
         }
         default:
@@ -225,12 +225,12 @@ inline detail::kernel_2d<T, Allocator> generate_dy_sobel(unsigned int degree = 1
     {
         case 0:
         {
-            return get_identity_kernel<T, Allocator>();
+            return detail::get_identity_kernel<T, Allocator>();
         }
         case 1:
         {
             detail::kernel_2d<T, Allocator> result(3, 1, 1);
-            std::copy(dy_sobel.begin(), dy_sobel.end(), result.begin());
+            std::copy(detail::dy_sobel.begin(), detail::dy_sobel.end(), result.begin());
             return result;
         }
         default:
@@ -255,12 +255,12 @@ inline detail::kernel_2d<T, Allocator> generate_dy_scharr(unsigned int degree = 
     {
         case 0:
         {
-            return get_identity_kernel<T, Allocator>();
+            return detail::get_identity_kernel<T, Allocator>();
         }
         case 1:
         {
             detail::kernel_2d<T, Allocator> result(3, 1, 1);
-            std::copy(dy_scharr.begin(), dy_scharr.end(), result.begin());
+            std::copy(detail::dy_scharr.begin(), detail::dy_scharr.end(), result.begin());
             return result;
         }
         default:

--- a/test/core/image_processing/sobel_scharr.cpp
+++ b/test/core/image_processing/sobel_scharr.cpp
@@ -19,25 +19,25 @@ namespace gil = boost::gil;
 void test_dx_sobel_kernel()
 {
     auto const kernel = gil::generate_dx_sobel(1);
-    BOOST_TEST_ALL_EQ(kernel.begin(), kernel.end(), gil::dx_sobel.begin(), gil::dx_sobel.end());
+    BOOST_TEST_ALL_EQ(kernel.begin(), kernel.end(), gil::detail::dx_sobel.begin(), gil::detail::dx_sobel.end());
 }
 
 void test_dx_scharr_kernel()
 {
     auto const kernel = gil::generate_dx_scharr(1);
-    BOOST_TEST_ALL_EQ(kernel.begin(), kernel.end(), gil::dx_scharr.begin(), gil::dx_scharr.end());
+    BOOST_TEST_ALL_EQ(kernel.begin(), kernel.end(), gil::detail::dx_scharr.begin(), gil::detail::dx_scharr.end());
 }
 
 void test_dy_sobel_kernel()
 {
     auto const kernel = gil::generate_dy_sobel(1);
-    BOOST_TEST_ALL_EQ(kernel.begin(), kernel.end(), gil::dy_sobel.begin(), gil::dy_sobel.end());
+    BOOST_TEST_ALL_EQ(kernel.begin(), kernel.end(), gil::detail::dy_sobel.begin(), gil::detail::dy_sobel.end());
 }
 
 void test_dy_scharr_kernel()
 {
     auto const kernel = gil::generate_dy_scharr(1);
-    BOOST_TEST_ALL_EQ(kernel.begin(), kernel.end(), gil::dy_scharr.begin(), gil::dy_scharr.end());
+    BOOST_TEST_ALL_EQ(kernel.begin(), kernel.end(), gil::detail::dy_scharr.begin(), gil::detail::dy_scharr.end());
 }
 
 int main()


### PR DESCRIPTION
### Description

Addresses #471. The constants are not part of public interface.

### References

#471

### Tasklist

- [x] Ensure all CI builds pass
- [x] Review and approve
