### PR TITLE
ci: Remove GCC 5 on GitHub Actions and Azure Pipelines

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -5,7 +5,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
 #
 variables:
-  system.debug: true
+  #system.debug: true
   configuration: release
 
 trigger:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -15,10 +15,13 @@ trigger:
   - ml/*
 
 jobs:
-  - job: 'ubuntu1604_gcc5_cxx11_cmake'
+  - job: 'ubuntu1604_gcc6_cxx14_cmake'
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
+      - template: .ci/azure-pipelines/steps-install-gcc.yml
+        parameters:
+          major_version: '6'
       - script: which g++ && g++ --version
         displayName: 'Check GCC'
       - template: .ci/azure-pipelines/steps-check-cmake.yml
@@ -28,12 +31,16 @@ jobs:
         displayName: 'Install dependencies'
       - template: .ci/azure-pipelines/steps-install-boost.yml
       - template: .ci/azure-pipelines/steps-cmake-build-and-test.yml
+        parameters:
+          cxxver: '14'
 
   - job: 'ubuntu1604_gcc8_cxx14_cmake'
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
       - template: .ci/azure-pipelines/steps-install-gcc.yml
+        parameters:
+          major_version: '8'
       - script: which g++ && g++ --version
         displayName: 'Check GCC'
       - template: .ci/azure-pipelines/steps-check-cmake.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - toolset: gcc-4.9
-            cxxstd: "11"
-            os: ubuntu-16.04
-            install: g++-4.9
-          - toolset: gcc-5
-            cxxstd: "11,14,1z"
-            os: ubuntu-16.04
           - toolset: gcc-6
             cxxstd: "11,14,1z"
             os: ubuntu-16.04


### PR DESCRIPTION
Required by #526

See also https://github.com/boostorg/website/pull/562


