### PR TITLE
fix: Added missing include guard to line rasterizer

### DIFF
--- a/include/boost/gil/extension/image_processing/diffusion.hpp
+++ b/include/boost/gil/extension/image_processing/diffusion.hpp
@@ -7,8 +7,8 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //
 
-#ifndef BOOST_GIL_IMAGE_PROCESSING_DIFFUSION_HPP
-#define BOOST_GIL_IMAGE_PROCESSING_DIFFUSION_HPP
+#ifndef BOOST_GIL_EXTENSION_IMAGE_PROCESSING_DIFFUSION_HPP
+#define BOOST_GIL_EXTENSION_IMAGE_PROCESSING_DIFFUSION_HPP
 
 #include <boost/gil/detail/math.hpp>
 #include <boost/gil/algorithm.hpp>
@@ -19,6 +19,7 @@
 #include <boost/gil/pixel.hpp>
 #include <boost/gil/point.hpp>
 #include <boost/gil/typedefs.hpp>
+
 #include <functional>
 #include <numeric>
 #include <vector>

--- a/include/boost/gil/extension/image_processing/hough_parameter.hpp
+++ b/include/boost/gil/extension/image_processing/hough_parameter.hpp
@@ -6,10 +6,11 @@
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
-#ifndef BOOST_GIL_IMAGE_PROCESSING_HOUGH_PARAMETER_HPP
-#define BOOST_GIL_IMAGE_PROCESSING_HOUGH_PARAMETER_HPP
+#ifndef BOOST_GIL_EXTENSION_IMAGE_PROCESSING_HOUGH_PARAMETER_HPP
+#define BOOST_GIL_EXTENSION_IMAGE_PROCESSING_HOUGH_PARAMETER_HPP
 
 #include "boost/gil/point.hpp"
+
 #include <cmath>
 #include <cstddef>
 

--- a/include/boost/gil/extension/image_processing/hough_transform.hpp
+++ b/include/boost/gil/extension/image_processing/hough_transform.hpp
@@ -6,12 +6,13 @@
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
-#ifndef BOOST_GIL_IMAGE_PROCESSING_HOUGH_TRANSFORM_HPP
-#define BOOST_GIL_IMAGE_PROCESSING_HOUGH_TRANSFORM_HPP
+#ifndef BOOST_GIL_EXTENSION_IMAGE_PROCESSING_HOUGH_TRANSFORM_HPP
+#define BOOST_GIL_EXTENSION_IMAGE_PROCESSING_HOUGH_TRANSFORM_HPP
 
-#include <algorithm>
 #include <boost/gil/extension/image_processing/hough_parameter.hpp>
 #include <boost/gil/extension/rasterization/circle.hpp>
+
+#include <algorithm>
 #include <cmath>
 #include <cstddef>
 #include <iterator>

--- a/include/boost/gil/extension/rasterization/circle.hpp
+++ b/include/boost/gil/extension/rasterization/circle.hpp
@@ -1,4 +1,3 @@
-// Boost.GIL (Generic Image Library) - tests
 //
 // Copyright 2020 Olzhas Zhumabek <anonymous.from.applecity@gmail.com>
 //
@@ -6,15 +5,17 @@
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
-#ifndef BOOST_GIL_RASTERIZATION_CIRCLE_HPP
-#define BOOST_GIL_RASTERIZATION_CIRCLE_HPP
+#ifndef BOOST_GIL_EXTENSION_RASTERIZATION_CIRCLE_HPP
+#define BOOST_GIL_EXTENSION_RASTERIZATION_CIRCLE_HPP
 
 #include <boost/gil/detail/math.hpp>
 #include <boost/gil/point.hpp>
+
 #include <cmath>
 #include <cstddef>
 
 namespace boost { namespace gil {
+
 /// \defgroup CircleRasterization
 /// \ingroup Rasterization
 /// \brief Circle rasterization algorithms
@@ -122,5 +123,7 @@ struct midpoint_circle_rasterizer
         }
     }
 };
+
 }} // namespace boost::gil
+
 #endif

--- a/include/boost/gil/extension/rasterization/ellipse.hpp
+++ b/include/boost/gil/extension/rasterization/ellipse.hpp
@@ -5,8 +5,8 @@
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
-#ifndef BOOST_GIL_RASTERIZATION_ELLIPSE_HPP
-#define BOOST_GIL_RASTERIZATION_ELLIPSE_HPP
+#ifndef BOOST_GIL_EXTENSION_RASTERIZATION_ELLIPSE_HPP
+#define BOOST_GIL_EXTENSION_RASTERIZATION_ELLIPSE_HPP
 
 #include <array>
 #include <vector>
@@ -187,6 +187,8 @@ struct midpoint_elliptical_rasterizer
             obtain_trajectory(semi_axes);
         draw_curve(view, colour, center, trajectory_points);
     }
-}; // midpoint elliptical rasterizer
+};
+
 }} // namespace boost::gil
+
 #endif

--- a/include/boost/gil/extension/rasterization/line.hpp
+++ b/include/boost/gil/extension/rasterization/line.hpp
@@ -1,4 +1,3 @@
-// Boost.GIL (Generic Image Library) - tests
 //
 // Copyright 2020 Olzhas Zhumabek <anonymous.from.applecity@gmail.com>
 //
@@ -6,15 +5,16 @@
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
+#ifndef BOOST_GIL_EXTENSION_RASTERIZATION_LINE_HPP
+#define BOOST_GIL_EXTENSION_RASTERIZATION_LINE_HPP
 
 #include <boost/gil/point.hpp>
+
 #include <cmath>
 #include <cstddef>
 
-namespace boost
-{
-namespace gil
-{
+namespace boost { namespace gil {
+
 /// \defgroup Rasterization
 /// \brief A set of functions to rasterize shapes
 ///
@@ -95,3 +95,5 @@ struct bresenham_line_rasterizer
 };
 
 }} // namespace boost::gil
+
+#endif


### PR DESCRIPTION
### Description

This PR adds the missing include guard to the line rasterizer and fixes the include guards for circle and ellipse rasterizers.

### Tasklist

- [ ] Ensure all CI builds pass
- [ ] Review and approve
