### PR TITLE
unified naming for pixel and channel operations

### DIFF
--- a/include/boost/gil/pixel_numeric_operations.hpp
+++ b/include/boost/gil/pixel_numeric_operations.hpp
@@ -20,8 +20,10 @@ namespace boost { namespace gil {
 // List of currently defined functors:
 //   pixel_plus_t (+)
 //   pixel_minus_t (-)
-//   pixel_multiplies_scalar_t (*)
-//   pixel_divides_scalar_t (/)
+//   pixel_multiplies_scalar_t (*s)
+//   pixel_multiplies_t (*)
+//   pixel_divides_scalar_t (/s)
+//   pixel_divides_t (/)
 //   pixel_halves_t (/=2),
 //   pixel_zeros_t (=0)
 //   pixel_assigns_t (=)
@@ -97,7 +99,7 @@ struct pixel_multiplies_scalar_t
 /// \tparam PixelRef1 - models PixelConcept
 /// \tparam PixelResult - models PixelValueConcept
 template <typename PixelRef1, typename PixelRef2, typename PixelResult>
-struct pixel_multiply_t
+struct pixel_multiplies_t
 {
     auto operator()(PixelRef1 const& p1, PixelRef2 const& p2) const -> PixelResult
     {
@@ -112,6 +114,9 @@ struct pixel_multiply_t
         return result;
     }
 };
+
+template <typename PixelRef1, typename PixelRef2, typename PixelResult>
+using pixel_multiply_t [[deprecated]] = pixel_multiplies_t<PixelRef1, PixelRef2, PixelResult>;
 
 /// \ingroup PixelNumericOperations
 /// \brief Performs channel-wise division of pixel elements by scalar.
@@ -139,7 +144,7 @@ struct pixel_divides_scalar_t
 /// \tparam PixelRef2 - models PixelConcept
 /// \tparam PixelResult - models PixelValueConcept
 template <typename PixelRef1, typename PixelRef2, typename PixelResult>
-struct pixel_divide_t
+struct pixel_divides_t
 {
     auto operator()(PixelRef1 const& p1, PixelRef2 const& p2) const -> PixelResult
     {
@@ -154,6 +159,9 @@ struct pixel_divide_t
         return result;
     }
 };
+
+template <typename PixelRef1, typename PixelRef2, typename PixelResult>
+using pixel_divide_t [[deprecated]] = pixel_divides_t<PixelRef1, PixelRef2, PixelResult>;
 
 /// \ingroup PixelNumericOperations
 /// \brief Performs channel-wise division by 2

--- a/test/core/pixel/pixel_numeric_operations.cpp
+++ b/test/core/pixel/pixel_numeric_operations.cpp
@@ -136,7 +136,7 @@ struct test_pixel_multiply_integer_same_types
     {
         using pixel_t = Pixel;
         using channel_t = typename gil::channel_type<pixel_t>::type;
-        gil::pixel_multiply_t<pixel_t, pixel_t, pixel_t> f;
+        gil::pixel_multiplies_t<pixel_t, pixel_t, pixel_t> f;
 
         pixel_t p0;
         gil::static_fill(p0, static_cast<channel_t>(0));
@@ -190,7 +190,7 @@ struct test_pixel_divide_integer_same_types
     {
         using pixel_t = Pixel;
         using channel_t = typename gil::channel_type<pixel_t>::type;
-        gil::pixel_divide_t<pixel_t, pixel_t, pixel_t> f;
+        gil::pixel_divides_t<pixel_t, pixel_t, pixel_t> f;
 
         pixel_t p0;
         gil::static_fill(p0, static_cast<channel_t>(0));

--- a/test/core/pixel/pixel_numeric_operations_float.cpp
+++ b/test/core/pixel/pixel_numeric_operations_float.cpp
@@ -49,7 +49,7 @@ void test_multiply()
     gil::rgb32f_pixel_t a(1.f, 2.f, 3.f);
     gil::bgr32f_pixel_t b(2.f, 2.f, 2.f);
 
-    gil::pixel_multiply_t<
+    gil::pixel_multiplies_t<
         gil::rgb32f_pixel_t, gil::bgr32f_pixel_t, gil::rgb32f_pixel_t>
         op;
     gil::rgb32f_pixel_t c = op(a, b);
@@ -67,7 +67,7 @@ void test_divide()
         gil::rgb8_pixel_t a(10, 20, 30);
         gil::bgr8_pixel_t b(2, 2, 2);
 
-        gil::pixel_divide_t<gil::rgb8_pixel_t, gil::bgr8_pixel_t, gil::rgb32f_pixel_t> op;
+        gil::pixel_divides_t<gil::rgb8_pixel_t, gil::bgr8_pixel_t, gil::rgb32f_pixel_t> op;
         gil::rgb32f_pixel_t c = op(a, b);
 
         BOOST_TEST_EQ(get_color(c, gil::red_t()), 5);
@@ -80,7 +80,7 @@ void test_divide()
         gil::rgb32f_pixel_t a(1.f, 2.f, 3.f);
         gil::bgr32f_pixel_t b(2.f, 2.f, 2.f);
 
-        gil::pixel_divide_t<gil::rgb32f_pixel_t, gil::bgr32f_pixel_t, gil::rgb32f_pixel_t> op;
+        gil::pixel_divides_t<gil::rgb32f_pixel_t, gil::bgr32f_pixel_t, gil::rgb32f_pixel_t> op;
         gil::rgb32f_pixel_t c = op(a, b);
 
         float epsilon = 1e-6f;


### PR DESCRIPTION
### Description

Closes #368 

Renamed `gil::pixel_multiply_t` to `gil::pixel_multiplies_t` and `gil::pixel_divide_t` to `gil::pixel_divides_t`.

### Tasklist

- [ ] Review and approve
