### PR TITLE
fix: Detection of std::filesystem header

### DIFF
--- a/include/boost/gil/io/detail/filesystem.hpp
+++ b/include/boost/gil/io/detail/filesystem.hpp
@@ -10,8 +10,8 @@
 
 #include <boost/config.hpp>
 
-#if !defined(BOOST_GIL_IO_USE_BOOST_FILESYSTEM)
-#if !defined(BOOST_NO_CXX17_HDR_FILESYSTEM) || defined(__cpp_lib_filesystem)
+#if !defined(BOOST_GIL_IO_USE_BOOST_FILESYSTEM) && !defined(BOOST_NO_CXX17_HDR_FILESYSTEM)
+#if defined(__cpp_lib_filesystem)
 #include <filesystem>
 #define BOOST_GIL_IO_USE_STD_FILESYSTEM
 #elif defined(__cpp_lib_experimental_filesystem)
@@ -19,7 +19,7 @@
 #define BOOST_GIL_IO_USE_STD_FILESYSTEM
 #define BOOST_GIL_IO_USE_STD_EXPERIMENTAL_FILESYSTEM
 #endif
-#endif // !BOOST_GIL_IO_USE_BOOST_FILESYSTEM
+#endif // !BOOST_GIL_IO_USE_BOOST_FILESYSTEM && !BOOST_NO_CXX17_HDR_FILESYSTEM
 
 #if !defined(BOOST_GIL_IO_USE_STD_FILESYSTEM)
 // Disable warning: conversion to 'std::atomic<int>::__integral_type {aka int}' from 'long int' may alter its value


### PR DESCRIPTION
### Description

PR #636 has added detection for the `<filesystem>` header, but now examples using the IO extensions can't be compiled with C++11 or C++14 anymore. This PR fixes this issue.

### References

Compiling one of the examples, e.g.

```
g++ x_gradient.cpp -std=c++11 -ljpeg
```
results in
```
In file included from ../../boost/libs/gil/include/boost/gil/io/path_spec.hpp:11,
                 from ../../boost/libs/gil/include/boost/gil/io/get_read_device.hpp:13,
                 from ../../boost/libs/gil/include/boost/gil/io/get_reader.hpp:11,
                 from ../../boost/libs/gil/include/boost/gil/extension/io/jpeg/read.hpp:18,
                 from ../../boost/libs/gil/include/boost/gil/extension/io/jpeg.hpp:11,
                 from ../../boost/libs/gil/example/x_gradient.cpp:9:
../../boost/libs/gil/include/boost/gil/io/detail/filesystem.hpp:55:29: error: ‘filesystem’ is not a namespace-name
   55 | namespace filesystem = std::filesystem;
....
```

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [ ] Add test case(s)
- [x] Ensure all CI builds pass
- [ ] Review and approve
