### PR TITLE
Add image constructor from compatible view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ doc/warnings.txt
 /.vs
 .vscode
 *.code-workspace
+out
 
 # Clang/LLVM
 /.clang-format

--- a/include/boost/gil/image.hpp
+++ b/include/boost/gil/image.hpp
@@ -109,9 +109,9 @@ public:
     {
        allocate_and_copy(img.dimensions(),img._view);
     }
-    
+
     template <typename Loc,
-              typename std::enable_if<std::is_convertible<typename Loc::value_type, Pixel>::value, int>::type = 0>
+              typename std::enable_if<pixels_are_compatible<typename Loc::value_type, Pixel>::value, int>::type = 0>
     image(const image_view<Loc>& view,
           std::size_t alignment = 0,
           const Alloc alloc_in = Alloc()) : _memory(nullptr), _align_in_bytes(alignment), _alloc(alloc_in)

--- a/include/boost/gil/image.hpp
+++ b/include/boost/gil/image.hpp
@@ -111,7 +111,7 @@ public:
     }
     
     template <typename Loc,
-              typename std::enable_if<std::is_convertible<typename Loc::value_type, Pixel>{}, int>::type = 0>
+              typename std::enable_if<std::is_convertible<typename Loc::value_type, Pixel>::value, int>::type = 0>
     image(const image_view<Loc>& view,
           std::size_t alignment = 0,
           const Alloc alloc_in = Alloc()) : _memory(nullptr), _align_in_bytes(alignment), _alloc(alloc_in)

--- a/include/boost/gil/image.hpp
+++ b/include/boost/gil/image.hpp
@@ -109,6 +109,16 @@ public:
     {
        allocate_and_copy(img.dimensions(),img._view);
     }
+    
+    template <typename Loc,
+              typename std::enable_if<std::is_convertible<typename Loc::value_type, Pixel>{}, int>::type = 0>
+    image(const image_view<Loc>& view,
+          std::size_t alignment = 0,
+          const Alloc alloc_in = Alloc()) : _memory(nullptr), _align_in_bytes(alignment), _alloc(alloc_in)
+                                          , _allocated_bytes( 0 )
+    {
+       allocate_and_copy(view.dimensions(),view);
+    }
 
     // TODO Optimization: use noexcept (requires _view to be nothrow copy constructible)
     image(image&& img) :

--- a/test/core/image/image.cpp
+++ b/test/core/image/image.cpp
@@ -72,6 +72,31 @@ struct test_constructor_from_other_image
     }
 };
 
+struct test_constructor_from_view
+{
+    template <typename Image>
+    void operator()(Image const&)
+    {
+        using image_t = Image;
+        gil::point_t const dimensions{ 256, 128 };
+        using pixel_t = typename image_t::view_t::value_type;
+        pixel_t const rnd_pixel = fixture::pixel_generator<pixel_t>::random();
+        {
+            //constructor interleaved from planar
+            gil::image<pixel_t, true> image1(dimensions, rnd_pixel);
+            auto v1 = gil::transposed_view(gil::const_view(image1));
+            image_t image2(gil::transposed_view(v1));
+            BOOST_TEST_EQ(image2.dimensions(), dimensions);
+            auto v2 = gil::const_view(image2);
+            BOOST_TEST_ALL_EQ(v1.begin(), v1.end(), v2.begin(), v2.end());
+        }
+    }
+    static void run()
+    {
+        boost::mp11::mp_for_each<fixture::rgb_interleaved_image_types>(test_constructor_from_view{});
+    }
+};
+
 struct test_move_constructor
 {
     template <typename Image>


### PR DESCRIPTION
### Description

For convenience, this PR introduces a new image constructor to "materialize" (in the SQL sense) an image_view.

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Add test case(s)
- [x] Ensure all CI builds pass
- [x] Review and approve
