### PR TITLE
Replace Boost.Variant with Boost.Variant2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -102,6 +102,7 @@ build: off
 build_script:
   - if NOT DEFINED GENERATOR b2 --abbreviate-paths address-model=%AM% toolset=%TOOLSET% variant=%VARIANT% cxxstd=%CXXSTD% libs/gil/test/core
   - if NOT DEFINED GENERATOR b2 --abbreviate-paths address-model=%AM% toolset=%TOOLSET% variant=%VARIANT% cxxstd=%CXXSTD% libs/gil/test/legacy
+  - if NOT DEFINED GENERATOR b2 --abbreviate-paths address-model=%AM% toolset=%TOOLSET% variant=%VARIANT% cxxstd=%CXXSTD% libs/gil/test/extension/dynamic_image
   - if NOT DEFINED GENERATOR b2 --abbreviate-paths address-model=%AM% toolset=%TOOLSET% variant=%VARIANT% cxxstd=%CXXSTD% libs/gil/test/extension/numeric
   - if NOT DEFINED GENERATOR b2 --abbreviate-paths address-model=%AM% toolset=%TOOLSET% variant=%VARIANT% cxxstd=%CXXSTD% libs/gil/test/extension/toolbox
   - if NOT DEFINED GENERATOR b2 --abbreviate-paths address-model=%AM% toolset=%TOOLSET% variant=%VARIANT% cxxstd=%CXXSTD% include=%VCPKG_I% library-path=%VCPKG_L% libs/gil/test/extension/io//simple

--- a/.ci/get-boost.sh
+++ b/.ci/get-boost.sh
@@ -47,7 +47,7 @@ git submodule --quiet update --init $GIT_SUBMODULE_OPTS \
     libs/numeric/conversion \
     libs/preprocessor \
     libs/type_traits \
-    libs/variant
+    libs/variant2
 # Transitive (of GIL tests too)
 git submodule --quiet update --init $GIT_SUBMODULE_OPTS \
     libs/atomic \

--- a/.travis.yml
+++ b/.travis.yml
@@ -236,6 +236,7 @@ script:
       echo "using $TOOLSET : : $COMPILER : ;" > ~/user-config.jam
     ./b2 -j 2 $B2_OPTIONS toolset=$TOOLSET variant=$VARIANT cxxstd=$CXXSTD libs/gil/test/core
     ./b2 -j 2 $B2_OPTIONS toolset=$TOOLSET variant=$VARIANT cxxstd=$CXXSTD libs/gil/test/legacy
+    ./b2 -j 2 $B2_OPTIONS toolset=$TOOLSET variant=$VARIANT cxxstd=$CXXSTD libs/gil/test/extension/dynamic_image
     ./b2 -j 2 $B2_OPTIONS toolset=$TOOLSET variant=$VARIANT cxxstd=$CXXSTD libs/gil/test/extension/numeric
     ./b2 -j 2 $B2_OPTIONS toolset=$TOOLSET variant=$VARIANT cxxstd=$CXXSTD libs/gil/test/extension/toolbox
     ./b2 -j 2 $B2_OPTIONS toolset=$TOOLSET variant=$VARIANT cxxstd=$CXXSTD libs/gil/test/extension/io//simple

--- a/doc/design/dynamic_image.rst
+++ b/doc/design/dynamic_image.rst
@@ -21,21 +21,18 @@ Here is an example:
 
   #define ASSERT_SAME(A,B) static_assert(is_same< A,B >::value, "")
 
-  // Define the set of allowed images
-  typedef mpl::vector<rgb8_image_t, cmyk16_planar_image_t> my_images_t;
-
-  // Create any_image class (or any_image_view) class
-  typedef any_image<my_images_t> my_any_image_t;
+  // Create any_image class (or any_image_view) class with a set of allowed images
+  typedef any_image<rgb8_image_t, cmyk16_planar_image_t> my_any_image_t;
 
   // Associated view types are available (equivalent to the ones in image_t)
-  typedef any_image_view<mpl::vector2<rgb8_view_t,  cmyk16_planar_view_t > > AV;
+  typedef any_image_view<rgb8_view_t, cmyk16_planar_view_t> AV;
   ASSERT_SAME(my_any_image_t::view_t, AV);
 
-  typedef any_image_view<mpl::vector2<rgb8c_view_t, cmyk16c_planar_view_t> > CAV;
+  typedef any_image_view<rgb8c_view_t, cmyk16c_planar_view_t>> CAV;
   ASSERT_SAME(my_any_image_t::const_view_t, CAV);
   ASSERT_SAME(my_any_image_t::const_view_t, my_any_image_t::view_t::const_t);
 
-  typedef any_image_view<mpl::vector2<rgb8_step_view_t, cmyk16_planar_step_view_t> > SAV;
+  typedef any_image_view<rgb8_step_view_t, cmyk16_planar_step_view_t> SAV;
   ASSERT_SAME(typename dynamic_x_step_type<my_any_image_t::view_t>::type, SAV);
 
   // Assign it a concrete image at run time:
@@ -47,73 +44,15 @@ Here is an example:
   // Assigning to an image not in the allowed set throws an exception
   myImg = gray8_image_t();        // will throw std::bad_cast
 
-The ``any_image`` and ``any_image_view`` subclass from GIL ``variant`` class,
-which breaks down the instantiated type into a non-templated underlying base
-type and a unique instantiation type identifier. The underlying base instance
-is represented as a block of bytes.
-The block is large enough to hold the largest of the specified types.
-
-GIL variant is similar to ``boost::variant`` in spirit (hence we borrow the
-name from there) but it differs in several ways from the current boost
-implementation. Perhaps the biggest difference is that GIL variant always
-takes a single argument, which is a model of MPL Random Access Sequence
-enumerating the allowed types. Having a single interface allows GIL variant
-to be used easier in generic code. Synopsis:
-
-.. code-block:: cpp
-
-  template <typename Types>    // models MPL Random Access Container
-  class variant
-  {
-    ...         _bits;
-    std::size_t _index;
-  public:
-    typedef Types types_t;
-
-    variant();
-    variant(const variant& v);
-    virtual ~variant();
-
-    variant& operator=(const variant& v);
-    template <typename TS> friend bool operator==(const variant<TS>& x, const variant<TS>& y);
-    template <typename TS> friend bool operator!=(const variant<TS>& x, const variant<TS>& y);
-
-    // Construct/assign to type T. Throws std::bad_cast if T is not in Types
-    template <typename T> explicit variant(const T& obj);
-    template <typename T> variant& operator=(const T& obj);
-
-    // Construct/assign by swapping T with its current instance. Only possible if they are swappable
-    template <typename T> explicit variant(T& obj, bool do_swap);
-    template <typename T> void move_in(T& obj);
-
-    template <typename T> static bool has_type();
-
-    template <typename T> const T& _dynamic_cast() const;
-    template <typename T>       T& _dynamic_cast();
-
-    template <typename T> bool current_type_is() const;
-  };
-
-  template <typename UOP, typename Types>
-   UOP::result_type apply_operation(variant<Types>& v, UOP op);
-  template <typename UOP, typename Types>
-   UOP::result_type apply_operation(const variant<Types>& v, UOP op);
-
-  template <typename BOP, typename Types1, typename Types2>
-   BOP::result_type apply_operation(      variant<Types1>& v1,       variant<Types2>& v2, UOP op);
-
-  template <typename BOP, typename Types1, typename Types2>
-   BOP::result_type apply_operation(const variant<Types1>& v1,       variant<Types2>& v2, UOP op);
-
-  template <typename BOP, typename Types1, typename Types2>
-   BOP::result_type apply_operation(const variant<Types1>& v1, const variant<Types2>& v2, UOP op);
+The ``any_image`` and ``any_image_view`` subclass from Boost.Variant2 ``variant`` class,
+a never valueless variant type, compatible with ``std::variant`` in C++17.
 
 GIL ``any_image_view`` and ``any_image`` are subclasses of ``variant``:
 
 .. code-block:: cpp
 
-  template <typename ImageViewTypes>
-  class any_image_view : public variant<ImageViewTypes>
+  template <typename ...ImageViewTypes>
+  class any_image_view : public variant<ImageViewTypes...>
   {
   public:
     typedef ... const_t; // immutable equivalent of this
@@ -137,10 +76,9 @@ GIL ``any_image_view`` and ``any_image`` are subclasses of ``variant``:
     y_coord_t   height()        const;
   };
 
-  template <typename ImageTypes>
-  class any_image : public variant<ImageTypes>
+  template <typename ...ImageTypes>
+  class any_image : public variant<ImageTypes...>
   {
-    typedef variant<ImageTypes> parent_t;
   public:
     typedef ... const_view_t;
     typedef ... view_t;

--- a/example/dynamic_image.cpp
+++ b/example/dynamic_image.cpp
@@ -14,8 +14,7 @@ int main()
 {
     namespace gil = boost::gil;
 
-    using my_images_t = boost::mp11::mp_list<gil::gray8_image_t, gil::rgb8_image_t, gil::gray16_image_t, gil::rgb16_image_t>;
-    gil::any_image<my_images_t> dynamic_image;
+    gil::any_image<gil::gray8_image_t, gil::rgb8_image_t, gil::gray16_image_t, gil::rgb16_image_t> dynamic_image;
     gil::read_image("test.jpg", dynamic_image, gil::jpeg_tag());
     // Save the image upside down, preserving its native color space and channel depth
     auto view = gil::flipped_up_down_view(gil::const_view(dynamic_image));

--- a/include/boost/gil/extension/dynamic_image/algorithm.hpp
+++ b/include/boost/gil/extension/dynamic_image/algorithm.hpp
@@ -42,8 +42,8 @@ struct equal_pixels_fn : binary_operation_obj<equal_pixels_fn, bool>
 /// \ingroup ImageViewSTLAlgorithmsEqualPixels
 /// \tparam Types Model Boost.MP11-compatible list of models of ImageViewConcept
 /// \tparam View Model MutableImageViewConcept
-template <typename Types, typename View>
-bool equal_pixels(any_image_view<Types> const& src, View const& dst)
+template <typename ...Types, typename View>
+bool equal_pixels(any_image_view<Types...> const& src, View const& dst)
 {
     return apply_operation(
         src,
@@ -53,8 +53,8 @@ bool equal_pixels(any_image_view<Types> const& src, View const& dst)
 /// \ingroup ImageViewSTLAlgorithmsEqualPixels
 /// \tparam View Model ImageViewConcept
 /// \tparam Types Model Boost.MP11-compatible list of models of MutableImageViewConcept
-template <typename View, typename Types>
-bool equal_pixels(View const& src, any_image_view<Types> const& dst)
+template <typename View, typename ...Types>
+bool equal_pixels(View const& src, any_image_view<Types...> const& dst)
 {
     return apply_operation(
         dst,
@@ -64,8 +64,8 @@ bool equal_pixels(View const& src, any_image_view<Types> const& dst)
 /// \ingroup ImageViewSTLAlgorithmsEqualPixels
 /// \tparam Types1 Model Boost.MP11-compatible list of models of ImageViewConcept
 /// \tparam Types2 Model Boost.MP11-compatible list of models of MutableImageViewConcept
-template <typename Types1, typename Types2>
-bool equal_pixels(any_image_view<Types1> const& src, any_image_view<Types2> const& dst)
+template <typename ...Types1, typename ...Types2>
+bool equal_pixels(any_image_view<Types1...> const& src, any_image_view<Types2...> const& dst)
 {
     return apply_operation(src, dst, detail::equal_pixels_fn());
 }
@@ -87,8 +87,8 @@ struct copy_pixels_fn : public binary_operation_obj<copy_pixels_fn>
 /// \ingroup ImageViewSTLAlgorithmsCopyPixels
 /// \tparam Types Model Boost.MP11-compatible list of models of ImageViewConcept
 /// \tparam View Model MutableImageViewConcept
-template <typename Types, typename View>
-void copy_pixels(any_image_view<Types> const& src, View const& dst)
+template <typename ...Types, typename View>
+void copy_pixels(any_image_view<Types...> const& src, View const& dst)
 {
     apply_operation(src, std::bind(detail::copy_pixels_fn(), std::placeholders::_1, dst));
 }
@@ -96,8 +96,8 @@ void copy_pixels(any_image_view<Types> const& src, View const& dst)
 /// \ingroup ImageViewSTLAlgorithmsCopyPixels
 /// \tparam Types Model Boost.MP11-compatible list of models of MutableImageViewConcept
 /// \tparam View Model ImageViewConcept
-template <typename Types, typename View>
-void copy_pixels(View const& src, any_image_view<Types> const& dst)
+template <typename ...Types, typename View>
+void copy_pixels(View const& src, any_image_view<Types...> const& dst)
 {
     apply_operation(dst, std::bind(detail::copy_pixels_fn(), src, std::placeholders::_1));
 }
@@ -105,8 +105,8 @@ void copy_pixels(View const& src, any_image_view<Types> const& dst)
 /// \ingroup ImageViewSTLAlgorithmsCopyPixels
 /// \tparam Types1 Model Boost.MP11-compatible list of models of ImageViewConcept
 /// \tparam Types2 Model Boost.MP11-compatible list of models of MutableImageViewConcept
-template <typename Types1, typename Types2>
-void copy_pixels(any_image_view<Types1> const& src, any_image_view<Types2> const& dst)
+template <typename ...Types1, typename ...Types2>
+void copy_pixels(any_image_view<Types1...> const& src, any_image_view<Types2...> const& dst)
 {
     apply_operation(src, dst, detail::copy_pixels_fn());
 }
@@ -118,8 +118,8 @@ struct default_color_converter;
 /// \tparam Types Model Boost.MP11-compatible list of models of ImageViewConcept
 /// \tparam View Model MutableImageViewConcept
 /// \tparam CC Model ColorConverterConcept
-template <typename Types, typename View, typename CC>
-void copy_and_convert_pixels(any_image_view<Types> const& src, View const& dst, CC cc)
+template <typename ...Types, typename View, typename CC>
+void copy_and_convert_pixels(any_image_view<Types...> const& src, View const& dst, CC cc)
 {
     using cc_fn = detail::copy_and_convert_pixels_fn<CC>;
     apply_operation(src, std::bind(cc_fn{cc}, std::placeholders::_1, dst));
@@ -128,8 +128,8 @@ void copy_and_convert_pixels(any_image_view<Types> const& src, View const& dst, 
 /// \ingroup ImageViewSTLAlgorithmsCopyAndConvertPixels
 /// \tparam Types Model Boost.MP11-compatible list of models of ImageViewConcept
 /// \tparam View Model MutableImageViewConcept
-template <typename Types, typename View>
-void copy_and_convert_pixels(any_image_view<Types> const& src, View const& dst)
+template <typename ...Types, typename View>
+void copy_and_convert_pixels(any_image_view<Types...> const& src, View const& dst)
 {
     using cc_fn = detail::copy_and_convert_pixels_fn<default_color_converter>;
     apply_operation(src, std::bind(cc_fn{}, std::placeholders::_1, dst));
@@ -139,8 +139,8 @@ void copy_and_convert_pixels(any_image_view<Types> const& src, View const& dst)
 /// \tparam View Model ImageViewConcept
 /// \tparam Types Model Boost.MP11-compatible list of models of MutableImageViewConcept
 /// \tparam CC Model ColorConverterConcept
-template <typename View, typename Types, typename CC>
-void copy_and_convert_pixels(View const& src, any_image_view<Types> const& dst, CC cc)
+template <typename View, typename ...Types, typename CC>
+void copy_and_convert_pixels(View const& src, any_image_view<Types...> const& dst, CC cc)
 {
     using cc_fn = detail::copy_and_convert_pixels_fn<CC>;
     apply_operation(dst, std::bind(cc_fn{cc}, src, std::placeholders::_1));
@@ -149,8 +149,8 @@ void copy_and_convert_pixels(View const& src, any_image_view<Types> const& dst, 
 /// \ingroup ImageViewSTLAlgorithmsCopyAndConvertPixels
 /// \tparam View Model ImageViewConcept
 /// \tparam Type Model Boost.MP11-compatible list of models of MutableImageViewConcept
-template <typename View, typename Types>
-void copy_and_convert_pixels(View const& src, any_image_view<Types> const& dst)
+template <typename View, typename ...Types>
+void copy_and_convert_pixels(View const& src, any_image_view<Types...> const& dst)
 {
     using cc_fn = detail::copy_and_convert_pixels_fn<default_color_converter>;
     apply_operation(dst, std::bind(cc_fn{}, src, std::placeholders::_1));
@@ -160,10 +160,10 @@ void copy_and_convert_pixels(View const& src, any_image_view<Types> const& dst)
 /// \tparam Types1 Model Boost.MP11-compatible list of models of ImageViewConcept
 /// \tparam Types2 Model Boost.MP11-compatible list of models of MutableImageViewConcept
 /// \tparam CC Model ColorConverterConcept
-template <typename Types1, typename Types2, typename CC>
+template <typename ...Types1, typename ...Types2, typename CC>
 void copy_and_convert_pixels(
-    any_image_view<Types1> const& src,
-    any_image_view<Types2> const& dst, CC cc)
+    any_image_view<Types1...> const& src,
+    any_image_view<Types2...> const& dst, CC cc)
 {
     apply_operation(src, dst, detail::copy_and_convert_pixels_fn<CC>(cc));
 }
@@ -171,10 +171,10 @@ void copy_and_convert_pixels(
 /// \ingroup ImageViewSTLAlgorithmsCopyAndConvertPixels
 /// \tparam Types1 Model Boost.MP11-compatible list of models of ImageViewConcept
 /// \tparam Types2 Model Boost.MP11-compatible list of models of MutableImageViewConcept
-template <typename Types1, typename Types2>
+template <typename ...Types1, typename ...Types2>
 void copy_and_convert_pixels(
-    any_image_view<Types1> const& src,
-    any_image_view<Types2> const& dst)
+    any_image_view<Types1...> const& src,
+    any_image_view<Types2...> const& dst)
 {
     apply_operation(src, dst,
         detail::copy_and_convert_pixels_fn<default_color_converter>());
@@ -224,8 +224,8 @@ struct fill_pixels_fn
 /// \ingroup ImageViewSTLAlgorithmsFillPixels
 /// \brief fill_pixels for any image view. The pixel to fill with must be compatible with the current view
 /// \tparam Types Model Boost.MP11-compatible list of models of MutableImageViewConcept
-template <typename Types, typename Value>
-void fill_pixels(any_image_view<Types> const& view, Value const& val)
+template <typename ...Types, typename Value>
+void fill_pixels(any_image_view<Types...> const& view, Value const& val)
 {
     apply_operation(view, detail::fill_pixels_fn<Value>(val));
 }

--- a/include/boost/gil/extension/dynamic_image/any_image.hpp
+++ b/include/boost/gil/extension/dynamic_image/any_image.hpp
@@ -15,7 +15,7 @@
 #include <boost/gil/detail/mp11.hpp>
 
 #include <boost/config.hpp>
-#include <boost/variant.hpp>
+#include <boost/variant2/variant.hpp>
 
 #if BOOST_WORKAROUND(BOOST_MSVC, >= 1400)
 #pragma warning(push)
@@ -84,13 +84,13 @@ struct any_image_get_const_view
 /// In particular, its \p view and \p const_view methods return \p any_image_view, which does not fully model ImageViewConcept. See \p any_image_view for more.
 ////////////////////////////////////////////////////////////////////////////////////////
 
-template <typename Images>
-class any_image : public make_variant_over<Images>::type
+template <typename ...Images>
+class any_image : public variant2::variant<Images...>
 {
-    using parent_t = typename make_variant_over<Images>::type;
-public:
-    using view_t = any_image_view<detail::images_get_views_t<Images>>;
-    using const_view_t = any_image_view<detail::images_get_const_views_t<Images>>;
+    using parent_t = variant2::variant<Images...>;
+public:    
+    using view_t = mp11::mp_rename<detail::images_get_views_t<any_image>, any_image_view>;
+    using const_view_t = mp11::mp_rename<detail::images_get_const_views_t<any_image>, any_image_view>;
     using x_coord_t = std::ptrdiff_t;
     using y_coord_t = std::ptrdiff_t;
     using point_t = point<std::ptrdiff_t>;
@@ -104,9 +104,9 @@ public:
     template <typename Image>
     explicit any_image(Image& img, bool do_swap) : parent_t(img, do_swap) {}
 
-    template <typename OtherImages>
-    any_image(any_image<OtherImages> const& img)
-        : parent_t((typename make_variant_over<OtherImages>::type const&)img)
+    template <typename ...OtherImages>
+    any_image(any_image<OtherImages...> const& img)
+        : parent_t((variant2::variant<OtherImages...> const&)img)
     {}
 
     any_image& operator=(any_image const& img)
@@ -122,10 +122,10 @@ public:
         return *this;
     }
 
-    template <typename OtherImages>
-    any_image& operator=(any_image<OtherImages> const& img)
+    template <typename ...OtherImages>
+    any_image& operator=(any_image<OtherImages...> const& img)
     {
-            parent_t::operator=((typename make_variant_over<OtherImages>::type const&)img);
+            parent_t::operator=((typename variant2::variant<OtherImages...> const&)img);
             return *this;
     }
 
@@ -160,22 +160,22 @@ public:
 /// \ingroup ImageModel
 
 /// \brief Returns the non-constant-pixel view of any image. The returned view is any view.
-/// \tparam Types Models ImageVectorConcept
-template <typename Types>
+/// \tparam Images Models ImageVectorConcept
+template <typename ...Images>
 BOOST_FORCEINLINE
-auto view(any_image<Types>& img) -> typename any_image<Types>::view_t
+auto view(any_image<Images...>& img) -> typename any_image<Images...>::view_t
 {
-    using view_t = typename any_image<Types>::view_t;
+    using view_t = typename any_image<Images...>::view_t;
     return apply_operation(img, detail::any_image_get_view<view_t>());
 }
 
 /// \brief Returns the constant-pixel view of any image. The returned view is any view.
 /// \tparam Types Models ImageVectorConcept
-template <typename Types>
+template <typename ...Images>
 BOOST_FORCEINLINE
-auto const_view(any_image<Types> const& img) -> typename any_image<Types>::const_view_t
+auto const_view(any_image<Images...> const& img) -> typename any_image<Images...>::const_view_t
 {
-    using view_t = typename any_image<Types>::const_view_t;
+    using view_t = typename any_image<Images...>::const_view_t;
     return apply_operation(img, detail::any_image_get_const_view<view_t>());
 }
 ///@}

--- a/include/boost/gil/extension/dynamic_image/any_image_view.hpp
+++ b/include/boost/gil/extension/dynamic_image/any_image_view.hpp
@@ -76,8 +76,7 @@ class any_image_view : public variant2::variant<Views...>
     using parent_t = variant2::variant<Views...>;
 
 public:    
-    using const_t = mp11::mp_rename<detail::views_get_const_t<any_image_view>, any_image_view>;
-    //using const_t = detail::views_get_const_t<any_image_view>;
+    using const_t = detail::views_get_const_t<any_image_view>;
     using x_coord_t = std::ptrdiff_t;
     using y_coord_t = std::ptrdiff_t;
     using point_t = point<std::ptrdiff_t>;

--- a/include/boost/gil/extension/dynamic_image/any_image_view.hpp
+++ b/include/boost/gil/extension/dynamic_image/any_image_view.hpp
@@ -14,7 +14,7 @@
 #include <boost/gil/point.hpp>
 #include <boost/gil/detail/mp11.hpp>
 
-#include <boost/variant.hpp>
+#include <boost/variant2/variant.hpp>
 
 namespace boost { namespace gil {
 
@@ -70,12 +70,14 @@ struct any_type_get_size
 /// To perform an algorithm on any_image_view, put the algorithm in a function object and invoke it by calling \p apply_operation(runtime_view, algorithm_fn);
 ////////////////////////////////////////////////////////////////////////////////////////
 
-template <typename Views>
-class any_image_view : public make_variant_over<Views>::type
+template <typename ...Views>
+class any_image_view : public variant2::variant<Views...>
 {
-    using parent_t = typename make_variant_over<Views>::type;
-public:
-    using const_t = any_image_view<detail::views_get_const_t<Views>>;
+    using parent_t = variant2::variant<Views...>;
+
+public:    
+    using const_t = mp11::mp_rename<detail::views_get_const_t<any_image_view>, any_image_view>;
+    //using const_t = detail::views_get_const_t<any_image_view>;
     using x_coord_t = std::ptrdiff_t;
     using y_coord_t = std::ptrdiff_t;
     using point_t = point<std::ptrdiff_t>;
@@ -87,9 +89,9 @@ public:
     template <typename View>
     explicit any_image_view(View const& view) : parent_t(view) {}
 
-    template <typename OtherViews>
-    any_image_view(any_image_view<OtherViews> const& view)
-        : parent_t((typename make_variant_over<OtherViews>::type const&)view)
+    template <typename ...OtherViews>
+    any_image_view(any_image_view<OtherViews...> const& view)
+        : parent_t((variant2::variant<OtherViews...> const&)view)
     {}
 
     any_image_view& operator=(any_image_view const& view)
@@ -105,10 +107,10 @@ public:
         return *this;
     }
 
-    template <typename OtherViews>
-    any_image_view& operator=(any_image_view<OtherViews> const& view)
+    template <typename ...OtherViews>
+    any_image_view& operator=(any_image_view<OtherViews...> const& view)
     {
-        parent_t::operator=((typename make_variant_over<OtherViews>::type const&)view);
+        parent_t::operator=((variant2::variant<OtherViews...> const&)view);
         return *this;
     }
 
@@ -123,8 +125,8 @@ public:
 //  HasDynamicXStepTypeConcept
 /////////////////////////////
 
-template <typename Views>
-struct dynamic_x_step_type<any_image_view<Views>>
+template <typename ...Views>
+struct dynamic_x_step_type<any_image_view<Views...>>
 {
 private:
     // FIXME: Remove class name injection with gil:: qualification
@@ -135,15 +137,15 @@ private:
     using dynamic_step_view = typename gil::dynamic_x_step_type<T>::type;
 
 public:
-    using type = any_image_view<mp11::mp_transform<dynamic_step_view, Views>>;
+    using type = mp11::mp_transform<dynamic_step_view, any_image_view<Views...>>;
 };
 
 /////////////////////////////
 //  HasDynamicYStepTypeConcept
 /////////////////////////////
 
-template <typename Views>
-struct dynamic_y_step_type<any_image_view<Views>>
+template <typename ...Views>
+struct dynamic_y_step_type<any_image_view<Views...>>
 {
 private:
     // FIXME: Remove class name injection with gil:: qualification
@@ -154,11 +156,11 @@ private:
     using dynamic_step_view = typename gil::dynamic_y_step_type<T>::type;
 
 public:
-    using type = any_image_view<mp11::mp_transform<dynamic_step_view, Views>>;
+    using type = mp11::mp_transform<dynamic_step_view, any_image_view<Views...>>;
 };
 
-template <typename Views>
-struct dynamic_xy_step_type<any_image_view<Views>>
+template <typename ...Views>
+struct dynamic_xy_step_type<any_image_view<Views...>>
 {
 private:
     // FIXME: Remove class name injection with gil:: qualification
@@ -169,11 +171,11 @@ private:
     using dynamic_step_view = typename gil::dynamic_xy_step_type<T>::type;
 
 public:
-    using type = any_image_view<mp11::mp_transform<dynamic_step_view, Views>>;
+    using type = mp11::mp_transform<dynamic_step_view, any_image_view<Views...>>;
 };
 
-template <typename Views>
-struct dynamic_xy_step_transposed_type<any_image_view<Views>>
+template <typename ...Views>
+struct dynamic_xy_step_transposed_type<any_image_view<Views...>>
 {
 private:
     // FIXME: Remove class name injection with gil:: qualification
@@ -184,7 +186,7 @@ private:
     using dynamic_step_view = typename gil::dynamic_xy_step_type<T>::type;
 
 public:
-    using type = any_image_view<mp11::mp_transform<dynamic_step_view, Views>>;
+    using type = mp11::mp_transform<dynamic_step_view, any_image_view<Views...>>;
 };
 
 }}  // namespace boost::gil

--- a/include/boost/gil/extension/dynamic_image/apply_operation.hpp
+++ b/include/boost/gil/extension/dynamic_image/apply_operation.hpp
@@ -10,47 +10,47 @@
 
 #include <boost/gil/detail/mp11.hpp>
 
-#include <boost/variant/apply_visitor.hpp>
+#include <boost/variant2/variant.hpp>
 
 namespace boost { namespace gil {
 
 /// \ingroup Variant
 /// \brief Invokes a generic mutable operation (represented as a unary function object) on a variant
-template <typename Types, typename UnaryOp>
+template <typename ...Types, typename UnaryOp>
 BOOST_FORCEINLINE
-auto apply_operation(variant<Types>& arg, UnaryOp op)
+auto apply_operation(variant2::variant<Types...>& arg, UnaryOp op)
 #if defined(BOOST_NO_CXX14_DECLTYPE_AUTO) || defined(BOOST_NO_CXX11_DECLTYPE_N3276)
     -> typename UnaryOp::result_type
 #endif
 {
-    return apply_visitor(op, arg);
+    return variant2::visit(op, arg);
 }
 
 /// \ingroup Variant
 /// \brief Invokes a generic constant operation (represented as a unary function object) on a variant
-template <typename Types, typename UnaryOp>
+template <typename ...Types, typename UnaryOp>
 BOOST_FORCEINLINE
-auto apply_operation(variant<Types> const& arg, UnaryOp op)
+auto apply_operation(variant2::variant<Types...> const& arg, UnaryOp op)
 #if defined(BOOST_NO_CXX14_DECLTYPE_AUTO) || defined(BOOST_NO_CXX11_DECLTYPE_N3276)
     -> typename UnaryOp::result_type
 #endif
 {
-    return apply_visitor(op, arg);
+    return variant2::visit(op, arg);
 }
 
 /// \ingroup Variant
 /// \brief Invokes a generic constant operation (represented as a binary function object) on two variants
-template <typename Types1, typename Types2, typename BinaryOp>
+template <typename ...Types1, typename ...Types2, typename BinaryOp>
 BOOST_FORCEINLINE
 auto apply_operation(
-    variant<Types1> const& arg1,
-    variant<Types2> const& arg2,
+    variant2::variant<Types1...> const& arg1,
+    variant2::variant<Types2...> const& arg2,
     BinaryOp op)
 #if defined(BOOST_NO_CXX14_DECLTYPE_AUTO) || defined(BOOST_NO_CXX11_DECLTYPE_N3276)
     -> typename BinaryOp::result_type
 #endif
 {
-    return apply_visitor(op, arg1, arg2);
+    return variant2::visit(op, arg1, arg2);
 }
 
 }}  // namespace boost::gil

--- a/include/boost/gil/extension/dynamic_image/image_view_factory.hpp
+++ b/include/boost/gil/extension/dynamic_image/image_view_factory.hpp
@@ -168,116 +168,116 @@ private:
 
 /// \ingroup ImageViewTransformationsFlipUD
 /// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
-template <typename Views>
+template <typename ...Views>
 inline
-auto flipped_up_down_view(any_image_view<Views> const& src)
-    -> typename dynamic_y_step_type<any_image_view<Views>>::type
+auto flipped_up_down_view(any_image_view<Views...> const& src)
+    -> typename dynamic_y_step_type<any_image_view<Views...>>::type
 {
-    using result_view_t = typename dynamic_y_step_type<any_image_view<Views>>::type;
+    using result_view_t = typename dynamic_y_step_type<any_image_view<Views...>>::type;
     return apply_operation(src, detail::flipped_up_down_view_fn<result_view_t>());
 }
 
 /// \ingroup ImageViewTransformationsFlipLR
 /// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
-template <typename Views>
+template <typename ...Views>
 inline
-auto flipped_left_right_view(any_image_view<Views> const& src)
-    -> typename dynamic_x_step_type<any_image_view<Views>>::type
+auto flipped_left_right_view(any_image_view<Views...> const& src)
+    -> typename dynamic_x_step_type<any_image_view<Views...>>::type
 {
-    using result_view_t = typename dynamic_x_step_type<any_image_view<Views>>::type;
+    using result_view_t = typename dynamic_x_step_type<any_image_view<Views...>>::type;
     return apply_operation(src, detail::flipped_left_right_view_fn<result_view_t>());
 }
 
 /// \ingroup ImageViewTransformationsTransposed
 /// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
-template <typename Views>
+template <typename ...Views>
 inline
-auto transposed_view(const any_image_view<Views>& src)
-    -> typename dynamic_xy_step_transposed_type<any_image_view<Views>>::type
+auto transposed_view(const any_image_view<Views...>& src)
+    -> typename dynamic_xy_step_transposed_type<any_image_view<Views...>>::type
 {
-    using result_view_t = typename dynamic_xy_step_transposed_type<any_image_view<Views>>::type;
+    using result_view_t = typename dynamic_xy_step_transposed_type<any_image_view<Views...>>::type;
     return apply_operation(src, detail::tranposed_view_fn<result_view_t>());
 }
 
 /// \ingroup ImageViewTransformations90CW
 /// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
-template <typename Views>
+template <typename ...Views>
 inline
-auto rotated90cw_view(const any_image_view<Views>& src)
-    -> typename dynamic_xy_step_transposed_type<any_image_view<Views>>::type
+auto rotated90cw_view(const any_image_view<Views...>& src)
+    -> typename dynamic_xy_step_transposed_type<any_image_view<Views...>>::type
 {
-    using result_view_t = typename dynamic_xy_step_transposed_type<any_image_view<Views>>::type;
+    using result_view_t = typename dynamic_xy_step_transposed_type<any_image_view<Views...>>::type;
     return apply_operation(src,detail::rotated90cw_view_fn<result_view_t>());
 }
 
 /// \ingroup ImageViewTransformations90CCW
 /// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
-template <typename Views>
+template <typename ...Views>
 inline
-auto rotated90ccw_view(const any_image_view<Views>& src)
-    -> typename dynamic_xy_step_transposed_type<any_image_view<Views>>::type
+auto rotated90ccw_view(const any_image_view<Views...>& src)
+    -> typename dynamic_xy_step_transposed_type<any_image_view<Views...>>::type
 {
-    return apply_operation(src,detail::rotated90ccw_view_fn<typename dynamic_xy_step_transposed_type<any_image_view<Views>>::type>());
+    return apply_operation(src,detail::rotated90ccw_view_fn<typename dynamic_xy_step_transposed_type<any_image_view<Views...>>::type>());
 }
 
 /// \ingroup ImageViewTransformations180
 /// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
-template <typename Views>
+template <typename ...Views>
 inline
-auto rotated180_view(any_image_view<Views> const& src)
-    -> typename dynamic_xy_step_type<any_image_view<Views>>::type
+auto rotated180_view(any_image_view<Views...> const& src)
+    -> typename dynamic_xy_step_type<any_image_view<Views...>>::type
 {
-    using step_type = typename dynamic_xy_step_type<any_image_view<Views>>::type;
+    using step_type = typename dynamic_xy_step_type<any_image_view<Views...>>::type;
     return apply_operation(src, detail::rotated180_view_fn<step_type>());
 }
 
 /// \ingroup ImageViewTransformationsSubimage
 /// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
-template <typename Views>
+template <typename ...Views>
 inline
 auto subimage_view(
-    any_image_view<Views> const& src,
+    any_image_view<Views...> const& src,
     point_t const& topleft,
     point_t const& dimensions)
-    -> any_image_view<Views>
+    -> any_image_view<Views...>
 {
-    using subimage_view_fn = detail::subimage_view_fn<any_image_view<Views>>;
+    using subimage_view_fn = detail::subimage_view_fn<any_image_view<Views...>>;
     return apply_operation(src, subimage_view_fn(topleft, dimensions));
 }
 
 /// \ingroup ImageViewTransformationsSubimage
 /// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
-template <typename Views>
+template <typename ...Views>
 inline
 auto subimage_view(
-    any_image_view<Views> const& src,
+    any_image_view<Views...> const& src,
     std::ptrdiff_t x_min, std::ptrdiff_t y_min, std::ptrdiff_t width, std::ptrdiff_t height)
-    -> any_image_view<Views>
+    -> any_image_view<Views...>
 {
-    using subimage_view_fn = detail::subimage_view_fn<any_image_view<Views>>;
+    using subimage_view_fn = detail::subimage_view_fn<any_image_view<Views...>>;
     return apply_operation(src, subimage_view_fn(point_t(x_min, y_min),point_t(width, height)));
 }
 
 /// \ingroup ImageViewTransformationsSubsampled
 /// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
-template <typename Views>
+template <typename ...Views>
 inline
-auto subsampled_view(any_image_view<Views> const& src, point_t const& step)
-    -> typename dynamic_xy_step_type<any_image_view<Views>>::type
+auto subsampled_view(any_image_view<Views...> const& src, point_t const& step)
+    -> typename dynamic_xy_step_type<any_image_view<Views...>>::type
 {
-    using step_type = typename dynamic_xy_step_type<any_image_view<Views>>::type;
+    using step_type = typename dynamic_xy_step_type<any_image_view<Views...>>::type;
     using subsampled_view = detail::subsampled_view_fn<step_type>;
     return apply_operation(src, subsampled_view(step));
 }
 
 /// \ingroup ImageViewTransformationsSubsampled
 /// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
-template <typename Views>
+template <typename ...Views>
 inline
-auto subsampled_view(any_image_view<Views> const& src, std::ptrdiff_t x_step, std::ptrdiff_t y_step)
-    -> typename dynamic_xy_step_type<any_image_view<Views>>::type
+auto subsampled_view(any_image_view<Views...> const& src, std::ptrdiff_t x_step, std::ptrdiff_t y_step)
+    -> typename dynamic_xy_step_type<any_image_view<Views...>>::type
 {
-    using step_type = typename dynamic_xy_step_type<any_image_view<Views>>::type;
+    using step_type = typename dynamic_xy_step_type<any_image_view<Views...>>::type;
     using subsampled_view_fn = detail::subsampled_view_fn<step_type>;
     return apply_operation(src, subsampled_view_fn(point_t(x_step, y_step)));
 }
@@ -294,20 +294,20 @@ struct views_get_nthchannel_type : mp11::mp_transform<get_nthchannel_type, Views
 
 /// \ingroup ImageViewTransformationsNthChannel
 /// \brief Given a runtime source image view, returns the type of a runtime image view over a single channel of the source view
-template <typename Views>
-struct nth_channel_view_type<any_image_view<Views>>
+template <typename ...Views>
+struct nth_channel_view_type<any_image_view<Views...>>
 {
-    using type = any_image_view<typename detail::views_get_nthchannel_type<Views>::type>;
+    using type = typename detail::views_get_nthchannel_type<any_image_view<Views...>>;
 };
 
 /// \ingroup ImageViewTransformationsNthChannel
 /// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
-template <typename Views>
+template <typename ...Views>
 inline
-auto nth_channel_view(const any_image_view<Views>& src, int n)
-    -> typename nth_channel_view_type<any_image_view<Views>>::type
+auto nth_channel_view(const any_image_view<Views...>& src, int n)
+    -> typename nth_channel_view_type<any_image_view<Views...>>::type
 {
-    using result_view_t = typename nth_channel_view_type<any_image_view<Views>>::type;
+    using result_view_t = typename nth_channel_view_type<any_image_view<Views...>>::type;
     return apply_operation(src,detail::nth_channel_view_fn<result_view_t>(n));
 }
 
@@ -335,41 +335,42 @@ public:
 
 /// \ingroup ImageViewTransformationsColorConvert
 /// \brief Returns the type of a runtime-specified view, color-converted to a given pixel type with user specified color converter
-template <typename Views, typename DstP, typename CC>
-struct color_converted_view_type<any_image_view<Views>,DstP,CC>
+template <typename ...Views, typename DstP, typename CC>
+struct color_converted_view_type<any_image_view<Views...>,DstP,CC>
 {
-    using type = any_image_view<typename detail::views_get_ccv_type<Views, DstP, CC>::type>;
+    //using type = any_image_view<typename detail::views_get_ccv_type<Views, DstP, CC>::type>;
+    using type = detail::views_get_ccv_type<any_image_view<Views...>, DstP, CC>;
 };
 
 /// \ingroup ImageViewTransformationsColorConvert
 /// \brief overload of generic color_converted_view with user defined color-converter
 /// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
-template <typename DstP, typename Views, typename CC>
+template <typename DstP, typename ...Views, typename CC>
 inline
-auto color_converted_view(const any_image_view<Views>& src, CC)
-    -> typename color_converted_view_type<any_image_view<Views>, DstP, CC>::type
+auto color_converted_view(const any_image_view<Views...>& src, CC)
+    -> typename color_converted_view_type<any_image_view<Views...>, DstP, CC>::type
 {
-    using cc_view_t = typename color_converted_view_type<any_image_view<Views>, DstP, CC>::type;
+    using cc_view_t = typename color_converted_view_type<any_image_view<Views...>, DstP, CC>::type;
     return apply_operation(src, detail::color_converted_view_fn<DstP, cc_view_t>());
 }
 
 /// \ingroup ImageViewTransformationsColorConvert
 /// \brief Returns the type of a runtime-specified view, color-converted to a given pixel type with the default coor converter
-template <typename Views, typename DstP>
-struct color_converted_view_type<any_image_view<Views>,DstP>
+template <typename ...Views, typename DstP>
+struct color_converted_view_type<any_image_view<Views...>,DstP>
 {
-    using type = any_image_view<typename detail::views_get_ccv_type<Views, DstP, default_color_converter>::type>;
+    using type = detail::views_get_ccv_type<any_image_view<Views...>, DstP, default_color_converter>;
 };
 
 /// \ingroup ImageViewTransformationsColorConvert
 /// \brief overload of generic color_converted_view with the default color-converter
 /// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
-template <typename DstP, typename Views>
+template <typename DstP, typename ...Views>
 inline
-auto color_converted_view(any_image_view<Views> const& src)
-    -> typename color_converted_view_type<any_image_view<Views>, DstP>::type
+auto color_converted_view(any_image_view<Views...> const& src)
+    -> typename color_converted_view_type<any_image_view<Views...>, DstP>::type
 {
-    using cc_view_t = typename color_converted_view_type<any_image_view<Views>, DstP>::type;
+    using cc_view_t = typename color_converted_view_type<any_image_view<Views...>, DstP>::type;
     return apply_operation(src, detail::color_converted_view_fn<DstP, cc_view_t>());
 }
 
@@ -377,12 +378,12 @@ auto color_converted_view(any_image_view<Views> const& src)
 /// \brief overload of generic color_converted_view with user defined color-converter
 ///        These are workarounds for GCC 3.4, which thinks color_converted_view is ambiguous with the same method for templated views (in gil/image_view_factory.hpp)
 /// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
-template <typename DstP, typename Views, typename CC>
+template <typename DstP, typename ...Views, typename CC>
 inline
-auto any_color_converted_view(const any_image_view<Views>& src, CC)
-    -> typename color_converted_view_type<any_image_view<Views>, DstP, CC>::type
+auto any_color_converted_view(const any_image_view<Views...>& src, CC)
+    -> typename color_converted_view_type<any_image_view<Views...>, DstP, CC>::type
 {
-    using cc_view_t = typename color_converted_view_type<any_image_view<Views>, DstP, CC>::type;
+    using cc_view_t = typename color_converted_view_type<any_image_view<Views...>, DstP, CC>::type;
     return apply_operation(src, detail::color_converted_view_fn<DstP, cc_view_t>());
 }
 
@@ -390,12 +391,12 @@ auto any_color_converted_view(const any_image_view<Views>& src, CC)
 /// \brief overload of generic color_converted_view with the default color-converter
 ///        These are workarounds for GCC 3.4, which thinks color_converted_view is ambiguous with the same method for templated views (in gil/image_view_factory.hpp)
 /// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
-template <typename DstP, typename Views>
+template <typename DstP, typename ...Views>
 inline
-auto any_color_converted_view(const any_image_view<Views>& src)
-    -> typename color_converted_view_type<any_image_view<Views>, DstP>::type
+auto any_color_converted_view(const any_image_view<Views...>& src)
+    -> typename color_converted_view_type<any_image_view<Views...>, DstP>::type
 {
-    using cc_view_t = typename color_converted_view_type<any_image_view<Views>, DstP>::type;
+    using cc_view_t = typename color_converted_view_type<any_image_view<Views...>, DstP>::type;
     return apply_operation(src, detail::color_converted_view_fn<DstP, cc_view_t>());
 }
 

--- a/include/boost/gil/extension/io/bmp/detail/read.hpp
+++ b/include/boost/gil/extension/io/bmp/detail/read.hpp
@@ -704,8 +704,8 @@ public:
               )
     {}
 
-    template< typename Images >
-    void apply( any_image< Images >& images )
+    template< typename ...Images >
+    void apply( any_image< Images... >& images )
     {
         detail::bmp_type_format_checker format_checker( this->_info._bits_per_pixel );
 

--- a/include/boost/gil/extension/io/bmp/detail/write.hpp
+++ b/include/boost/gil/extension/io/bmp/detail/write.hpp
@@ -194,8 +194,8 @@ public:
               )
     {}
 
-    template< typename Views >
-    void apply( const any_image_view< Views >& views )
+    template< typename ...Views >
+    void apply( const any_image_view< Views... >& views )
     {
         detail::dynamic_io_fnobj< detail::bmp_write_is_supported
                                 , parent_t

--- a/include/boost/gil/extension/io/jpeg/detail/read.hpp
+++ b/include/boost/gil/extension/io/jpeg/detail/read.hpp
@@ -276,8 +276,8 @@ public:
               )
     {}
 
-    template< typename Images >
-    void apply( any_image< Images >& images )
+    template< typename ...Images >
+    void apply( any_image< Images... >& images )
     {
         detail::jpeg_type_format_checker format_checker( this->_info._color_space != JCS_YCbCr
                                                        ? this->_info._color_space

--- a/include/boost/gil/extension/io/jpeg/detail/write.hpp
+++ b/include/boost/gil/extension/io/jpeg/detail/write.hpp
@@ -160,8 +160,8 @@ public:
               )
     {}
 
-    template< typename Views >
-    void apply( const any_image_view< Views >& views )
+    template< typename ...Views >
+    void apply( const any_image_view< Views... >& views )
     {
         detail::dynamic_io_fnobj< detail::jpeg_write_is_supported
                                 , parent_t

--- a/include/boost/gil/extension/io/png/detail/read.hpp
+++ b/include/boost/gil/extension/io/png/detail/read.hpp
@@ -409,8 +409,8 @@ public:
               )
     {}
 
-    template< typename Images >
-    void apply( any_image< Images >& images )
+    template< typename ...Images >
+    void apply( any_image< Images... >& images )
     {
         detail::png_type_format_checker format_checker( this->_info._bit_depth
                                                       , this->_info._color_type

--- a/include/boost/gil/extension/io/png/detail/write.hpp
+++ b/include/boost/gil/extension/io/png/detail/write.hpp
@@ -227,8 +227,8 @@ public:
               )
     {}
 
-    template< typename Views >
-    void apply( const any_image_view< Views >& views )
+    template< typename ...Views >
+    void apply( const any_image_view< Views... >& views )
     {
         detail::dynamic_io_fnobj< detail::png_write_is_supported
                                 , parent_t

--- a/include/boost/gil/extension/io/pnm/detail/read.hpp
+++ b/include/boost/gil/extension/io/pnm/detail/read.hpp
@@ -416,8 +416,8 @@ public:
               )
     {}
 
-    template< typename Images >
-    void apply( any_image< Images >& images )
+    template< typename ...Images >
+    void apply( any_image< Images... >& images )
     {
         detail::pnm_type_format_checker format_checker( this->_info._type );
 

--- a/include/boost/gil/extension/io/pnm/detail/write.hpp
+++ b/include/boost/gil/extension/io/pnm/detail/write.hpp
@@ -226,8 +226,8 @@ public:
               )
     {}
 
-    template< typename Views >
-    void apply( const any_image_view< Views >& views )
+    template< typename ...Views >
+    void apply( const any_image_view< Views... >& views )
     {
         detail::dynamic_io_fnobj< detail::pnm_write_is_supported
                                 , parent_t

--- a/include/boost/gil/extension/io/raw/detail/read.hpp
+++ b/include/boost/gil/extension/io/raw/detail/read.hpp
@@ -200,8 +200,8 @@ public:
               )
     {}
 
-    template< typename Images >
-    void apply( any_image< Images >& images )
+    template< typename ...Images >
+    void apply( any_image< Images... >& images )
     {
         detail::raw_type_format_checker format_checker( this->_info );
 

--- a/include/boost/gil/extension/io/targa/detail/read.hpp
+++ b/include/boost/gil/extension/io/targa/detail/read.hpp
@@ -362,8 +362,8 @@ public:
               )
     {}
 
-    template< typename Images >
-    void apply( any_image< Images >& images )
+    template< typename ...Images >
+    void apply( any_image< Images... >& images )
     {
         detail::targa_type_format_checker format_checker( this->_info._bits_per_pixel );
 

--- a/include/boost/gil/extension/io/targa/detail/write.hpp
+++ b/include/boost/gil/extension/io/targa/detail/write.hpp
@@ -163,8 +163,8 @@ public:
               )
     {}
 
-    template< typename Views >
-    void apply( const any_image_view< Views >& views )
+    template< typename ...Views >
+    void apply( const any_image_view< Views... >& views )
     {
         detail::dynamic_io_fnobj< detail::targa_write_is_supported
                                 , parent_t

--- a/include/boost/gil/extension/io/tiff/detail/read.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/read.hpp
@@ -745,8 +745,8 @@ public:
               )
     {}
 
-    template< typename Images >
-    void apply( any_image< Images >& images )
+    template< typename ...Images >
+    void apply( any_image< Images... >& images )
     {
         detail::tiff_type_format_checker format_checker( this->_info );
 

--- a/include/boost/gil/extension/io/tiff/detail/write.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/write.hpp
@@ -430,8 +430,8 @@ public:
               )
     {}
 
-    template< typename Views >
-    void apply( const any_image_view< Views >& views )
+    template< typename ...Views >
+    void apply( const any_image_view< Views... >& views )
     {
         detail::dynamic_io_fnobj< detail::tiff_write_is_supported
                                 , parent_t

--- a/include/boost/gil/extension/numeric/resample.hpp
+++ b/include/boost/gil/extension/numeric/resample.hpp
@@ -70,8 +70,8 @@ namespace detail {
 /// \brief resample_pixels when the source is run-time specified
 ///        If invoked on incompatible views, throws std::bad_cast()
 /// \ingroup ImageAlgorithms
-template <typename Sampler, typename Types1, typename V2, typename MapFn>
-void resample_pixels(const any_image_view<Types1>& src, const V2& dst, const MapFn& dst_to_src, Sampler sampler=Sampler())
+template <typename Sampler, typename ...Types1, typename V2, typename MapFn>
+void resample_pixels(const any_image_view<Types1...>& src, const V2& dst, const MapFn& dst_to_src, Sampler sampler=Sampler())
 {
     apply_operation(src, std::bind(
         detail::resample_pixels_fn<Sampler, MapFn>(dst_to_src, sampler),
@@ -82,8 +82,8 @@ void resample_pixels(const any_image_view<Types1>& src, const V2& dst, const Map
 /// \brief resample_pixels when the destination is run-time specified
 ///        If invoked on incompatible views, throws std::bad_cast()
 /// \ingroup ImageAlgorithms
-template <typename Sampler, typename V1, typename Types2, typename MapFn>
-void resample_pixels(const V1& src, const any_image_view<Types2>& dst, const MapFn& dst_to_src, Sampler sampler=Sampler())
+template <typename Sampler, typename V1, typename ...Types2, typename MapFn>
+void resample_pixels(const V1& src, const any_image_view<Types2...>& dst, const MapFn& dst_to_src, Sampler sampler=Sampler())
 {
     using namespace std::placeholders;
     apply_operation(dst, std::bind(
@@ -95,8 +95,8 @@ void resample_pixels(const V1& src, const any_image_view<Types2>& dst, const Map
 /// \brief resample_pixels when both the source and the destination are run-time specified
 ///        If invoked on incompatible views, throws std::bad_cast()
 /// \ingroup ImageAlgorithms
-template <typename Sampler, typename SrcTypes, typename DstTypes, typename MapFn>
-void resample_pixels(const any_image_view<SrcTypes>& src, const any_image_view<DstTypes>& dst, const MapFn& dst_to_src, Sampler sampler=Sampler()) {
+template <typename Sampler, typename ...SrcTypes, typename ...DstTypes, typename MapFn>
+void resample_pixels(const any_image_view<SrcTypes...>& src, const any_image_view<DstTypes...>& dst, const MapFn& dst_to_src, Sampler sampler=Sampler()) {
     apply_operation(src,dst,detail::resample_pixels_fn<Sampler,MapFn>(dst_to_src,sampler));
 }
 

--- a/include/boost/gil/extension/toolbox/metafunctions/get_pixel_type.hpp
+++ b/include/boost/gil/extension/toolbox/metafunctions/get_pixel_type.hpp
@@ -30,8 +30,8 @@ struct get_pixel_type
         >;
 };
 
-template<typename Views>
-struct get_pixel_type<any_image_view<Views>>
+template<typename ...Views>
+struct get_pixel_type<any_image_view<Views...>>
 {
     using type = any_image_pixel_t;
 };

--- a/include/boost/gil/io/dynamic_io_new.hpp
+++ b/include/boost/gil/io/dynamic_io_new.hpp
@@ -22,12 +22,12 @@ namespace detail {
 template <long N>
 struct construct_matched_t
 {
-    template <typename Images,typename Pred>
-    static bool apply(any_image<Images>& img, Pred pred)
+    template <typename ...Images,typename Pred>
+    static bool apply(any_image<Images...>& img, Pred pred)
     {
-        if (pred.template apply<mp11::mp_at_c<Images, N-1>>())
+        if (pred.template apply<mp11::mp_at_c<any_image<Images...>, N-1>>())
         {
-            using image_t = mp11::mp_at_c<Images, N-1>;
+            using image_t = mp11::mp_at_c<any_image<Images...>, N-1>;
             image_t x;
             img = std::move(x);
             return true;
@@ -39,8 +39,8 @@ struct construct_matched_t
 template <>
 struct construct_matched_t<0>
 {
-    template <typename Images,typename Pred>
-    static bool apply(any_image<Images>&,Pred) { return false; }
+    template <typename ...Images,typename Pred>
+    static bool apply(any_image<Images...>&,Pred) { return false; }
 };
 
 // A function object that can be passed to apply_operation.
@@ -92,10 +92,10 @@ public:
 
 /// \brief Within the any_image, constructs an image with the given dimensions
 ///        and a type that satisfies the given predicate
-template <typename Images,typename Pred>
-inline bool construct_matched(any_image<Images>& img, Pred pred)
+template <typename ...Images,typename Pred>
+inline bool construct_matched(any_image<Images...>& img, Pred pred)
 {
-    constexpr auto size = mp11::mp_size<Images>::value;
+    constexpr auto size = mp11::mp_size<any_image<Images...>>::value;
     return detail::construct_matched_t<size>::apply(img, pred);
 }
 

--- a/include/boost/gil/io/read_image.hpp
+++ b/include/boost/gil/io/read_image.hpp
@@ -170,9 +170,9 @@ void read_image(String const& file_name, Image& img, FormatTag const& tag,
 
 ///
 
-template <typename Reader, typename Images>
+template <typename Reader, typename ...Images>
 inline
-void read_image(Reader& reader, any_image<Images>& images,
+void read_image(Reader& reader, any_image<Images...>& images,
     typename std::enable_if
     <
         mp11::mp_and
@@ -190,11 +190,11 @@ void read_image(Reader& reader, any_image<Images>& images,
 /// \param images    Dynamic image (mp11::mp_list). See boost::gil::dynamic_image extension.
 /// \param settings  Specifies read settings depending on the image format.
 /// \throw std::ios_base::failure
-template <typename Device, typename Images, typename FormatTag>
+template <typename Device, typename ...Images, typename FormatTag>
 inline
 void read_image(
     Device& file,
-    any_image<Images>& images,
+    any_image<Images...>& images,
     image_read_settings<FormatTag> const& settings,
     typename std::enable_if
     <
@@ -216,9 +216,9 @@ void read_image(
 /// \param images    Dynamic image (mp11::mp_list). See boost::gil::dynamic_image extension.
 /// \param tag       Defines the image format. Must satisfy is_format_tag metafunction.
 /// \throw std::ios_base::failure
-template <typename Device, typename Images, typename FormatTag>
+template <typename Device, typename ...Images, typename FormatTag>
 inline
-void read_image(Device& file, any_image<Images>& images, FormatTag const& tag,
+void read_image(Device& file, any_image<Images...>& images, FormatTag const& tag,
     typename std::enable_if
     <
         mp11::mp_and
@@ -239,11 +239,11 @@ void read_image(Device& file, any_image<Images>& images, FormatTag const& tag,
 /// \param images    Dynamic image (mp11::mp_list). See boost::gil::dynamic_image extension.
 /// \param settings  Specifies read settings depending on the image format.
 /// \throw std::ios_base::failure
-template <typename String, typename Images, typename FormatTag>
+template <typename String, typename ...Images, typename FormatTag>
 inline
 void read_image(
     String const& file_name,
-    any_image<Images>& images,
+    any_image<Images...>& images,
     image_read_settings<FormatTag> const& settings,
     typename std::enable_if
     <
@@ -265,9 +265,9 @@ void read_image(
 /// \param images    Dynamic image (mp11::mp_list). See boost::gil::dynamic_image extension.
 /// \param tag       Defines the image format. Must satisfy is_format_tag metafunction.
 /// \throw std::ios_base::failure
-template <typename String, typename Images, typename FormatTag>
+template <typename String, typename ...Images, typename FormatTag>
 inline
-void read_image(String const& file_name, any_image<Images>& images, FormatTag const& tag,
+void read_image(String const& file_name, any_image<Images...>& images, FormatTag const& tag,
     typename std::enable_if
     <
         mp11::mp_and

--- a/include/boost/gil/io/write_view.hpp
+++ b/include/boost/gil/io/write_view.hpp
@@ -137,9 +137,9 @@ void write_view(
 ////////////////////////////////////// dynamic_image
 
 // without image_write_info
-template <typename Writer, typename Views>
+template <typename Writer, typename ...Views>
 inline
-void write_view(Writer& writer, any_image_view<Views> const& view,
+void write_view(Writer& writer, any_image_view<Views...> const& view,
     typename std::enable_if
     <
         mp11::mp_and
@@ -153,10 +153,10 @@ void write_view(Writer& writer, any_image_view<Views> const& view,
 }
 
 // without image_write_info
-template <typename Device, typename Views, typename FormatTag>
+template <typename Device, typename ...Views, typename FormatTag>
 inline
 void write_view(
-    Device& device, any_image_view<Views> const& views, FormatTag const& tag,
+    Device& device, any_image_view<Views...> const& views, FormatTag const& tag,
     typename std::enable_if
     <
         mp11::mp_and
@@ -171,10 +171,10 @@ void write_view(
     write_view(writer, views);
 }
 
-template <typename String, typename Views, typename FormatTag>
+template <typename String, typename ...Views, typename FormatTag>
 inline
 void write_view(
-    String const& file_name, any_image_view<Views> const& views, FormatTag const& tag,
+    String const& file_name, any_image_view<Views...> const& views, FormatTag const& tag,
     typename std::enable_if
     <
         mp11::mp_and
@@ -191,10 +191,10 @@ void write_view(
 
 // with image_write_info
 /// \ingroup IO
-template <typename Device, typename Views, typename FormatTag, typename Log>
+template <typename Device, typename ...Views, typename FormatTag, typename Log>
 inline
 void write_view(
-    Device& device, any_image_view<Views> const& views, image_write_info<FormatTag, Log> const& info,
+    Device& device, any_image_view<Views...> const& views, image_write_info<FormatTag, Log> const& info,
     typename std::enable_if
     <
         mp11::mp_and
@@ -209,10 +209,10 @@ void write_view(
     write_view(writer, views);
 }
 
-template <typename String, typename Views, typename FormatTag, typename Log>
+template <typename String, typename ...Views, typename FormatTag, typename Log>
 inline
 void write_view(
-    String const& file_name, any_image_view<Views> const& views, image_write_info<FormatTag, Log> const& info,
+    String const& file_name, any_image_view<Views...> const& views, image_write_info<FormatTag, Log> const& info,
     typename std::enable_if
     <
         mp11::mp_and

--- a/test/extension/dynamic_image/test_fixture.hpp
+++ b/test/extension/dynamic_image/test_fixture.hpp
@@ -7,7 +7,6 @@
 //
 #include <boost/gil.hpp>
 #include <boost/gil/extension/dynamic_image/any_image.hpp>
-#include <boost/mp11.hpp>
 
 #include <tuple>
 
@@ -17,21 +16,18 @@ namespace test { namespace fixture {
 
 using dynamic_image = gil::any_image
 <
-    boost::mp11::mp_list
-    <
-        gil::gray8_image_t,
-        gil::gray16_image_t,
-        gil::gray32_image_t,
-        gil::bgr8_image_t,
-        gil::bgr16_image_t,
-        gil::bgr32_image_t,
-        gil::rgb8_image_t,
-        gil::rgb16_image_t,
-        gil::rgb32_image_t,
-        gil::rgba8_image_t,
-        gil::rgba16_image_t,
-        gil::rgba32_image_t
-    >
+    gil::gray8_image_t,
+    gil::gray16_image_t,
+    gil::gray32_image_t,
+    gil::bgr8_image_t,
+    gil::bgr16_image_t,
+    gil::bgr32_image_t,
+    gil::rgb8_image_t,
+    gil::rgb16_image_t,
+    gil::rgb32_image_t,
+    gil::rgba8_image_t,
+    gil::rgba16_image_t,
+    gil::rgba32_image_t
 >;
 
 template <typename Image>

--- a/test/legacy/image.cpp
+++ b/test/legacy/image.cpp
@@ -326,14 +326,11 @@ void image_test::dynamic_image_test()
 {
     using any_image_t = any_image
         <
-            mp11::mp_list
-            <
-                gray8_image_t,
-                bgr8_image_t,
-                argb8_image_t,
-                rgb8_image_t,
-                rgb8_planar_image_t
-            >
+            gray8_image_t,
+            bgr8_image_t,
+            argb8_image_t,
+            rgb8_image_t,
+            rgb8_planar_image_t
         >;
     rgb8_planar_image_t img(sample_view.dimensions());
     copy_pixels(sample_view, view(img));


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

Implements dynamic extension with Boost.Variant2 instead of Boost.Variant.

### References

Fixes #232

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Update/Add test case(s)
- [x] Update doc(s)
- [x] Update extension usage in I/O
- [x] Ensure all CI builds pass
- [x] Review and approve
