### PR TITLE
Fix missing header in numeric/kernel.hpp to make it self-contained.

### DIFF
--- a/include/boost/gil/extension/numeric/kernel.hpp
+++ b/include/boost/gil/extension/numeric/kernel.hpp
@@ -21,6 +21,7 @@
 #include <memory>
 #include <vector>
 #include <cmath>
+#include <stdexcept>
 
 namespace boost { namespace gil {
 


### PR DESCRIPTION
`#include <stdexcept>` is missing in `numeric/kernel.hpp`.

- [ ] Ensure all CI builds pass
- [ ] Review and approve
