### PR TITLE
Fix any_image_view::const_t

### DIFF
--- a/include/boost/gil/extension/dynamic_image/any_image.hpp
+++ b/include/boost/gil/extension/dynamic_image/any_image.hpp
@@ -89,29 +89,15 @@ template <typename ...Images>
 class any_image : public variant2::variant<Images...>
 {
     using parent_t = variant2::variant<Images...>;
+
 public:    
     using view_t = mp11::mp_rename<detail::images_get_views_t<any_image>, any_image_view>;
     using const_view_t = mp11::mp_rename<detail::images_get_const_views_t<any_image>, any_image_view>;
     using x_coord_t = std::ptrdiff_t;
     using y_coord_t = std::ptrdiff_t;
     using point_t = point<std::ptrdiff_t>;
-
-    any_image() = default;
-    any_image(any_image const& img) : parent_t((parent_t const&)img) {}
-
-    template <typename Image>
-    explicit any_image(Image const& img) : parent_t(img) {}
     
-    template <typename Image>
-    any_image(Image&& img) : parent_t(std::move(img)) {}
-
-    template <typename Image>
-    explicit any_image(Image& img, bool do_swap) : parent_t(img, do_swap) {}
-
-    template <typename ...OtherImages>
-    any_image(any_image<OtherImages...> const& img)
-        : parent_t((variant2::variant<OtherImages...> const&)img)
-    {}
+    using parent_t::parent_t;
 
     any_image& operator=(any_image const& img)
     {

--- a/include/boost/gil/extension/dynamic_image/any_image_view.hpp
+++ b/include/boost/gil/extension/dynamic_image/any_image_view.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright 2005-2007 Adobe Systems Incorporated
+// Copyright 2020 Samuel Debionne
 //
 // Distributed under the Boost Software License, Version 1.0
 // See accompanying file LICENSE_1_0.txt or copy at
@@ -82,16 +83,7 @@ public:
     using point_t = point<std::ptrdiff_t>;
     using size_type = std::size_t;
 
-    any_image_view() = default;
-    any_image_view(any_image_view const& view) : parent_t((parent_t const&)view) {}
-
-    template <typename View>
-    explicit any_image_view(View const& view) : parent_t(view) {}
-
-    template <typename ...OtherViews>
-    any_image_view(any_image_view<OtherViews...> const& view)
-        : parent_t((variant2::variant<OtherViews...> const&)view)
-    {}
+    using parent_t::parent_t;
 
     any_image_view& operator=(any_image_view const& view)
     {

--- a/include/boost/gil/extension/dynamic_image/any_image_view.hpp
+++ b/include/boost/gil/extension/dynamic_image/any_image_view.hpp
@@ -24,10 +24,10 @@ struct dynamic_xy_step_transposed_type;
 namespace detail {
 
 template <typename View>
-struct get_const_t { using type = typename View::const_t; };
+using get_const_t = typename View::const_t;
 
 template <typename Views>
-struct views_get_const_t : mp11::mp_transform<get_const_t, Views> {};
+using views_get_const_t = mp11::mp_transform<get_const_t, Views>;
 
 // works for both image_view and image
 struct any_type_get_num_channels

--- a/test/extension/dynamic_image/CMakeLists.txt
+++ b/test/extension/dynamic_image/CMakeLists.txt
@@ -8,6 +8,7 @@
 message(STATUS "Boost.GIL: Configuring tests in test/extension/dynamic_image")
 foreach(_name
   any_image
+  any_image_view
   subimage_view)
   set(_test t_ext_dynamic_image_${_name})
   set(_target test_ext_dynamic_image_${_name})

--- a/test/extension/dynamic_image/Jamfile
+++ b/test/extension/dynamic_image/Jamfile
@@ -11,4 +11,5 @@ import testing ;
 alias headers : [ generate_self_contained_headers extension/dynamic_image ] ;
 
 run any_image.cpp ;
+run any_image_view.cpp ;
 run subimage_view.cpp ;

--- a/test/extension/dynamic_image/any_image_view.cpp
+++ b/test/extension/dynamic_image/any_image_view.cpp
@@ -1,0 +1,27 @@
+//
+// Copyright 2020 Samuel Debionne
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/gil.hpp>
+#include <boost/gil/extension/dynamic_image/any_image_view.hpp>
+
+#include <boost/core/lightweight_test.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
+
+#include <type_traits>
+
+#include "test_fixture.hpp"
+#include "core/image/test_fixture.hpp"
+
+namespace gil = boost::gil;
+namespace fixture = boost::gil::test::fixture;
+
+int main()
+{
+    BOOST_TEST_TRAIT_SAME(gil::any_image_view<gil::gray8_view_t>::const_t, gil::any_image_view<gil::gray8c_view_t>);
+
+    return ::boost::report_errors();
+}

--- a/test/extension/dynamic_image/any_image_view.cpp
+++ b/test/extension/dynamic_image/any_image_view.cpp
@@ -19,9 +19,110 @@
 namespace gil = boost::gil;
 namespace fixture = boost::gil::test::fixture;
 
-int main()
+void test_any_image_view_nested_types()
 {
     BOOST_TEST_TRAIT_SAME(gil::any_image_view<gil::gray8_view_t>::const_t, gil::any_image_view<gil::gray8c_view_t>);
+}
+
+
+struct test_any_image_view_init_ctor
+{
+    template <typename Image>
+    void operator()(Image const&)
+    {
+        using image_t = Image;
+        using view_t = typename Image::view_t;
+        using any_view_t = gil::any_image_view<view_t>;
+        using any_const_view_t = typename any_view_t::const_t;
+        Image i0(fixture::create_image<image_t>(4, 4, 128));
+
+        view_t v0 = gil::view(i0);
+        any_view_t v1 = v0;
+
+        BOOST_TEST_EQ(v1.dimensions().x, 4);
+        BOOST_TEST_EQ(v1.dimensions().y, 4);
+
+        any_const_view_t v2 = v0;
+
+        BOOST_TEST_EQ(v2.dimensions().x, 4);
+        BOOST_TEST_EQ(v2.dimensions().y, 4);
+
+        //any_const_view_t v3 = v1;
+    }
+    static void run()
+    {
+        boost::mp11::mp_for_each<fixture::image_types>(test_any_image_view_init_ctor{});
+    }
+};
+
+struct test_any_image_view_copy_ctor
+{
+    template <typename Image>
+    void operator()(Image const&)
+    {
+        using image_t = Image;
+        using view_t = typename Image::view_t;
+        using any_view_t = gil::any_image_view<view_t>;
+        using any_const_view_t = typename any_view_t::const_t;
+        Image i0(fixture::create_image<image_t>(4, 4, 128));
+
+        view_t v0 = gil::view(i0);
+        any_view_t v1 = v0;
+
+        BOOST_TEST_EQ(v1.dimensions().x, 4);
+        BOOST_TEST_EQ(v1.dimensions().y, 4);
+
+        any_const_view_t v2 = v0;
+
+        BOOST_TEST_EQ(v2.dimensions().x, 4);
+        BOOST_TEST_EQ(v2.dimensions().y, 4);
+
+        //any_const_view_t v3 = v1;
+    }
+    static void run()
+    {
+        boost::mp11::mp_for_each<fixture::image_types>(test_any_image_view_copy_ctor{});
+    }
+};
+
+struct test_any_image_view_assign_operator
+{
+    template <typename Image>
+    void operator()(Image const&)
+    {
+        using image_t = Image;
+        using view_t = typename Image::view_t;
+        using any_view_t = gil::any_image_view<view_t>;
+        using any_const_view_t = typename any_view_t::const_t;
+        Image i0(fixture::create_image<image_t>(4, 4, 128));
+
+        view_t v0 = gil::view(i0);
+        any_view_t v1;
+        any_const_view_t v2;
+
+        v1 = v0;
+
+        BOOST_TEST_EQ(v1.dimensions().x, 4);
+        BOOST_TEST_EQ(v1.dimensions().y, 4);
+
+        v2 = v0;
+
+        BOOST_TEST_EQ(v2.dimensions().x, 4);
+        BOOST_TEST_EQ(v2.dimensions().y, 4);
+
+        //v2 = v1;
+    }
+    static void run()
+    {
+        boost::mp11::mp_for_each<fixture::image_types>(test_any_image_view_assign_operator{});
+    }
+};
+
+int main()
+{
+    test_any_image_view_init_ctor::run();
+    test_any_image_view_copy_ctor::run();
+    test_any_image_view_assign_operator::run();
 
     return ::boost::report_errors();
 }


### PR DESCRIPTION
### Description

Fix `any_image_view<>::const_t` that currently returns an invalid type, see the provided test case that fails on `develop`.

### Tasklist

- [x] Add test case(s)
- [ ] Ensure all CI builds pass
- [ ] Review and approve
