### PR TITLE
Fix image constructor from other image

### DIFF
--- a/include/boost/gil/image.hpp
+++ b/include/boost/gil/image.hpp
@@ -339,7 +339,8 @@ public:
 
     view_t       _view;      // contains pointer to the pixels, the image size and ways to navigate pixels
     
-    template <typename P2, bool IP2, typename Alloc2> friend class image; // for construction from other type
+    // for construction from other type
+    template <typename P2, bool IP2, typename Alloc2> friend class image;
 private:
     unsigned char* _memory;
     std::size_t    _align_in_bytes;

--- a/include/boost/gil/image.hpp
+++ b/include/boost/gil/image.hpp
@@ -338,6 +338,8 @@ public:
     }
 
     view_t       _view;      // contains pointer to the pixels, the image size and ways to navigate pixels
+    
+    template <typename P2, bool IP2, typename Alloc2> friend class image; // for construction from other type
 private:
     unsigned char* _memory;
     std::size_t    _align_in_bytes;

--- a/test/core/image/image.cpp
+++ b/test/core/image/image.cpp
@@ -38,6 +38,40 @@ struct test_constructor_with_dimensions_pixel
     }
 };
 
+struct test_constructor_from_other_image
+{
+    template <typename Image>
+    void operator()(Image const &)
+    {
+        using image_t = Image;
+        gil::point_t const dimensions{256, 128};
+        using pixel_t = typename image_t::view_t::value_type;
+        pixel_t const rnd_pixel = fixture::pixel_generator<pixel_t>::random();
+        {
+            //constructor interleaved from planar
+            gil::image<pixel_t, true> image1(dimensions, rnd_pixel); 
+            image_t image2(image1);
+            BOOST_TEST_EQ(image2.dimensions(), dimensions);
+            auto v1 = gil::const_view(image1);
+            auto v2 = gil::const_view(image2);
+            BOOST_TEST_ALL_EQ(v1.begin(), v1.end(), v2.begin(), v2.end());
+        }
+        // {
+        //     //constructor planar from interleaved
+        //     image_t image1(dimensions, rnd_pixel); 
+        //     gil::image<pixel_t, true> image2(image1); 
+        //     BOOST_TEST_EQ(image2.dimensions(), dimensions);
+        //     auto v1 = gil::const_view(image1);
+        //     auto v2 = gil::const_view(image2);
+        //     BOOST_TEST_ALL_EQ(v1.begin(), v1.end(), v2.begin(), v2.end());
+        // }
+    }
+    static void run()
+    {
+        boost::mp11::mp_for_each<fixture::multiband_image_types>(test_constructor_from_other_image{});
+    }
+};
+
 struct test_move_constructor
 {
     template <typename Image>
@@ -83,6 +117,7 @@ struct test_move_assignement
 int main()
 {
     test_constructor_with_dimensions_pixel::run();
+    test_constructor_from_other_image::run();
 
     test_move_constructor::run();
     test_move_assignement::run();

--- a/test/core/image/image.cpp
+++ b/test/core/image/image.cpp
@@ -68,7 +68,7 @@ struct test_constructor_from_other_image
     }
     static void run()
     {
-        boost::mp11::mp_for_each<fixture::multiband_image_types>(test_constructor_from_other_image{});
+        boost::mp11::mp_for_each<fixture::rgb_interleaved_image_types>(test_constructor_from_other_image{});
     }
 };
 

--- a/test/core/image/test_fixture.hpp
+++ b/test/core/image/test_fixture.hpp
@@ -38,6 +38,19 @@ using image_types = std::tuple
     gil::rgba32_image_t
 >;
 
+using multiband_image_types = std::tuple
+<
+    gil::bgr8_image_t,
+    gil::bgr16_image_t,
+    gil::bgr32_image_t,
+    gil::rgb8_image_t,
+    gil::rgb16_image_t,
+    gil::rgb32_image_t,
+    gil::rgba8_image_t,
+    gil::rgba16_image_t,
+    gil::rgba32_image_t
+>;
+
 template <typename Image, typename Generator>
 auto generate_image(std::ptrdiff_t size_x, std::ptrdiff_t size_y, Generator&& generate) -> Image
 {

--- a/test/core/image/test_fixture.hpp
+++ b/test/core/image/test_fixture.hpp
@@ -38,7 +38,7 @@ using image_types = std::tuple
     gil::rgba32_image_t
 >;
 
-using multiband_image_types = std::tuple
+using rgb_interleaved_image_types = std::tuple
 <
     gil::bgr8_image_t,
     gil::bgr16_image_t,


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

Fixes

```c++
template <typename P2, bool IP2, typename Alloc2>
image(const image<P2,IP2,Alloc2>& img)
```

giving

```
include/boost/gil/image.hpp:108:84: error: 'std::size_t boost::gil::image<boost::gil::pixel<unsigned char, boost::gil
::layout<boost::mp11::mp_list<boost::gil::gray_color_t> > >, false, std::allocator<unsigned char> >::_align_in_bytes' is
 private within this context
     image(const image<P2,IP2,Alloc2>& img) : _memory(nullptr), _align_in_bytes(img._align_in_bytes), _alloc(img._alloc)
                                                                                ~~~~^~~~~~~~~~~~~~~
../include/boost/gil/image.hpp:345:20: note: declared private here
     std::size_t    _align_in_bytes;
```

### References

<!-- Any links related to this PR: issues, other PRs, mailing list threads, StackOverflow questions, etc. -->

- Raised on [Slack](https://cpplang.slack.com/archives/CSVT0STV2/p1586328948062100).
- Work on this revealed #478 issue

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Add test case(s)
- [ ] Ensure all CI builds pass
- [x] Review and approve
