### PR TITLE
ci: remove Windows Server 2016 from builds on Azure Pipelines

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -53,41 +53,6 @@ jobs:
         parameters:
           cxxver: '14'
 
-  - job: 'win2016_vs2017_cxx14_cmake'
-    pool:
-      vmImage: 'vs2017-win2016'
-    steps:
-      - task: UsePythonVersion@0
-        displayName: 'Setup Python'
-        inputs:
-          versionSpec: '3.6'
-          addToPath: true
-          architecture: 'x64'
-      - template: .ci/azure-pipelines/steps-check-cmake.yml
-      - template: .ci/azure-pipelines/steps-install-conan.yml
-      - template: .ci/azure-pipelines/steps-install-boost.yml
-      - template: .ci/azure-pipelines/steps-cmake-build-and-test.yml
-        parameters:
-          use_conan: 'ON'
-
-  - job: 'win2016_vs2017_cxx17_cmake'
-    pool:
-      vmImage: 'vs2017-win2016'
-    steps:
-      - task: UsePythonVersion@0
-        displayName: 'Setup Python'
-        inputs:
-          versionSpec: '3.6'
-          addToPath: true
-          architecture: 'x64'
-      - template: .ci/azure-pipelines/steps-check-cmake.yml
-      - template: .ci/azure-pipelines/steps-install-conan.yml
-      - template: .ci/azure-pipelines/steps-install-boost.yml
-      - template: .ci/azure-pipelines/steps-cmake-build-and-test.yml
-        parameters:
-          cxxver: '17'
-          use_conan: 'ON'
-
   - job: 'macos1015_xcode11_cmake'
     pool:
       vmImage: 'macOS-10.15'


### PR DESCRIPTION
### Description

The images with Windows Server 2016 / Visual Studio 2017 have
been deprecated by Microsoft and are in the process of being
removed completely, so that no further builds with that image
will be possible.

I've just encountered the problem in https://github.com/boostorg/gil/pull/651
where the VS 2017 / Windows 2016 builds refused to start:

https://dev.azure.com/boostorg/gil/_build/results?buildId=1813&view=results

### References

For reference, see
* <https://devblogs.microsoft.com/devops/hosted-pipelines-image-deprecation/>
* <https://github.com/actions/virtual-environments/issues/5238>
* <https://github.com/actions/virtual-environments/issues/5403>

Since it seems that Microsoft is basically using the same build
environments on both Azure and GitHub Actions when it comes to
Windows and Visual Studio, I decided to remove those jobs instead
of updating them to a newer version of the image. The tests that
would be possible with newer images on Azure are basically what
we are already doing with GitHub Actions here.

Looks like the new final deadline for removal of Windows 2016 is
30th June 2022. But until that happens there will be several   
"brownouts" lasting 24 hours each where users will see error 
messages that indicate the image will be removed soon. This
basically means we cannot rely on Windows 2016 anymore, even
before 30th June.

### Tasklist

- [x] Ensure all CI builds pass
- [x] Review and approve
