### PR TITLE
Fixed io extension build error

### DIFF
--- a/include/boost/gil/extension/io/bmp/detail/write.hpp
+++ b/include/boost/gil/extension/io/bmp/detail/write.hpp
@@ -13,6 +13,7 @@
 
 #include <boost/gil/io/base.hpp>
 #include <boost/gil/io/device.hpp>
+#include <boost/gil/io/detail/dynamic.hpp>
 
 #include <vector>
 

--- a/include/boost/gil/extension/io/jpeg/detail/write.hpp
+++ b/include/boost/gil/extension/io/jpeg/detail/write.hpp
@@ -14,6 +14,7 @@
 
 #include <boost/gil/io/base.hpp>
 #include <boost/gil/io/device.hpp>
+#include <boost/gil/io/detail/dynamic.hpp>
 
 #include <vector>
 

--- a/include/boost/gil/extension/io/png/detail/write.hpp
+++ b/include/boost/gil/extension/io/png/detail/write.hpp
@@ -11,6 +11,7 @@
 #include <boost/gil/extension/io/png/detail/writer_backend.hpp>
 
 #include <boost/gil/io/device.hpp>
+#include <boost/gil/io/detail/dynamic.hpp>
 #include <boost/gil/io/row_buffer_helper.hpp>
 #include <boost/gil/detail/mp11.hpp>
 

--- a/include/boost/gil/extension/io/pnm/detail/write.hpp
+++ b/include/boost/gil/extension/io/pnm/detail/write.hpp
@@ -14,6 +14,7 @@
 #include <boost/gil/io/base.hpp>
 #include <boost/gil/io/bit_operations.hpp>
 #include <boost/gil/io/device.hpp>
+#include <boost/gil/io/detail/dynamic.hpp>
 #include <boost/gil/detail/mp11.hpp>
 
 #include <cstdlib>

--- a/include/boost/gil/extension/io/targa/detail/write.hpp
+++ b/include/boost/gil/extension/io/targa/detail/write.hpp
@@ -13,6 +13,7 @@
 
 #include <boost/gil/io/base.hpp>
 #include <boost/gil/io/device.hpp>
+#include <boost/gil/io/detail/dynamic.hpp>
 
 #include <vector>
 

--- a/include/boost/gil/extension/io/tiff/detail/write.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/write.hpp
@@ -15,6 +15,7 @@
 #include <boost/gil/premultiply.hpp>
 #include <boost/gil/io/base.hpp>
 #include <boost/gil/io/device.hpp>
+#include <boost/gil/io/detail/dynamic.hpp>
 
 #include <algorithm>
 #include <string>


### PR DESCRIPTION


<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

The error was due to missing dynamic.hpp header that contained dynamic_io_fnobj. Adding the header back in to write.hpp headers of io extensions fixed the problem.
### References

[#653 (comment)](https://github.com/boostorg/gil/pull/653#issuecomment-1125804514).

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

<s>Add test case(s)</s> N/A (run build and tests locally, all passed)
- [ ] Ensure all CI builds pass
- [ ] Review and approve
