### PR TITLE
added select_most_precise<T1, T2>::type

### DIFF
--- a/include/boost/gil/detail/select_most_precise.hpp
+++ b/include/boost/gil/detail/select_most_precise.hpp
@@ -1,0 +1,108 @@
+#ifndef BOOST_GIL_DETAIL_SELECT_MOST_PRECISE_HPP
+#define BOOST_GIL_DETAIL_SELECT_MOST_PRECISE_HPP
+
+#include <type_traits>
+
+namespace boost { namespace gil { namespace detail {
+
+template <typename ...Ts>
+struct dependent_false : std::integral_constant<bool, false> {};
+
+template <bool Fundamental1, bool Fundamental2, typename T1, typename T2>
+struct select_non_fundamental
+{
+    using type = void;
+};
+
+template <typename T1, typename T2>
+struct select_non_fundamental<false, false, T1, T2>
+{
+    static_assert(dependent_false<T1, T2>::value, "Specialization needed, if both types are not fundamental.");
+    using type = void;
+};
+
+template <typename T1, typename T2>
+struct select_non_fundamental<true, false, T1, T2>
+{
+    using type = T2;
+};
+
+template <typename T1, typename T2>
+struct select_non_fundamental<false, true, T1, T2>
+{
+    using type = T1;
+};
+
+template <bool FP1, bool FP2, typename T1, typename T2>
+struct select_floating_point
+{
+    using type = void;
+};
+
+template <typename T1, typename T2>
+struct select_floating_point<false, false, T1, T2>
+{
+    static_assert(dependent_false<T1, T2>::value, "At least one of both types has to be floating point.");
+    using type = void;
+};
+
+template <typename T1, typename T2>
+struct select_floating_point<true, false, T1, T2>
+{
+    using type = T1;
+};
+
+template <typename T1, typename T2>
+struct select_floating_point<false, true, T1, T2>
+{
+    using type = T2;
+};
+
+template <typename T1, typename T2>
+struct select_most_precise
+{
+    static constexpr bool second_larger = sizeof(T2) > sizeof(T1);
+    static constexpr bool one_not_fundamental = !
+        (std::is_fundamental<T1>::value
+        & std::is_fundamental<T2>::value);
+
+    static constexpr bool both_floating_point =
+        std::is_floating_point<T1>::value
+        && std::is_floating_point<T2>::value;
+
+    using type = typename std::conditional
+        <
+            one_not_fundamental,
+            typename select_non_fundamental
+            <
+                std::is_fundamental<T1>::value,
+                std::is_fundamental<T2>::value,
+                T1,
+                T2
+            >::type,
+            typename std::conditional
+            <
+                both_floating_point,
+                typename std::conditional
+                <
+                    second_larger,
+                    T2,
+                    T1
+                >::type,
+                typename select_floating_point
+                <
+                    std::is_floating_point<T1>::value,
+                    std::is_floating_point<T2>::value,
+                    T1,
+                    T2
+                >::type
+            >::type
+        >::type;
+};
+
+template <typename T1, typename T2>
+using select_most_precise_t = typename select_most_precise<T1, T2>::type;
+
+} } } // namespace boost::gil::detail
+
+#endif

--- a/test/core/Jamfile
+++ b/test/core/Jamfile
@@ -25,6 +25,7 @@ build-project point ;
 build-project channel ;
 build-project color ;
 build-project color_base ;
+build-project detail ;
 build-project pixel ;
 build-project iterator ;
 build-project locator ;

--- a/test/core/detail/Jamfile
+++ b/test/core/detail/Jamfile
@@ -1,0 +1,12 @@
+#
+# Copyright 2022 Marco Langer <langer.m86 at gmail dot com>
+#
+# Distributed under the Boost Software License, Version 1.0
+# See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt
+#
+
+import testing ;
+
+run select_most_precise.cpp ;
+

--- a/test/core/detail/select_most_precise.cpp
+++ b/test/core/detail/select_most_precise.cpp
@@ -1,0 +1,83 @@
+//
+// Copyright 2022 Marco Langer
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+#include <boost/gil/detail/select_most_precise.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+#include <type_traits>
+
+namespace gil = boost::gil;
+
+struct my_non_fundamental{};
+
+void test_select_most_precise()
+{
+    BOOST_TEST((std::is_same
+        <
+            gil::detail::select_most_precise<double, double>::type,
+            double
+        >::value));
+
+    BOOST_TEST((std::is_same
+        <
+            gil::detail::select_most_precise<float, float>::type,
+            float
+        >::value));
+
+    // float, double
+    BOOST_TEST((std::is_same
+        <
+            gil::detail::select_most_precise<float, double>::type,
+            double
+        >::value));
+    BOOST_TEST((std::is_same
+        <
+            gil::detail::select_most_precise<double, float>::type,
+            double
+        >::value));
+    BOOST_TEST((std::is_same
+        <
+            gil::detail::select_most_precise<double, double>::type,
+            double
+        >::value));
+    BOOST_TEST((std::is_same
+        <
+            gil::detail::select_most_precise<float, float>::type,
+            float
+        >::value));
+
+    // int, double
+    BOOST_TEST((std::is_same
+        <
+            gil::detail::select_most_precise<int, double>::type,
+            double
+        >::value));
+    BOOST_TEST((std::is_same
+        <
+            gil::detail::select_most_precise<double, int>::type,
+            double
+        >::value));
+
+    // double, my_non_fundamental
+    BOOST_TEST((std::is_same
+        <
+            gil::detail::select_most_precise<double, my_non_fundamental>::type,
+            my_non_fundamental
+        >::value));
+    BOOST_TEST((std::is_same
+        <
+            gil::detail::select_most_precise<my_non_fundamental, double>::type,
+            my_non_fundamental
+        >::value));
+}
+
+int main()
+{
+    test_select_most_precise();
+
+    return ::boost::report_errors();
+}


### PR DESCRIPTION
### Description

This is a first draft to implement a compile-time selection of a most precise type as suggested in #363.

It follows closely the solution offered by Boost.Geometry, with the following changes:

- arity of just 2 (but variable arity can be added later)
- modernized to C++11
- improved error handling in cases where one cannot select one of both types

Some pending questions:
- `std::is_floating_point` does not support floating point types other than float, double and long double. Do we expect other floating point types?

Any thoughts on this?

### Tasklist

- [x] Add test case(s)
- [ ] Ensure all CI builds pass
- [ ] Review and approve
