### PR TITLE
refactor: Replace deprecated libtiff v4.3 typedefs with C99 fixed-size integers

### DIFF
--- a/include/boost/gil/extension/io/tiff/detail/device.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/device.hpp
@@ -15,6 +15,7 @@
 #include <boost/gil/io/device.hpp>
 
 #include <algorithm>
+#include <cstdint>
 #include <memory>
 #include <sstream>
 #include <type_traits>
@@ -221,9 +222,9 @@ public:
     {
         if( TIFFReadTile( _tiff_file.get()
                         , reinterpret_cast< tdata_t >( &buffer.front() )
-                        , (uint32) x
-                        , (uint32) y
-                        , (uint32) z
+                        , static_cast< std::uint32_t >( x )
+                        , static_cast< std::uint32_t >( y )
+                        , static_cast< std::uint32_t >( z )
                         , plane
                         ) == -1 )
         {
@@ -234,9 +235,9 @@ public:
     }
 
     template< typename Buffer >
-    void write_scaline( Buffer&     buffer
-                      , uint32      row
-                      , tsample_t   plane
+    void write_scaline( Buffer&       buffer
+                      , std::uint32_t row
+                      , tsample_t     plane
                       )
     {
        io_error_if( TIFFWriteScanline( _tiff_file.get()
@@ -248,9 +249,9 @@ public:
                    );
     }
 
-    void write_scaline( byte_t*     buffer
-                      , uint32      row
-                      , tsample_t   plane
+    void write_scaline( byte_t*        buffer
+                      , std::uint32_t  row
+                      , tsample_t      plane
                       )
     {
        io_error_if( TIFFWriteScanline( _tiff_file.get()
@@ -263,11 +264,11 @@ public:
     }
 
     template< typename Buffer >
-    void write_tile( Buffer&     buffer
-                   , uint32      x
-                   , uint32      y
-                   , uint32      z
-                   , tsample_t   plane
+    void write_tile( Buffer&         buffer
+                   , std::uint32_t   x
+                   , std::uint32_t   y
+                   , std::uint32_t   z
+                   , tsample_t       plane
                    )
     {
        if( TIFFWriteTile( _tiff_file.get()
@@ -300,8 +301,8 @@ public:
                         )
     {
         bool result = true;
-        uint32 tw = static_cast< uint32 >( width  );
-        uint32 th = static_cast< uint32 >( height );
+        std::uint32_t tw = static_cast< std::uint32_t >( width  );
+        std::uint32_t th = static_cast< std::uint32_t >( height );
 
         TIFFDefaultTileSize( _tiff_file.get()
                            , &tw

--- a/include/boost/gil/extension/io/tiff/detail/device.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/device.hpp
@@ -193,7 +193,7 @@ public:
     {
         io_error_if( TIFFReadScanline( _tiff_file.get()
                                      , reinterpret_cast< tdata_t >( &buffer.front() )
-                                     , (uint32) row
+                                     , static_cast<std::uint32_t>( row )
                                      , plane           ) == -1
                    , "Read error."
                    );
@@ -206,7 +206,7 @@ public:
     {
         io_error_if( TIFFReadScanline( _tiff_file.get()
                                      , reinterpret_cast< tdata_t >( buffer )
-                                     , (uint32) row
+                                     , static_cast<std::uint32_t>( row )
                                      , plane           ) == -1
                    , "Read error."
                    );

--- a/include/boost/gil/extension/io/tiff/detail/write.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/write.hpp
@@ -184,7 +184,7 @@ private:
 
 
             this->_io_dev.write_scaline( row
-                                       , (uint32) y
+                                       , static_cast<std::uint32_t>( y )
                                        , 0
                                        );
 
@@ -212,7 +212,7 @@ private:
 
 
             this->_io_dev.write_scaline( row
-                                       , (uint32) y
+                                       , static_cast<std::uint32_t>( y )
                                        , 0
                                        );
 
@@ -274,7 +274,7 @@ private:
 						);
 
             this->_io_dev.write_scaline( row_addr
-                                       , (uint32) y
+                                       , static_cast<std::uint32_t>( y )
                                        , 0
                                        );
 

--- a/include/boost/gil/extension/io/tiff/detail/write.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/write.hpp
@@ -18,6 +18,7 @@
 #include <boost/gil/io/detail/dynamic.hpp>
 
 #include <algorithm>
+#include <cstdint>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -393,8 +394,8 @@ private:
                 }
 
                 this->_io_dev.write_tile( row
-                                        , static_cast< uint32 >( j )
-                                        , static_cast< uint32 >( i )
+                                        , static_cast< std::uint32_t >( j )
+                                        , static_cast< std::uint32_t >( i )
                                         , 0
                                         , 0
                                         );


### PR DESCRIPTION
### Description

This PR replaces libtiff's fixed-size typedef `uint32` with C99's fixed-size typedef `std::uint32_t`.

Rational: libtiff's typedefs are deprecated since v4.3.0 and we already see this deprecation warning in our CI for builds with clang on macos-10.15.

C99's fixed-size typedefs and libtiffs typedefs are almost interchangeable, with the notable exception for 64 bit macOS and a breaking change between long and long long according to [this](https://gitlab.com/libtiff/libtiff/-/merge_requests/185) and [this](https://gitlab.com/libtiff/libtiff/-/merge_requests/205) discussion. Currently I don't think this will affect Gil as we only used `uint32` from libtiffs typedefs, but nevertheless it might be a good idea to check the impact of this PR on macOS builds before merging it into develop.

- [ ] Add test case(s)
- [x] Ensure all CI builds pass
- [x] Review and approve
