### PR TITLE
Replace Ubuntu 16.04 with Ubuntu 18.04 in some GitHub Actions jobs

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -15,9 +15,9 @@ trigger:
   - ml/*
 
 jobs:
-  - job: 'ubuntu1604_gcc6_cxx14_cmake'
+  - job: 'ubuntu1804_gcc6_cxx14_cmake'
     pool:
-      vmImage: 'ubuntu-16.04'
+      vmImage: 'ubuntu-18.04'
     steps:
       - template: .ci/azure-pipelines/steps-install-gcc.yml
         parameters:
@@ -34,9 +34,9 @@ jobs:
         parameters:
           cxxver: '14'
 
-  - job: 'ubuntu1604_gcc8_cxx14_cmake'
+  - job: 'ubuntu1804_gcc8_cxx14_cmake'
     pool:
-      vmImage: 'ubuntu-16.04'
+      vmImage: 'ubuntu-18.04'
     steps:
       - template: .ci/azure-pipelines/steps-install-gcc.yml
         parameters:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         include:
           - toolset: gcc-6
             cxxstd: "11,14,1z"
-            os: ubuntu-16.04
+            os: ubuntu-18.04
             install: g++-6
           - toolset: gcc-7
             cxxstd: "11,14,17"
@@ -62,17 +62,17 @@ jobs:
           - toolset: clang
             compiler: clang++-3.9
             cxxstd: "11,14"
-            os: ubuntu-16.04
+            os: ubuntu-18.04
             install: clang-3.9
           - toolset: clang
             compiler: clang++-4.0
             cxxstd: "11,14"
-            os: ubuntu-16.04
+            os: ubuntu-18.04
             install: clang-4.0
           - toolset: clang
             compiler: clang++-5.0
             cxxstd: "11,14,1z"
-            os: ubuntu-16.04
+            os: ubuntu-18.04
             install: clang-5.0
           - toolset: clang
             compiler: clang++-6.0


### PR DESCRIPTION
### Description

Ubuntu 16.04 is no longer available for GitHub Actions, because support for it has ended. However, some build jobs still try to use Ubuntu 16.04. This pull request tries to change that for those cases where a replacement with Ubuntu 18.04 is possible.

Note: Some older Clang versions (Clang 3.8 and older) seem to be unavailable in the APT package repository, so those are not
changed to 18.04. _This is intended._ Maybe tests for Clang 3.4 to Clang 3.8 should be removed, but that is probably worth another discussion.

### References

Ubuntu 16.04 has been removed from GitHub in 2021. See <https://github.com/actions/virtual-environments/issues/3287> for more information.

### Tasklist

- [x] Ensure updated CI builds pass
- [x] Review and approve
