### PR TITLE
Remove <cxxflags> and other cruft from Jamfile

### DIFF
--- a/test/Jamfile
+++ b/test/Jamfile
@@ -22,18 +22,6 @@ project
     <include>.
     # TODO: Enable concepts check for all, not just test/core
     #<define>BOOST_GIL_USE_CONCEPT_CHECK=1
-    <toolset>msvc:<define>_SCL_SECURE_NO_DEPRECATE
-    <toolset>msvc:<define>_CRT_SECURE_NO_WARNINGS
-    <toolset>msvc:<define>_CRT_NONSTDC_NO_DEPRECATE
-    <toolset>msvc:<define>NOMINMAX
-    <toolset>intel:<debug-symbols>off
-    <toolset>gcc:<cxxflags>"-fstrict-aliasing"
-    <toolset>darwin:<cxxflags>"-fstrict-aliasing"
-    # variant filter for clang is necessary to allow ubsan_*
-    # custom variants declare distinct set of <cxxflags>
-    <toolset>clang,<variant>debug:<cxxflags>"-fstrict-aliasing"
-    <toolset>clang,<variant>release:<cxxflags>"-fstrict-aliasing"
-    $(DEVELOPMENT_EXTRA_WARNINGS)
     [ requires
         cxx11_constexpr
         cxx11_defaulted_functions


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

The warnings, debug-symbols and other build properties
can (and should) be controlled via b2 command line options.

By the way, most of `<cxxflags>` uses in `Jamfile`-s [are usually incorrect](https://cpplang.slack.com/archives/C27KZLB0X/p1611538905042200).
Instead, [better option is to](https://cpplang.slack.com/archives/C27KZLB0X/p1611592269057100?thread_ts=1611553747.045400&cid=C27KZLB0X):

> use `warnings=pedantic` to control the warnings instead of `cxxflags` options directly
> either in `requirements` or in `default-build`, depending on whether you want to override it from the command line or not

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Ensure all CI builds pass
