### PR TITLE
Rotation of image by any arbitrary Angle

### DIFF
--- a/include/boost/gil/extension/numeric/affine.hpp
+++ b/include/boost/gil/extension/numeric/affine.hpp
@@ -117,11 +117,11 @@ boost::gil::matrix3x2<T> inverse(boost::gil::matrix3x2<T> m)
 /// \brief    rotates an image from its center point
 ///           using consecutive affine transformations.
 template<typename T, typename F> 
-    boost::gil::matrix3x2<F> center_rotate(boost::gil::point<T> dims,F rads)
+boost::gil::matrix3x2<F> center_rotate(boost::gil::point<T> dims,F rads)
 {   
-    F PI = F(3.141592653589793238);
-    F c_theta = std::abs(std::cos(rads));
-    F s_theta = std::abs(std::sin(rads));
+    const F PI = F(3.141592653589793238);
+    const F c_theta = std::abs(std::cos(rads));
+    const F s_theta = std::abs(std::sin(rads));
 
     // Bound checks for angle rads
     while(rads + PI < 0) 

--- a/include/boost/gil/extension/numeric/affine.hpp
+++ b/include/boost/gil/extension/numeric/affine.hpp
@@ -108,12 +108,14 @@ boost::gil::matrix3x2<T> inverse(boost::gil::matrix3x2<T> m)
     return res;
 }
 
-//feature
-//rotate an image from its center point for -180 deg <= theta <= 180 deg
-//using consecutive affine transformations
-//As top-left corner of source image is taken as origin, idea is to rotate the source image about the origin and then translate the new image
-//according to the mentioned rotation angle, and to re-center and fit the image in the source dimensions 
-// preferably use type double for less precision errors
+/// \fn gil::matrix3x2 center_rotate 
+/// @tparam T     Data type for source image dimensions
+/// @tparam F     Data type for angle through which image is to be rotated
+/// @param  dims  dimensions of source image
+/// @param  rads  angle through which image is to be rotated
+/// @return   A transformation matrix for rotating the source image about its center
+/// \brief    rotate an image from its center point
+///           using consecutive affine transformations.
 template<typename T, typename F> boost::gil::matrix3x2<F> center_rotate(boost::gil::point<T> dims,F rads)
 {   
     F PI = F(3.141592653589793238);
@@ -122,14 +124,14 @@ template<typename T, typename F> boost::gil::matrix3x2<F> center_rotate(boost::g
     
     // Bound checks for theta
     while(rads + PI < 0) { rads = rads + PI; }
-    while(rads > PI) { rads = rads - PI; }
+    while(rads > PI)     { rads = rads - PI; }
 
     boost::gil::matrix3x2<F> rotate = boost::gil::matrix3x2<F>::get_rotate(rads);
     
-    // Find distance for translation
+    // Find distance for translating the image into complete view
     boost::gil::matrix3x2<F> translation(0,0,0,0,0,0);
     if(rads >= 0) { translation.b = -1 * s_theta; }
-    else { translation.c = -1 * s_theta; }
+    else          { translation.c = -1 * s_theta; }
 
     if(std::abs(rads) > PI/2) 
     {
@@ -137,9 +139,11 @@ template<typename T, typename F> boost::gil::matrix3x2<F> center_rotate(boost::g
         translation.d = -1 * c_theta;
     }
 
+    // To bring the complete image into view
     boost::gil::matrix3x2<F> translate =
         boost::gil::matrix3x2<F>::get_translate(dims * translation);
 
+    // To fit inside the source dimensions
     boost::gil::matrix3x2<F> scale =
         boost::gil::matrix3x2<F>::get_scale(
             s_theta * dims.y / dims.x + c_theta ,
@@ -149,9 +153,18 @@ template<typename T, typename F> boost::gil::matrix3x2<F> center_rotate(boost::g
     return scale *  translate * rotate;  
 }
 
-template<typename T, typename F> boost::gil::matrix3x2<F> center_rotate(T x, T y, F rads)    
+/// \fn gil::matrix3x2 center_rotate
+/// @tparam T       Data type for source image dimensions
+/// @tparam F       Data type for angle through which image is to be rotated
+/// @param  width   Width of the source image
+/// @param  height  Height of the source image
+/// @param  rads    Angle through which image is to be rotated
+/// @return   A transformation matrix for rotating the source image about its center
+/// \brief    rotate an image from its center point
+///           using consecutive affine transformations.
+template<typename T, typename F> boost::gil::matrix3x2<F> center_rotate(T width, T height, F rads)  
 { 
-    return center_rotate(boost::gil::point<T> {x,y}, rads); 
+    return center_rotate(boost::gil::point<T> {width,height}, rads); 
 }
 
 }} // namespace boost::gil

--- a/include/boost/gil/extension/numeric/affine.hpp
+++ b/include/boost/gil/extension/numeric/affine.hpp
@@ -114,6 +114,9 @@ boost::gil::matrix3x2<T> inverse(boost::gil::matrix3x2<T> m)
 
 template<typename T, typename F> boost::gil::matrix3x2<F> center_rotate(boost::gil::point<T> dims,F rads)
 {   
+    while(rads < F(-M_PI)) rads = rads + F(M_PI);
+    while(rads > F(M_PI)) rads = rads - F(M_PI);
+
     F c_theta = std::abs(std::cos(rads));
     F s_theta = std::abs(std::sin(rads));
     
@@ -123,7 +126,8 @@ template<typename T, typename F> boost::gil::matrix3x2<F> center_rotate(boost::g
 
     if(std::abs(rads) > F(M_PI/2)) { translation.a = -c_theta, translation.d = -c_theta; }
 
-    return boost::gil::matrix3x2<F>::get_translate(dims * translation) *  //re-center the image [top-left of image taken as (0,0)]
+    return boost::gil::matrix3x2<F>::get_scale(s_theta * dims.y / dims.x + c_theta, s_theta * dims.x / dims.y + c_theta) *  //to fit inside given dimensions
+           boost::gil::matrix3x2<F>::get_translate(dims * translation) *  //re-center the image [top-left of image taken as (0,0)]
            boost::gil::matrix3x2<F>::get_rotate(rads);
 }
 

--- a/include/boost/gil/extension/numeric/affine.hpp
+++ b/include/boost/gil/extension/numeric/affine.hpp
@@ -108,6 +108,26 @@ boost::gil::matrix3x2<T> inverse(boost::gil::matrix3x2<T> m)
     return res;
 }
 
+//feature
+//rotate an image from its center point for -180 deg <= theta <= 180 deg
+//using consecutive affine transformations
+
+template<typename T, typename F> boost::gil::matrix3x2<F> center_rotate(boost::gil::point<T> dims,F rads)
+{   
+    F c_theta = std::abs(std::cos(rads));
+    F s_theta = std::abs(std::sin(rads));
+    
+    boost::gil::matrix3x2<F> translation(0,0,0,0,0,0);
+    if(rads >= 0) { translation.b = -s_theta; }
+    else { translation.c = -s_theta; }
+
+    if(std::abs(rads) > F(M_PI/2)) { translation.a = -c_theta, translation.d = -c_theta; }
+
+    return boost::gil::matrix3x2<F>::get_translate(dims * translation) *  //re-center the image [top-left of image taken as (0,0)]
+           boost::gil::matrix3x2<F>::get_rotate(rads);
+}
+
+
 }} // namespace boost::gil
 
 #endif

--- a/include/boost/gil/extension/numeric/affine.hpp
+++ b/include/boost/gil/extension/numeric/affine.hpp
@@ -109,39 +109,54 @@ boost::gil::matrix3x2<T> inverse(boost::gil::matrix3x2<T> m)
 }
 
 /// \fn gil::matrix3x2 center_rotate 
-/// @tparam T     Data type for source image dimensions
-/// @tparam F     Data type for angle through which image is to be rotated
+/// \tparam T     Data type for source image dimensions
+/// \tparam F     Data type for angle through which image is to be rotated
 /// @param  dims  dimensions of source image
 /// @param  rads  angle through which image is to be rotated
 /// @return   A transformation matrix for rotating the source image about its center
-/// \brief    rotate an image from its center point
+/// \brief    rotates an image from its center point
 ///           using consecutive affine transformations.
-template<typename T, typename F> boost::gil::matrix3x2<F> center_rotate(boost::gil::point<T> dims,F rads)
+template<typename T, typename F> 
+    boost::gil::matrix3x2<F> center_rotate(boost::gil::point<T> dims,F rads)
 {   
     F PI = F(3.141592653589793238);
     F c_theta = std::abs(std::cos(rads));
     F s_theta = std::abs(std::sin(rads));
-    
-    // Bound checks for theta
-    while(rads + PI < 0) { rads = rads + PI; }
-    while(rads > PI)     { rads = rads - PI; }
 
+    // Bound checks for angle rads
+    while(rads + PI < 0) 
+    { 
+        rads = rads + PI; 
+    }
+
+    while(rads > PI)     
+    { 
+        rads = rads - PI; 
+    }
+
+    // Basic Rotation Matrix
     boost::gil::matrix3x2<F> rotate = boost::gil::matrix3x2<F>::get_rotate(rads);
     
-    // Find distance for translating the image into complete view
+    // Find distance for translating the image into view
     boost::gil::matrix3x2<F> translation(0,0,0,0,0,0);
-    if(rads >= 0) { translation.b = -1 * s_theta; }
-    else          { translation.c = -1 * s_theta; }
+    if(rads > 0) 
+    { 
+        translation.b = s_theta; 
+    }
+    else 
+    { 
+        translation.c = s_theta;
+    }
 
     if(std::abs(rads) > PI/2) 
     {
-        translation.a = -1 * c_theta;
-        translation.d = -1 * c_theta;
+        translation.a = c_theta;
+        translation.d = c_theta;
     }
 
     // To bring the complete image into view
     boost::gil::matrix3x2<F> translate =
-        boost::gil::matrix3x2<F>::get_translate(dims * translation);
+        boost::gil::matrix3x2<F>::get_translate(-1 * dims * translation);
 
     // To fit inside the source dimensions
     boost::gil::matrix3x2<F> scale =
@@ -151,20 +166,6 @@ template<typename T, typename F> boost::gil::matrix3x2<F> center_rotate(boost::g
         );
 
     return scale *  translate * rotate;  
-}
-
-/// \fn gil::matrix3x2 center_rotate
-/// @tparam T       Data type for source image dimensions
-/// @tparam F       Data type for angle through which image is to be rotated
-/// @param  width   Width of the source image
-/// @param  height  Height of the source image
-/// @param  rads    Angle through which image is to be rotated
-/// @return   A transformation matrix for rotating the source image about its center
-/// \brief    rotate an image from its center point
-///           using consecutive affine transformations.
-template<typename T, typename F> boost::gil::matrix3x2<F> center_rotate(T width, T height, F rads)  
-{ 
-    return center_rotate(boost::gil::point<T> {width,height}, rads); 
 }
 
 }} // namespace boost::gil

--- a/include/boost/gil/extension/numeric/affine.hpp
+++ b/include/boost/gil/extension/numeric/affine.hpp
@@ -111,7 +111,9 @@ boost::gil::matrix3x2<T> inverse(boost::gil::matrix3x2<T> m)
 //feature
 //rotate an image from its center point for -180 deg <= theta <= 180 deg
 //using consecutive affine transformations
-
+//As top-left corner of source image is taken as origin, idea is to rotate the source image about the origin and then translate the new image
+//according to the mentioned rotation angle, and to re-center and fit the image in the source dimensions 
+// preferably use type double for less precision errors
 template<typename T, typename F> boost::gil::matrix3x2<F> center_rotate(boost::gil::point<T> dims,F rads)
 {   
     while(rads < F(-M_PI)) rads = rads + F(M_PI);
@@ -131,6 +133,10 @@ template<typename T, typename F> boost::gil::matrix3x2<F> center_rotate(boost::g
            boost::gil::matrix3x2<F>::get_rotate(rads);
 }
 
+template<typename T, typename F> boost::gil::matrix3x2<F> center_rotate(T x, T y, F rads)    
+{ 
+    return center_rotate(boost::gil::point<T> {x,y}, rads); 
+}
 
 }} // namespace boost::gil
 

--- a/test/extension/numeric/matrix3x2.cpp
+++ b/test/extension/numeric/matrix3x2.cpp
@@ -201,6 +201,21 @@ void test_matrix3x2_inverse()
     BOOST_TEST_WITH(p.y, p2.y, with_tolerance<double>(1e-9));
 }
 
+void test_matrix3x2_center_rotate()
+{
+    gil::point<double> dimension(100.0,100.0);
+    gil::matrix3x2<double> m1;
+
+    m1 = gil::center_rotate(dimension, HALF_PI);
+
+    BOOST_TEST_WITH(m1.a , std::cos(HALF_PI) , with_tolerance<double>(1e-9));
+    BOOST_TEST_EQ  (m1.b ,  1);
+    BOOST_TEST_EQ  (m1.c , -1);
+    BOOST_TEST_WITH(m1.d , std::cos(HALF_PI) , with_tolerance<double>(1e-9));
+    BOOST_TEST_EQ  (m1.e ,  100);
+    BOOST_TEST_WITH(m1.f , std::cos(HALF_PI) , with_tolerance<double>(1e-9));
+}
+
 int main()
 {
     test_matrix3x2_default_constructor();
@@ -215,6 +230,7 @@ int main()
     test_matrix3x2_get_translate();
     test_matrix3x2_transform();
     test_matrix3x2_inverse();
+    test_matrix3x2_center_rotate();
 
     return ::boost::report_errors();
 }


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->
## [Feature] Added Rotation function to rotate image from its center in numeric/affine.hpp
### Description

The rotation function already existed however, the rotation was about the top-left vertex of the image as the origin, resulting in some parts being out of view. I have added a function that rotates the image about its center, using affine transformations, and scales it according to the dimensions of the source image.

This pull request is in reference to issue #533 

### References
#533 


### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Add test case(s)
- [x] Ensure all CI builds pass
- [x] Review and approve
