### PR TITLE
docs!: Announce plan to require C++17 after Boost 1.80

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [1.80.0] - 2022-08-10
 
+NOTICE: We are planning BREAKING switch to C++17 as minimum required C++ language version in one or two releases after Boost 1.80 ([Discussion #676](https://github.com/boostorg/gil/discussions/676))
+
 ### Added
 - Added `image` constructor from compatible view ([PR #520](https://github.com/boostorg/gil/pull/520))
 - Added inverse function for affine `matrix3x2` ([PR #527](https://github.com/boostorg/gil/pull/527))


### PR DESCRIPTION
### Description

<!-- What does this pull request do? -->

For Boost 1.80 we have announced switch from C++11 to C++14
as an intermediate step.

As we will be moving forward with refactoring and modernisations,
we are planning to switch to C++17 in (near) future Boost release.

### References

- https://github.com/boostorg/gil/pull/677
- https://github.com/boostorg/gil/discussions/676

