### PR TITLE
Switch Azure's macOS build to supported OS version

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -88,9 +88,9 @@ jobs:
           cxxver: '17'
           use_conan: 'ON'
 
-  - job: 'macos1014_xcode11_cmake'
+  - job: 'macos1015_xcode11_cmake'
     pool:
-      vmImage: 'macOS-10.14'
+      vmImage: 'macOS-10.15'
     steps:
       - script: which clang++ && clang++ --version
         displayName: 'Check clang'


### PR DESCRIPTION
### Description

The image `macOS-10.14` is not available anymore, but `macOS-10.15` is still available. So this PR simply switches to that image.

If this is successful, then at least all the Azure pipeline builds of GIL are passing. :)

### References

See <https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml> for available images in Azure pipelines.

This builds on the following idea mentioned in #642:

> As a general idea, we should probably make sure that the existing CI pipelines pass (except for the outdated stuff that may potentially get removed). Otherwise we may just be migrating existing build failures to another CI configuration with boost-ci.

### Tasklist

- [x] Ensure Azure pipeline CI with macOS build passes
- [ ] Review and approve
