### PR TITLE
Fix conversion of rgb to signed cmyk(boostorg#479)

### DIFF
--- a/include/boost/gil/color_convert.hpp
+++ b/include/boost/gil/color_convert.hpp
@@ -162,10 +162,10 @@ struct default_color_converter_impl<rgb_t, cmyk_t>
         src_t const b = get_color(src, blue_t());
 
         using uint_t = typename channel_type<cmyk8_pixel_t>::type;
-        uint_t c = channel_invert(channel_convert<uint_t>(r)); // c = 1 - r 
+        uint_t c = channel_invert(channel_convert<uint_t>(r)); // c = 1 - r
         uint_t m = channel_invert(channel_convert<uint_t>(g)); // m = 1 - g
         uint_t y = channel_invert(channel_convert<uint_t>(b)); // y = 1 - b
-        uint_t k = (std::min)(c,(std::min)(m,y));              //k = minimum(c, m, y)
+        uint_t k = (std::min)(c,(std::min)(m,y));              // k = minimum(c, m, y)
 
         // Apply color correction, strengthening, reducing non-zero components by
         // s = 1 / (1 - k) for k < 1, where 1 denotes dst_t max, otherwise s = 1 (literal).

--- a/include/boost/gil/color_convert.hpp
+++ b/include/boost/gil/color_convert.hpp
@@ -157,20 +157,20 @@ struct default_color_converter_impl<rgb_t, cmyk_t>
     void operator()(SrcPixel const& src, DstPixel& dst) const
     {
         using src_t = typename channel_type<SrcPixel>::type;
-        src_t const r  = get_color(src,red_t());
-        src_t const g  = get_color(src,green_t());
-        src_t const b  = get_color(src,blue_t());
+        src_t const r = get_color(src, red_t());
+        src_t const g = get_color(src, green_t());
+        src_t const b = get_color(src, blue_t());
 
-        using dst_us_t = typename channel_type< cmyk8_pixel_t >::type;
-        dst_us_t c = channel_invert(channel_convert<dst_us_t>(r)); // c = 1 - r 
-        dst_us_t m = channel_invert(channel_convert<dst_us_t>(g)); // m = 1 - g
-        dst_us_t y = channel_invert(channel_convert<dst_us_t>(b)); // y = 1 - b
-        dst_us_t k   = (std::min)(c,(std::min)(m,y));              //k = minimum(c, m, y)
+        using uint_t = typename channel_type<cmyk8_pixel_t>::type;
+        uint_t c = channel_invert(channel_convert<uint_t>(r)); // c = 1 - r 
+        uint_t m = channel_invert(channel_convert<uint_t>(g)); // m = 1 - g
+        uint_t y = channel_invert(channel_convert<uint_t>(b)); // y = 1 - b
+        uint_t k = (std::min)(c,(std::min)(m,y));              //k = minimum(c, m, y)
 
         // Apply color correction, strengthening, reducing non-zero components by
         // s = 1 / (1 - k) for k < 1, where 1 denotes dst_t max, otherwise s = 1 (literal).
-        dst_us_t const dst_max = channel_traits<dst_us_t>::max_value();
-        dst_us_t const s_div   = dst_max - k;
+        uint_t const dst_max = channel_traits<uint_t>::max_value();
+        uint_t const s_div   = dst_max - k;
         if (s_div != 0)
         {
             double const s = dst_max / static_cast<double>(s_div);
@@ -181,9 +181,9 @@ struct default_color_converter_impl<rgb_t, cmyk_t>
         else
         {
             // Black only for k = 1 (max of dst_t)
-            c = channel_traits<dst_us_t>::min_value();
-            m = channel_traits<dst_us_t>::min_value();
-            y = channel_traits<dst_us_t>::min_value();
+            c = channel_traits<uint_t>::min_value();
+            m = channel_traits<uint_t>::min_value();
+            y = channel_traits<uint_t>::min_value();
         }
         using dst_t   = typename channel_type<DstPixel>::type;
         get_color(dst, cyan_t())    = channel_convert<dst_t>(c);
@@ -192,6 +192,7 @@ struct default_color_converter_impl<rgb_t, cmyk_t>
         get_color(dst, black_t())   = channel_convert<dst_t>(k);
     }
 };
+
 
 /// \ingroup ColorConvert
 /// \brief CMYK to RGB (not the fastest code in the world)

--- a/test/core/color/CMakeLists.txt
+++ b/test/core/color/CMakeLists.txt
@@ -8,7 +8,8 @@
 foreach(_name
   concepts
   color_spaces_are_compatible
-  default_color_converter_impl)
+  default_color_converter_impl
+  default_color_converter_rgb_to_cmyk)
   set(_test t_core_color_${_name})
   set(_target test_core_color_${_name})
 

--- a/test/core/color/Jamfile
+++ b/test/core/color/Jamfile
@@ -13,3 +13,4 @@ compile color_spaces_are_compatible.cpp ;
 compile-fail default_color_converter_impl_fail.cpp ;
 
 run default_color_converter_impl.cpp ;
+run default_color_converter_rgb_to_cmyk.cpp ;

--- a/test/core/color/default_color_converter_rgb_to_cmyk.cpp
+++ b/test/core/color/default_color_converter_rgb_to_cmyk.cpp
@@ -1,0 +1,325 @@
+#include <boost/gil.hpp>
+#include <boost/gil/color_convert.hpp>
+#include <boost/gil/rgb.hpp>
+#include <boost/gil/cmyk.hpp>
+#include <boost/mp11.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <type_traits>
+
+#include "test_utility_output_stream.hpp"
+#include "test_fixture.hpp"
+
+namespace gil = boost::gil;
+
+void test_unsigned_rgb_to_unsigned_cmyk()
+{
+    // black
+    {
+        gil::rgb8_pixel_t src{0, 0, 0};
+        gil::cmyk8_pixel_t dst;
+        gil::cmyk8_pixel_t expected_dst{0,0,0,255};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+    // white
+    {
+        gil::rgb8_pixel_t src{255, 255, 255};
+        gil::cmyk8_pixel_t dst;
+        gil::cmyk8_pixel_t expected_dst{0, 0, 0, 0};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+    // blue
+    {
+        gil::rgb8_pixel_t src{0, 0, 255};
+        gil::cmyk8_pixel_t dst;
+        gil::cmyk8_pixel_t expected_dst{255, 255, 0, 0};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+    // yellow
+    {
+        gil::rgb8_pixel_t src{255, 255, 0};
+        gil::cmyk8_pixel_t dst;
+        gil::cmyk8_pixel_t expected_dst{0, 0, 255, 0};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+    //random pixel values 1
+    {
+        gil::rgb8_pixel_t src{1, 2, 3};
+        gil::cmyk8_pixel_t dst;
+        gil::cmyk8_pixel_t expected_dst{170, 85, 0, 252};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+    //random pixel values 2
+    {
+        gil::rgb8_pixel_t src{11, 117, 250};
+        gil::cmyk8_pixel_t dst;
+        gil::cmyk8_pixel_t expected_dst{243, 135, 0, 5};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+    //random pixel values 3
+    {
+        gil::rgb8_pixel_t src{230, 45, 100};
+        gil::cmyk8_pixel_t dst;
+        gil::cmyk8_pixel_t expected_dst{0, 205, 144, 25};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+    //random pixel values 4
+    {
+        gil::rgb8_pixel_t src{200, 255, 53};
+        gil::cmyk8_pixel_t dst;
+        gil::cmyk8_pixel_t expected_dst{55, 0, 202, 0};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+}
+
+void test_signed_rgb_to_unsigned_cmyk()
+{
+    // black
+    {
+        gil::rgb8s_pixel_t src{-128, -128, -128};
+        gil::cmyk8_pixel_t dst;
+        gil::cmyk8_pixel_t expected_dst{0,0,0,255};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+    // white
+    {
+        gil::rgb8s_pixel_t src{127, 127, 127};
+        gil::cmyk8_pixel_t dst;
+        gil::cmyk8_pixel_t expected_dst{0, 0, 0, 0};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+    // blue
+    {
+        gil::rgb8s_pixel_t src{-128, -128, 127};
+        gil::cmyk8_pixel_t dst;
+        gil::cmyk8_pixel_t expected_dst{255, 255, 0, 0};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+    // yellow
+    {
+        gil::rgb8s_pixel_t src{127, 127, -128};
+        gil::cmyk8_pixel_t dst;
+        gil::cmyk8_pixel_t expected_dst{0, 0, 255, 0};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+    //random pixel values 1
+    {
+        gil::rgb8s_pixel_t src{-127, -126, -125};
+        gil::cmyk8_pixel_t dst;
+        gil::cmyk8_pixel_t expected_dst{170, 85, 0, 252};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+    //random pixel values 2
+    {
+        gil::rgb8s_pixel_t src{-117, -11, 122};
+        gil::cmyk8_pixel_t dst;
+        gil::cmyk8_pixel_t expected_dst{243, 135, 0, 5};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+    //random pixel values 3
+    {
+        gil::rgb8s_pixel_t src{102, -83, -28};
+        gil::cmyk8_pixel_t dst;
+        gil::cmyk8_pixel_t expected_dst{0, 205, 144, 25};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+    //random pixel values 4
+    {
+        gil::rgb8s_pixel_t src{72, 127, -75};
+        gil::cmyk8_pixel_t dst;
+        gil::cmyk8_pixel_t expected_dst{55, 0, 202, 0};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+}
+
+void test_unsigned_rgb_to_signed_cmyk()
+{
+    // black
+    {
+        gil::rgb8_pixel_t src{0, 0, 0};
+        gil::cmyk8s_pixel_t dst;
+        gil::cmyk8s_pixel_t expected_dst{-128, -128, -128, 127};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+    // white
+    {
+        gil::rgb8_pixel_t src{255, 255, 255};
+        gil::cmyk8s_pixel_t dst;
+        gil::cmyk8s_pixel_t expected_dst{-128, -128, -128, -128};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+    // blue
+    {
+        gil::rgb8_pixel_t src{0, 0, 255};
+        gil::cmyk8s_pixel_t dst;
+        gil::cmyk8s_pixel_t expected_dst{127, 127, -128, -128};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+    // yellow
+    {
+        gil::rgb8_pixel_t src{255, 255, 0};
+        gil::cmyk8s_pixel_t dst;
+        gil::cmyk8s_pixel_t expected_dst{-128, -128, 127, -128};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+    //random pixel values 1
+    {
+        gil::rgb8_pixel_t src{1, 2, 3};
+        gil::cmyk8s_pixel_t dst;
+        gil::cmyk8s_pixel_t expected_dst{42, -43, -128, 124};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+    //random pixel values 2
+    {
+        gil::rgb8_pixel_t src{11, 117, 250};
+        gil::cmyk8s_pixel_t dst;
+        gil::cmyk8s_pixel_t expected_dst{115, 7, -128, -123};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+    //random pixel values 3
+    {
+        gil::rgb8_pixel_t src{230, 45, 100};
+        gil::cmyk8s_pixel_t dst;
+        gil::cmyk8s_pixel_t expected_dst{-128, 77, 16, -103};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+    //random pixel values 4
+    {
+        gil::rgb8_pixel_t src{200, 255, 53};
+        gil::cmyk8s_pixel_t dst;
+        gil::cmyk8s_pixel_t expected_dst{-73, -128, 74, -128};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+}
+
+void test_signed_rgb_to_signed_cmyk()
+{
+    // black
+    {
+        gil::rgb8s_pixel_t src{-128, -128, -128};
+        gil::cmyk8s_pixel_t dst;
+        gil::cmyk8s_pixel_t expected_dst{-128,-128,-128, 127};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+    // white
+    {
+        gil::rgb8s_pixel_t src{127, 127, 127};
+        gil::cmyk8s_pixel_t dst;
+        gil::cmyk8s_pixel_t expected_dst{-128, -128, -128, -128};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+    // blue
+    {
+        gil::rgb8s_pixel_t src{-128, -128, 127};
+        gil::cmyk8s_pixel_t dst;
+        gil::cmyk8s_pixel_t expected_dst{127, 127, -128, -128};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+    // yellow
+    {
+        gil::rgb8s_pixel_t src{127, 127, -128};
+        gil::cmyk8s_pixel_t dst;
+        gil::cmyk8s_pixel_t expected_dst{-128, -128, 127, -128};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+    //random pixel values 1
+    {
+        gil::rgb8s_pixel_t src{-127, -126, -125};
+        gil::cmyk8s_pixel_t dst;
+        gil::cmyk8s_pixel_t expected_dst{42, -43, -128, 124};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+    //random pixel values 2
+    {
+        gil::rgb8s_pixel_t src{-117, -11, 122};
+        gil::cmyk8s_pixel_t dst;
+        gil::cmyk8s_pixel_t expected_dst{115, 7, -128, -123};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+    //random pixel values 3
+    {
+        gil::rgb8s_pixel_t src{102, -83, -28};
+        gil::cmyk8s_pixel_t dst;
+        gil::cmyk8s_pixel_t expected_dst{-128, 77, 16, -103};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+    //random pixel values 4
+    {
+        gil::rgb8s_pixel_t src{72, 127, -75};
+        gil::cmyk8s_pixel_t dst;
+        gil::cmyk8s_pixel_t expected_dst{-73, -128, 74, -128};
+
+        gil::color_convert(src, dst);
+        BOOST_TEST_EQ(dst, expected_dst);
+    }
+}
+
+int main()
+{
+    test_unsigned_rgb_to_unsigned_cmyk();
+    test_signed_rgb_to_unsigned_cmyk();
+    test_unsigned_rgb_to_signed_cmyk();
+    test_signed_rgb_to_signed_cmyk();
+    return ::boost::report_errors();
+}

--- a/test/core/color/default_color_converter_rgb_to_cmyk.cpp
+++ b/test/core/color/default_color_converter_rgb_to_cmyk.cpp
@@ -7,7 +7,6 @@
 #include <type_traits>
 
 #include "test_utility_output_stream.hpp"
-#include "test_fixture.hpp"
 
 namespace gil = boost::gil;
 


### PR DESCRIPTION
### Description

Conversion of RGB pixels based on unsigned integral channels to CMYK based on signed integral channels was/is broken (issue #479). It happend because relations used for color correction like `c' = (c - k) * s` etc. didn't work well for signed integral channels. 

This correction is attempted by doing **all color correction calculations of pixel values based on unsigned** integral channels then(after the calculations are finished) converting those values to signed ones.

### References

Principles of Digital Image Processing - Fundamental Techniques (Book name provided in `color_convert.hpp`)

### Tasklist

- [x] Add test case(s)
- [x] Ensure all CI builds pass
- [ ] Review and approve
