### PR TITLE
Fixed int -> float truncation warning in pixel.hpp

### DIFF
--- a/include/boost/gil/pixel.hpp
+++ b/include/boost/gil/pixel.hpp
@@ -211,7 +211,7 @@ private:
     void assign(Channel const& channel, std::false_type)
     {
         check_gray();
-        gil::at_c<0>(*this) = channel;
+        gil::at_c<0>(*this) = static_cast<channel_t::base_channel_t>( channel );
     }
 
     template <typename Channel>

--- a/include/boost/gil/pixel.hpp
+++ b/include/boost/gil/pixel.hpp
@@ -211,7 +211,7 @@ private:
     void assign(Channel const& channel, std::false_type)
     {
         check_gray();
-        gil::at_c<0>(*this) = static_cast<channel_t::base_channel_t>( channel );
+        gil::at_c<0>(*this) = static_cast<typename channel_t::base_channel_t>( channel );
     }
 
     template <typename Channel>


### PR DESCRIPTION
### Description

The underlying channel type for grayscale pixels is a 32-bit float. If `Channel` cannot be losslessly converted to a float--for example, if it is `int`--this would generate a compiler warning. The fix here is to perform an explicit cast. Fixes #688.

### References

See related issue: #688.