### PR TITLE
chore: do not use deprecated header in test or elsewhere

### DIFF
--- a/example/convolution.cpp
+++ b/example/convolution.cpp
@@ -19,7 +19,7 @@
 
 // Work can be done row by row and column by column, as in this example,
 // using the functions convolve_rows and convolve_cols (or their _fixed counterpart)
-// but the header boost/gil/extension/numeric/convolve.hpp also offers the function convolve_1d which combines the two.
+// but the header boost/gil/image_processing/convolve.hpp also offers the function convolve_1d which combines the two.
 
 // See also:
 // convolve2d.cpp - Convolution with 2d kernels

--- a/include/boost/gil/extension/numeric/kernel.hpp
+++ b/include/boost/gil/extension/numeric/kernel.hpp
@@ -13,6 +13,6 @@
 
 #include <boost/config/header_deprecated.hpp>
 
-BOOST_HEADER_DEPRECATED("<boost/gil/image_processing/convolve.hpp>")
+BOOST_HEADER_DEPRECATED("<boost/gil/image_processing/kernel.hpp>")
 
 #endif

--- a/test/core/channel/channel_numeric_operations.cpp
+++ b/test/core/channel/channel_numeric_operations.cpp
@@ -7,7 +7,7 @@
 // http://www.boost.org/LICENSE_1_0.txt
 //
 #include <boost/gil.hpp>
-#include <boost/gil/extension/numeric/channel_numeric_operations.hpp>
+#include <boost/gil/channel_numeric_operations.hpp>
 
 #include <boost/core/lightweight_test.hpp>
 


### PR DESCRIPTION
### Description

Replaces the use of the deprecated header `<boost/gil/extension/numeric/channel_numeric_operations.hpp>` by the newer header `<boost/gil/channel_numeric_operations.hpp>`. (Move occurred as part of #573.)

This PR also fixes other two instances related to the move + deprecation of headers from the numeric extension.

### References

Using the deprecated header causes a warning like
```
../boost/gil/extension/numeric/channel_numeric_operations.hpp:14:1: warning: This header is deprecated. Use <boost/gil/channel_numeric_operations.hpp> instead. [-W#pragma-messages]
1 warning generated.
```
Warning occurs when running tests, e. g. here: https://web.archive.org/web/20220518134058/https://www.boost.org/development/tests/develop/output/teeks99-dkr-dc12-20-gil-clang-linux-12~c++20-warnings.html#channel_numeric_operations
(archived from [the original](https://www.boost.org/development/tests/develop/output/teeks99-dkr-dc12-20-gil-clang-linux-12~c++20-warnings.html#channel_numeric_operations), because that changes with every new build on the develop branch)

### Tasklist

- [ ] Ensure all CI builds pass
- [ ] Review and approve
