### PR TITLE
Fix interleaved_view factory using point<std::ptrdiff_t> for dimension

### DIFF
--- a/include/boost/gil/image_view_factory.hpp
+++ b/include/boost/gil/image_view_factory.hpp
@@ -64,7 +64,7 @@ interleaved_view(std::size_t width, std::size_t height,
 /// \ingroup ImageViewConstructors
 /// \brief Constructing image views from raw interleaved pixel data
 template <typename Iterator>
-auto interleaved_view(point<std::size_t> dim, Iterator pixels,
+auto interleaved_view(point<std::ptrdiff_t> dim, Iterator pixels,
                       std::ptrdiff_t rowsize_in_bytes)
     -> typename type_from_x_iterator<Iterator>::view_t
 {


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

Stick to the existing convention of `ptrdiff_t` and ensure it is used consistently across the existing code and new code.

### References

https://cpplang.slack.com/archives/CSVT0STV2/p1587562275123700

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Ensure all CI builds pass
- [x] Review and approve
