### PR TITLE
fix documentation links in "See also" sections

### DIFF
--- a/doc/design/channel.rst
+++ b/doc/design/channel.rst
@@ -86,11 +86,11 @@ such as support for arithmetic operations.
 
 .. seealso::
 
-  - `ChannelConcept<T> <reference/structboost_1_1gil_1_1_channel_concept.html>`_
-  - `ChannelValueConcept<T> <reference/structboost_1_1gil_1_1_channel_value_concept.html>`_
-  - `MutableChannelConcept<T> <reference/structboost_1_1gil_1_1_mutable_channel_concept.html>`_
-  - `ChannelsCompatibleConcept<T1,T2> <reference/structboost_1_1gil_1_1_channels_compatible_concept.html>`_
-  - `ChannelConvertibleConcept<SrcChannel,DstChannel> <reference/structboost_1_1gil_1_1_channel_convertible_concept.html>`_
+  - `ChannelConcept<T> <../reference/structboost_1_1gil_1_1_channel_concept.html>`_
+  - `ChannelValueConcept<T> <../reference/structboost_1_1gil_1_1_channel_value_concept.html>`_
+  - `MutableChannelConcept<T> <../reference/structboost_1_1gil_1_1_mutable_channel_concept.html>`_
+  - `ChannelsCompatibleConcept<T1,T2> <../reference/structboost_1_1gil_1_1_channels_compatible_concept.html>`_
+  - `ChannelConvertibleConcept<SrcChannel,DstChannel> <../reference/structboost_1_1gil_1_1_channel_convertible_concept.html>`_
 
 Models
 ------

--- a/doc/design/color_space.rst
+++ b/doc/design/color_space.rst
@@ -17,9 +17,9 @@ same set of colors in the same order).
 
 .. seealso::
 
-  - `ColorSpaceConcept<ColorSpace> <reference/structboost_1_1gil_1_1_color_space_concept.html>`_
-  - `ColorSpacesCompatibleConcept<ColorSpace1,ColorSpace2> <reference/structboost_1_1gil_1_1_color_spaces_compatible_concept.html>`_
-  - `ChannelMappingConcept<Mapping> <reference/structboost_1_1gil_1_1_channel_mapping_concept.html>`_
+  - `ColorSpaceConcept<ColorSpace> <../reference/structboost_1_1gil_1_1_color_space_concept.html>`_
+  - `ColorSpacesCompatibleConcept<ColorSpace1,ColorSpace2> <../reference/structboost_1_1gil_1_1_color_spaces_compatible_concept.html>`_
+  - `ChannelMappingConcept<Mapping> <../reference/structboost_1_1gil_1_1_channel_mapping_concept.html>`_
 
 Models
 ------

--- a/doc/design/image.rst
+++ b/doc/design/image.rst
@@ -73,9 +73,9 @@ because immutable images are not very useful.
 
 .. seealso::
 
-  - `RandomAccessNDImageConcept<Image> <reference/structboost_1_1gil_1_1_random_access_n_d_image_concept.html>`_
-  - `RandomAccess2DImageConcept<Image> <reference/structboost_1_1gil_1_1_random_access2_d_image_concept.html>`_
-  - `ImageConcept<Image> <reference/structboost_1_1gil_1_1_image_concept.html>`_
+  - `RandomAccessNDImageConcept<Image> <../reference/structboost_1_1gil_1_1_random_access_n_d_image_concept.html>`_
+  - `RandomAccess2DImageConcept<Image> <../reference/structboost_1_1gil_1_1_random_access2_d_image_concept.html>`_
+  - `ImageConcept<Image> <../reference/structboost_1_1gil_1_1_image_concept.html>`_
 
 Models
 ------

--- a/doc/design/image_view.rst
+++ b/doc/design/image_view.rst
@@ -151,13 +151,13 @@ compatible.
 
 .. seealso::
 
-   - `RandomAccessNDImageViewConcept<View> <reference/structboost_1_1gil_1_1_random_access_n_d_image_view_concept.html>`_
-   - `MutableRandomAccessNDImageViewConcept<View> <reference/structboost_1_1gil_1_1_mutable_random_access_n_d_image_view_concept.html>`_
-   - `RandomAccess2DImageViewConcept<View> <reference/structboost_1_1gil_1_1_random_access2_d_image_view_concept.html>`_
-   - `MutableRandomAccess2DImageViewConcept<View> <reference/structboost_1_1gil_1_1_mutable_random_access2_d_image_view_concept.html>`_
-   - `ImageViewConcept<View> <reference/structboost_1_1gil_1_1_image_view_concept.html>`_
-   - `MutableImageViewConcept<View> <reference/structboost_1_1gil_1_1_mutable_image_view_concept.html>`_
-   - `ViewsCompatibleConcept<View1,View2> <reference/structboost_1_1gil_1_1_views_compatible_concept.html>`_
+   - `RandomAccessNDImageViewConcept<View> <../reference/structboost_1_1gil_1_1_random_access_n_d_image_view_concept.html>`_
+   - `MutableRandomAccessNDImageViewConcept<View> <../reference/structboost_1_1gil_1_1_mutable_random_access_n_d_image_view_concept.html>`_
+   - `RandomAccess2DImageViewConcept<View> <../reference/structboost_1_1gil_1_1_random_access2_d_image_view_concept.html>`_
+   - `MutableRandomAccess2DImageViewConcept<View> <../reference/structboost_1_1gil_1_1_mutable_random_access2_d_image_view_concept.html>`_
+   - `ImageViewConcept<View> <../reference/structboost_1_1gil_1_1_image_view_concept.html>`_
+   - `MutableImageViewConcept<View> <../reference/structboost_1_1gil_1_1_mutable_image_view_concept.html>`_
+   - `ViewsCompatibleConcept<View1,View2> <../reference/structboost_1_1gil_1_1_views_compatible_concept.html>`_
 
 Models
 ------

--- a/doc/design/pixel.rst
+++ b/doc/design/pixel.rst
@@ -119,15 +119,15 @@ both, but only pixel values model the latter.
 
 .. seealso::
 
-  - `PixelBasedConcept<P> <reference/structboost_1_1gil_1_1_pixel_based_concept.html>`_
-  - `PixelConcept<Pixel> <reference/structboost_1_1gil_1_1_pixel_concept.html>`_
-  - `MutablePixelConcept<Pixel> <reference/structboost_1_1gil_1_1_mutable_pixel_concept.html>`_
-  - `PixelValueConcept<Pixel> <reference/structboost_1_1gil_1_1_pixel_value_concept.html>`_
-  - `HomogeneousPixelConcept<Pixel> <reference/structboost_1_1gil_1_1_homogeneous_pixel_based_concept.html>`_
-  - `MutableHomogeneousPixelConcept<Pixel> <reference/structboost_1_1gil_1_1_mutable_homogeneous_pixel_concept.html>`_
-  - `HomogeneousPixelValueConcept<Pixel> <reference/structboost_1_1gil_1_1_homogeneous_pixel_value_concept.html>`_
-  - `PixelsCompatibleConcept<Pixel1, Pixel2> <reference/structboost_1_1gil_1_1_pixels_compatible_concept.html>`_
-  - `PixelConvertibleConcept<SrcPixel, DstPixel> <reference/structboost_1_1gil_1_1_pixel_convertible_concept.html>`_
+  - `PixelBasedConcept<P> <../reference/structboost_1_1gil_1_1_pixel_based_concept.html>`_
+  - `PixelConcept<Pixel> <../reference/structboost_1_1gil_1_1_pixel_concept.html>`_
+  - `MutablePixelConcept<Pixel> <../reference/structboost_1_1gil_1_1_mutable_pixel_concept.html>`_
+  - `PixelValueConcept<Pixel> <../reference/structboost_1_1gil_1_1_pixel_value_concept.html>`_
+  - `HomogeneousPixelConcept<Pixel> <../reference/structboost_1_1gil_1_1_homogeneous_pixel_based_concept.html>`_
+  - `MutableHomogeneousPixelConcept<Pixel> <../reference/structboost_1_1gil_1_1_mutable_homogeneous_pixel_concept.html>`_
+  - `HomogeneousPixelValueConcept<Pixel> <../reference/structboost_1_1gil_1_1_homogeneous_pixel_value_concept.html>`_
+  - `PixelsCompatibleConcept<Pixel1, Pixel2> <../reference/structboost_1_1gil_1_1_pixels_compatible_concept.html>`_
+  - `PixelConvertibleConcept<SrcPixel, DstPixel> <../reference/structboost_1_1gil_1_1_pixel_convertible_concept.html>`_
 
 Models
 ------

--- a/doc/design/pixel_iterator.rst
+++ b/doc/design/pixel_iterator.rst
@@ -36,8 +36,8 @@ plain iterators or adaptors over another pixel iterator:
 
 .. seealso::
 
-  - `PixelIteratorConcept<Iterator> <reference/group___pixel_iterator_concept_pixel_iterator.html>`_
-  - `MutablePixelIteratorConcept<Iterator> <reference/structboost_1_1gil_1_1_mutable_pixel_iterator_concept.html>`_
+  - `PixelIteratorConcept<Iterator> <../reference/group___pixel_iterator_concept_pixel_iterator.html>`_
+  - `MutablePixelIteratorConcept<Iterator> <../reference/structboost_1_1gil_1_1_mutable_pixel_iterator_concept.html>`_
 
 Models
 ^^^^^^
@@ -120,8 +120,8 @@ type, and a metafunction to rebind to another base iterator:
 
 .. seealso::
 
-  - `IteratorAdaptorConcept<Iterator> <reference/structboost_1_1gil_1_1_iterator_adaptor_concept.html>`_
-  - `MutableIteratorAdaptorConcept<Iterator> <reference/structboost_1_1gil_1_1_mutable_iterator_adaptor_concept.html>`_
+  - `IteratorAdaptorConcept<Iterator> <../reference/structboost_1_1gil_1_1_iterator_adaptor_concept.html>`_
+  - `MutableIteratorAdaptorConcept<Iterator> <../reference/structboost_1_1gil_1_1_mutable_iterator_adaptor_concept.html>`_
 
 Models
 ^^^^^^
@@ -262,10 +262,10 @@ support ``HasDynamicXStepTypeConcept``.
 
 .. seealso::
 
-  - `StepIteratorConcept<Iterator> <reference/structboost_1_1gil_1_1_step_iterator_concept.html>`_
-  - `MutableStepIteratorConcept<Iterator> <reference/structboost_1_1gil_1_1_mutable_step_iterator_concept.html>`_
-  - `MemoryBasedIteratorConcept<Iterator> <reference/structboost_1_1gil_1_1_memory_based_iterator_concept.html>`_
-  - `HasDynamicXStepTypeConcept<T> <reference/structboost_1_1gil_1_1_has_dynamic_x_step_type_concept.html>`_
+  - `StepIteratorConcept<Iterator> <../reference/structboost_1_1gil_1_1_step_iterator_concept.html>`_
+  - `MutableStepIteratorConcept<Iterator> <../reference/structboost_1_1gil_1_1_mutable_step_iterator_concept.html>`_
+  - `MemoryBasedIteratorConcept<Iterator> <../reference/structboost_1_1gil_1_1_memory_based_iterator_concept.html>`_
+  - `HasDynamicXStepTypeConcept<T> <../reference/structboost_1_1gil_1_1_has_dynamic_x_step_type_concept.html>`_
 
 Models
 ^^^^^^

--- a/doc/design/pixel_locator.rst
+++ b/doc/design/pixel_locator.rst
@@ -159,14 +159,14 @@ y dimension types are the same. They model the following concept:
 
 .. seealso::
 
-  - `HasDynamicYStepTypeConcept<T> <reference/structboost_1_1gil_1_1_has_dynamic_y_step_type_concept.html>`_
-  - `HasTransposedTypeConcept<T> <reference/structboost_1_1gil_1_1_has_transposed_type_concept.html>`_
-  - `RandomAccessNDLocatorConcept<Locator> <reference/structboost_1_1gil_1_1_random_access_n_d_locator_concept.html>`_
-  - `MutableRandomAccessNDLocatorConcept<Locator> <reference/structboost_1_1gil_1_1_mutable_random_access_n_d_locator_concept.html>`_
-  - `RandomAccess2DLocatorConcept<Locator> <reference/structboost_1_1gil_1_1_random_access2_d_locator_concept.html>`_
-  - `MutableRandomAccess2DLocatorConcept<Locator> <reference/structboost_1_1gil_1_1_mutable_random_access2_d_locator_concept.html>`_
-  - `PixelLocatorConcept<Locator> <reference/structboost_1_1gil_1_1_pixel_locator_concept.html>`_
-  - `MutablePixelLocatorConcept<Locator> <reference/structboost_1_1gil_1_1_mutable_pixel_locator_concept.html>`_
+  - `HasDynamicYStepTypeConcept<T> <../reference/structboost_1_1gil_1_1_has_dynamic_y_step_type_concept.html>`_
+  - `HasTransposedTypeConcept<T> <../reference/structboost_1_1gil_1_1_has_transposed_type_concept.html>`_
+  - `RandomAccessNDLocatorConcept<Locator> <../reference/structboost_1_1gil_1_1_random_access_n_d_locator_concept.html>`_
+  - `MutableRandomAccessNDLocatorConcept<Locator> <../reference/structboost_1_1gil_1_1_mutable_random_access_n_d_locator_concept.html>`_
+  - `RandomAccess2DLocatorConcept<Locator> <../reference/structboost_1_1gil_1_1_random_access2_d_locator_concept.html>`_
+  - `MutableRandomAccess2DLocatorConcept<Locator> <../reference/structboost_1_1gil_1_1_mutable_random_access2_d_locator_concept.html>`_
+  - `PixelLocatorConcept<Locator> <../reference/structboost_1_1gil_1_1_pixel_locator_concept.html>`_
+  - `MutablePixelLocatorConcept<Locator> <../reference/structboost_1_1gil_1_1_mutable_pixel_locator_concept.html>`_
 
 Models
 ------

--- a/doc/design/point.rst
+++ b/doc/design/point.rst
@@ -46,8 +46,8 @@ in which both dimensions are of the same type:
 
 .. seealso::
 
-  - `PointNDConcept <reference/structboost_1_1gil_1_1_point_n_d_concept.html>`_
-  - `Point2DConcept <reference/structboost_1_1gil_1_1_point2_d_concept.html>`_
+  - `PointNDConcept <../reference/structboost_1_1gil_1_1_point_n_d_concept.html>`_
+  - `Point2DConcept <../reference/structboost_1_1gil_1_1_point2_d_concept.html>`_
 
 Models
 ------


### PR DESCRIPTION
### Description

This PR fixes broken links in the "See also" section of various documentation pages.

### References

Fixes #591.

Compare:
* Current state: https://boostorg.github.io/gil/html/design/point.html
  * links in "See also" are broken (404)

vs.

* fixed state: https://striezel-stash.github.io/gil/html/design/point.html
  * links in "See also" lead to reference pages

### Tasklist

- [ ] Ensure all CI builds pass
- [ ] Review and approve
