### PR TITLE
Remove unnecessary numeric_cast in hsv.hpp

### DIFF
--- a/include/boost/gil/extension/toolbox/color_spaces/hsv.hpp
+++ b/include/boost/gil/extension/toolbox/color_spaces/hsv.hpp
@@ -8,8 +8,6 @@
 #ifndef BOOST_GIL_EXTENSION_TOOLBOX_COLOR_SPACES_HSV_HPP
 #define BOOST_GIL_EXTENSION_TOOLBOX_COLOR_SPACES_HSV_HPP
 
-#include <boost/numeric/conversion/cast.hpp>
-
 #include <boost/gil/color_convert.hpp>
 #include <boost/gil/typedefs.hpp>
 #include <boost/gil/detail/mp11.hpp>
@@ -86,7 +84,7 @@ struct default_color_converter_impl< rgb_t, hsv_t >
       }
       else
       {
-         if( (std::abs)( boost::numeric_cast<float32_t>(temp_red - max_color) ) < 0.0001f )
+         if( (std::abs)( temp_red - max_color ) < 0.0001f )
          {
             hue = ( temp_green - temp_blue )
                 / diff;


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description
Removes an unnecessary numeric_cast in include\boost\gil\extension\toolbox\color_spaces\hsv.hpp that casts from float32_t to float32_t.
This removes the only dependency on Boost.NumericConversion I could find

### References

https://cpplang.slack.com/archives/C27KZLB0X/p1605793604490300

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Ensure all CI builds pass
- [x] Review and approve
