### PR TITLE
Fix dynamic image apply_operation when building with -std=c++11

### DIFF
--- a/include/boost/gil/extension/dynamic_image/apply_operation.hpp
+++ b/include/boost/gil/extension/dynamic_image/apply_operation.hpp
@@ -18,7 +18,7 @@ template <typename Variant1, typename Visitor>
 BOOST_FORCEINLINE
 auto apply_operation(Variant1&& arg1, Visitor&& op)
 #if defined(BOOST_NO_CXX14_DECLTYPE_AUTO) || defined(BOOST_NO_CXX11_DECLTYPE_N3276)
-    -> typename Visitor::result_type
+    -> decltype(variant2::visit(std::forward<Visitor>(op), std::forward<Variant1>(arg1)))
 #endif
 {
     return variant2::visit(std::forward<Visitor>(op), std::forward<Variant1>(arg1));
@@ -30,7 +30,7 @@ template <typename Variant1, typename Variant2, typename Visitor>
 BOOST_FORCEINLINE
 auto apply_operation(Variant1&& arg1, Variant2&& arg2, Visitor&& op)
 #if defined(BOOST_NO_CXX14_DECLTYPE_AUTO) || defined(BOOST_NO_CXX11_DECLTYPE_N3276)
--> typename Visitor::result_type
+    -> decltype(variant2::visit(std::forward<Visitor>(op), std::forward<Variant1>(arg1), std::forward<Variant2>(arg2)))
 #endif
 {
     return variant2::visit(std::forward<Visitor>(op), std::forward<Variant1>(arg1), std::forward<Variant2>(arg2));


### PR DESCRIPTION
### Description

Fix a regression introduce in #491 when building with -std=c++11

### References

Fixes #510 

### Tasklist

- [x] Ensure all CI builds pass
- [x] Review and approve
