### PR TITLE
chore!: Deprecate any_color_converted_view

### DIFF
--- a/include/boost/gil/extension/dynamic_image/image_view_factory.hpp
+++ b/include/boost/gil/extension/dynamic_image/image_view_factory.hpp
@@ -379,12 +379,11 @@ auto color_converted_view(any_image_view<Views...> const& src)
 ///        These are workarounds for GCC 3.4, which thinks color_converted_view is ambiguous with the same method for templated views (in gil/image_view_factory.hpp)
 /// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
 template <typename DstP, typename ...Views, typename CC>
-inline
-auto any_color_converted_view(const any_image_view<Views...>& src, CC)
+[[deprecated]] inline
+auto any_color_converted_view(const any_image_view<Views...>& src, CC cc)
     -> typename color_converted_view_type<any_image_view<Views...>, DstP, CC>::type
 {
-    using cc_view_t = typename color_converted_view_type<any_image_view<Views...>, DstP, CC>::type;
-    return apply_operation(src, detail::color_converted_view_fn<DstP, cc_view_t>());
+    return color_converted_view(src, cc);
 }
 
 /// \ingroup ImageViewTransformationsColorConvert
@@ -392,12 +391,11 @@ auto any_color_converted_view(const any_image_view<Views...>& src, CC)
 ///        These are workarounds for GCC 3.4, which thinks color_converted_view is ambiguous with the same method for templated views (in gil/image_view_factory.hpp)
 /// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
 template <typename DstP, typename ...Views>
-inline
+[[deprecated]] inline
 auto any_color_converted_view(const any_image_view<Views...>& src)
     -> typename color_converted_view_type<any_image_view<Views...>, DstP>::type
 {
-    using cc_view_t = typename color_converted_view_type<any_image_view<Views...>, DstP>::type;
-    return apply_operation(src, detail::color_converted_view_fn<DstP, cc_view_t>());
+    return color_converted_view(src);
 }
 
 /// \}


### PR DESCRIPTION
### Description

I suggest to deprecate the function `any_color_converted_view` from `gil/extension/dynamic_image/image_view_factory.hpp`, because it has the exact same implementation as the function `color_converted_view`:

```
template <typename DstP, typename ...Views>
inline
auto color_converted_view(any_image_view<Views...> const& src)
    -> typename color_converted_view_type<any_image_view<Views...>, DstP>::type
{
    using cc_view_t = typename color_converted_view_type<any_image_view<Views...>, DstP>::type;
    return apply_operation(src, detail::color_converted_view_fn<DstP, cc_view_t>());
}
```
```
template <typename DstP, typename ...Views>
inline
auto any_color_converted_view(const any_image_view<Views...>& src)
    -> typename color_converted_view_type<any_image_view<Views...>, DstP>::type
{
    using cc_view_t = typename color_converted_view_type<any_image_view<Views...>, DstP>::type;
    return apply_operation(src, detail::color_converted_view_fn<DstP, cc_view_t>());
}
```

According to the documentation of `any_color_converted_view`, the prefix `any_` was added to avoid an ambiguous overload resolution for GCC 3.4, which however, we do not have to support anymore with C++11. 

### Tasklist

- [ ] Ensure all CI builds pass
- [ ] Review and approve
