### PR TITLE
style: Remove trailing space characters

### DIFF
--- a/example/adaptive_threshold.cpp
+++ b/example/adaptive_threshold.cpp
@@ -29,13 +29,13 @@ int main()
 
     boost::gil::threshold_adaptive(const_view(img), view(img_out), 11, threshold_adaptive_method::mean, threshold_direction::regular, 2);
     write_view("out-threshold-adaptive-mean.png", view(img_out), png_tag{});
-    
+
     boost::gil::threshold_adaptive(const_view(img), view(img_out), 11, threshold_adaptive_method::mean, threshold_direction::inverse, 2);
     write_view("out-threshold-adaptive-mean-inv.png", view(img_out), png_tag{});
 
     boost::gil::threshold_adaptive(const_view(img), view(img_out), 7, threshold_adaptive_method::gaussian, threshold_direction::regular, 2);
     write_view("out-threshold-adaptive-gaussian.png", view(img_out), png_tag{});
-    
+
     boost::gil::threshold_adaptive(const_view(img), view(img_out), 11, threshold_adaptive_method::gaussian, threshold_direction::inverse, 2);
     write_view("out-threshold-adaptive-gaussian-inv.png", view(img_out), png_tag{});
 

--- a/example/harris.cpp
+++ b/example/harris.cpp
@@ -161,11 +161,11 @@ int main(int argc, char* argv[])
 
     gil::rgb8_image_t input_image;
 
-    gil::read_image(argv[1], input_image, gil::png_tag{}); 
+    gil::read_image(argv[1], input_image, gil::png_tag{});
     auto original_image = input_image;
     auto original_view = gil::view(original_image);
     auto input_view = gil::view(input_image);
-    auto grayscaled = to_grayscale(input_view); 
+    auto grayscaled = to_grayscale(input_view);
     gil::gray8_image_t smoothed_image(grayscaled.dimensions());
     auto smoothed = gil::view(smoothed_image);
     apply_gaussian_blur(gil::view(grayscaled), smoothed);

--- a/example/hessian.cpp
+++ b/example/hessian.cpp
@@ -1,9 +1,9 @@
-// 
+//
 // Copyright 2019 Olzhas Zhumabek <anonymous.from.applecity@gmail.com>
-// 
-// Distributed under the Boost Software License, Version 1.0 
-// See accompanying file LICENSE_1_0.txt or copy at 
-// http://www.boost.org/LICENSE_1_0.txt 
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
 //
 
 #include <boost/gil/image.hpp>

--- a/example/histogram.cpp
+++ b/example/histogram.cpp
@@ -45,7 +45,7 @@ int main()
         true     // Use specified limits if this is true (default is false)
     );
 
-    // Normalize the histogram 
+    // Normalize the histogram
     h.normalize();
 
     // Get a cumulative histogram from the histogram

--- a/example/histogram_equalization.cpp
+++ b/example/histogram_equalization.cpp
@@ -1,10 +1,10 @@
-// 
+//
 // Copyright 2020 Debabrata Mandal <mandaldebabrata123@gmail.com>
-// 
-// Distributed under the Boost Software License, Version 1.0 
-// See accompanying file LICENSE_1_0.txt or copy at 
-// http://www.boost.org/LICENSE_1_0.txt 
-// 
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
 
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/png.hpp>
@@ -22,7 +22,7 @@ using namespace boost::gil;
 int main()
 {
     gray8_image_t img;
-    
+
     read_image("test_adaptive.png", img, png_tag{});
     gray8_image_t img_out(img.dimensions());
 

--- a/example/hvstack.hpp
+++ b/example/hvstack.hpp
@@ -1,9 +1,9 @@
-// 
+//
 // // Copyright 2021 Olzhas Zhumabek <anonymous.from.applecity@gmail.com>
-// 
-// Distributed under the Boost Software License, Version 1.0 
-// See accompanying file LICENSE_1_0.txt or copy at 
-// http://www.boost.org/LICENSE_1_0.txt 
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
 //
 
 #include "boost/gil/image_view_factory.hpp"

--- a/example/morphology.cpp
+++ b/example/morphology.cpp
@@ -48,7 +48,7 @@ int main(int argc, char** argv)
         // User has to enter atleast one operation and they can enter maximum 8
         // operations considering binary conversion to be an
         // operation.Output_image_template argument is the common component which
-        // will be added in names of all output images followed by a hyphen and 
+        // will be added in names of all output images followed by a hyphen and
         // the operation name.
         // Example :
         // ./example_morphology morphology_original.png out black_hat top_hat

--- a/example/rasterizer_ellipse.cpp
+++ b/example/rasterizer_ellipse.cpp
@@ -24,12 +24,12 @@ namespace gil = boost::gil;
 
 int main()
 {
-    // Syntax for usage :- 
+    // Syntax for usage :-
     // auto rasterizer = gil::midpoint_elliptical_rasterizer{};
     // rasterizer(img_view, colour, center, semi-axes_length);
     // Where
     // img_view : gil view of the image on which ellipse is to be drawn.
-    // colour : Vector containing channel intensity values for img_view. Number of colours 
+    // colour : Vector containing channel intensity values for img_view. Number of colours
     // provided must be equal to the number of channels present in img_view.
     // center : Array containing positive integer x co-ordinate and y co-ordinate of the center
     // respectively.

--- a/example/rasterizer_line.cpp
+++ b/example/rasterizer_line.cpp
@@ -17,7 +17,7 @@ namespace gil = boost::gil;
 // Demonstrates the use of a rasterizer to generate an image of a line
 // The various rasterizers available are defined in include/boost/gil/rasterization/circle.hpp,
 // include/boost/gil/rasterization/ellipse.hpp and include/boost/gil/rasterization/line.hpp
-// The rasterizer used implements the Bresenham's line algorithm. 
+// The rasterizer used implements the Bresenham's line algorithm.
 // Multiple images are created, all of the same size, but with areas of different sizes passed to the rasterizer, resulting in different lines.
 // See also:
 // rasterizer_circle.cpp - Demonstrates the use of a rasterizer to generate an image of a circle

--- a/example/threshold.cpp
+++ b/example/threshold.cpp
@@ -21,7 +21,7 @@ using namespace boost::gil;
 //     - threshold and regular: truncates the pixels whose values are greater than the threshold
 //     - threshold and inverse: truncates the pixels whose values are less than the threshold
 //     - zero and regular: zeroes the pixels whose values are less than the threshold
-//     - zero and inverse: zeroes the pixels whose values are greater than the threshold 
+//     - zero and inverse: zeroes the pixels whose values are greater than the threshold
 // See also:
 // adaptive_threshold.cpp - Adaptive thresholding
 

--- a/include/boost/gil/color_base.hpp
+++ b/include/boost/gil/color_base.hpp
@@ -309,7 +309,7 @@ struct homogeneous_color_base<Element, Layout, 4>
     homogeneous_color_base() : v0_{}, v1_{}, v2_{}, v3_{} {}
 
     explicit homogeneous_color_base(Element v) : v0_(v), v1_(v), v2_(v), v3_(v) {}
-    
+
     homogeneous_color_base(Element v0, Element v1, Element v2, Element v3)
         : v0_(v0), v1_(v1), v2_(v2), v3_(v3)
     {}

--- a/include/boost/gil/extension/dynamic_image/any_image.hpp
+++ b/include/boost/gil/extension/dynamic_image/any_image.hpp
@@ -90,13 +90,13 @@ class any_image : public variant2::variant<Images...>
 {
     using parent_t = variant2::variant<Images...>;
 
-public:    
+public:
     using view_t = mp11::mp_rename<detail::images_get_views_t<any_image>, any_image_view>;
     using const_view_t = mp11::mp_rename<detail::images_get_const_views_t<any_image>, any_image_view>;
     using x_coord_t = std::ptrdiff_t;
     using y_coord_t = std::ptrdiff_t;
     using point_t = point<std::ptrdiff_t>;
-    
+
     using parent_t::parent_t;
 
     any_image& operator=(any_image const& img)

--- a/include/boost/gil/extension/dynamic_image/any_image_view.hpp
+++ b/include/boost/gil/extension/dynamic_image/any_image_view.hpp
@@ -76,7 +76,7 @@ class any_image_view : public variant2::variant<Views...>
 {
     using parent_t = variant2::variant<Views...>;
 
-public:    
+public:
     using const_t = detail::views_get_const_t<any_image_view>;
     using x_coord_t = std::ptrdiff_t;
     using y_coord_t = std::ptrdiff_t;

--- a/include/boost/gil/extension/histogram/std.hpp
+++ b/include/boost/gil/extension/histogram/std.hpp
@@ -25,7 +25,7 @@ namespace boost { namespace gil {
 //////////////////////////////////////////////////////////
 /// Histogram extension for STL container
 //////////////////////////////////////////////////////////
-/// \defgroup Histogram - STL Containers 
+/// \defgroup Histogram - STL Containers
 /// \brief Collection of functions to provide histogram support in GIL using Standard
 ///        Template Library Containers
 /// The conversion from Boost.GIL images to compatible histograms are provided. The supported

--- a/include/boost/gil/extension/numeric/affine.hpp
+++ b/include/boost/gil/extension/numeric/affine.hpp
@@ -108,7 +108,7 @@ boost::gil::matrix3x2<T> inverse(boost::gil::matrix3x2<T> m)
     return res;
 }
 
-/// \fn gil::matrix3x2 center_rotate 
+/// \fn gil::matrix3x2 center_rotate
 /// \tparam T     Data type for source image dimensions
 /// \tparam F     Data type for angle through which image is to be rotated
 /// @param  dims  dimensions of source image
@@ -116,39 +116,39 @@ boost::gil::matrix3x2<T> inverse(boost::gil::matrix3x2<T> m)
 /// @return   A transformation matrix for rotating the source image about its center
 /// \brief    rotates an image from its center point
 ///           using consecutive affine transformations.
-template<typename T, typename F> 
+template<typename T, typename F>
 boost::gil::matrix3x2<F> center_rotate(boost::gil::point<T> dims,F rads)
-{   
+{
     const F PI = F(3.141592653589793238);
     const F c_theta = std::abs(std::cos(rads));
     const F s_theta = std::abs(std::sin(rads));
 
     // Bound checks for angle rads
-    while(rads + PI < 0) 
-    { 
-        rads = rads + PI; 
+    while(rads + PI < 0)
+    {
+        rads = rads + PI;
     }
 
-    while(rads > PI)     
-    { 
-        rads = rads - PI; 
+    while(rads > PI)
+    {
+        rads = rads - PI;
     }
 
     // Basic Rotation Matrix
     boost::gil::matrix3x2<F> rotate = boost::gil::matrix3x2<F>::get_rotate(rads);
-    
+
     // Find distance for translating the image into view
     boost::gil::matrix3x2<F> translation(0,0,0,0,0,0);
-    if(rads > 0) 
-    { 
-        translation.b = s_theta; 
+    if(rads > 0)
+    {
+        translation.b = s_theta;
     }
-    else 
-    { 
+    else
+    {
         translation.c = s_theta;
     }
 
-    if(std::abs(rads) > PI/2) 
+    if(std::abs(rads) > PI/2)
     {
         translation.a = c_theta;
         translation.d = c_theta;
@@ -165,7 +165,7 @@ boost::gil::matrix3x2<F> center_rotate(boost::gil::point<T> dims,F rads)
             s_theta * dims.x / dims.y + c_theta
         );
 
-    return scale *  translate * rotate;  
+    return scale *  translate * rotate;
 }
 
 }} // namespace boost::gil

--- a/include/boost/gil/histogram.hpp
+++ b/include/boost/gil/histogram.hpp
@@ -60,12 +60,12 @@ inline typename std::enable_if<Index != sizeof...(T), void>::type
 }
 
 /// \ingroup Histogram-Helpers
-/// \brief Functor provided for the hashing of tuples. 
-///        The following approach makes use hash_combine from 
-///        boost::container_hash. Although there is a direct hashing 
+/// \brief Functor provided for the hashing of tuples.
+///        The following approach makes use hash_combine from
+///        boost::container_hash. Although there is a direct hashing
 ///        available for tuples, this approach will ease adopting in
 ///        future to a std::hash_combine. In case std::hash extends
-///        support to tuples this functor as well as the helper 
+///        support to tuples this functor as well as the helper
 ///        implementation hash_tuple_impl can be removed.
 ///
 template <typename... T>
@@ -115,7 +115,7 @@ bool tuple_compare(Tuple const& t1, Tuple const& t2, boost::mp11::index_sequence
 }
 
 /// \ingroup Histogram-Helpers
-/// \brief Compares 2 tuples and outputs t1 <= t2 
+/// \brief Compares 2 tuples and outputs t1 <= t2
 ///        Comparison is not in a lexicographic manner but on every element of the tuple hence
 ///        (2, 2) > (1, 3) evaluates to false
 ///
@@ -199,13 +199,13 @@ struct filler<1>
 /// \brief Default histogram class provided by boost::gil.
 ///
 /// The class inherits over the std::unordered_map provided by STL. A complete example/tutorial
-/// of how to use the class resides in the docs. 
+/// of how to use the class resides in the docs.
 /// Simple calling syntax for a 3D dimensional histogram :
 /// \code
 /// histogram<int, int , int> h;
 /// h(1, 1, 1) = 0;
 /// \endcode
-/// This is just a starter to what all can be achieved with it, refer to the docs for the 
+/// This is just a starter to what all can be achieved with it, refer to the docs for the
 /// full demo.
 ///
 template <typename... T>
@@ -237,7 +237,7 @@ public:
         return base_t::operator[](key);
     }
 
-    /// \brief Checks if 2 histograms are equal. Ignores type, and checks if 
+    /// \brief Checks if 2 histograms are equal. Ignores type, and checks if
     ///        the keys (after type casting) match.
     template <typename OtherType>
     bool equals(OtherType const& otherhist) const
@@ -258,7 +258,7 @@ public:
         });
         return check;
     }
-    
+
     /// \brief Checks if the histogram class is compatible to be used with
     ///        a GIL image type
     static constexpr bool is_pixel_compatible()
@@ -502,7 +502,7 @@ public:
         return sub_h;
     }
 
-    /// \brief Normalize this histogram class 
+    /// \brief Normalize this histogram class
     void normalize()
     {
         double sum = 0.0;
@@ -593,7 +593,7 @@ private:
 /// \ingroup Histogram Algorithms
 /// \tparam SrcView Input image view
 /// \tparam Container Input histogram container
-/// \brief Overload this function to provide support for boost::gil::histogram or 
+/// \brief Overload this function to provide support for boost::gil::histogram or
 /// any other external histogram
 ///
 /// Example :
@@ -618,7 +618,7 @@ void fill_histogram(SrcView const&, Container&);
 /// @param lower       Input  Lower limit on the values in histogram (default numeric_limit::min() on axes)
 /// @param upper       Input  Upper limit on the values in histogram (default numeric_limit::max() on axes)
 /// @param setlimits   Input  Use specified limits if this is true (default is false)
-/// \brief Overload version of fill_histogram 
+/// \brief Overload version of fill_histogram
 ///
 /// Takes a third argument to determine whether to clear container before filling.
 /// For eg, when there is a need to accumulate the histograms do
@@ -643,11 +643,11 @@ void fill_histogram(
 {
     if (!accumulate)
         hist.clear();
-    
+
     detail::filler<histogram<T...>::dimension()> f;
     if (!sparsefill)
         f(hist, lower, upper, bin_width);
-    
+
     hist.template fill<Dimensions...>(srcview, bin_width, applymask, mask, lower, upper, setlimits);
 }
 
@@ -673,7 +673,7 @@ histogram<T...> cumulative_histogram(histogram<T...> const& hist)
     static_assert(
         boost::mp11::mp_all_of<check_list, boost::mp11::mp_to_bool>::value,
         "Cumulative histogram not possible of this type");
-    
+
     using histogram_t = histogram<T...>;
     using pair_t  = std::pair<typename histogram_t::key_type, typename histogram_t::mapped_type>;
     using value_t = typename histogram_t::value_type;

--- a/include/boost/gil/image_processing/adaptive_histogram_equalization.hpp
+++ b/include/boost/gil/image_processing/adaptive_histogram_equalization.hpp
@@ -27,9 +27,9 @@ namespace boost { namespace gil {
 /// \defgroup AHE AHE
 /// \brief Contains implementation and description of the algorithm used to compute
 ///        adaptive histogram equalization of input images. Naming for the AHE functions
-///        are done in the following way 
+///        are done in the following way
 ///             <feature-1>_<feature-2>_.._<feature-n>ahe
-///        For example, for AHE done using local (non-overlapping) tiles/blocks and 
+///        For example, for AHE done using local (non-overlapping) tiles/blocks and
 ///        final output interpolated among tiles , it is called
 ///             non_overlapping_interpolated_clahe
 ///
@@ -75,11 +75,11 @@ double actual_clip_limit(SrcHist const& src_hist, double cliplimit = 0.03)
 
 /// \fn void clip_and_redistribute
 /// \ingroup AHE-helpers
-/// \brief Clips and redistributes excess pixels based on the actual clip limit value 
+/// \brief Clips and redistributes excess pixels based on the actual clip limit value
 ///        obtained from the other helper function actual_clip_limit
 ///        Reference - Graphic Gems 4, Pg. 474
 ///        (http://cas.xav.free.fr/Graphics%20Gems%204%20-%20Paul%20S.%20Heckbert.pdf)
-/// 
+///
 template <typename SrcHist, typename DstHist>
 void clip_and_redistribute(SrcHist const& src_hist, DstHist& dst_hist, double clip_limit = 0.03)
 {
@@ -131,8 +131,8 @@ void clip_and_redistribute(SrcHist const& src_hist, DstHist& dst_hist, double cl
 /// @param src_mask      Input   Mask on input image to ignore specified pixels
 /// \brief Performs local histogram equalization on tiles of size (tile_width_x, tile_width_y)
 ///        Then uses the clip limit to redistribute excess pixels above the limit uniformly to
-///        other bins. The clip limit is specified as a fraction i.e. a bin's value is clipped 
-///        if bin_value >= clip_limit * (Total number of pixels in the tile) 
+///        other bins. The clip limit is specified as a fraction i.e. a bin's value is clipped
+///        if bin_value >= clip_limit * (Total number of pixels in the tile)
 ///
 template <typename SrcView, typename DstView>
 void non_overlapping_interpolated_clahe(
@@ -153,7 +153,7 @@ void non_overlapping_interpolated_clahe(
             typename color_space_type<SrcView>::type,
             typename color_space_type<DstView>::type>::value,
         "Source and destination views must have same color space");
-    
+
     using source_channel_t = typename channel_type<SrcView>::type;
     using dst_channel_t    = typename channel_type<DstView>::type;
     using coord_t          = typename SrcView::x_coord_t;
@@ -192,7 +192,7 @@ void non_overlapping_interpolated_clahe(
         std::vector<std::map<source_channel_t, source_channel_t>> prev_map(
             new_width / tile_width_x),
             next_map((new_width / tile_width_x));
-        
+
         coord_t prev = 0, next = 1;
         auto channel_view = nth_channel_view(view(padded_img), k);
 
@@ -223,7 +223,7 @@ void non_overlapping_interpolated_clahe(
                     fill_histogram(
                         img_view, next_row[(j - sample_x1) / tile_width_x], bin_width, false,
                         false);
-                    
+
                     detail::clip_and_redistribute(
                         next_row[(j - sample_x1) / tile_width_x],
                         next_row[(j - sample_x1) / tile_width_x], clip_limit);
@@ -244,7 +244,7 @@ void non_overlapping_interpolated_clahe(
                     prev_col_mask = false;
                 else if ((j - sample_x1) / tile_width_x + 1 == new_width / tile_width_x - 1)
                     next_col_mask = false;
-                
+
                 // Bilinear interpolation
                 point_t top_left(
                     (j - sample_x1) / tile_width_x * tile_width_x + sample_x1,
@@ -252,7 +252,7 @@ void non_overlapping_interpolated_clahe(
                 point_t top_right(top_left.x + tile_width_x, top_left.y);
                 point_t bottom_left(top_left.x, top_left.y + tile_width_y);
                 point_t bottom_right(top_left.x + tile_width_x, top_left.y + tile_width_y);
-                
+
                 long double x_diff = top_right.x - top_left.x;
                 long double y_diff = bottom_left.y - top_left.y;
 
@@ -281,16 +281,16 @@ void non_overlapping_interpolated_clahe(
                      (next_row_mask & next_col_mask) * x1 *
                          next_map[(bottom_right.x - sample_x1) / tile_width_x][channel_view(j, i)]) *
                         y1;
-                
+
                 if (mask && !src_mask[i - top_left_y][j - top_left_x])
                 {
-                    dst_view(j - top_left_x, i - top_left_y) = 
+                    dst_view(j - top_left_x, i - top_left_y) =
                         channel_convert<dst_channel_t>(
                             static_cast<source_channel_t>(channel_view(i, j)));
                 }
                 else
                 {
-                    dst_view(j - top_left_x, i - top_left_y) = 
+                    dst_view(j - top_left_x, i - top_left_y) =
                         channel_convert<dst_channel_t>(static_cast<source_channel_t>(numerator));
                 }
             }

--- a/include/boost/gil/image_processing/histogram_equalization.hpp
+++ b/include/boost/gil/image_processing/histogram_equalization.hpp
@@ -38,7 +38,7 @@ namespace boost { namespace gil {
 /// \ingroup HE
 /// \tparam SrcKeyType Key Type of input histogram
 /// @param src_hist INPUT Input source histogram
-/// \brief Overload for histogram equalization algorithm, takes in a single source histogram 
+/// \brief Overload for histogram equalization algorithm, takes in a single source histogram
 ///        and returns the color map used for histogram equalization.
 ///
 template <typename SrcKeyType>
@@ -111,7 +111,7 @@ void histogram_equalization(
             typename color_space_type<SrcView>::type,
             typename color_space_type<DstView>::type>::value,
         "Source and destination views must have same color space");
-    
+
     // Defining channel type
     using source_channel_t = typename channel_type<SrcView>::type;
     using dst_channel_t    = typename channel_type<DstView>::type;

--- a/include/boost/gil/image_processing/histogram_matching.hpp
+++ b/include/boost/gil/image_processing/histogram_matching.hpp
@@ -58,7 +58,7 @@ std::map<SrcKeyType, SrcKeyType>
 /// @param src_hist INPUT source histogram
 /// @param ref_hist INPUT reference histogram
 /// @param dst_hist OUTPUT Output histogram
-/// \brief Overload for histogram matching algorithm, takes in source histogram, reference 
+/// \brief Overload for histogram matching algorithm, takes in source histogram, reference
 ///        histogram & destination histogram and returns the color map used for histogram
 ///        matching as well as transforming the destination histogram.
 ///
@@ -81,7 +81,7 @@ std::map<SrcKeyType, DstKeyType> histogram_matching(
     auto cumltv_srchist = cumulative_histogram(src_hist);
     auto cumltv_refhist = cumulative_histogram(ref_hist);
     std::map<SrcKeyType, RefKeyType> inverse_mapping;
-    
+
     std::vector<typename histogram<RefKeyType>::key_type> src_keys, ref_keys;
     src_keys             = src_hist.sorted_keys();
     ref_keys             = ref_hist.sorted_keys();
@@ -89,7 +89,7 @@ std::map<SrcKeyType, DstKeyType> histogram_matching(
     RefKeyType ref_max;
     if (start >= 0)
         ref_max = std::get<0>(ref_keys[start]);
-    
+
     for (std::ptrdiff_t j = src_keys.size() - 1; j >= 0; --j)
     {
         double src_val = (cumltv_srchist[src_keys[j]] * ref_sum) / src_sum;
@@ -101,7 +101,7 @@ std::map<SrcKeyType, DstKeyType> histogram_matching(
             std::abs(cumltv_refhist(std::min<RefKeyType>(ref_max, std::get<0>(ref_keys[start + 1]))) -
                 src_val))
         {
-            inverse_mapping[std::get<0>(src_keys[j])] = 
+            inverse_mapping[std::get<0>(src_keys[j])] =
                 std::min<RefKeyType>(ref_max, std::get<0>(ref_keys[start + 1]));
         }
         else
@@ -126,8 +126,8 @@ std::map<SrcKeyType, DstKeyType> histogram_matching(
 /// @param mask      INPUT Specify is mask is to be used
 /// @param src_mask  INPUT Mask vector over input image
 /// @param ref_mask  INPUT Mask vector over reference image
-/// \brief Overload for histogram matching algorithm, takes in both source, reference & 
-///        destination image views and histogram matches the input image using the 
+/// \brief Overload for histogram matching algorithm, takes in both source, reference &
+///        destination image views and histogram matches the input image using the
 ///        reference image.
 ///
 template <typename SrcView, typename ReferenceView, typename DstView>
@@ -155,7 +155,7 @@ void histogram_matching(
             typename color_space_type<SrcView>::type,
             typename color_space_type<DstView>::type>::value,
         "Source and destination view must have same color space");
-    
+
     // Defining channel type
     using source_channel_t = typename channel_type<SrcView>::type;
     using ref_channel_t    = typename channel_type<ReferenceView>::type;

--- a/include/boost/gil/promote_integral.hpp
+++ b/include/boost/gil/promote_integral.hpp
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2015, Oracle and/or its affiliates.
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
-// 
+//
 // Copyright (c) 2020, Debabrata Mandal <mandaldebabrata123@gmail.com>
 //
 // Licensed under the Boost Software License version 1.0.

--- a/include/boost/gil/rasterization/ellipse.hpp
+++ b/include/boost/gil/rasterization/ellipse.hpp
@@ -38,8 +38,8 @@ struct midpoint_elliptical_rasterizer
         // url: https://doi.ieeecomputersociety.org/10.1109/MCG.1984.275994
         std::vector<std::array<std::ptrdiff_t, 2>> trajectory_points;
         std::ptrdiff_t x = semi_axes[0], y = 0;
-        
-        // Variables declared on following lines are temporary variables used for improving 
+
+        // Variables declared on following lines are temporary variables used for improving
         // performance since they help in converting all multiplicative operations inside the while
         // loop into additive/subtractive operations.
         long long int const t1 = semi_axes[0] * semi_axes[0];
@@ -54,7 +54,7 @@ struct midpoint_elliptical_rasterizer
         // to be included in rasterizer trajectory.
         long long int d1, d2;
         d1 = t2 - t7 + t4 / 2, d2 = t1 / 2 - t8 + t5;
-        
+
         while (d2 < 0)
         {
             trajectory_points.push_back({x, y});
@@ -65,7 +65,7 @@ struct midpoint_elliptical_rasterizer
                 d1 += t9 + t2;
                 d2 += t9;
             }
-            else 
+            else
             {
                 x -= 1;
                 t8 -= t6;
@@ -84,7 +84,7 @@ struct midpoint_elliptical_rasterizer
                 t9 += t3;
                 d2 += t5 + t9 - t8;
             }
-            else 
+            else
             {
                 d2 += t5 - t8;
             }
@@ -99,7 +99,7 @@ struct midpoint_elliptical_rasterizer
     /// \param colour - Constant vector specifying colour intensity values for all channels present
     ///                 in 'view'.
     /// \param center - Constant array specifying co-ordinates of center of ellipse to be drawn.
-    /// \param trajectory_points - Constant vector specifying pixel co-ordinates of points lying 
+    /// \param trajectory_points - Constant vector specifying pixel co-ordinates of points lying
     ///                            on rasterizer trajectory.
     /// \tparam View - Type of input image view.
     template<typename View>
@@ -107,7 +107,7 @@ struct midpoint_elliptical_rasterizer
         std::array<unsigned int, 2> const center,
         std::vector<std::array<std::ptrdiff_t, 2>> const trajectory_points)
     {
-        for (int i = 0, colour_index = 0; i < static_cast<int>(view.num_channels()); 
+        for (int i = 0, colour_index = 0; i < static_cast<int>(view.num_channels());
             ++i, ++colour_index)
         {
             for (std::array<std::ptrdiff_t, 2> point : trajectory_points)
@@ -173,17 +173,17 @@ struct midpoint_elliptical_rasterizer
                 "number of colours provided.");
         }
         if (center[0] + semi_axes[0] >= view.width() || center[1] + semi_axes[1] >= view.height()
-            || static_cast<int>(center[0] - semi_axes[0]) < 0 
+            || static_cast<int>(center[0] - semi_axes[0]) < 0
             || static_cast<int>(center[0] - semi_axes[0]) >= view.width()
             || static_cast<int>(center[1] - semi_axes[1]) < 0
             || static_cast<int>(center[1] - semi_axes[1]) >= view.height())
         {
             std::cout << "Image can't contain whole curve.\n"
                 "However, it will contain those parts of curve which can fit inside it.\n"
-                "Note : Image width = " << view.width() << " and Image height = " << 
+                "Note : Image width = " << view.width() << " and Image height = " <<
                 view.height() << "\n";
         }
-        std::vector<std::array<std::ptrdiff_t, 2>> trajectory_points = 
+        std::vector<std::array<std::ptrdiff_t, 2>> trajectory_points =
             obtain_trajectory(semi_axes);
         draw_curve(view, colour, center, trajectory_points);
     }

--- a/test/core/histogram/access.cpp
+++ b/test/core/histogram/access.cpp
@@ -14,7 +14,7 @@
 
 namespace gil = boost::gil;
 
-void check_indexing_operator() 
+void check_indexing_operator()
 {
     gil::histogram<int> h1;
     h1(1) = 3;

--- a/test/core/histogram/constructor.cpp
+++ b/test/core/histogram/constructor.cpp
@@ -13,7 +13,7 @@
 namespace gil = boost::gil;
 namespace mp11 = boost::mp11;
 
-void check_histogram_constructors() 
+void check_histogram_constructors()
 {
     gil::histogram<int> h1;
     gil::histogram<int> h2 = h1;

--- a/test/core/histogram/cumulative.cpp
+++ b/test/core/histogram/cumulative.cpp
@@ -25,7 +25,7 @@ void check_cumulative()
     {
         if(h2(i) != i+1)
             check1 = false;
-    }    
+    }
     BOOST_TEST(check1);
 
     gil::histogram<int , int> h3;

--- a/test/core/histogram/dimension.cpp
+++ b/test/core/histogram/dimension.cpp
@@ -11,7 +11,7 @@
 namespace gil = boost::gil;
 namespace mp11 = boost::mp11;
 
-void check_histogram_constructors() 
+void check_histogram_constructors()
 {
     gil::histogram<int> h1;
     gil::histogram<int> h2 = h1;

--- a/test/core/histogram/fill.cpp
+++ b/test/core/histogram/fill.cpp
@@ -23,15 +23,15 @@ gil::gray8_view_t v1 = view(img1);
 gil::rgb8_image_t img2(4, 4, gil::rgb8_pixel_t(1));
 gil::rgb8_view_t v2 = view(img2);
 
-std::uint8_t sparse_matrix[] = 
+std::uint8_t sparse_matrix[] =
 {
-    1, 1, 1, 1, 
-    3, 3, 3, 3, 
+    1, 1, 1, 1,
+    3, 3, 3, 3,
     5, 5, 5, 5,
     7, 7, 7, 7
 };
 
-std::uint8_t big_matrix[] = 
+std::uint8_t big_matrix[] =
 {
     1, 2, 3, 4, 5, 6, 7, 8,
     1, 2, 1, 2, 1, 2, 1, 2,
@@ -43,7 +43,7 @@ std::uint8_t big_matrix[] =
     7, 8, 7, 8, 7, 8, 7, 8
 };
 
-std::uint8_t big_rgb_matrix[] = 
+std::uint8_t big_rgb_matrix[] =
 {
     1, 2, 3, 2, 3, 4, 3, 4, 5, 4, 5, 6, 5, 6, 7, 6, 7, 8, 7, 8, 9, 8, 9, 10,
     1, 2, 3, 2, 3, 4, 1, 2, 3, 2, 3, 4, 1, 2, 3, 2, 3, 4, 1, 2, 3, 2, 3, 4,
@@ -69,7 +69,7 @@ gil::gray8c_view_t big_gray_view = gil::interleaved_view(8, 8, reinterpret_cast<
 
 gil::rgb8c_view_t big_rgb_view = gil::interleaved_view(8, 8, reinterpret_cast<gil::rgb8c_pixel_t*>(big_rgb_matrix), 24);
 
-void check_histogram_fill_test1() 
+void check_histogram_fill_test1()
 {
     gil::histogram<int> h1;
 
@@ -86,7 +86,7 @@ void check_histogram_fill_test1()
     BOOST_TEST(check_gray_fill);
 }
 
-void check_histogram_fill_test2() 
+void check_histogram_fill_test2()
 {
     gil::histogram<int, int, int> h3;
     h3.fill(big_rgb_view);
@@ -102,7 +102,7 @@ void check_histogram_fill_test2()
     BOOST_TEST(check_rgb_fill);
 }
 
-void check_histogram_fill_test3() 
+void check_histogram_fill_test3()
 {
     gil::histogram<int> h2;
     h2.fill<1>(big_rgb_view);
@@ -117,7 +117,7 @@ void check_histogram_fill_test3()
     BOOST_TEST(check_gray_fill2);
 }
 
-void check_histogram_fill_test4() 
+void check_histogram_fill_test4()
 {
     gil::histogram<int> h1;
     // Check with limits
@@ -140,7 +140,7 @@ void check_histogram_fill_test4()
     BOOST_TEST(check_gray_fill);
 }
 
-void check_histogram_fill_test5() 
+void check_histogram_fill_test5()
 {
     gil::histogram<int, int, int> h3;
     std::tuple<int, int ,int> lower1{2,2,2}, higher1{6,6,6};
@@ -163,7 +163,7 @@ void check_histogram_fill_test5()
     BOOST_TEST(check_rgb_fill);
 }
 
-void check_histogram_fill_test6() 
+void check_histogram_fill_test6()
 {
     gil::histogram<int> h2;
     h2.clear();
@@ -185,13 +185,13 @@ void check_histogram_fill_test6()
     BOOST_TEST(check_gray_fill2);
 }
 
-void check_histogram_fill_test7() 
+void check_histogram_fill_test7()
 {
     //Check masking
     gil::histogram<int> h4;
     std::tuple<int> low{1}, high{8};
     gil::fill_histogram(sparse_gray_view, h4, 1, false, false, true, mask, low, high, true);
-    
+
     bool check_1d = true;
     for (std::size_t i = 1; i <= 8; ++i)
     {
@@ -203,12 +203,12 @@ void check_histogram_fill_test7()
     BOOST_TEST(check_1d);
 }
 
-void check_histogram_fill_algorithm() 
+void check_histogram_fill_algorithm()
 {
     gil::histogram<short> h1;
 
     gil::fill_histogram<1>(big_rgb_view, h1);
-    
+
     bool check_1d = true;
     for (std::size_t i = 1; i <= 8; ++i)
     {
@@ -222,7 +222,7 @@ void check_histogram_fill_algorithm()
     gil::histogram<int, int> h2;
 
     gil::fill_histogram<2, 1>(big_rgb_view, h2);
-    
+
     bool check_2d = true;
     for (std::size_t i = 1; i <= 8; ++i)
     {
@@ -237,7 +237,7 @@ void check_histogram_fill_algorithm()
 
     std::tuple<int> low(1), high(8);
     gil::fill_histogram(sparse_gray_view, h3, 1, false, false, false, {{}}, low, high, true);
-    
+
     check_1d = true;
     for (std::size_t i = 1; i <= 8; ++i)
     {

--- a/test/core/histogram/helpers.cpp
+++ b/test/core/histogram/helpers.cpp
@@ -18,7 +18,7 @@
 namespace gil = boost::gil;
 namespace mp11 = boost::mp11;
 
-void check_helper_fn_pixel_to_tuple() 
+void check_helper_fn_pixel_to_tuple()
 {
     gil::gray8_pixel_t g1(2);
     auto g2 = gil::detail::pixel_to_tuple(g1, mp11::make_index_sequence<1>{});
@@ -39,7 +39,7 @@ void check_helper_fn_pixel_to_tuple()
     BOOST_TEST(r1[0] == std::get<2>(r3) && r1[1] == std::get<0>(r3) && r1[2] == std::get<1>(r3));
 }
 
-void check_helper_fn_tuple_to_tuple() 
+void check_helper_fn_tuple_to_tuple()
 {
     std::tuple<int> t1(1);
     auto t2 = gil::detail::tuple_to_tuple(t1, mp11::make_index_sequence<1>{});
@@ -54,13 +54,13 @@ void check_helper_fn_tuple_to_tuple()
     bool const same_rgb_type = std::is_same<std::tuple<int, int, std::string>,
                     decltype(r2)>::value;
     BOOST_TEST(same_rgb_type);
-    BOOST_TEST( std::get<0>(r1) == std::get<0>(r2) && 
-                std::get<1>(r1) == std::get<1>(r2) && 
+    BOOST_TEST( std::get<0>(r1) == std::get<0>(r2) &&
+                std::get<1>(r1) == std::get<1>(r2) &&
                 std::get<2>(r1) == std::get<2>(r2));
 
     auto r3 = gil::detail::tuple_to_tuple(r1, mp11::index_sequence<1, 2, 0>{});
-    BOOST_TEST( std::get<0>(r1) == std::get<2>(r3) && 
-                std::get<1>(r1) == std::get<0>(r3) && 
+    BOOST_TEST( std::get<0>(r1) == std::get<2>(r3) &&
+                std::get<1>(r1) == std::get<0>(r3) &&
                 std::get<2>(r1) == std::get<1>(r3));
 }
 

--- a/test/core/histogram/is_compatible.cpp
+++ b/test/core/histogram/is_compatible.cpp
@@ -16,7 +16,7 @@ namespace gil = boost::gil;
 namespace mp11 = boost::mp11;
 
 
-void check_is_pixel_compatible() 
+void check_is_pixel_compatible()
 {
     gil::histogram<int> h1;
     gil::histogram<int, double> h2;
@@ -29,7 +29,7 @@ void check_is_pixel_compatible()
     BOOST_TEST(!h4.is_pixel_compatible());
 }
 
-void check_is_tuple_compatible() 
+void check_is_tuple_compatible()
 {
     gil::histogram<int> h1;
     gil::histogram<double> h2;

--- a/test/core/histogram/key.cpp
+++ b/test/core/histogram/key.cpp
@@ -16,31 +16,31 @@
 
 namespace gil = boost::gil;
 
-void check_histogram_key_from_tuple() 
+void check_histogram_key_from_tuple()
 {
     gil::histogram<int, int> h1;
     std::tuple<int, int> t1(1, 2);
     auto t2 = h1.key_from_tuple(t1);
     const bool same_type = std::is_same<std::tuple<int, int>, decltype(t2)>::value;
-    
+
     BOOST_TEST(same_type);
     BOOST_TEST(std::get<0>(t2) == 1 && std::get<1>(t2) == 2);
 
     std::tuple<int, int, int, int> t3(1, 2, 4, 2);
     auto t4 = h1.key_from_tuple<0, 2>(t3);
     const bool same_type1 = std::is_same<std::tuple<int, int>, decltype(t4)>::value;
-    
+
     BOOST_TEST(same_type1);
     BOOST_TEST(std::get<0>(t4) == 1 && std::get<1>(t4) == 4);
 }
 
-void check_histogram_key_from_pixel() 
+void check_histogram_key_from_pixel()
 {
     gil::histogram<int> h1;
     gil::gray8_pixel_t g1(1);
     auto t1 = h1.key_from_pixel(g1);
     const bool same_type = std::is_same<std::tuple<int>, decltype(t1)>::value;
-    
+
     BOOST_TEST(same_type);
     BOOST_TEST(std::get<0>(t1) == 1);
 
@@ -48,7 +48,7 @@ void check_histogram_key_from_pixel()
     gil::rgb8_pixel_t r1(1, 0, 3);
     auto t2 = h2.key_from_pixel<0, 2>(r1);
     const bool same_type1 = std::is_same<std::tuple<int, int>, decltype(t2)>::value;
-    
+
     BOOST_TEST(same_type1);
     BOOST_TEST(std::get<0>(t2) == 1 && std::get<1>(t2) == 3);
 }
@@ -60,4 +60,3 @@ int main() {
 
     return boost::report_errors();
 }
-   

--- a/test/core/histogram/sub_histogram.cpp
+++ b/test/core/histogram/sub_histogram.cpp
@@ -14,7 +14,7 @@
 
 namespace gil = boost::gil;
 
-void check_sub_histogram_without_tuple() 
+void check_sub_histogram_without_tuple()
 {
     gil::histogram<int, int, std::string, int> h;
     h(1, 1, "A", 1) = 1;
@@ -23,13 +23,13 @@ void check_sub_histogram_without_tuple()
     h(2, 1, "D", 1) = 1;
     h(2, 3, "E", 4) = 1;
     auto h1 = h.sub_histogram<0,3>();
-    BOOST_TEST(h1(1, 1) == 2); 
-    BOOST_TEST(h1(2, 1) == 2); 
-    BOOST_TEST(h1(2, 4) == 1); 
+    BOOST_TEST(h1(1, 1) == 2);
+    BOOST_TEST(h1(2, 1) == 2);
+    BOOST_TEST(h1(2, 4) == 1);
     BOOST_TEST(h1(5, 5) == 0);
 }
 
-void check_sub_histogram_with_tuple() 
+void check_sub_histogram_with_tuple()
 {
     gil::histogram<int, int, std::string, int> h;
     h(1, 1, "A", 1) = 3;
@@ -41,9 +41,9 @@ void check_sub_histogram_with_tuple()
     std::tuple<double, int, std::string, int> t(1.0, 1000, "A", 1);
     // This means 1st dimension is useless for matching.
     auto h1 = h.sub_histogram<0,2,3>(t, t);
-    BOOST_TEST(h1(1, 1, "A", 1) == 3); 
-    BOOST_TEST(h1(1, 2, "C", 1) == 0); 
-    BOOST_TEST(h1(2, 1, "C", 1) == 0); 
+    BOOST_TEST(h1(1, 1, "A", 1) == 3);
+    BOOST_TEST(h1(1, 2, "C", 1) == 0);
+    BOOST_TEST(h1(2, 1, "C", 1) == 0);
     BOOST_TEST(h1(2, 1, "A", 1) == 0);
     BOOST_TEST(h1(2, 1, "A", 1) == 0);
     BOOST_TEST(h1(1, 3, "A", 1) == 2);

--- a/test/core/histogram/utilities.cpp
+++ b/test/core/histogram/utilities.cpp
@@ -19,7 +19,7 @@
 namespace gil = boost::gil;
 namespace mp11 = boost::mp11;
 
-std::uint8_t big_matrix[] = 
+std::uint8_t big_matrix[] =
 {
     1, 2, 3, 4, 5, 6, 7, 8,
     1, 2, 1, 2, 1, 2, 1, 2,
@@ -52,7 +52,7 @@ void check_normalize()
     bool check = true;
     for (std::size_t i = 0; i < 64; i++)
     {
-        check = check & (std::abs(expected[i] - h1(i)) < epsilon); 
+        check = check & (std::abs(expected[i] - h1(i)) < epsilon);
     }
     BOOST_TEST(check);
 
@@ -74,7 +74,7 @@ void check_normalize()
     bool check2 = true;
     for (std::size_t i = 0; i < 64; i++)
     {
-        check2 = check2 & (std::abs(expected2[i/8][i%8] - h2(i/8,i%8)) < epsilon); 
+        check2 = check2 & (std::abs(expected2[i/8][i%8] - h2(i/8,i%8)) < epsilon);
     }
     BOOST_TEST(check2);
 }
@@ -212,4 +212,4 @@ int main() {
     check_sorted_keys();
 
     return boost::report_errors();
-}   
+}

--- a/test/core/image/image.cpp
+++ b/test/core/image/image.cpp
@@ -49,7 +49,7 @@ struct test_constructor_from_other_image
         pixel_t const rnd_pixel = fixture::pixel_generator<pixel_t>::random();
         {
             //constructor interleaved from planar
-            gil::image<pixel_t, true> image1(dimensions, rnd_pixel); 
+            gil::image<pixel_t, true> image1(dimensions, rnd_pixel);
             image_t image2(image1);
             BOOST_TEST_EQ(image2.dimensions(), dimensions);
             auto v1 = gil::const_view(image1);

--- a/test/core/image_processing/adaptive_he.cpp
+++ b/test/core/image_processing/adaptive_he.cpp
@@ -20,10 +20,10 @@ namespace gil = boost::gil;
 
 double epsilon = 1.0;
 
-std::uint8_t image_matrix[] = 
+std::uint8_t image_matrix[] =
 {
-    1, 1, 1, 1, 
-    3, 3, 3, 3, 
+    1, 1, 1, 1,
+    3, 3, 3, 3,
     5, 5, 5, 5,
     7, 7, 7, 7
 };
@@ -72,7 +72,7 @@ void check_clip_and_redistribute()
         }
     }
     bool check = true;
-    double limit = 0.001; 
+    double limit = 0.001;
     gil::detail::clip_and_redistribute(h, h2, limit);
     for(std::size_t i = 0; i < 100; i++)
     {

--- a/test/core/image_processing/histogram_equalization.cpp
+++ b/test/core/image_processing/histogram_equalization.cpp
@@ -18,7 +18,7 @@
 #include <vector>
 
 const int a = 5;
-const double epsilon = 0.005; // Decided by the value 1/255 i.e. an error of 1 px in 255 px 
+const double epsilon = 0.005; // Decided by the value 1/255 i.e. an error of 1 px in 255 px
 boost::gil::gray8_image_t original(a, a);
 boost::gil::gray8_image_t processed_1(a, a), processed_2(a, a), expected(a, a);
 std::vector<std::vector<int> > test1_random{
@@ -115,7 +115,7 @@ void vector_to_gray_image(boost::gil::gray8_image_t& img,
     {
         for(std::ptrdiff_t x=0; x<grid[0].size(); ++x)
         {
-            boost::gil::view(img)(x,y) = boost::gil::gray8_pixel_t(grid[y][x]);      
+            boost::gil::view(img)(x,y) = boost::gil::gray8_pixel_t(grid[y][x]);
         }
     }
 }
@@ -149,7 +149,7 @@ void test_random_image()
 {
     vector_to_gray_image(original,test1_random);
     vector_to_gray_image(expected,expected_test1);
-    
+
     histogram_equalization(boost::gil::const_view(original),boost::gil::view(processed_1));
     BOOST_TEST(equal_pixels(boost::gil::view(processed_1), boost::gil::view(expected), epsilon));
 

--- a/test/core/image_processing/histogram_matching.cpp
+++ b/test/core/image_processing/histogram_matching.cpp
@@ -17,7 +17,7 @@
 #include <iostream>
 
 const int a = 5;
-const double epsilon = 0.000001; // Decided by the value 5/255 i.e. an error of 5 px in 255 px 
+const double epsilon = 0.000001; // Decided by the value 5/255 i.e. an error of 5 px in 255 px
 boost::gil::gray8_image_t original(a, a), reference(a, a);
 boost::gil::gray8_image_t processed(a, a), processed2(a, a);
 std::vector<std::vector<int> > test1_random{
@@ -67,7 +67,7 @@ void vector_to_gray_image(boost::gil::gray8_image_t& img,
     {
         for(std::ptrdiff_t x=0; x<grid[0].size(); ++x)
         {
-            boost::gil::view(img)(x,y) = boost::gil::gray8_pixel_t(grid[y][x]);      
+            boost::gil::view(img)(x,y) = boost::gil::gray8_pixel_t(grid[y][x]);
         }
     }
 }
@@ -82,7 +82,7 @@ bool equal_histograms(SrcView const& v1, SrcView const& v2, double threshold = e
     channel_t max_p = std::numeric_limits<channel_t>::max();
     channel_t min_p = std::numeric_limits<channel_t>::min();
     long int num_pixels = v1.width() * v1.height();
-    
+
     boost::gil::fill_histogram(v1, h1, 1, false, false);
     boost::gil::fill_histogram(v2, h2, 1, false, false);
     auto ch1 = boost::gil::cumulative_histogram(h1);
@@ -110,7 +110,7 @@ void test_uniform_image()
     vector_to_gray_image(reference,test2_reference);
     histogram_matching(boost::gil::const_view(original),boost::gil::const_view(reference),boost::gil::view(processed));
     BOOST_TEST(equal_histograms(boost::gil::view(processed), boost::gil::view(reference)));
-    
+
     histogram_matching(boost::gil::const_view(processed),boost::gil::const_view(reference),boost::gil::view(processed2));
     BOOST_TEST(equal_histograms(boost::gil::view(processed), boost::gil::view(processed2)));
 }
@@ -121,7 +121,7 @@ void test_equal_image()
     vector_to_gray_image(reference,test3_reference);
     histogram_matching(boost::gil::const_view(original),boost::gil::const_view(reference),boost::gil::view(processed));
     BOOST_TEST(equal_histograms(boost::gil::view(processed), boost::gil::view(reference)));
-    
+
     histogram_matching(boost::gil::const_view(processed),boost::gil::const_view(reference),boost::gil::view(processed2));
     BOOST_TEST(equal_histograms(boost::gil::view(processed), boost::gil::view(processed2)));
 }

--- a/test/core/image_processing/threshold_binary.cpp
+++ b/test/core/image_processing/threshold_binary.cpp
@@ -87,7 +87,7 @@ void binary_rgb_to_rgb()
 {
     //expected_rgb view after thresholding of the original_rgb view with threshold value of 100
     //filling expected_rgb view's upper half part with rgb pixels of value 0, 165, 165
-    //filling expected_rgb view's lower half part with rgb pixels of value 165, 0, 0 
+    //filling expected_rgb view's lower half part with rgb pixels of value 165, 0, 0
     gil::fill_pixels(gil::subimage_view(gil::view(expected_rgb), 0, 0, original_rgb.width(),
         original_rgb.height() / 2), gil::rgb8_pixel_t(0, 165, 165));
     gil::fill_pixels(gil::subimage_view(gil::view(expected_rgb), 0, original_rgb.height() / 2,
@@ -102,7 +102,7 @@ void binary_rgb_to_rgb()
 void binary_inverse_rgb_to_rgb()
 {
     //expected_rgb view after thresholding of the original_rgb view with threshold value of 100
-    //filling expected_rgb view's upper half part with rgb pixels of value 90, 0, 0 
+    //filling expected_rgb view's upper half part with rgb pixels of value 90, 0, 0
     //filling expected_rgb view's lower half part with rgb pixels of value 0, 90, 90
     gil::fill_pixels(gil::subimage_view(gil::view(expected_rgb), 0, 0, original_rgb.width(),
         original_rgb.height() / 2), gil::rgb8_pixel_t(90, 0, 0));
@@ -127,7 +127,7 @@ int main()
 {
     fill_original_gray();
     fill_original_rgb();
-    
+
     binary_gray_to_gray();
     binary_inverse_gray_to_gray();
     binary_rgb_to_rgb();

--- a/test/core/rasterization/ellipse.cpp
+++ b/test/core/rasterization/ellipse.cpp
@@ -13,7 +13,7 @@
 
 namespace gil = boost::gil;
 
-// This function utilizes the fact that sum of distances of a point on an ellipse from its foci 
+// This function utilizes the fact that sum of distances of a point on an ellipse from its foci
 // is equal to the length of major axis of the ellipse.
 // Parameters b and a represent half of lengths of vertical and horizontal axis respectively.
 void test_rasterizer_follows_equation(
@@ -30,21 +30,21 @@ void test_rasterizer_follows_equation(
         focus_x = 0;
         focus_y = b * std::sqrt(1 - a * a / (b * b));
     }
-    
+
     for (auto trajectory_point : trajectory_points)
     {
         // To suppress conversion warnings from compiler
         std::array<float, 2> point {
             static_cast<float>(trajectory_point[0]), static_cast<float>(trajectory_point[1])};
 
-        double dist_sum = std::sqrt(std::pow(focus_x - point[0], 2) + 
-            std::pow(focus_y - point[1], 2)) + std::sqrt(std::pow( - focus_x - point[0], 2) + 
+        double dist_sum = std::sqrt(std::pow(focus_x - point[0], 2) +
+            std::pow(focus_y - point[1], 2)) + std::sqrt(std::pow( - focus_x - point[0], 2) +
             std::pow( - focus_y - point[1], 2));
         if (a > b)
         {
             BOOST_TEST(std::abs(dist_sum - 2 * a) < 1);
         }
-        else 
+        else
         {
             BOOST_TEST(std::abs(dist_sum - 2 * b) < 1);
         }

--- a/test/extension/dynamic_image/any_image.cpp
+++ b/test/extension/dynamic_image/any_image.cpp
@@ -25,7 +25,7 @@ struct test_any_image_move_ctor
         fixture::dynamic_image i0(fixture::create_image<image_t>(4, 4, 128));
         BOOST_TEST_EQ(i0.dimensions().x, 4);
         BOOST_TEST_EQ(i0.dimensions().y, 4);
-        
+
         fixture::dynamic_image i1 = fixture::create_image<image_t>(4, 4, 128);
         BOOST_TEST_EQ(i1.dimensions().x, 4);
         BOOST_TEST_EQ(i1.dimensions().y, 4);

--- a/test/extension/histogram/histogram.cpp
+++ b/test/extension/histogram/histogram.cpp
@@ -17,7 +17,7 @@
 #include <array>
 #include <unordered_map>
 
-// Basic tests to make sure compatible container types produce 
+// Basic tests to make sure compatible container types produce
 // expected output histogram.
 
 namespace gil = boost::gil;
@@ -167,7 +167,7 @@ int main()
     check_fill_histogram_vector();
     check_fill_histogram_array();
     check_fill_histogram_map();
-    
+
     check_cumulative_histogram_vector();
     check_cumulative_histogram_array();
     check_cumulative_histogram_map();

--- a/test/extension/io/targa/targa_old_test.cpp
+++ b/test/extension/io/targa/targa_old_test.cpp
@@ -71,7 +71,7 @@ void test_old_dynamic_image()
         gil::rgb8_image_t,
         gil::rgba8_image_t
     > image;
-    
+
     gil::targa_read_image(targa_filename.c_str(), image);
 
     targa_write_view(targa_out + "old_dynamic_image_test.tga", gil::view(image));


### PR DESCRIPTION
### Description

Removes unnecessary trailing space characters in .cpp/.hpp files.

No functional changes, this is just a "nice to have" cleanup thing.

### References

None.

### Tasklist

- [ ] Ensure all CI builds pass
- [ ] Review and approve
