### PR TITLE
Fix convolve_2d for images with float32_t channel model

### DIFF
--- a/include/boost/gil/extension/numeric/convolve.hpp
+++ b/include/boost/gil/extension/numeric/convolve.hpp
@@ -373,7 +373,7 @@ void convolve_2d_impl(SrcView const& src_view, DstView const& dst_view, Kernel c
                         col_boundary >= 0 && col_boundary < src_view.width())
                     {
                         aux_total +=
-                            src_view(col_boundary, row_boundary) *
+                            src_view(col_boundary, row_boundary)[0] *
                             kernel.at(flip_ker_row, flip_ker_col);
                     }
                 }

--- a/test/extension/numeric/convolve_2d.cpp
+++ b/test/extension/numeric/convolve_2d.cpp
@@ -60,9 +60,48 @@ void test_convolve_2d_with_normalized_mean_filter()
     BOOST_TEST(gil::equal_pixels(out_view, dst_view));
 }
 
+void test_convolve_2d_with_image_using_float32_t()
+{
+gil::float32_t img[] =
+{
+    0.1, 0.2, 0.1, 0.1, 0.4, 0.1, 0.76, 0.1, 0.1,
+    0.1, 0.2, 0.1, 0.1, 0.4, 0.1, 0.5, 0.1, 0.1,
+    0.1, 0.2, 0.1, 0.1, 0.4, 0.1, 0.5, 0.1, 0.1,
+    0.1, 0.6, 0.6, 0.1, 0.54, 0.1, 0.5, 0.1, 0.1,
+    0.1, 0.2, 0.1, 0.1, 0.4, 0.1, 0.5, 0.1, 0.1,
+    0.1, 0.2, 0.1, 0.84, 0.4, 0.1, 0.5, 0.1, 0.1,
+    0.1, 0.1, 0.1, 0.1, 0.4, 0.1, 0.5, 0.1, 0.1,
+    0.1, 0.3, 0.1, 0.1, 0.4, 0.1, 0.32, 0.1, 0.1,
+    0.1, 0.2, 0.1, 0.1, 0.4, 0.1, 0.21, 0.1, 0.1
+};
+
+gil::float32_t exp_output[] =
+{
+    0.1, 0.2, 0.1, 0.1, 0.4, 0.1, 0.76, 0.1, 0.1,
+    0.1, 0.2, 0.1, 0.1, 0.4, 0.1, 0.5, 0.1, 0.1,
+    0.1, 0.2, 0.1, 0.1, 0.4, 0.1, 0.5, 0.1, 0.1,
+    0.1, 0.6, 0.6, 0.1, 0.54, 0.1, 0.5, 0.1, 0.1,
+    0.1, 0.2, 0.1, 0.1, 0.4, 0.1, 0.5, 0.1, 0.1,
+    0.1, 0.2, 0.1, 0.84, 0.4, 0.1, 0.5, 0.1, 0.1,
+    0.1, 0.1, 0.1, 0.1, 0.4, 0.1, 0.5, 0.1, 0.1,
+    0.1, 0.3, 0.1, 0.1, 0.4, 0.1, 0.32, 0.1, 0.1,
+    0.1, 0.2, 0.1, 0.1, 0.4, 0.1, 0.21, 0.1, 0.1
+};
+
+gil::gray32f_image_t img_gray_out(9, 9);
+gil::gray32fc_view_t src_view =
+        gil::interleaved_view(9, 9, reinterpret_cast<const gil::gray32f_pixel_t*>(img), 9);
+gil::gray32fc_view_t exp_out_view =
+        gil::interleaved_view(9, 9, reinterpret_cast<const gil::gray32f_pixel_t*>(exp_output), 9);
+std::vector<float> v(1, 1);
+gil::detail::kernel_2d<float> kernel(v.begin(), v.size(), 0, 0); //impulse kernel
+gil::detail::convolve_2d(src_view, kernel, view(img_gray_out));
+BOOST_TEST(gil::equal_pixels(exp_out_view, view(img_gray_out)));
+}
+
 int main()
 {
     test_convolve_2d_with_normalized_mean_filter();
-
+    test_convolve_2d_with_image_using_float32_t();
     return ::boost::report_errors();
 }

--- a/test/extension/numeric/convolve_2d.cpp
+++ b/test/extension/numeric/convolve_2d.cpp
@@ -90,11 +90,11 @@ gil::float32_t exp_output[] =
 
 gil::gray32f_image_t img_gray_out(9, 9);
 gil::gray32fc_view_t src_view =
-        gil::interleaved_view(9, 9, reinterpret_cast<const gil::gray32f_pixel_t*>(img), 9);
+        gil::interleaved_view(9, 9, reinterpret_cast<gil::gray32f_pixel_t const*>(img), 9);
 gil::gray32fc_view_t exp_out_view =
-        gil::interleaved_view(9, 9, reinterpret_cast<const gil::gray32f_pixel_t*>(exp_output), 9);
+        gil::interleaved_view(9, 9, reinterpret_cast<gil::gray32f_pixel_t const*>(exp_output), 9);
 std::vector<float> v(1, 1);
-gil::detail::kernel_2d<float> kernel(v.begin(), v.size(), 0, 0); //impulse kernel
+gil::detail::kernel_2d<float> kernel(v.begin(), v.size(), 0, 0); // impulse kernel
 gil::detail::convolve_2d(src_view, kernel, view(img_gray_out));
 BOOST_TEST(gil::equal_pixels(exp_out_view, view(img_gray_out)));
 }


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

Convolve_2d currently does not work  with images using float32_t channel model due to a trivial issue. This PR fixes that.

### References

Fixes #575

### Tasklist

- [x] Add test case(s)
- [x] Ensure all CI builds pass
- [x] Review and approve
