### PR TITLE
refactor: ellipse rasterizer

### DIFF
--- a/example/rasterizer_circle.cpp
+++ b/example/rasterizer_circle.cpp
@@ -8,6 +8,7 @@
 
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/png.hpp>
+
 #include <cmath>
 #include <limits>
 #include <vector>
@@ -15,8 +16,8 @@
 namespace gil = boost::gil;
 
 // Demonstrates the use of a rasterizer to generate an image of a circle
-// The various rasterizers available are defined in include/boost/gil/rasterization/circle.hpp,
-// include/boost/gil/rasterization/ellipse.hpp and include/boost/gil/rasterization/line.hpp
+// The various rasterizers available are defined in include/boost/gil/extension/rasterization/circle.hpp,
+// include/boost/gil/extension/rasterization/ellipse.hpp and include/boost/gil/extension/rasterization/line.hpp
 // This example uses a trigonometric rasterizer; GIL also offers the rasterizer midpoint_circle_rasterizer,
 // which implements the Midpoint algorithm.
 // See also:

--- a/example/rasterizer_ellipse.cpp
+++ b/example/rasterizer_ellipse.cpp
@@ -6,14 +6,14 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //
 
-#include <boost/gil/extension/io/jpeg.hpp>
 #include <boost/gil.hpp>
+#include <boost/gil/extension/io/jpeg.hpp>
 
 namespace gil = boost::gil;
 
 // Demonstrates the use of a rasterizer to generate an image of an ellipse
-// The various rasterizers available are defined in include/boost/gil/rasterization/circle.hpp,
-// include/boost/gil/rasterization/ellipse.hpp and include/boost/gil/rasterization/line.hpp
+// The various rasterizers available are defined in include/boost/gil/extension/rasterization/circle.hpp,
+// include/boost/gil/extension/rasterization/ellipse.hpp and include/boost/gil/extension/rasterization/line.hpp
 // The rasterizer used is a generalisation of the midpoint algorithm often used for drawing circle.
 // This examples also shows how to create images with various pixel depth, as well as the behaviour
 // in case of the rasterization of a curve that doesn't fit in a view.
@@ -25,28 +25,28 @@ namespace gil = boost::gil;
 int main()
 {
     // Syntax for usage :-
-    // auto rasterizer = gil::midpoint_elliptical_rasterizer{};
-    // rasterizer(img_view, colour, center, semi-axes_length);
+    // auto rasterizer = gil::midpoint_ellipse_rasterizer{};
+    // rasterizer(img_view, pixel, center, semi-axes_length);
     // Where
     // img_view : gil view of the image on which ellipse is to be drawn.
-    // colour : Vector containing channel intensity values for img_view. Number of colours
-    // provided must be equal to the number of channels present in img_view.
-    // center : Array containing positive integer x co-ordinate and y co-ordinate of the center
+    // pixel : Pixel value for the elliptical curve to be drawn. Pixel's type must be compatible to the
+    // pixel type of the image view.
+    // center : Point containing positive integer x co-ordinate and y co-ordinate of the center
     // respectively.
-    // semi-axes_length : Array containing positive integer lengths of horizontal semi-axis
+    // semi-axes_length : Point containing positive integer lengths of horizontal semi-axis
     // and vertical semi-axis respectively.
 
     gil::gray8_image_t gray_buffer_image(256, 256);
-    auto gray_elliptical_rasterizer = gil::midpoint_elliptical_rasterizer{};
-    gray_elliptical_rasterizer(view(gray_buffer_image), {128}, {128, 128}, {100, 50});
+    auto gray_ellipse_rasterizer = gil::midpoint_ellipse_rasterizer{};
+    gray_ellipse_rasterizer(view(gray_buffer_image), gil::gray8_pixel_t{128}, {128, 128}, {100, 50});
 
     gil::rgb8_image_t rgb_buffer_image(256, 256);
-    auto rgb_elliptical_rasterizer = gil::midpoint_elliptical_rasterizer{};
-    rgb_elliptical_rasterizer(view(rgb_buffer_image), {0, 0, 255}, {128, 128}, {50, 100});
+    auto rgb_ellipse_rasterizer = gil::midpoint_ellipse_rasterizer{};
+    rgb_ellipse_rasterizer(view(rgb_buffer_image), gil::rgb8_pixel_t{0, 0, 255}, {128, 128}, {50, 100});
 
     gil::rgb8_image_t rgb_buffer_image_out_of_bound(256, 256);
-    auto rgb_elliptical_rasterizer_out_of_bound = gil::midpoint_elliptical_rasterizer{};
-    rgb_elliptical_rasterizer_out_of_bound(view(rgb_buffer_image_out_of_bound), {255, 0, 0},
+    auto rgb_ellipse_rasterizer_out_of_bound = gil::midpoint_ellipse_rasterizer{};
+    rgb_ellipse_rasterizer_out_of_bound(view(rgb_buffer_image_out_of_bound), gil::rgb8_pixel_t{255, 0, 0},
         {100, 100}, {160, 160});
 
     gil::write_view("rasterized_ellipse_gray.jpg", view(gray_buffer_image), gil::jpeg_tag{});

--- a/example/rasterizer_line.cpp
+++ b/example/rasterizer_line.cpp
@@ -15,8 +15,8 @@
 namespace gil = boost::gil;
 
 // Demonstrates the use of a rasterizer to generate an image of a line
-// The various rasterizers available are defined in include/boost/gil/rasterization/circle.hpp,
-// include/boost/gil/rasterization/ellipse.hpp and include/boost/gil/rasterization/line.hpp
+// The various rasterizers available are defined in include/boost/gil/extension/rasterization/circle.hpp,
+// include/boost/gil/extension/rasterization/ellipse.hpp and include/boost/gil/extension/rasterization/line.hpp
 // The rasterizer used implements the Bresenham's line algorithm.
 // Multiple images are created, all of the same size, but with areas of different sizes passed to the rasterizer, resulting in different lines.
 // See also:

--- a/test/extension/rasterization/ellipse.cpp
+++ b/test/extension/rasterization/ellipse.cpp
@@ -6,8 +6,8 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //
 #include <boost/core/lightweight_test.hpp>
-#include "boost/gil.hpp"
-#include <array>
+#include <boost/gil.hpp>
+
 #include <cmath>
 #include <vector>
 
@@ -17,7 +17,7 @@ namespace gil = boost::gil;
 // is equal to the length of major axis of the ellipse.
 // Parameters b and a represent half of lengths of vertical and horizontal axis respectively.
 void test_rasterizer_follows_equation(
-    std::vector<std::array<std::ptrdiff_t, 2>> trajectory_points, float a, float b)
+    std::vector<gil::point_t> const& trajectory_points, float a, float b)
 {
     float focus_x, focus_y;
     if (a > b) // For horizontal ellipse
@@ -34,7 +34,7 @@ void test_rasterizer_follows_equation(
     for (auto trajectory_point : trajectory_points)
     {
         // To suppress conversion warnings from compiler
-        std::array<float, 2> point {
+        gil::point<float> point {
             static_cast<float>(trajectory_point[0]), static_cast<float>(trajectory_point[1])};
 
         double dist_sum = std::sqrt(std::pow(focus_x - point[0], 2) +
@@ -53,7 +53,7 @@ void test_rasterizer_follows_equation(
 
 // This function verifies that the difference between x co-ordinates and y co-ordinates for two
 // successive trajectory points is less than or equal to 1. This ensures that the curve is connected.
-void test_connectivity(std::vector<std::array<std::ptrdiff_t, 2>> points)
+void test_connectivity(std::vector<gil::point_t> const& points)
 {
     for (std::size_t i = 1; i < points.size(); ++i)
     {
@@ -72,8 +72,8 @@ int main()
     {
         for (float b = 1; b < 101; ++b)
         {
-            auto rasterizer = gil::midpoint_elliptical_rasterizer{};
-            std::vector<std::array<std::ptrdiff_t, 2>> points = rasterizer.obtain_trajectory(
+            auto rasterizer = gil::midpoint_ellipse_rasterizer{};
+            std::vector<gil::point_t> points = rasterizer.obtain_trajectory(
                 {static_cast<unsigned int>(a), static_cast<unsigned int>(b)});
             test_rasterizer_follows_equation(points, a, b);
             test_connectivity(points);


### PR DESCRIPTION
### Description

This PR implements some of the mentioned issues in [my other comment](https://github.com/boostorg/gil/pull/585#issuecomment-1144412220) regarding the ellipse rasterizer, namely:

- renamed `midpoint_elliptical_rasterizer` to `midpoint_ellipse_rasterizer`
- replaced colour vector with pixel type
- replaced std::array with point type for center and semi-axis
- removed unnecessary deep copies of temporaries.
- removed printing warnings to cout

There are still some open questions, e.g. why circle/line and ellipse rasterizer have different signedness for point types and why they implement the call operator differently. However, I am not sure if we are able to find any consensus on these topics before the deadline for Boost 1.80.


### Tasklist

- [x] Ensure all CI builds pass
- [x] Review and approve
