### PR TITLE
test: Catch up IO with switch to variant2 migration

### DIFF
--- a/test/extension/io/bmp/bmp_old_test.cpp
+++ b/test/extension/io/bmp/bmp_old_test.cpp
@@ -63,15 +63,13 @@ void test_old_write_view()
 
 void test_old_dynamic_image()
 {
-    using my_img_types = mp11::mp_list
+    gil::any_image
     <
         gil::gray8_image_t,
         gil::gray16_image_t,
         gil::rgb8_image_t,
         gil::rgba8_image_t
-    >;
-
-    gil::any_image<my_img_types> image;
+    > image;
     gil::bmp_read_image(bmp_filename.c_str(), image);
 
     gil::bmp_write_view(bmp_out + "old_dynamic_image_test.bmp", gil::view(image));

--- a/test/extension/io/bmp/bmp_test.cpp
+++ b/test/extension/io/bmp/bmp_test.cpp
@@ -247,15 +247,13 @@ void test_subimage()
 
 void test_dynamic_image()
 {
-    using my_img_types = mp11::mp_list
-        <
-            gil::gray8_image_t,
-            gil::gray16_image_t,
-            gil::rgb8_image_t,
-            gil::rgba8_image_t
-        >;
-
-    gil::any_image<my_img_types> image;
+    gil::any_image
+    <
+        gil::gray8_image_t,
+        gil::gray16_image_t,
+        gil::rgb8_image_t,
+        gil::rgba8_image_t
+    > image;
     gil::read_image(bmp_filename.c_str(), image, gil::bmp_tag());
 
     gil::write_view(bmp_out + "dynamic_image_test.bmp", gil::view(image), gil::bmp_tag());

--- a/test/extension/io/jpeg/jpeg_old_test.cpp
+++ b/test/extension/io/jpeg/jpeg_old_test.cpp
@@ -67,15 +67,13 @@ void test_old_write_view()
 
 void test_old_dynamic_image()
 {
-    using my_img_types = mp11::mp_list
-        <
-            gil::gray8_image_t,
-            gil::gray16_image_t,
-            gil::rgb8_image_t,
-            gil::rgba8_image_t
-        >;
-
-    gil::any_image<my_img_types> image;
+    gil::any_image
+    <
+        gil::gray8_image_t,
+        gil::gray16_image_t,
+        gil::rgb8_image_t,
+        gil::rgba8_image_t
+    > image;
     gil::jpeg_read_image(jpeg_filename.c_str(), image);
 
 #ifdef BOOST_GIL_IO_TEST_ALLOW_WRITING_IMAGES

--- a/test/extension/io/jpeg/jpeg_test.cpp
+++ b/test/extension/io/jpeg/jpeg_test.cpp
@@ -237,15 +237,13 @@ void test_subimage()
 
 void test_dynamic_image()
 {
-    using my_img_types = mp11::mp_list
+    gil::any_image
     <
         gil::gray8_image_t,
         gil::gray16_image_t,
         gil::rgb8_image_t,
         gil::rgba8_image_t
-    >;
-
-    gil::any_image<my_img_types> image;
+    > image;
     gil::read_image(jpeg_filename.c_str(), image, gil::jpeg_tag());
 
 #ifdef BOOST_GIL_IO_TEST_ALLOW_WRITING_IMAGES

--- a/test/extension/io/png/png_old_test.cpp
+++ b/test/extension/io/png/png_old_test.cpp
@@ -67,14 +67,13 @@ void test_old_write_view()
 
 void test_old_dynamic_image()
 {
-    using my_img_types = mp11::mp_list
+    gil::any_image
     <
         gil::gray8_image_t,
         gil::gray16_image_t,
         gil::rgb8_image_t,
         gil::rgba8_image_t
-    >;
-    gil::any_image<my_img_types> image;
+    > image;
 
     gil::png_read_image(png_filename.c_str(), image);
 

--- a/test/extension/io/png/png_test.cpp
+++ b/test/extension/io/png/png_test.cpp
@@ -265,14 +265,13 @@ void test_subimage()
 
 void test_dynamic_image()
 {
-    using my_img_types = mp11::mp_list
+    gil::any_image
     <
         gil::gray8_image_t,
         gil::gray16_image_t,
         gil::rgb8_image_t,
         gil::rgba8_image_t
-    >;
-    gil::any_image<my_img_types> image;
+    > image;
 
     gil::read_image(png_filename.c_str(), image, gil::png_tag());
 

--- a/test/extension/io/pnm/pnm_old_test.cpp
+++ b/test/extension/io/pnm/pnm_old_test.cpp
@@ -66,10 +66,13 @@ void test_old_write_view()
 
 void test_old_dynamic_image()
 {
-    using my_img_types =
-        mp11::mp_list<gil::gray8_image_t, gil::gray16_image_t, gil::rgb8_image_t, gil::gray1_image_t>;
-
-    gil::any_image<my_img_types> image;
+    gil::any_image
+    <
+        gil::gray8_image_t,
+        gil::gray16_image_t,
+        gil::rgb8_image_t,
+        gil::gray1_image_t
+    > image;
 
     gil::pnm_read_image(pnm_filename.c_str(), image);
 

--- a/test/extension/io/pnm/pnm_test.cpp
+++ b/test/extension/io/pnm/pnm_test.cpp
@@ -204,15 +204,13 @@ void test_subimage()
 
 void test_dynamic_image_test()
 {
-    using my_img_types = mp11::mp_list
+    gil::any_image
     <
         gil::gray8_image_t,
         gil::gray16_image_t,
         gil::rgb8_image_t,
         gil::gray1_image_t
-    >;
-
-    gil::any_image<my_img_types> image;
+    > image;
 
     gil::read_image(pnm_filename.c_str(), image, gil::pnm_tag());
 

--- a/test/extension/io/raw/raw_test.cpp
+++ b/test/extension/io/raw/raw_test.cpp
@@ -97,16 +97,14 @@ void test_subimage()
 
 void test_dynamic_image()
 {
-  using my_img_types = mp11::mp_list
-      <
-          gil::gray8_image_t,
-          gil::gray16_image_t,
-          gil::rgb8_image_t,
-          gil::rgba8_image_t
-      >;
-
-  gil::any_image<my_img_types> image;
-  gil::read_image(raw_filename.c_str(), image, gil::raw_tag());
+    gil::any_image
+    <
+        gil::gray8_image_t,
+        gil::gray16_image_t,
+        gil::rgb8_image_t,
+        gil::rgba8_image_t
+    > image;
+    gil::read_image(raw_filename.c_str(), image, gil::raw_tag());
 }
 
 int main()

--- a/test/extension/io/targa/targa_old_test.cpp
+++ b/test/extension/io/targa/targa_old_test.cpp
@@ -64,15 +64,14 @@ void test_old_write_view()
 
 void test_old_dynamic_image()
 {
-    using my_img_types = mp11::mp_list
+    gil::any_image
     <
         gil::gray8_image_t,
         gil::gray16_image_t,
         gil::rgb8_image_t,
         gil::rgba8_image_t
-    >;
-
-    gil::any_image<my_img_types> image;
+    > image;
+    
     gil::targa_read_image(targa_filename.c_str(), image);
 
     targa_write_view(targa_out + "old_dynamic_image_test.tga", gil::view(image));

--- a/test/extension/io/targa/targa_test.cpp
+++ b/test/extension/io/targa/targa_test.cpp
@@ -254,15 +254,14 @@ void test_subimage()
 
 void test_dynamic_image()
 {
-    using my_img_types = mp11::mp_list
+    gil::any_image
     <
         gil::gray8_image_t,
         gil::gray16_image_t,
         gil::rgb8_image_t,
         gil::rgba8_image_t
-    >;
+    > image;
 
-    gil::any_image<my_img_types> image;
     gil::read_image(targa_filename.c_str(), image, gil::targa_tag());
     gil::write_view(targa_out + "dynamic_image_test.tga", gil::view(image), gil::targa_tag());
 }

--- a/test/extension/io/tiff/tiff_old_test.cpp
+++ b/test/extension/io/tiff/tiff_old_test.cpp
@@ -60,14 +60,13 @@ void test_old_read_and_convert_view()
 
 void test_old_dynamic_image()
 {
-    using my_img_types = mp11::mp_list
+    gil::any_image
     <
         gil::gray8_image_t,
         gil::gray16_image_t,
         gil::rgba8_image_t,
         gil::gray1_image_t
-    >;
-    gil::any_image<my_img_types> image;
+    > image;
 
     gil::tiff_read_image(tiff_filename.c_str(), image);
 

--- a/test/extension/io/tiff/tiff_test.cpp
+++ b/test/extension/io/tiff/tiff_test.cpp
@@ -267,15 +267,13 @@ void test_dynamic_image()
 {
     // FIXME: This test has been disabled for now because of compilation issues with MSVC10.
 
-    using my_img_types = mp11::mp_list
+    gil::any_image
     <
         gil::gray8_image_t,
         gil::gray16_image_t,
         gil::rgb8_image_t,
-        gil::rgba8_image_t,
-        gil::gray1_image_t
-    >;
-    gil::any_image<my_img_types> image;
+        gil::rgba8_image_t
+    > image;
 
     gil::read_image(tiff_filename.c_str(), image, gil::tiff_tag());
 


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

Tests update missing from commits switching the `any_image` to modern variant2 and mp11.

### References

<!-- Any links related to this PR: issues, other PRs, mailing list threads, StackOverflow questions, etc. -->

- https://github.com/boostorg/gil/issues/453#issuecomment-833898207


### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [ ] Ensure all CI builds pass
