### PR TITLE
Fix default ctor of homogeneous_color_base for reference pixel elements

### DIFF
--- a/include/boost/gil/color_base.hpp
+++ b/include/boost/gil/color_base.hpp
@@ -79,8 +79,14 @@ struct homogeneous_color_base<Element, Layout, 1>
 {
     using layout_t = Layout;
 
-    homogeneous_color_base() = default;
-    homogeneous_color_base(Element v) : v0_(v) {}
+    template
+    <
+        typename U = Element,
+        typename = typename std::enable_if<!std::is_reference<U>::value>::type
+    >
+    homogeneous_color_base() : v0_{} {};
+
+    explicit homogeneous_color_base(Element v) : v0_(v) {}
 
     template <typename E2, typename L2>
     homogeneous_color_base(homogeneous_color_base<E2, L2, 1> const& c)
@@ -100,7 +106,7 @@ struct homogeneous_color_base<Element, Layout, 1>
     operator Element() const { return v0_; }
 
 private:
-    Element v0_{};
+    Element v0_;
 };
 
 /// \brief A homogeneous color base holding two color elements
@@ -111,8 +117,15 @@ struct homogeneous_color_base<Element, Layout, 2>
 {
     using layout_t = Layout;
 
-    homogeneous_color_base() = default;
+    template
+    <
+        typename U = Element,
+        typename = typename std::enable_if<!std::is_reference<U>::value>::type
+    >
+    homogeneous_color_base() : v0_{}, v1_{} {}
+
     explicit homogeneous_color_base(Element v) : v0_(v), v1_(v) {}
+
     homogeneous_color_base(Element v0, Element v1) : v0_(v0), v1_(v1) {}
 
     template <typename E2, typename L2>
@@ -174,8 +187,8 @@ struct homogeneous_color_base<Element, Layout, 2>
     }
 
 private:
-    Element v0_{};
-    Element v1_{};
+    Element v0_;
+    Element v1_;
 };
 
 /// \brief A homogeneous color base holding three color elements.
@@ -186,8 +199,15 @@ struct homogeneous_color_base<Element, Layout, 3>
 {
     using layout_t = Layout;
 
-    homogeneous_color_base() = default;
+    template
+    <
+        typename U = Element,
+        typename = typename std::enable_if<!std::is_reference<U>::value>::type
+    >
+    homogeneous_color_base() : v0_{}, v1_{}, v2_{} {}
+
     explicit homogeneous_color_base(Element v) : v0_(v), v1_(v), v2_(v) {}
+
     homogeneous_color_base(Element v0, Element v1, Element v2)
         : v0_(v0), v1_(v1), v2_(v2)
     {}
@@ -268,9 +288,9 @@ struct homogeneous_color_base<Element, Layout, 3>
     }
 
 private:
-    Element v0_{};
-    Element v1_{};
-    Element v2_{};
+    Element v0_;
+    Element v1_;
+    Element v2_;
 };
 
 /// \brief A homogeneous color base holding four color elements.
@@ -281,8 +301,15 @@ struct homogeneous_color_base<Element, Layout, 4>
 {
     using layout_t = Layout;
 
-    homogeneous_color_base() = default;
+    template
+    <
+        typename U = Element,
+        typename = typename std::enable_if<!std::is_reference<U>::value>::type
+    >
+    homogeneous_color_base() : v0_{}, v1_{}, v2_{}, v3_{} {}
+
     explicit homogeneous_color_base(Element v) : v0_(v), v1_(v), v2_(v), v3_(v) {}
+    
     homogeneous_color_base(Element v0, Element v1, Element v2, Element v3)
         : v0_(v0), v1_(v1), v2_(v2), v3_(v3)
     {}
@@ -377,10 +404,10 @@ struct homogeneous_color_base<Element, Layout, 4>
     }
 
 private:
-    Element v0_{};
-    Element v1_{};
-    Element v2_{};
-    Element v3_{};
+    Element v0_;
+    Element v1_;
+    Element v2_;
+    Element v3_;
 };
 
 /// \brief A homogeneous color base holding five color elements.
@@ -391,7 +418,15 @@ struct homogeneous_color_base<Element, Layout, 5>
 {
     using layout_t = Layout;
 
-    homogeneous_color_base() = default;
+    template
+    <
+        typename U = Element,
+        typename = typename std::enable_if<!std::is_reference<U>::value>::type
+    >
+    homogeneous_color_base()
+        : v0_{}, v1_{}, v2_{}, v3_{}, v4_{}
+    {}
+
     explicit homogeneous_color_base(Element v)
         : v0_(v), v1_(v), v2_(v), v3_(v), v4_(v)
     {}
@@ -505,11 +540,11 @@ struct homogeneous_color_base<Element, Layout, 5>
     }
 
 private:
-    Element v0_{};
-    Element v1_{};
-    Element v2_{};
-    Element v3_{};
-    Element v4_{};
+    Element v0_;
+    Element v1_;
+    Element v2_;
+    Element v3_;
+    Element v4_;
 };
 
 #if BOOST_WORKAROUND(BOOST_MSVC, >= 1400)

--- a/test/core/pixel/test_fixture.hpp
+++ b/test/core/pixel/test_fixture.hpp
@@ -69,7 +69,7 @@ class pixel_value
 public:
     using type = Pixel;
     using pixel_t = type;
-    type pixel_{};
+    type pixel_;
 
     pixel_value() = default;
     explicit pixel_value(pixel_t const& pixel)


### PR DESCRIPTION
### Description

If `Element` is a reference, then Element v{} is ill-formed.

<!-- What does this pull request do? -->

### References

<!-- Any links related to this PR: issues, other PRs, mailing list threads, StackOverflow questions, etc. -->

- Refines #273 which aimed to correctly value-initialize channel and pixel value members

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Add test case(s) - already in place
- [x] Ensure all CI builds pass - Travis CI, R.I.P. 
- [x] Review and approve (via [#boost at Slack](https://cpplang.slack.com/archives/C27KZLB0X/p1611301724009500))
