### PR TITLE
Add support for <filesystem> to IO

### DIFF
--- a/doc/io.rst
+++ b/doc/io.rst
@@ -205,9 +205,10 @@ If that's the case the user has to use the xxx_and_convert_xxx variants.
 
 All functions take the filename or a device as the first parameter.
 The filename can be anything from a C-string, ``std::string``,
-``std::wstring`` and ``boost::filesystem`` path. When using the path
-object the user needs to define the ADD_FS_PATH_SUPPORT compiler symbol to
-include the boost::filesystem dependency.
+``std::wstring`` to ``std::filesystem`` and ``boost::filesystem`` path.
+The availability of the ``std::filesystem`` is detected automatically,
+unless ``BOOST_GIL_IO_USE_BOOST_FILESYSTEM`` macro is defined that forces
+preference of the Boost.Filesystem.
 Devices could be a ``FILE*``, ``std::ifstream``, and ``TIFF*`` for TIFF images.
 
 The second parameter is either an image or view type depending on the
@@ -303,9 +304,10 @@ Write Interface
 There is only one function for writing out images, write_view.
 Similar to reading the first parameter is either a filename or a device.
 The filename can be anything from a C-string, ``std::string``,
-``std::wstring``, and ``boost::filesystem`` path. When using the path object
-the user needs to define the ``ADD_FS_PATH_SUPPORT`` compiler symbol to
-include the ``boost::filesystem`` dependency.
+``std::wstring`` to ``std::filesystem`` and ``boost::filesystem`` path.
+The availability of the ``std::filesystem`` is detected automatically,
+unless ``BOOST_GIL_IO_USE_BOOST_FILESYSTEM`` macro is defined that forces
+preference of the Boost.Filesystem.
 Devices could be ``FILE*``, ``std::ifstream``, and ``TIFF*`` for TIFF images.
 
 The second parameter is an view object to image being written.
@@ -342,7 +344,6 @@ that can be set by the user:
    Symbol                                                   Description
 ======================================================== ========================================================
 BOOST_GIL_IO_ENABLE_GRAY_ALPHA                           Enable the color space "gray_alpha".
-BOOST_GIL_IO_ADD_FS_PATH_SUPPORT                         Enable boost::filesystem 3.0 library.
 BOOST_GIL_IO_PNG_FLOATING_POINT_SUPPORTED                Use libpng in floating point mode. This symbol is incompatible with BOOST_GIL_IO_PNG_FIXED_POINT_SUPPORTED.
 BOOST_GIL_IO_PNG_FIXED_POINT_SUPPORTED                   Use libpng in integer mode. This symbol is incompatible with BOOST_GIL_IO_PNG_FLOATING_POINT_SUPPORTED.
 BOOST_GIL_IO_PNG_DITHERING_SUPPORTED                     Look up "dithering" in libpng manual for explanation.

--- a/include/boost/gil/io/detail/filesystem.hpp
+++ b/include/boost/gil/io/detail/filesystem.hpp
@@ -1,0 +1,65 @@
+//
+// Copyright 2022 Mateusz Loskot <mateusz at loskot dot net>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#ifndef BOOST_GIL_IO_DETAIL_FILESYSTEM_HPP
+#define BOOST_GIL_IO_DETAIL_FILESYSTEM_HPP
+
+#include <boost/config.hpp>
+
+#if !defined(BOOST_GIL_IO_USE_BOOST_FILESYSTEM)
+#if !defined(BOOST_NO_CXX17_HDR_FILESYSTEM) || defined(__cpp_lib_filesystem)
+#include <filesystem>
+#define BOOST_GIL_IO_USE_STD_FILESYSTEM
+#elif defined(__cpp_lib_experimental_filesystem)
+#include <experimental/filesystem>
+#define BOOST_GIL_IO_USE_STD_FILESYSTEM
+#define BOOST_GIL_IO_USE_STD_EXPERIMENTAL_FILESYSTEM
+#endif
+#endif // !BOOST_GIL_IO_USE_BOOST_FILESYSTEM
+
+#if !defined(BOOST_GIL_IO_USE_STD_FILESYSTEM)
+// Disable warning: conversion to 'std::atomic<int>::__integral_type {aka int}' from 'long int' may alter its value
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#endif
+
+#define BOOST_FILESYSTEM_VERSION 3
+#include <boost/filesystem.hpp>
+#define BOOST_GIL_IO_USE_BOOST_FILESYSTEM
+
+#if defined(BOOST_CLANG)
+#pragma clang diagnostic pop
+#endif
+
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
+#pragma GCC diagnostic pop
+#endif
+
+#endif
+
+namespace boost { namespace gil { namespace detail {
+
+#if defined(BOOST_GIL_IO_USE_STD_EXPERIMENTAL_FILESYSTEM)
+namespace filesystem = std::experimental::filesystem;
+#elif defined(BOOST_GIL_IO_USE_STD_FILESYSTEM)
+namespace filesystem = std::filesystem;
+#else
+#if !defined(BOOST_GIL_IO_USE_BOOST_FILESYSTEM)
+#error "Boost.Filesystem is required if C++17 <filesystem> is not available"
+#endif
+namespace filesystem = boost::filesystem;
+#endif
+
+}}} // namespace boost::gil::detail
+
+#endif

--- a/include/boost/gil/io/make_backend.hpp
+++ b/include/boost/gil/io/make_backend.hpp
@@ -55,17 +55,15 @@ auto make_reader_backend(
     return reader_backend<device_t, FormatTag>(device, settings);
 }
 
-#ifdef BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 template <typename FormatTag>
 inline
 auto make_reader_backend(
-    filesystem::path const& path,
+    detail::filesystem::path const& path,
     image_read_settings<FormatTag> const& settings)
     -> typename get_reader_backend<std::wstring, FormatTag>::type
 {
     return make_reader_backend(path.wstring(), settings);
 }
-#endif  // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 
 template <typename Device, typename FormatTag>
 inline

--- a/include/boost/gil/io/make_dynamic_image_reader.hpp
+++ b/include/boost/gil/io/make_dynamic_image_reader.hpp
@@ -54,16 +54,14 @@ auto make_dynamic_image_reader(
         typename get_dynamic_image_reader<std::wstring, FormatTag>::type(device, settings);
 }
 
-#ifdef BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 template <typename FormatTag>
 inline
 auto make_dynamic_image_reader(
-    filesystem::path const& path, image_read_settings<FormatTag> const& settings)
+    detail::filesystem::path const& path, image_read_settings<FormatTag> const& settings)
     -> typename get_dynamic_image_reader<std::wstring, FormatTag>::type
 {
     return make_dynamic_image_reader(path.wstring(), settings);
 }
-#endif  // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 
 template <typename Device, typename FormatTag>
 inline
@@ -109,15 +107,13 @@ auto make_dynamic_image_reader(std::wstring const& file_name, FormatTag const&)
     return make_dynamic_image_reader(file_name, image_read_settings<FormatTag>());
 }
 
-#ifdef BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 template <typename FormatTag>
 inline
-auto make_dynamic_image_reader(filesystem::path const& path, FormatTag const&)
+auto make_dynamic_image_reader(detail::filesystem::path const& path, FormatTag const&)
     -> typename get_dynamic_image_reader<std::wstring, FormatTag>::type
 {
     return make_dynamic_image_reader(path.wstring(), image_read_settings<FormatTag>());
 }
-#endif  // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 
 template <typename Device, typename FormatTag>
 inline

--- a/include/boost/gil/io/make_dynamic_image_writer.hpp
+++ b/include/boost/gil/io/make_dynamic_image_writer.hpp
@@ -69,8 +69,8 @@ inline
 typename get_dynamic_image_writer< std::wstring
                                  , FormatTag
                                  >::type
-make_dynamic_image_writer( const filesystem::path&              path
-                         , const image_write_info< FormatTag >& info
+make_dynamic_image_writer( detail::filesystem::path const& path
+                         , image_write_info<FormatTag> const& info
                          )
 {
     return make_dynamic_image_writer( path.wstring()

--- a/include/boost/gil/io/make_reader.hpp
+++ b/include/boost/gil/io/make_reader.hpp
@@ -70,7 +70,6 @@ make_reader( const std::wstring& file_name
                                      );
 }
 
-#ifdef BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 template< typename FormatTag
         , typename ConversionPolicy
         >
@@ -79,7 +78,7 @@ typename get_reader< std::wstring
                    , FormatTag
                    , ConversionPolicy
                    >::type
-make_reader( const filesystem::path&                 path
+make_reader( detail::filesystem::path const& path
            , const image_read_settings< FormatTag >& settings
            , const ConversionPolicy&                 cc
            )
@@ -89,7 +88,6 @@ make_reader( const filesystem::path&                 path
                       , cc
                       );
 }
-#endif // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 
 template <typename Device, typename FormatTag, typename ConversionPolicy>
 inline
@@ -153,7 +151,6 @@ make_reader( const std::wstring&     file_name
                       );
 }
 
-#ifdef BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 template< typename FormatTag
         , typename ConversionPolicy
         >
@@ -162,7 +159,7 @@ typename get_reader< std::wstring
                    , FormatTag
                    , ConversionPolicy
                    >::type
-make_reader( const filesystem::path& path
+make_reader( detail::filesystem::path const& path
            , const FormatTag&
            , const ConversionPolicy& cc
            )
@@ -172,7 +169,6 @@ make_reader( const filesystem::path& path
                       , cc
                       );
 }
-#endif // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 
 template <typename Device, typename FormatTag, typename ConversionPolicy>
 inline

--- a/include/boost/gil/io/make_scanline_reader.hpp
+++ b/include/boost/gil/io/make_scanline_reader.hpp
@@ -63,13 +63,12 @@ make_scanline_reader( const std::wstring& file_name
                                               );
 }
 
-#ifdef BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 template< typename FormatTag >
 inline
 typename get_scanline_reader< std::wstring
                             , FormatTag
                             >::type
-make_scanline_reader( const filesystem::path& path
+make_scanline_reader( detail::filesystem::path const& path
                     , FormatTag const&
                     )
 {
@@ -77,7 +76,6 @@ make_scanline_reader( const filesystem::path& path
                                , image_read_settings< FormatTag >()
                                );
 }
-#endif // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 
 template <typename Device, typename FormatTag>
 inline

--- a/include/boost/gil/io/make_writer.hpp
+++ b/include/boost/gil/io/make_writer.hpp
@@ -60,13 +60,12 @@ make_writer( const std::wstring&                  file_name
                                      );
 }
 
-#ifdef BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 template< typename FormatTag >
 inline
 typename get_writer< std::wstring
                    , FormatTag
                    >::type
-make_writer( const filesystem::path&              path
+make_writer( detail::filesystem::path const& path
            , const image_write_info< FormatTag >& info
            )
 {
@@ -74,7 +73,6 @@ make_writer( const filesystem::path&              path
                       , info
                       );
 }
-#endif // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 
 template <typename Device, typename FormatTag>
 inline
@@ -125,13 +123,12 @@ make_writer( const std::wstring& file_name
                       );
 }
 
-#ifdef BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 template< typename FormatTag >
 inline
 typename get_writer< std::wstring
                    , FormatTag
                    >::type
-make_writer( const filesystem::path& path
+make_writer( detail::filesystem::path const& path
            , const FormatTag&        tag
            )
 {
@@ -139,7 +136,6 @@ make_writer( const filesystem::path& path
                       , tag
                       );
 }
-#endif // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 
 template <typename Device, typename FormatTag>
 inline

--- a/include/boost/gil/io/path_spec.hpp
+++ b/include/boost/gil/io/path_spec.hpp
@@ -8,29 +8,7 @@
 #ifndef BOOST_GIL_IO_PATH_SPEC_HPP
 #define BOOST_GIL_IO_PATH_SPEC_HPP
 
-#ifdef BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
-// Disable warning: conversion to 'std::atomic<int>::__integral_type {aka int}' from 'long int' may alter its value
-#if defined(BOOST_CLANG)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wshorten-64-to-32"
-#endif
-
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wconversion"
-#endif
-
-#define BOOST_FILESYSTEM_VERSION 3
-#include <boost/filesystem/path.hpp>
-
-#if defined(BOOST_CLANG)
-#pragma clang diagnostic pop
-#endif
-
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
-#pragma GCC diagnostic pop
-#endif
-#endif // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
+#include <boost/gil/io/detail/filesystem.hpp>
 
 #include <cstdlib>
 #include <string>
@@ -53,15 +31,8 @@ template<int i> struct is_supported_path_spec<char [i]>             : std::true_
 template<int i> struct is_supported_path_spec<const wchar_t [i]>    : std::true_type {};
 template<int i> struct is_supported_path_spec<wchar_t [i]>          : std::true_type {};
 
-#ifdef BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
-template<> struct is_supported_path_spec< filesystem::path > : std::true_type {};
-template<> struct is_supported_path_spec< const filesystem::path > : std::true_type {};
-#endif // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
-
-
-///
-/// convert_to_string
-///
+template<> struct is_supported_path_spec<filesystem::path> : std::true_type {};
+template<> struct is_supported_path_spec<filesystem::path const> : std::true_type {};
 
 inline std::string convert_to_string( std::string const& obj)
 {
@@ -87,16 +58,10 @@ inline std::string convert_to_string( char* str )
     return std::string( str );
 }
 
-#ifdef BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
-inline std::string convert_to_string( const filesystem::path& path )
+inline std::string convert_to_string(filesystem::path const& path)
 {
-    return convert_to_string( path.string() );
+    return convert_to_string(path.string());
 }
-#endif // BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
-
-///
-/// convert_to_native_string
-///
 
 inline const char* convert_to_native_string( char* str )
 {
@@ -131,8 +96,6 @@ inline const char* convert_to_native_string( const std::wstring& str )
     return c;
 }
 
-} // namespace detail
-} // namespace gil
-} // namespace boost
+}}} // namespace boost::gil::detail
 
 #endif

--- a/test/extension/io/bmp/bmp_make.cpp
+++ b/test/extension/io/bmp/bmp_make.cpp
@@ -5,8 +5,6 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
-#define BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
-#define BOOST_FILESYSTEM_VERSION 3
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/bmp.hpp>
 
@@ -22,7 +20,7 @@
 
 #include "paths.hpp"
 
-namespace fs = boost::filesystem;
+namespace fs  = boost::gil::detail::filesystem;
 namespace gil = boost::gil;
 
 void test_make_reader_backend()

--- a/test/extension/io/bmp/bmp_test.cpp
+++ b/test/extension/io/bmp/bmp_test.cpp
@@ -5,8 +5,6 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
-#define BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
-#define BOOST_FILESYSTEM_VERSION 3
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/bmp.hpp>
 
@@ -21,7 +19,7 @@
 #include "paths.hpp"
 #include "subimage_test.hpp"
 
-namespace fs = boost::filesystem;
+namespace fs  = boost::gil::detail::filesystem;
 namespace gil = boost::gil;
 namespace mp11 = boost::mp11;
 

--- a/test/extension/io/jpeg/jpeg_test.cpp
+++ b/test/extension/io/jpeg/jpeg_test.cpp
@@ -5,8 +5,6 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
-#define BOOST_FILESYSTEM_VERSION 3
-#define BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/jpeg.hpp>
 
@@ -21,7 +19,7 @@
 #include "paths.hpp"
 #include "subimage_test.hpp"
 
-namespace fs = boost::filesystem;
+namespace fs  = boost::gil::detail::filesystem;
 namespace gil = boost::gil;
 namespace mp11 = boost::mp11;
 

--- a/test/extension/io/paths.hpp
+++ b/test/extension/io/paths.hpp
@@ -8,33 +8,13 @@
 #ifndef BOOST_GIL_TEST_EXTENSION_IO_PATHS_HPP
 #define BOOST_GIL_TEST_EXTENSION_IO_PATHS_HPP
 
-// Disable warning: conversion to 'std::atomic<int>::__integral_type {aka int}' from 'long int' may alter its value
-#if defined(BOOST_CLANG)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wshorten-64-to-32"
-#endif
-
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wconversion"
-#endif
-
-#define BOOST_FILESYSTEM_VERSION 3
-#include <boost/filesystem.hpp>
-
-#if defined(BOOST_CLANG)
-#pragma clang diagnostic pop
-#endif
-
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40900)
-#pragma GCC diagnostic pop
-#endif
+#include <boost/gil/io/detail/filesystem.hpp>
 
 #include <string>
 
 // `base` holds the path to ../.., i.e. the directory containing `images`
 static const std::string base =
-    (boost::filesystem::absolute(boost::filesystem::path(__FILE__)).parent_path().string()) + "/";
+    (boost::gil::detail::filesystem::absolute(boost::gil::detail::filesystem::path(__FILE__)).parent_path().string()) + "/";
 
 static const std::string bmp_in  = base + "images/bmp/";
 static const std::string bmp_out = base + "output/";

--- a/test/extension/io/png/png_file_format_test.cpp
+++ b/test/extension/io/png/png_file_format_test.cpp
@@ -5,9 +5,7 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
-#define BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 #define BOOST_GIL_IO_ENABLE_GRAY_ALPHA
-#define BOOST_FILESYSTEM_VERSION 3
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/png.hpp>
 
@@ -15,8 +13,8 @@
 
 #include "paths.hpp"
 
+namespace fs  = boost::gil::detail::filesystem;
 namespace gil = boost::gil;
-namespace fs = boost::filesystem;
 
 #ifdef BOOST_GIL_IO_USE_PNG_TEST_SUITE_IMAGES
 

--- a/test/extension/io/png/png_read_test.cpp
+++ b/test/extension/io/png/png_read_test.cpp
@@ -5,9 +5,7 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
-#define BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 #define BOOST_GIL_IO_ENABLE_GRAY_ALPHA
-#define BOOST_FILESYSTEM_VERSION 3
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/png.hpp>
 
@@ -22,8 +20,8 @@
 #include "scanline_read_test.hpp"
 #include "test_utility_output_stream.hpp"
 
+namespace fs  = boost::gil::detail::filesystem;
 namespace gil = boost::gil;
-namespace fs = boost::filesystem;
 
 using gray_alpha8_pixel_t = gil::pixel<std::uint8_t, gil::gray_alpha_layout_t>;
 using gray_alpha8c_pixel_t = gil::pixel<std::uint8_t, gil::gray_alpha_layout_t> const;

--- a/test/extension/io/png/png_write_test.cpp
+++ b/test/extension/io/png/png_write_test.cpp
@@ -5,9 +5,7 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
-#define BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 #define BOOST_GIL_IO_ENABLE_GRAY_ALPHA
-#define BOOST_FILESYSTEM_VERSION 3
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/png.hpp>
 

--- a/test/extension/io/raw/raw_test.cpp
+++ b/test/extension/io/raw/raw_test.cpp
@@ -5,8 +5,6 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
-#define BOOST_FILESYSTEM_VERSION 3
-#define BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/raw.hpp>
 
@@ -19,7 +17,7 @@
 #include "paths.hpp"
 #include "subimage_test.hpp"
 
-namespace fs = boost::filesystem;
+namespace fs  = boost::gil::detail::filesystem;
 namespace gil = boost::gil;
 namespace mp11 = boost::mp11;
 

--- a/test/extension/io/simple_all_formats.cpp
+++ b/test/extension/io/simple_all_formats.cpp
@@ -16,8 +16,8 @@
 
 #include "paths.hpp"
 
+namespace fs  = boost::gil::detail::filesystem;
 namespace gil = boost::gil;
-namespace fs = boost::filesystem;
 
 // Test will include all format's headers and load and write some images.
 // This test is more of a compilation test.

--- a/test/extension/io/targa/targa_test.cpp
+++ b/test/extension/io/targa/targa_test.cpp
@@ -5,7 +5,6 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
-#define BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/targa.hpp>
 
@@ -21,7 +20,7 @@
 #include "subimage_test.hpp"
 #include "test_utility_output_stream.hpp"
 
-namespace fs = boost::filesystem;
+namespace fs  = boost::gil::detail::filesystem;
 namespace gil = boost::gil;
 namespace mp11 = boost::mp11;
 

--- a/test/extension/io/tiff/tiff_test.cpp
+++ b/test/extension/io/tiff/tiff_test.cpp
@@ -5,8 +5,6 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
-#define BOOST_FILESYSTEM_VERSION 3
-#define BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/tiff.hpp>
 
@@ -21,7 +19,7 @@
 #include "paths.hpp"
 #include "subimage_test.hpp"
 
-namespace fs   = boost::filesystem;
+namespace fs   = boost::gil::detail::filesystem;
 namespace gil  = boost::gil;
 namespace mp11 = boost::mp11;
 


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

<!-- What does this pull request do? -->

If neither <filesystem> nor <experimental/filesystem> is detected,
then require <boost/filesystem.hpp>.

If user defines BOOST_GIL_IO_USE_BOOST_FILESYSTEM macro,
then <boost/filesystem.hpp> is pre-selected and required,
and search for any of the C++ standard implementation is skipped.

Remove end-user macro BOOST_GIL_IO_ADD_FS_PATH_SUPPORT
Require tests to always build with support of either
detected C++ filesystem or pre-selected Boost.Filesystem.

### References

<!-- Any links related to this PR: issues, other PRs, mailing list threads, StackOverflow questions, etc. -->

- #222 - this PR removes `BOOST_GIL_IO_ADD_FS_PATH_SUPPORT` macro 

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [ ] Add note to [RELEASES.md](https://github.com/boostorg/gil/blob/develop/RELEASES.md) changelog.
- [ ] Ensure all CI builds pass
- [ ] Review and approve
