### PR TITLE
chore: update metadata for switch to C++ 14

### DIFF
--- a/meta/libraries.json
+++ b/meta/libraries.json
@@ -6,7 +6,7 @@
         "Hailin Jin",
         "Christian Henning"
     ],
-    "description": "(C++11) Generic Image Library",
+    "description": "(C++14) Generic Image Library",
     "category": [
         "Algorithms",
         "Containers",
@@ -19,5 +19,5 @@
         "Mateusz Loskot <mateusz -at- loskot.net>",
         "Pranam Lashkari <plashkari628 -at- gmail.com>"
     ],
-    "cxxstd": "11"
+    "cxxstd": "14"
 }


### PR DESCRIPTION
### Description

The switch to C++ 14 was already announced in #677, but the metadata was not updated at the same time.

### References

Announcement to switch from C++11 to C++14 was merged in #677.

### Tasklist

- [ ] Review and approve
