### PR TITLE
Fix error plane_view_t is not a class or namespace name

### DIFF
--- a/include/boost/gil/extension/toolbox/image_types/subchroma_image.hpp
+++ b/include/boost/gil/extension/toolbox/image_types/subchroma_image.hpp
@@ -525,23 +525,24 @@ typename subchroma_image< Pixel
                                    * u_channel_size;
 
     using plane_view_t = typename subchroma_image<Pixel, Factors>::plane_view_t;
+    using plane_value_t = typename plane_view_t::value_type;
 
     plane_view_t y_plane = interleaved_view( y_width
                                            , y_height
-                                           , (typename plane_view_t::value_type*) y_base // pixels
-                                           , y_width                            // rowsize_in_bytes
+                                           , (plane_value_t*) y_base // pixels
+                                           , y_width                 // rowsize_in_bytes
                                            );
 
     plane_view_t v_plane = interleaved_view( y_width  / scaling_factors_t::ss_X
                                            , y_height / scaling_factors_t::ss_Y
-                                           , (typename plane_view_t::value_type*) v_base // pixels
-                                           , y_width                            // rowsize_in_bytes
+                                           , (plane_value_t*) v_base // pixels
+                                           , y_width                 // rowsize_in_bytes
                                            );
 
     plane_view_t u_plane = interleaved_view( y_width  / scaling_factors_t::ss_X
                                            , y_height / scaling_factors_t::ss_Y
-                                           , (typename plane_view_t::value_type*) u_base // pixels
-                                           , y_width                            // rowsize_in_bytes
+                                           , (plane_value_t*) u_base // pixels
+                                           , y_width                 // rowsize_in_bytes
                                            );
 
     using defer_fn_t = subchroma_image_deref_fn


### PR DESCRIPTION
Issued when compiling toolbox extension using MSVC 14.x with `-permissive-` flag for strict mode.

### References

Fixes #480

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Ensure all CI builds pass (not waiting for Travis on boostorg as Travis here https://travis-ci.org/github/mloskot/gil/builds/673572458 completed fine)
