### PR TITLE
refactor: Make packed_pixel trivially copyable and assignable

### DIFF
--- a/include/boost/gil/packed_pixel.hpp
+++ b/include/boost/gil/packed_pixel.hpp
@@ -61,9 +61,6 @@ struct packed_pixel
     packed_pixel() = default;
     explicit packed_pixel(const BitField& bitfield) : _bitfield(bitfield) {}
 
-    // Construct from another compatible pixel type
-    packed_pixel(const packed_pixel& p) : _bitfield(p._bitfield) {}
-
     template <typename Pixel>
     packed_pixel(Pixel const& p,
         typename std::enable_if<is_pixel<Pixel>::value>::type* /*dummy*/ = nullptr)
@@ -108,12 +105,6 @@ struct packed_pixel
         gil::at_c<2>(*this) = chan2;
         gil::at_c<3>(*this) = chan3;
         gil::at_c<4>(*this) = chan4;
-    }
-
-    auto operator=(packed_pixel const& p) -> packed_pixel&
-    {
-        _bitfield = p._bitfield;
-        return *this;
     }
 
     template <typename Pixel>


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

Following the Rule of Zero, this PR removes the user-defined copy constructor and copy assignment operator from `packed_pixel`. The type is now trivially copyable and trivially assignable:

```C++
#include <boost/gil.hpp>
#include <boost/mp11.hpp>
#include <type_traits>

namespace gil = boost::gil;
namespace mp11 = boost::mp11;

int main()
{
  using packed_channel_references_3 = typename gil::detail::packed_channel_references_vector_type
  <
      std::uint8_t,
      mp11::mp_list_c<int, 3>
  >::type;

  using packed_pixel_gray3 = gil::packed_pixel
  <
      std::uint8_t,
      packed_channel_references_3,
      gil::gray_layout_t
  >;

  static_assert(std::is_trivially_copyable<packed_pixel_gray3>::value);
  static_assert(std::is_trivially_assignable<packed_pixel_gray3, packed_pixel_gray3>::value);

  return 0;
}
```

### Tasklist

- [x] Ensure all CI builds pass
- [x] Review and approve
