### PR TITLE
Fix dynamic_image extension header dependencies

### DIFF
--- a/include/boost/gil/extension/dynamic_image/dynamic_image_all.hpp
+++ b/include/boost/gil/extension/dynamic_image/dynamic_image_all.hpp
@@ -12,6 +12,5 @@
 #include <boost/gil/extension/dynamic_image/any_image.hpp>
 #include <boost/gil/extension/dynamic_image/apply_operation.hpp>
 #include <boost/gil/extension/dynamic_image/image_view_factory.hpp>
-#include <boost/gil.hpp> // FIXME: Include what you use!
 
 #endif

--- a/test/extension/toolbox/channel_type.cpp
+++ b/test/extension/toolbox/channel_type.cpp
@@ -9,6 +9,7 @@
 #include <boost/gil/extension/toolbox/metafunctions/is_bit_aligned.hpp>
 
 #include <boost/gil/channel.hpp>
+#include <boost/gil/packed_pixel.hpp>
 #include <boost/gil/detail/is_channel_integral.hpp>
 
 #include <type_traits>


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

Remove `#include <boost/gil.hpp>` from `<boost/gil/extension/dynamic_image/dynamic_image_all.hpp>`. It ends up that all individual headers in the extension were already including what they need.

### References

Fixes #501 

### Tasklist

- [x] Ensure all CI builds pass
- [x] Review and approve
