### PR TITLE
chore!: deprecate any_color_converted_view

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   Currently, large parts of GIL still compile with a C++11 compiler. However,
   there is no guarantee that it stays that way, and any compilers that do not
   support at least C++14 are considered unsupported as of now.
+- BREAKING: `any_color_converted_view()` is deprecated and will be removed in the next release.
+  Use `color_converted_view()` instead, which provides the same feature.
 - documentation: Display that GIL is a header-only library
 - Moved numeric extension to core ([PR #573](https://github.com/boostorg/gil/pull/573))
 - Added support for C++17's `<filesystem>` ([PR #636](https://github.com/boostorg/gil/pull/636)).

--- a/include/boost/gil/extension/dynamic_image/image_view_factory.hpp
+++ b/include/boost/gil/extension/dynamic_image/image_view_factory.hpp
@@ -379,6 +379,7 @@ auto color_converted_view(any_image_view<Views...> const& src)
 ///        These are workarounds for GCC 3.4, which thinks color_converted_view is ambiguous with the same method for templated views (in gil/image_view_factory.hpp)
 /// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
 template <typename DstP, typename ...Views, typename CC>
+[[deprecated("Use color_converted_view(const any_image_view<Views...>& src, CC) instead.")]]
 inline
 auto any_color_converted_view(const any_image_view<Views...>& src, CC)
     -> typename color_converted_view_type<any_image_view<Views...>, DstP, CC>::type
@@ -392,6 +393,7 @@ auto any_color_converted_view(const any_image_view<Views...>& src, CC)
 ///        These are workarounds for GCC 3.4, which thinks color_converted_view is ambiguous with the same method for templated views (in gil/image_view_factory.hpp)
 /// \tparam Views Models Boost.MP11-compatible list of models of ImageViewConcept
 template <typename DstP, typename ...Views>
+[[deprecated("Use color_converted_view(any_image_view<Views...> const& src) instead.")]]
 inline
 auto any_color_converted_view(const any_image_view<Views...>& src)
     -> typename color_converted_view_type<any_image_view<Views...>, DstP>::type


### PR DESCRIPTION
### Description

`color_converted_view` has the same implementation and can be used as a replacement, providing the same functionality.

### References

This builds on https://github.com/boostorg/gil/pull/660 by @marco-langer.
Since there needs to be a deprecation notice first before removing a feature, here it is.

Due to the fact that the switch to C++14 has been announced in #677, we can now officially use the [`[[deprecated]]` attribute](https://en.cppreference.com/w/cpp/language/attributes/deprecated) which was standardized in C++14.

### Tasklist

- [ ] Ensure all CI builds pass
- [ ] Review and approve
