### PR TITLE
Support constructing a planar image from interleaved image

### DIFF
--- a/include/boost/gil/algorithm.hpp
+++ b/include/boost/gil/algorithm.hpp
@@ -734,10 +734,21 @@ void default_construct_pixels(View const& view)
 
 namespace detail {
 
+enum class view_x_view_planarity
+{
+    true_x_true,
+    false_x_true,
+    all_x_true
+};
+
 /// std::uninitialized_copy for pairs of planar iterators
 template <typename It1, typename It2>
 BOOST_FORCEINLINE
-void uninitialized_copy_aux(It1 first1, It1 last1, It2 first2, std::true_type)
+void uninitialized_copy_aux(It1 first1,
+                            It1 last1,
+                            It2 first2, 
+                            It2 last2,
+                            std::integral_constant<view_x_view_planarity, view_x_view_planarity::true_x_true>)
 {
     std::size_t channel=0;
     try {
@@ -761,12 +772,31 @@ void uninitialized_copy_aux(It1 first1, It1 last1, It2 first2, std::true_type)
     }
 }
 
-/// std::uninitialized_copy for interleaved or mixed iterators
+/// std::uninitialized_copy for interleaved or mixed(planar into interleaved) iterators
 template <typename It1, typename It2>
 BOOST_FORCEINLINE
-void uninitialized_copy_aux(It1 first1, It1 last1, It2 first2, std::false_type)
+void uninitialized_copy_aux(It1 first1,
+                            It1 last1, 
+                            It2 first2, 
+                            It2 last2, 
+                            std::integral_constant<view_x_view_planarity, view_x_view_planarity::false_x_true>)
 {
     std::uninitialized_copy(first1, last1, first2);
+}
+
+/// std::uninitialized_copy for interleaved to planar iterators
+template <typename It1, typename It2>
+BOOST_FORCEINLINE
+void uninitialized_copy_aux(It1 first1,
+                            It1 last1, 
+                            It2 first2, 
+                            It2 last2,
+                            std::integral_constant<view_x_view_planarity, view_x_view_planarity::all_x_true>)
+{
+    default_construct_range(first2, last2);
+
+    typename It2::difference_type n = last2 - first2;
+    copier_n<It1,It2>()(first1, n, first2);
 }
 } // namespace detail
 
@@ -777,13 +807,19 @@ void uninitialized_copy_aux(It1 first1, It1 last1, It2 first2, std::false_type)
 template <typename View1, typename View2>
 void uninitialized_copy_pixels(View1 const& view1, View2 const& view2)
 {
-    using is_planar = std::integral_constant<bool, is_planar<View1>::value && is_planar<View2>::value>;
+    using view_x_view_planarity = detail::view_x_view_planarity;
+    using vxv_planarity = std::integral_constant<view_x_view_planarity,
+                                    !is_planar<View2>::value ? 
+                                        view_x_view_planarity::false_x_true : 
+                                        (is_planar<View1>::value ?
+                                            view_x_view_planarity::true_x_true :
+                                            view_x_view_planarity::all_x_true)>;
     BOOST_ASSERT(view1.dimensions() == view2.dimensions());
 
     if (view1.is_1d_traversable() && view2.is_1d_traversable())
     {
         detail::uninitialized_copy_aux(
-            view1.begin().x(), view1.end().x(), view2.begin().x(), is_planar());
+            view1.begin().x(), view1.end().x(), view2.begin().x(), view2.end().x(), vxv_planarity());
     }
     else
     {
@@ -792,12 +828,12 @@ void uninitialized_copy_pixels(View1 const& view1, View2 const& view2)
         {
             for (y = 0; y < view1.height(); ++y)
                 detail::uninitialized_copy_aux(
-                    view1.row_begin(y), view1.row_end(y), view2.row_begin(y), is_planar());
+                    view1.row_begin(y), view1.row_end(y), view2.row_begin(y), view2.row_end(y), vxv_planarity());
         }
         catch(...)
         {
             for (typename View1::y_coord_t y0 = 0; y0 < y; ++y0)
-                detail::destruct_aux(view2.row_begin(y0), view2.row_end(y0), is_planar());
+                detail::destruct_aux(view2.row_begin(y0), view2.row_end(y0), is_planar<View2>());
             throw;
         }
     }

--- a/include/boost/gil/algorithm.hpp
+++ b/include/boost/gil/algorithm.hpp
@@ -738,7 +738,7 @@ enum class view_x_view_planarity
 {
     true_x_true,
     false_x_true,
-    all_x_true
+    all_x_false
 };
 
 /// std::uninitialized_copy for pairs of planar iterators
@@ -779,7 +779,7 @@ void uninitialized_copy_aux(It1 first1,
                             It1 last1, 
                             It2 first2, 
                             It2 last2, 
-                            std::integral_constant<view_x_view_planarity, view_x_view_planarity::false_x_true>)
+                            std::integral_constant<view_x_view_planarity, view_x_view_planarity::all_x_false>)
 {
     std::uninitialized_copy(first1, last1, first2);
 }
@@ -791,7 +791,7 @@ void uninitialized_copy_aux(It1 first1,
                             It1 last1, 
                             It2 first2, 
                             It2 last2,
-                            std::integral_constant<view_x_view_planarity, view_x_view_planarity::all_x_true>)
+                            std::integral_constant<view_x_view_planarity, view_x_view_planarity::false_x_true>)
 {
     default_construct_range(first2, last2);
 
@@ -810,10 +810,10 @@ void uninitialized_copy_pixels(View1 const& view1, View2 const& view2)
     using view_x_view_planarity = detail::view_x_view_planarity;
     using vxv_planarity = std::integral_constant<view_x_view_planarity,
                                     !is_planar<View2>::value ? 
-                                        view_x_view_planarity::false_x_true : 
+                                        view_x_view_planarity::all_x_false : 
                                         (is_planar<View1>::value ?
-                                            view_x_view_planarity::true_x_true :
-                                            view_x_view_planarity::all_x_true)>;
+                                            view_x_view_planarity::true_x_true:
+                                            view_x_view_planarity::false_x_true)>;
     BOOST_ASSERT(view1.dimensions() == view2.dimensions());
 
     if (view1.is_1d_traversable() && view2.is_1d_traversable())

--- a/include/boost/gil/algorithm.hpp
+++ b/include/boost/gil/algorithm.hpp
@@ -800,7 +800,7 @@ void uninitialized_copy_aux(It1 first1,
                             It2 last2,
                             interleaved_2_planar_type)
 {
-    default_construct_range(first2, last2);
+    default_construct_aux(first2, last2, std::true_type());
 
     typename It2::difference_type n = last2 - first2;
     copier_n<It1,It2>()(first1, n, first2);
@@ -815,7 +815,7 @@ template <typename View1, typename View2>
 void uninitialized_copy_pixels(View1 const& view1, View2 const& view2)
 {
     using copy_planarity_condition = detail::copy_planarity_condition;
-    using vxv_planarity = std::integral_constant<copy_planarity_condition
+    using vxv_planarity = std::integral_constant<copy_planarity_condition,
                                     !is_planar<View2>::value ?
                                         copy_planarity_condition::mixed_2_interleaved :
                                         (is_planar<View1>::value ?

--- a/test/core/image/image.cpp
+++ b/test/core/image/image.cpp
@@ -56,15 +56,15 @@ struct test_constructor_from_other_image
             auto v2 = gil::const_view(image2);
             BOOST_TEST_ALL_EQ(v1.begin(), v1.end(), v2.begin(), v2.end());
         }
-        // {
-        //     //constructor planar from interleaved
-        //     image_t image1(dimensions, rnd_pixel); 
-        //     gil::image<pixel_t, true> image2(image1); 
-        //     BOOST_TEST_EQ(image2.dimensions(), dimensions);
-        //     auto v1 = gil::const_view(image1);
-        //     auto v2 = gil::const_view(image2);
-        //     BOOST_TEST_ALL_EQ(v1.begin(), v1.end(), v2.begin(), v2.end());
-        // }
+        {
+            // constructor planar from interleaved
+            image_t image1(dimensions, rnd_pixel);
+            gil::image<pixel_t, true> image2(image1);
+            BOOST_TEST_EQ(image2.dimensions(), dimensions);
+            auto v1 = gil::const_view(image1);
+            auto v2 = gil::const_view(image2);
+            BOOST_TEST_ALL_EQ(v1.begin(), v1.end(), v2.begin(), v2.end());
+        }
     }
     static void run()
     {
@@ -86,6 +86,15 @@ struct test_constructor_from_view
             gil::image<pixel_t, true> image1(dimensions, rnd_pixel);
             auto v1 = gil::transposed_view(gil::const_view(image1));
             image_t image2(gil::transposed_view(v1));
+            BOOST_TEST_EQ(image2.dimensions(), dimensions);
+            auto v2 = gil::const_view(image2);
+            BOOST_TEST_ALL_EQ(v1.begin(), v1.end(), v2.begin(), v2.end());
+        }
+        {
+            //constructor planar from interleaved
+            image_t image1(dimensions, rnd_pixel);
+            auto v1 = gil::transposed_view(gil::const_view(image1));
+            gil::image<pixel_t, true> image2(gil::transposed_view(v1));
             BOOST_TEST_EQ(image2.dimensions(), dimensions);
             auto v2 = gil::const_view(image2);
             BOOST_TEST_ALL_EQ(v1.begin(), v1.end(), v2.begin(), v2.end());


### PR DESCRIPTION
### Description

Due to the different layout of planar images (e.g. `rgb8_planar_image_t`), construction of them using interleaved images(e.g. `rgb8_image_t`) failed on `std::unintialized_copy()` and this workflow needed special care.

This implementation of the constructor does-

1. allocate buffer according to the interleaved's dimensions.
2. default-constructs the elements.
3. copies the interleaved image.

### References

fixes #478 which was opened by @mloskot 

### Tasklist


- [x] Add test case(s)
- [x] Ensure all CI builds pass
- [x] Review and approve
