### PR TITLE
release notes update up to Boost 1.75

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,6 +3,10 @@
 All notable changes to [Boost.GIL](https://github.com/boostorg/gil/) project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.75.0] - 2020-12-09
+
+BREAKING: In next release, we are going to drop support for GCC 5. We may also change the required minimum C++ version from C++11 to C++14.
+
 ## [1.74.0] - 2020-08-12
 
 ### Added


### PR DESCRIPTION
### Description

@mloskot:
This updates the release notes on master to be up to date with those from develop. Those are the release notes of GIL for Boost 1.75. As you know, Boost 1.75 has already been release and the contained text was part of the release notes for that release: https://www.boost.org/users/history/version_1_75_0.html

The sole intention of this PR is to get the release notes file on master up to date with what already has been released.

(Cherry-pick of 8b1c2d3ea4eb5bf0a1e7e093862962313dd6c2bb from develop.)

**Note:** This PR targets the branch `master`, _not_ `develop` as PRs usually do. That is intentional.

### References

Consider this the first "baby step" for a possible next release of GIL. See #663 for the ongoing discussion.

### Tasklist

- [x] Review and approve
