### PR TITLE
Removed two instaces of boost.mpl (Issue #483)

### DIFF
--- a/include/boost/gil/detail/mp11.hpp
+++ b/include/boost/gil/detail/mp11.hpp
@@ -10,7 +10,6 @@
 #define BOOST_GIL_DETAIL_MP11_HPP
 
 #include <boost/mp11.hpp>
-#include <boost/mp11/mpl.hpp> // required by dynamic_image and boost::variant (?)
 
 namespace boost { namespace gil { namespace detail {
 

--- a/test/core/pixel/test_fixture.hpp
+++ b/test/core/pixel/test_fixture.hpp
@@ -21,7 +21,6 @@
 
 #include <boost/core/ignore_unused.hpp>
 #include <boost/mp11.hpp>
-#include <boost/mp11/mpl.hpp> // for compatibility with Boost.Test
 
 #include <cstdint>
 #include <iterator>


### PR DESCRIPTION
### Description

Removed "#include <boost/mp11/mpl.hpp>"
at include/boost/gil/detail/mp11/hpp
and test/core/pixel/test_fixture.hpp


### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Removed instances of boost.mpl
- [x] Ensure all CI builds pass
- [x] Review and approve
