### PR TITLE
chore: Remove unused variable in diffusion.hpp

### DIFF
--- a/include/boost/gil/image_processing/diffusion.hpp
+++ b/include/boost/gil/image_processing/diffusion.hpp
@@ -370,7 +370,6 @@ void anisotropic_diffusion(const InputView& input, const OutputView& output, uns
     using computation_image = image<pixel_type>;
     const auto width = input.width();
     const auto height = input.height();
-    const point_t dims(width, height);
     const auto zero_pixel = []() {
         pixel_type pixel;
         static_fill(pixel, static_cast<channel_type>(0));


### PR DESCRIPTION
### Description

The variable `dims` is not used and can cause a compiler warning.

### References

It causes compiler warning, e.g. here:
https://web.archive.org/web/20220511164304/https://www.boost.org/development/tests/develop/output/teeks99-06-dc9-2a-64onaarch64-gil-clang-linux-9~c++2a-warnings.html#anisotropic_diffusion (archived from [the original](https://www.boost.org/development/tests/develop/output/teeks99-06-dc9-2a-64onaarch64-gil-clang-linux-9~c++2a-warnings.html#anisotropic_diffusion), because that changes with every build on the `develop` branch)

```
../boost/gil/image_processing/diffusion.hpp:373:19: warning: unused variable 'dims' [-Wunused-variable]
1 warning generated.
```

### Tasklist

- [ ] Ensure all CI builds pass
- [x] Review and approve
