### PR TITLE
Fix typo in copyright headers.

### DIFF
--- a/test/extension/toolbox/Jamfile
+++ b/test/extension/toolbox/Jamfile
@@ -1,7 +1,7 @@
 # Boost.GIL (Generic Image Library) - Toolbox tests
 #
 # Copyright (c) 2012 Christian Henning
-# Copyright (c) 2012-202 Mateusz Loskot <mateusz@loskot.net>
+# Copyright (c) 2012-2020 Mateusz Loskot <mateusz@loskot.net>
 #
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

I discovered another typo in copyright headers. Sorry for not noticing this in my first PR.
