### PR TITLE
build: Remove most of uses of cxxflags from test/Jamfile

### DIFF
--- a/test/Jamfile
+++ b/test/Jamfile
@@ -16,32 +16,12 @@ import regex ;
 import sequence ;
 import testing ;
 
-# Avoid warnings flood from CI builds
-if ! [ os.environ CI ] && ! [ os.environ AGENT_JOBSTATUS ] && ! [ os.environ GITHUB_ACTIONS ]
-{
-  DEVELOPMENT_EXTRA_WARNINGS =
-    <toolset>msvc:<cxxflags>"-W4"
-    <toolset>gcc:<cxxflags>"-pedantic -Wextra -Wcast-align -Wconversion -Wfloat-equal -Wshadow -Wsign-promo -Wstrict-aliasing -Wunused-parameter"
-    <toolset>clang,<variant>debug:<cxxflags>"-pedantic -Wextra -Wcast-align -Wconversion -Wfloat-equal -Wshadow -Wsign-promo -Wstrict-aliasing -Wunused-parameter -Wsign-conversion"
-    <toolset>clang,<variant>release:<cxxflags>"-pedantic -Wextra -Wcast-align -Wconversion -Wfloat-equal -Wshadow -Wsign-promo -Wstrict-aliasing -Wunused-parameter -Wsign-conversion"
-    <toolset>darwin:<cxxflags>"-pedantic -Wextra -Wcast-align -Wconversion -Wfloat-equal -Wshadow -Wsign-promo -Wstrict-aliasing -Wunused-parameter"
-    ;
-}
-else
-{
-  DEVELOPMENT_EXTRA_WARNINGS =
-    <toolset>msvc:<cxxflags>"-W1"
-    ;
-}
-
 project
   :
   requirements
     <include>.
     # TODO: Enable concepts check for all, not just test/core
     #<define>BOOST_GIL_USE_CONCEPT_CHECK=1
-    <toolset>msvc:<cxxflags>"-bigobj"
-    <toolset>msvc:<asynch-exceptions>on
     <toolset>msvc:<define>_SCL_SECURE_NO_DEPRECATE
     <toolset>msvc:<define>_CRT_SECURE_NO_WARNINGS
     <toolset>msvc:<define>_CRT_NONSTDC_NO_DEPRECATE


### PR DESCRIPTION
Most uses of cxxflags are wrong.
Use b2 warnings instead, e.g. warnings=pedantic
