### PR TITLE
test: Add tests for RGB to HSL

### DIFF
--- a/test/extension/toolbox/color_convert_hsl.cpp
+++ b/test/extension/toolbox/color_convert_hsl.cpp
@@ -12,8 +12,11 @@
 #include <boost/core/lightweight_test.hpp>
 
 #include <cstdint>
+#include <tuple>
+#include <vector>
 
 #include "test_utility_output_stream.hpp"
+#include "test_utility_with_tolerance.hpp"
 
 namespace gil = boost::gil;
 
@@ -28,6 +31,43 @@ void test_basic_hsl_to_rgb()
     BOOST_TEST_EQ(b, p);
 }
 
+void test_colors_hsl_to_rgb()
+{
+    using color_t = std::tuple<float, float, float, std::uint8_t, std::uint8_t, std::uint8_t>;
+    std::vector<color_t> colors = {
+        {0, 0, 0, 0, 0, 0},               // black
+        {0, 0, 1, 255, 255, 255},         // white
+        {0, 1, 0.5, 255, 0, 0},           // red
+        {2 / 6.f, 1, 0.5, 0, 255, 0},     // lime
+        {4 / 6.f, 1, 0.5, 0, 0, 255},     // blue
+        {5 / 6.f, 1, 0.25, 128, 0, 128},  // purple
+        {3 / 6.f, 1, 0.25, 0, 128, 128},  // teal
+        {4 / 6.f, 1, 0.25, 0, 0, 128},    // navy
+    };
+
+    for (auto&& color : colors)
+    {
+        float h{0}, s{0}, l{0};
+        std::uint8_t r{0}, g{0}, b{0};
+        std::tie(h, s, l, r, g, b) = color;
+
+        gil::hsl32f_pixel_t hsl(h, s, l);
+        gil::rgb8_pixel_t rgb;
+        gil::color_convert(hsl, rgb);
+
+        float const abs_error = 1;
+        BOOST_TEST_WITH(
+            r, gil::get_color(rgb, gil::red_t()),
+            gil::test::utility::with_tolerance<double>(abs_error));
+        BOOST_TEST_WITH(
+            g, gil::get_color(rgb, gil::green_t()),
+            gil::test::utility::with_tolerance<double>(abs_error));
+        BOOST_TEST_WITH(
+            b, gil::get_color(rgb, gil::blue_t()),
+            gil::test::utility::with_tolerance<double>(abs_error));
+    }
+}
+
 void test_image_assign_hsl()
 {
     std::ptrdiff_t const w = 320;
@@ -37,7 +77,7 @@ void test_image_assign_hsl()
     for (std::ptrdiff_t y = 0; y < h; y++)
     {
         gil::hsl32f_view_t::x_iterator hsl_x_it = view(hsl_img).row_begin(y);
-        float v = static_cast<float>(h - y) / h;
+        float v                                 = static_cast<float>(h - y) / h;
         for (std::ptrdiff_t x = 0; x < w; x++)
         {
             float const hue = (x + 1.f) / w;
@@ -51,6 +91,7 @@ void test_image_assign_hsl()
 int main()
 {
     test_basic_hsl_to_rgb();
+    test_colors_hsl_to_rgb();
     test_image_assign_hsl();
 
     return ::boost::report_errors();

--- a/test/extension/toolbox/color_convert_rgb.cpp
+++ b/test/extension/toolbox/color_convert_rgb.cpp
@@ -13,11 +13,12 @@
 
 #include <cstdint>
 #include <tuple>
+#include <vector>
 
+#include "test_utility_output_stream.hpp"
 #include "test_utility_with_tolerance.hpp"
 
 namespace gil = boost::gil;
-
 
 void test_basic_rgb_to_hsl()
 {
@@ -28,6 +29,50 @@ void test_basic_rgb_to_hsl()
     BOOST_TEST_GT(gil::get_color(h, gil::hsl_color_space::hue_t()), 0.8);         // 0.83333331
     BOOST_TEST_EQ(gil::get_color(h, gil::hsl_color_space::saturation_t()), 1.0);  // 1.00000000
     BOOST_TEST_GT(gil::get_color(h, gil::hsl_color_space::lightness_t()), 0.25);  // 0.25098040
+}
+
+void test_colors_rgb_to_hsl()
+{
+    using color_t = std::tuple<std::uint8_t, std::uint8_t, std::uint8_t, float, float, float>;
+    std::vector<color_t> colors = {
+        {0, 0, 0, 0, 0, 0},               // black
+        {255, 255, 255, 0, 0, 1},         // white
+        {255, 0, 0, 0, 1, 0.5},           // red
+        {0, 255, 0, 2 / 6.f, 1, 0.5},     // lime
+        {0, 0, 255, 4 / 6.f, 1, 0.5},     // blue
+        {255, 255, 0, 1 / 6.f, 1, 0.5},   // yellow
+        {0, 255, 255, 3 / 6.f, 1, 0.5},   // cyan
+        {255, 0, 255, 5 / 6.f, 1, 0.5},   // magenta
+        {191, 191, 191, 0, 0, 0.75},      // silver
+        {128, 128, 128, 0, 0, 0.5},       // gray
+        {128, 0, 0, 0, 1, 0.25},          // maroon
+        {128, 128, 0, 1 / 6.f, 1, 0.25},  // olive
+        {0, 128, 0, 2 / 6.f, 1, 0.25},    // green
+        {128, 0, 128, 5 / 6.f, 1, 0.25},  // purple
+        {0, 128, 128, 3 / 6.f, 1, 0.25},  // teal
+        {0, 0, 128, 4 / 6.f, 1, 0.25},    // navy
+    };
+
+    for (auto&& color : colors)
+    {
+        std::uint8_t r{0}, g{0}, b{0};
+        float h{0}, s{0}, l{0};
+        std::tie(r, g, b, h, s, l) = color;
+        gil::rgb8_pixel_t rgb(r, g, b);
+        gil::hsl32f_pixel_t hsl;
+        gil::color_convert(rgb, hsl);
+
+        float const abs_error = 0.002;
+        BOOST_TEST_WITH(
+            h, get_color(hsl, gil::hsl_color_space::hue_t()),
+            gil::test::utility::with_tolerance<double>(abs_error));
+        BOOST_TEST_WITH(
+            s, get_color(hsl, gil::hsl_color_space::saturation_t()),
+            gil::test::utility::with_tolerance<double>(abs_error));
+        BOOST_TEST_WITH(
+            l, get_color(hsl, gil::hsl_color_space::lightness_t()),
+            gil::test::utility::with_tolerance<double>(abs_error));
+    }
 }
 
 void test_copy_pixels_rgb_to_hsl()
@@ -50,6 +95,7 @@ void test_copy_pixels_rgb_to_hsl()
 int main()
 {
     test_basic_rgb_to_hsl();
+    test_colors_rgb_to_hsl();
     test_copy_pixels_rgb_to_hsl();
 
     return ::boost::report_errors();


### PR DESCRIPTION
### Description

Contributor of PR #505 posted GTest-based tests in.
This commit ports those tests to Boost.LightweightTest.

### References

Closes #690

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Add test case(s)
- [x] Ensure all CI builds pass
- [ ] Review and approve
