### PR TITLE
fix: is_equal_to_sixteen in PNG I/O was less-than test

### DIFF
--- a/include/boost/gil/extension/io/png/detail/write.hpp
+++ b/include/boost/gil/extension/io/png/detail/write.hpp
@@ -171,10 +171,24 @@ private:
     {};
 
     template<typename Info>
-    struct is_equal_to_sixteen : mp11::mp_less
+    struct is_equal_to_sixteen : mp11::mp_and
         <
-            std::integral_constant<int, Info::_bit_depth>,
-            std::integral_constant<int, 16>
+            mp11::mp_not
+            <
+                mp11::mp_less
+                <
+                    std::integral_constant<int, Info::_bit_depth>,
+                    std::integral_constant<int, 16>
+                >
+            >,
+            mp11::mp_not
+            <
+                mp11::mp_less
+                <
+                    std::integral_constant<int, 16>,
+                    std::integral_constant<int, Info::_bit_depth>
+                >
+            >
         >
     {};
 


### PR DESCRIPTION
### Description

While `is_equal_to_sixteen` should (as the name suggests) check for equality to 16, it actually checked whether the bit depth was less than 16.

Since Boost.MP11 does not contain an `mp11::mp_equal` but only `mp11::mp_less`, the equality check is performed by making sure that
* the bit depth is not less than 16,
* 16 is not less than the bit depth,
* and both of those hold true.

It's a bit laborious, but it works.

### References

The wrong comparison was introduced by PR #274 in https://github.com/boostorg/gil/commit/5611bd58071873d6346fe3cc05fe86c72f697717#diff-e2c958c778b464b94146992b6aeb7c814839ddbcbbb901f9f4175e797fa543d2 when `boost::mpl` was replaced with `boost::mp11`. In that commit the original `mpl::equal_to` was replaced by `mp11::mp_less`. To be fair though, unlike MPL the MP11 library does not contain an equivalent to `mpl::equal_to`.

### Tasklist

- [ ] Ensure all CI builds pass
- [ ] Review and approve
