### PR TITLE
refactor: Renamed io/dynamic_io_new.hpp to io/detail/dynamic.hpp

### DIFF
--- a/include/boost/gil/extension/io/bmp/detail/read.hpp
+++ b/include/boost/gil/extension/io/bmp/detail/read.hpp
@@ -11,11 +11,11 @@
 #include <boost/gil/extension/io/bmp/detail/is_allowed.hpp>
 #include <boost/gil/extension/io/bmp/detail/reader_backend.hpp>
 
+#include <boost/gil/io/detail/dynamic.hpp>
 #include <boost/gil/io/base.hpp>
 #include <boost/gil/io/bit_operations.hpp>
 #include <boost/gil/io/conversion_policies.hpp>
 #include <boost/gil/io/device.hpp>
-#include <boost/gil/io/dynamic_io_new.hpp>
 #include <boost/gil/io/reader_base.hpp>
 #include <boost/gil/io/row_buffer_helper.hpp>
 #include <boost/gil/io/typedefs.hpp>
@@ -709,7 +709,7 @@ public:
     {
         detail::bmp_type_format_checker format_checker( this->_info._bits_per_pixel );
 
-        if( !construct_matched( images
+        if( !detail::construct_matched( images
                               , format_checker
                               ))
         {

--- a/include/boost/gil/extension/io/bmp/detail/write.hpp
+++ b/include/boost/gil/extension/io/bmp/detail/write.hpp
@@ -13,7 +13,6 @@
 
 #include <boost/gil/io/base.hpp>
 #include <boost/gil/io/device.hpp>
-#include <boost/gil/io/dynamic_io_new.hpp>
 
 #include <vector>
 

--- a/include/boost/gil/extension/io/jpeg/detail/read.hpp
+++ b/include/boost/gil/extension/io/jpeg/detail/read.hpp
@@ -12,10 +12,10 @@
 #include <boost/gil/extension/io/jpeg/detail/base.hpp>
 #include <boost/gil/extension/io/jpeg/detail/is_allowed.hpp>
 
+#include <boost/gil/io/detail/dynamic.hpp>
 #include <boost/gil/io/base.hpp>
 #include <boost/gil/io/conversion_policies.hpp>
 #include <boost/gil/io/device.hpp>
-#include <boost/gil/io/dynamic_io_new.hpp>
 #include <boost/gil/io/reader_base.hpp>
 #include <boost/gil/io/typedefs.hpp>
 
@@ -284,7 +284,7 @@ public:
                                                        : JCS_RGB
                                                        );
 
-        if( !construct_matched( images
+        if( !detail::construct_matched( images
                               , format_checker
                               ))
         {

--- a/include/boost/gil/extension/io/jpeg/detail/write.hpp
+++ b/include/boost/gil/extension/io/jpeg/detail/write.hpp
@@ -14,7 +14,6 @@
 
 #include <boost/gil/io/base.hpp>
 #include <boost/gil/io/device.hpp>
-#include <boost/gil/io/dynamic_io_new.hpp>
 
 #include <vector>
 

--- a/include/boost/gil/extension/io/png/detail/read.hpp
+++ b/include/boost/gil/extension/io/png/detail/read.hpp
@@ -13,10 +13,10 @@
 #include <boost/gil/extension/io/png/detail/is_allowed.hpp>
 
 #include <boost/gil.hpp> // FIXME: Include what you use!
+#include <boost/gil/io/detail/dynamic.hpp>
 #include <boost/gil/io/base.hpp>
 #include <boost/gil/io/conversion_policies.hpp>
 #include <boost/gil/io/device.hpp>
-#include <boost/gil/io/dynamic_io_new.hpp>
 #include <boost/gil/io/error.hpp>
 #include <boost/gil/io/reader_base.hpp>
 #include <boost/gil/io/row_buffer_helper.hpp>
@@ -416,7 +416,7 @@ public:
                                                       , this->_info._color_type
                                                       );
 
-        if( !construct_matched( images
+        if( !detail::construct_matched( images
                               , format_checker
                               ))
         {

--- a/include/boost/gil/extension/io/png/detail/write.hpp
+++ b/include/boost/gil/extension/io/png/detail/write.hpp
@@ -11,7 +11,6 @@
 #include <boost/gil/extension/io/png/detail/writer_backend.hpp>
 
 #include <boost/gil/io/device.hpp>
-#include <boost/gil/io/dynamic_io_new.hpp>
 #include <boost/gil/io/row_buffer_helper.hpp>
 #include <boost/gil/detail/mp11.hpp>
 

--- a/include/boost/gil/extension/io/pnm/detail/read.hpp
+++ b/include/boost/gil/extension/io/pnm/detail/read.hpp
@@ -13,11 +13,11 @@
 #include <boost/gil/extension/io/pnm/detail/is_allowed.hpp>
 
 #include <boost/gil.hpp> // FIXME: Include what you use!
+#include <boost/gil/io/detail/dynamic.hpp>
 #include <boost/gil/io/base.hpp>
 #include <boost/gil/io/bit_operations.hpp>
 #include <boost/gil/io/conversion_policies.hpp>
 #include <boost/gil/io/device.hpp>
-#include <boost/gil/io/dynamic_io_new.hpp>
 #include <boost/gil/io/reader_base.hpp>
 #include <boost/gil/io/row_buffer_helper.hpp>
 #include <boost/gil/io/typedefs.hpp>
@@ -421,7 +421,7 @@ public:
     {
         detail::pnm_type_format_checker format_checker( this->_info._type );
 
-        if( !construct_matched( images
+        if( !detail::construct_matched( images
                               , format_checker
                               ))
         {

--- a/include/boost/gil/extension/io/pnm/detail/write.hpp
+++ b/include/boost/gil/extension/io/pnm/detail/write.hpp
@@ -14,7 +14,6 @@
 #include <boost/gil/io/base.hpp>
 #include <boost/gil/io/bit_operations.hpp>
 #include <boost/gil/io/device.hpp>
-#include <boost/gil/io/dynamic_io_new.hpp>
 #include <boost/gil/detail/mp11.hpp>
 
 #include <cstdlib>

--- a/include/boost/gil/extension/io/raw/detail/read.hpp
+++ b/include/boost/gil/extension/io/raw/detail/read.hpp
@@ -13,11 +13,11 @@
 #include <boost/gil/extension/io/raw/detail/is_allowed.hpp>
 #include <boost/gil/extension/io/raw/detail/reader_backend.hpp>
 
+#include <boost/gil/io/detail/dynamic.hpp>
 #include <boost/gil/io/base.hpp>
 #include <boost/gil/io/bit_operations.hpp>
 #include <boost/gil/io/conversion_policies.hpp>
 #include <boost/gil/io/device.hpp>
-#include <boost/gil/io/dynamic_io_new.hpp>
 #include <boost/gil/io/reader_base.hpp>
 #include <boost/gil/io/row_buffer_helper.hpp>
 #include <boost/gil/io/typedefs.hpp>
@@ -205,7 +205,7 @@ public:
     {
         detail::raw_type_format_checker format_checker( this->_info );
 
-        if( !construct_matched( images
+        if( !detail::construct_matched( images
                                , format_checker
                                ))
         {

--- a/include/boost/gil/extension/io/targa/detail/read.hpp
+++ b/include/boost/gil/extension/io/targa/detail/read.hpp
@@ -12,11 +12,11 @@
 #include <boost/gil/extension/io/targa/detail/reader_backend.hpp>
 #include <boost/gil/extension/io/targa/detail/is_allowed.hpp>
 
+#include <boost/gil/io/detail/dynamic.hpp>
 #include <boost/gil/io/base.hpp>
 #include <boost/gil/io/bit_operations.hpp>
 #include <boost/gil/io/conversion_policies.hpp>
 #include <boost/gil/io/device.hpp>
-#include <boost/gil/io/dynamic_io_new.hpp>
 #include <boost/gil/io/reader_base.hpp>
 #include <boost/gil/io/row_buffer_helper.hpp>
 #include <boost/gil/io/typedefs.hpp>
@@ -367,7 +367,7 @@ public:
     {
         detail::targa_type_format_checker format_checker( this->_info._bits_per_pixel );
 
-        if( !construct_matched( images
+        if( !detail::construct_matched( images
                               , format_checker
                               ))
         {

--- a/include/boost/gil/extension/io/targa/detail/write.hpp
+++ b/include/boost/gil/extension/io/targa/detail/write.hpp
@@ -13,7 +13,6 @@
 
 #include <boost/gil/io/base.hpp>
 #include <boost/gil/io/device.hpp>
-#include <boost/gil/io/dynamic_io_new.hpp>
 
 #include <vector>
 

--- a/include/boost/gil/extension/io/tiff/detail/read.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/read.hpp
@@ -12,11 +12,11 @@
 #include <boost/gil/extension/io/tiff/detail/is_allowed.hpp>
 #include <boost/gil/extension/io/tiff/detail/reader_backend.hpp>
 
+#include <boost/gil/io/detail/dynamic.hpp>
 #include <boost/gil/io/base.hpp>
 #include <boost/gil/io/bit_operations.hpp>
 #include <boost/gil/io/conversion_policies.hpp>
 #include <boost/gil/io/device.hpp>
-#include <boost/gil/io/dynamic_io_new.hpp>
 #include <boost/gil/io/reader_base.hpp>
 #include <boost/gil/io/row_buffer_helper.hpp>
 

--- a/include/boost/gil/extension/io/tiff/detail/write.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/write.hpp
@@ -15,7 +15,6 @@
 #include <boost/gil/premultiply.hpp>
 #include <boost/gil/io/base.hpp>
 #include <boost/gil/io/device.hpp>
-#include <boost/gil/io/dynamic_io_new.hpp>
 
 #include <algorithm>
 #include <string>

--- a/include/boost/gil/io/detail/dynamic.hpp
+++ b/include/boost/gil/io/detail/dynamic.hpp
@@ -5,8 +5,8 @@
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 //
-#ifndef BOOST_GIL_IO_DYNAMIC_IO_NEW_HPP
-#define BOOST_GIL_IO_DYNAMIC_IO_NEW_HPP
+#ifndef BOOST_GIL_IO_DETAIL_DYNAMIC_HPP
+#define BOOST_GIL_IO_DETAIL_DYNAMIC_HPP
 
 #include <boost/gil/extension/dynamic_image/dynamic_image_all.hpp>
 
@@ -15,14 +15,12 @@
 
 #include <type_traits>
 
-namespace boost { namespace gil {
-
-namespace detail {
+namespace boost { namespace gil { namespace detail {
 
 template <long N>
 struct construct_matched_t
 {
-    template <typename ...Images,typename Pred>
+    template <typename ...Images, typename Pred>
     static bool apply(any_image<Images...>& img, Pred pred)
     {
         if (pred.template apply<mp11::mp_at_c<any_image<Images...>, N-1>>())
@@ -39,8 +37,8 @@ struct construct_matched_t
 template <>
 struct construct_matched_t<0>
 {
-    template <typename ...Images,typename Pred>
-    static bool apply(any_image<Images...>&,Pred) { return false; }
+    template <typename ...Images, typename Pred>
+    static bool apply(any_image<Images...>&, Pred) { return false; }
 };
 
 // A function object that can be passed to apply_operation.
@@ -81,24 +79,22 @@ public:
         apply(view, typename IsSupported::template apply<View>::type());
     }
 
-    template< typename View, typename Info >
+    template <typename View, typename Info>
     void operator()(View const& view, Info const& info)
     {
         apply(view, info, typename IsSupported::template apply<View>::type());
     }
 };
 
-} // namespace detail
-
 /// \brief Within the any_image, constructs an image with the given dimensions
 ///        and a type that satisfies the given predicate
-template <typename ...Images,typename Pred>
+template <typename ...Images, typename Pred>
 inline bool construct_matched(any_image<Images...>& img, Pred pred)
 {
     constexpr auto size = mp11::mp_size<any_image<Images...>>::value;
-    return detail::construct_matched_t<size>::apply(img, pred);
+    return construct_matched_t<size>::apply(img, pred);
 }
 
-} }  // namespace boost::gil
+} } }  // namespace boost::gil::detail
 
 #endif


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

Renamed `io/dynamic_io_new.hpp` to `io/detail/dynamic.hpp`. 

The function `construct_matched` was only used by other detail headers, thus I moved the function into the detail namespace as already suggested in the issue. Additionally I moved the whole file into the detail directory, because it only contains details now.


### References

Fixes #189

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->
- [ ] Ensure all CI builds pass
- [x] Review and approve
