### PR TITLE
Fix warning: unused variable in diffusion.hpp

### DIFF
--- a/include/boost/gil/image_processing/diffusion.hpp
+++ b/include/boost/gil/image_processing/diffusion.hpp
@@ -157,8 +157,6 @@ struct stencil_5points
     template <typename Pixel>
     Pixel reduce(const stencil_type<Pixel>& stencil)
     {
-        auto first = stencil.begin();
-        auto last = stencil.end();
         using channel_type = typename channel_type<Pixel>::type;
         auto result = []() {
             Pixel zero_pixel;


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

<!-- What does this pull request do? -->

@simmplecoder  Could you confirm these were just unused and not meant to be used but overlooked?

```
../../boost/gil/image_processing/diffusion.hpp:160:14: warning: unused variable ‘first’ [-Wunused-variable]
  160 |         auto first = stencil.begin();
      |              ^~~~~
../../boost/gil/image_processing/diffusion.hpp:161:14: warning: unused variable ‘last’ [-Wunused-variable]
  161 |         auto last = stencil.end();
      |              ^~~~
```

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [ ] Review and approve
