### PR TITLE
ci: Switch GitHub Action's MSVC build to supported OS version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,10 +147,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - toolset: msvc-14.1
-            cxxstd: "14,17,latest"
-            addrmd: 32,64
-            os: windows-2016
           - toolset: msvc-14.2
             cxxstd: "14,17,latest"
             addrmd: 32,64
@@ -159,6 +155,10 @@ jobs:
             cxxstd: "11,14,17,2a"
             addrmd: 64
             os: windows-2019
+          - toolset: msvc-14.3
+            cxxstd: "14,17,latest"
+            addrmd: 32,64
+            os: windows-2022
 
     runs-on: ${{matrix.os}}
 


### PR DESCRIPTION
### Description

The Windows-2016 environment for GitHub Actions has been retired in March 2022, so it's not available anymore. For further information on that see <https://github.com/actions/virtual-environments/issues/4312>. However, we can test on the newer Windows 2022 environment instead. This also brings Visual Studio 2022.

So this pull request removes the GitHub Actions job using the Windows 2016 environment and introduces a new one with the Windows 2022 environment.

### References

See https://github.com/actions/virtual-environments/issues/4312 for the removal announcement of the `windows-2016` environment.

### Tasklist

- [ ] Check that the new CI build with `windows-2022` passes
- [ ] Review and approve