### PR TITLE
Fix C++20 incompatibilities in IO extensions

### DIFF
--- a/include/boost/gil/extension/io/bmp/tags.hpp
+++ b/include/boost/gil/extension/io/bmp/tags.hpp
@@ -73,7 +73,7 @@ template<>
 struct image_read_info< bmp_tag >
 {
     /// Default contructor.
-    image_read_info< bmp_tag >()
+    image_read_info()
     : _top_down(false)
     , _valid( false )
     {}

--- a/include/boost/gil/extension/io/jpeg/tags.hpp
+++ b/include/boost/gil/extension/io/jpeg/tags.hpp
@@ -141,7 +141,7 @@ template<>
 struct image_read_settings< jpeg_tag > : public image_read_settings_base
 {
     /// Default constructor
-    image_read_settings<jpeg_tag>()
+    image_read_settings()
     : image_read_settings_base()
     , _dct_method( jpeg_dct_method::default_value )
     {}

--- a/include/boost/gil/extension/io/png/tags.hpp
+++ b/include/boost/gil/extension/io/png/tags.hpp
@@ -573,7 +573,7 @@ template<>
 struct image_read_info< png_tag > : public png_info_base
 {
     /// Default constructor.
-    image_read_info< png_tag >()
+    image_read_info()
     : png_info_base()
     {}
 };
@@ -669,7 +669,7 @@ struct image_read_settings< png_tag > : public image_read_settings_base
                                       , public png_read_settings_base
 {
     /// Default Constructor
-    image_read_settings< png_tag >()
+    image_read_settings()
     : image_read_settings_base()
     , png_read_settings_base()
     , _screen_gamma( 1.0 )
@@ -708,7 +708,7 @@ struct image_read_settings< png_tag > : public image_read_settings_base
                                       , public png_read_settings_base
 {
     /// Default Constructor.
-    image_read_settings< png_tag >()
+    image_read_settings()
     : image_read_settings_base()
     , png_read_settings_base()
     , _apply_screen_gamma( false )

--- a/include/boost/gil/extension/io/pnm/tags.hpp
+++ b/include/boost/gil/extension/io/pnm/tags.hpp
@@ -65,7 +65,7 @@ template<>
 struct image_read_settings< pnm_tag > : public image_read_settings_base
 {
     /// Default constructor
-    image_read_settings< pnm_tag >()
+    image_read_settings()
     : image_read_settings_base()
     {}
 

--- a/include/boost/gil/extension/io/raw/tags.hpp
+++ b/include/boost/gil/extension/io/raw/tags.hpp
@@ -123,7 +123,7 @@ template<>
 struct image_read_info< raw_tag >
 {
     /// Default contructor.
-    image_read_info< raw_tag >()
+    image_read_info()
     : _valid( false )
     {}
 

--- a/include/boost/gil/extension/io/targa/tags.hpp
+++ b/include/boost/gil/extension/io/targa/tags.hpp
@@ -77,7 +77,7 @@ template<>
 struct image_read_info< targa_tag >
 {
     /// Default contructor.
-    image_read_info< targa_tag >()
+    image_read_info()
     : _screen_origin_bit(false)
     , _valid( false )
     {}

--- a/include/boost/gil/extension/io/tiff/tags.hpp
+++ b/include/boost/gil/extension/io/tiff/tags.hpp
@@ -270,7 +270,7 @@ template<>
 struct image_read_settings< tiff_tag > : public image_read_settings_base
 {
     /// Default constructor
-    image_read_settings< tiff_tag >()
+    image_read_settings()
     : image_read_settings_base()
     , _directory( tiff_directory::default_value::value )
     {}


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

Replace the *simple-template-id*s used in the IO extension tags as constructor names for specializations of `image_read_info` and `image_read_settings` with the associated plain class names.

### References

resolves #616 

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [ ] Ensure all CI builds pass
- [ ] Review and approve
