### PR TITLE
Fix Clang 9 build on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
             compiler: clang++-9
             cxxstd: "11,14,17,2a"
             os: ubuntu-20.04
+            install: clang-9
           - toolset: clang
             compiler: clang++-10
             cxxstd: "11,14,17,2a"


### PR DESCRIPTION
### Description

The name of the clang-9 package was missing, so it was not installed. This PR fixes it, so that Clang 9 gets installed an can be used during CI.

### References

None.

### Tasklist

- [x] Ensure Clang 9 CI builds passed
- [ ] Review and approve
