### PR TITLE
feat: added apply_rasterizer() free function

### DIFF
--- a/example/hough_transform_circle.cpp
+++ b/example/hough_transform_circle.cpp
@@ -8,6 +8,7 @@
 
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/png.hpp>
+#include <boost/gil/extension/rasterization/circle.hpp>
 
 #include <iostream>
 #include <limits>
@@ -33,13 +34,8 @@ int main()
 
     const std::ptrdiff_t circle_radius = 16;
     const gil::point_t circle_center = {64, 64};
-    const auto rasterizer = gil::midpoint_circle_rasterizer{};
-    std::vector<gil::point_t> circle_points(rasterizer.point_count(circle_radius));
-    rasterizer(circle_radius, circle_center, circle_points.begin());
-    for (const auto& point : circle_points)
-    {
-        input(point) = std::numeric_limits<gil::uint8_t>::max();
-    }
+    const auto rasterizer = gil::midpoint_circle_rasterizer{circle_center, circle_radius};
+    gil::apply_rasterizer(input, rasterizer, gil::gray8_pixel_t{255});
 
     const auto radius_parameter =
         gil::hough_parameter<std::ptrdiff_t>::from_step_count(circle_radius, 3, 3);

--- a/example/rasterizer_circle.cpp
+++ b/example/rasterizer_circle.cpp
@@ -8,10 +8,7 @@
 
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/png.hpp>
-
-#include <cmath>
-#include <limits>
-#include <vector>
+#include <boost/gil/extension/rasterization/circle.hpp>
 
 namespace gil = boost::gil;
 
@@ -30,14 +27,10 @@ int main()
     gil::gray8_image_t buffer_image(size, size);
     auto buffer = gil::view(buffer_image);
 
+    const gil::point_t center = {128, 128};
     const std::ptrdiff_t radius = 64;
-    const auto rasterizer = gil::trigonometric_circle_rasterizer{};
-    std::vector<gil::point_t> circle_points(rasterizer.point_count(radius));
-    rasterizer(radius, {128, 128}, circle_points.begin());
-    for (const auto& point : circle_points)
-    {
-        buffer(point) = std::numeric_limits<gil::uint8_t>::max();
-    }
+    const auto rasterizer = gil::trigonometric_circle_rasterizer{center, radius};
+    gil::apply_rasterizer(buffer, rasterizer, gil::gray8_pixel_t{255});
 
     gil::write_view("circle.png", buffer, gil::png_tag{});
 }

--- a/example/rasterizer_ellipse.cpp
+++ b/example/rasterizer_ellipse.cpp
@@ -37,17 +37,16 @@ int main()
     // and vertical semi-axis respectively.
 
     gil::gray8_image_t gray_buffer_image(256, 256);
-    auto gray_ellipse_rasterizer = gil::midpoint_ellipse_rasterizer{};
-    gray_ellipse_rasterizer(view(gray_buffer_image), gil::gray8_pixel_t{128}, {128, 128}, {100, 50});
+    auto gray_ellipse_rasterizer = gil::midpoint_ellipse_rasterizer{{128, 128}, {100, 50}};
+    gil::apply_rasterizer(view(gray_buffer_image), gray_ellipse_rasterizer, gil::gray8_pixel_t{128});
 
     gil::rgb8_image_t rgb_buffer_image(256, 256);
-    auto rgb_ellipse_rasterizer = gil::midpoint_ellipse_rasterizer{};
-    rgb_ellipse_rasterizer(view(rgb_buffer_image), gil::rgb8_pixel_t{0, 0, 255}, {128, 128}, {50, 100});
+    auto rgb_ellipse_rasterizer = gil::midpoint_ellipse_rasterizer{{128, 128}, {50, 100}};
+    gil::apply_rasterizer(view(rgb_buffer_image), rgb_ellipse_rasterizer, gil::rgb8_pixel_t{0, 0, 255});
 
     gil::rgb8_image_t rgb_buffer_image_out_of_bound(256, 256);
-    auto rgb_ellipse_rasterizer_out_of_bound = gil::midpoint_ellipse_rasterizer{};
-    rgb_ellipse_rasterizer_out_of_bound(view(rgb_buffer_image_out_of_bound), gil::rgb8_pixel_t{255, 0, 0},
-        {100, 100}, {160, 160});
+    auto rgb_ellipse_rasterizer_out_of_bound = gil::midpoint_ellipse_rasterizer{{100, 100}, {160, 160}};
+    apply_rasterizer(view(rgb_buffer_image_out_of_bound), rgb_ellipse_rasterizer_out_of_bound, gil::rgb8_pixel_t{255, 0, 0});
 
     gil::write_view("rasterized_ellipse_gray.jpg", view(gray_buffer_image), gil::jpeg_tag{});
     gil::write_view("rasterized_ellipse_rgb.jpg", view(rgb_buffer_image), gil::jpeg_tag{});

--- a/example/rasterizer_line.cpp
+++ b/example/rasterizer_line.cpp
@@ -8,9 +8,7 @@
 
 #include <boost/gil.hpp>
 #include <boost/gil/extension/io/png.hpp>
-
-#include <limits>
-#include <vector>
+#include <boost/gil/extension/rasterization/line.hpp>
 
 namespace gil = boost::gil;
 
@@ -28,18 +26,11 @@ const std::ptrdiff_t size = 256;
 
 void line_bresenham(std::ptrdiff_t width, std::ptrdiff_t height, const std::string& output_name)
 {
-    const auto rasterizer = gil::bresenham_line_rasterizer{};
-    std::vector<gil::point_t> line_points(rasterizer.point_count(width, height));
+    const auto rasterizer = gil::bresenham_line_rasterizer{{0, 0}, {width - 1, height - 1}};
 
     gil::gray8_image_t image(size, size);
     auto view = gil::view(image);
-
-    rasterizer({0, 0}, {width - 1, height - 1}, line_points.begin());
-    for (const auto& point : line_points)
-    {
-        view(point) = std::numeric_limits<gil::uint8_t>::max();
-    }
-
+    gil::apply_rasterizer(view, rasterizer, gil::gray8_pixel_t{255});
     gil::write_view(output_name, view, gil::png_tag{});
 }
 

--- a/include/boost/gil/extension/image_processing/hough_transform.hpp
+++ b/include/boost/gil/extension/image_processing/hough_transform.hpp
@@ -86,14 +86,15 @@ void hough_circle_transform_brute(const ImageView& input,
                                   const hough_parameter<std::ptrdiff_t> radius_parameter,
                                   const hough_parameter<std::ptrdiff_t> x_parameter,
                                   const hough_parameter<std::ptrdiff_t>& y_parameter,
-                                  ForwardIterator d_first, Rasterizer rasterizer)
+                                  ForwardIterator d_first, Rasterizer)
 {
     for (std::size_t radius_index = 0; radius_index < radius_parameter.step_count; ++radius_index)
     {
         const auto radius = radius_parameter.start_point +
                             radius_parameter.step_size * static_cast<std::ptrdiff_t>(radius_index);
-        std::vector<point_t> circle_points(rasterizer.point_count(radius));
-        rasterizer(radius, {0, 0}, circle_points.begin());
+        Rasterizer rasterizer{point_t{}, radius};
+        std::vector<point_t> circle_points(rasterizer.point_count());
+        rasterizer(circle_points.begin());
         // sort by scanline to improve cache coherence for row major images
         std::sort(circle_points.begin(), circle_points.end(),
                   [](const point_t& lhs, const point_t& rhs) { return lhs.y < rhs.y; });

--- a/include/boost/gil/extension/rasterization/apply_rasterizer.hpp
+++ b/include/boost/gil/extension/rasterization/apply_rasterizer.hpp
@@ -1,0 +1,28 @@
+#ifndef BOOST_GIL_EXTENSION_RASTERIZATION_APPLY_RASTERIZER
+#define BOOST_GIL_EXTENSION_RASTERIZATION_APPLY_RASTERIZER
+
+namespace boost { namespace gil {
+
+namespace detail {
+
+template <typename View, typename Rasterizer, typename Pixel, typename Tag>
+struct apply_rasterizer_op
+{
+    void operator()(
+        View const& view, Rasterizer const& rasterizer, Pixel const& pixel);
+};
+
+} // namespace detail
+
+template <typename View, typename Rasterizer, typename Pixel>
+void apply_rasterizer(
+    View const& view, Rasterizer const& rasterizer, Pixel const& pixel)
+{
+    using tag_t = typename Rasterizer::type;
+    detail::apply_rasterizer_op<View, Rasterizer, Pixel, tag_t>{}(
+        view, rasterizer, pixel);
+}
+
+}} // namespace boost::gil
+
+#endif

--- a/include/boost/gil/extension/rasterization/circle.hpp
+++ b/include/boost/gil/extension/rasterization/circle.hpp
@@ -9,12 +9,16 @@
 #define BOOST_GIL_EXTENSION_RASTERIZATION_CIRCLE_HPP
 
 #include <boost/gil/detail/math.hpp>
+#include <boost/gil/extension/rasterization/apply_rasterizer.hpp>
 #include <boost/gil/point.hpp>
 
 #include <cmath>
 #include <cstddef>
+#include <vector>
 
 namespace boost { namespace gil {
+
+struct circle_rasterizer_t{};
 
 /// \defgroup CircleRasterization
 /// \ingroup Rasterization
@@ -32,39 +36,49 @@ namespace boost { namespace gil {
 /// produces quite round like shapes.
 struct trigonometric_circle_rasterizer
 {
+    using type = circle_rasterizer_t;
+
+    /// \brief Creates a trigonometric circle rasterizer
+    /// \param center_point - Point containing positive integer x co-ordinate and y co-ordinate of the
+    /// center respectively.
+    /// \param circle_radius - Radius of the circle
+    trigonometric_circle_rasterizer(point_t center_point, std::ptrdiff_t circle_radius)
+        : center(center_point), radius(circle_radius)
+    {}
+
     /// \brief Calculates minimum angle step that is distinguishable when walking on circle
     ///
     /// It is important to not have disconnected circle and to not compute unnecessarily,
     /// thus the result of this function is used when rendering.
-    double minimum_angle_step(std::ptrdiff_t radius) const noexcept
+    double minimum_angle_step() const noexcept
     {
         const auto diameter = radius * 2 - 1;
         return std::atan2(1.0, diameter);
     }
 
     /// \brief Calculate the amount of points that rasterizer will output
-    std::ptrdiff_t point_count(std::ptrdiff_t radius) const noexcept
+    std::ptrdiff_t point_count() const noexcept
     {
         return 8 * static_cast<std::ptrdiff_t>(
-                       std::round(detail::pi / 4 / minimum_angle_step(radius)) + 1);
+                       std::round(detail::pi / 4 / minimum_angle_step()) + 1);
     }
 
     /// \brief perform rasterization and output into d_first
-    template <typename RandomAccessIterator>
-    void operator()(std::ptrdiff_t radius, point_t offset, RandomAccessIterator d_first) const
+    template <typename OutputIterator>
+    void operator()(OutputIterator d_first) const
     {
         const double minimum_angle_step = std::atan2(1.0, radius);
-        auto translate_mirror_points = [&d_first, offset](point_t p) {
-            *d_first++ = point_t{offset.x + p.x, offset.y + p.y};
-            *d_first++ = point_t{offset.x + p.x, offset.y - p.y};
-            *d_first++ = point_t{offset.x - p.x, offset.y + p.y};
-            *d_first++ = point_t{offset.x - p.x, offset.y - p.y};
-            *d_first++ = point_t{offset.x + p.y, offset.y + p.x};
-            *d_first++ = point_t{offset.x + p.y, offset.y - p.x};
-            *d_first++ = point_t{offset.x - p.y, offset.y + p.x};
-            *d_first++ = point_t{offset.x - p.y, offset.y - p.x};
+        auto translate_mirror_points = [this, &d_first](point_t p) {
+            *d_first++ = point_t{center.x + p.x, center.y + p.y};
+            *d_first++ = point_t{center.x + p.x, center.y - p.y};
+            *d_first++ = point_t{center.x - p.x, center.y + p.y};
+            *d_first++ = point_t{center.x - p.x, center.y - p.y};
+            *d_first++ = point_t{center.x + p.y, center.y + p.x};
+            *d_first++ = point_t{center.x + p.y, center.y - p.x};
+            *d_first++ = point_t{center.x - p.y, center.y + p.x};
+            *d_first++ = point_t{center.x - p.y, center.y - p.x};
         };
-        const std::ptrdiff_t iteration_count = point_count(radius) / 8;
+        const std::ptrdiff_t iteration_count = point_count() / 8;
         double angle = 0;
         // do note that + 1 was done inside count estimation, thus <= is not needed, only <
         for (std::ptrdiff_t i = 0; i < iteration_count; ++i, angle += minimum_angle_step)
@@ -74,6 +88,9 @@ struct trigonometric_circle_rasterizer
             translate_mirror_points({x, y});
         }
     }
+
+    point_t center;
+    std::ptrdiff_t radius;
 };
 
 /// \ingroup CircleRasterization
@@ -84,8 +101,18 @@ struct trigonometric_circle_rasterizer
 /// https://en.wikipedia.org/wiki/Midpoint_circle_algorithm
 struct midpoint_circle_rasterizer
 {
+    using type = circle_rasterizer_t;
+
+    /// \brief Creates a midpoint circle rasterizer
+    /// \param center_point - Point containing positive integer x co-ordinate and y co-ordinate of the
+    /// center respectively.
+    /// \param circle_radius - Radius of the circle
+    midpoint_circle_rasterizer(point_t center_point, std::ptrdiff_t circle_radius)
+        : center(center_point), radius(circle_radius)
+    {}
+
     /// \brief Calculate the amount of points that rasterizer will output
-    std::ptrdiff_t point_count(std::ptrdiff_t radius) const noexcept
+    std::ptrdiff_t point_count() const noexcept
     {
         // the reason for pulling 8 out is so that when the expression radius * cos(45 degrees)
         // is used, it would yield the same result as here
@@ -95,20 +122,20 @@ struct midpoint_circle_rasterizer
     }
 
     /// \brief perform rasterization and output into d_first
-    template <typename RAIterator>
-    void operator()(std::ptrdiff_t radius, point_t offset, RAIterator d_first) const
+    template <typename OutputIterator>
+    void operator()(OutputIterator d_first) const
     {
-        auto translate_mirror_points = [&d_first, offset](point_t p) {
-            *d_first++ = point_t{offset.x + p.x, offset.y + p.y};
-            *d_first++ = point_t{offset.x + p.x, offset.y - p.y};
-            *d_first++ = point_t{offset.x - p.x, offset.y + p.y};
-            *d_first++ = point_t{offset.x - p.x, offset.y - p.y};
-            *d_first++ = point_t{offset.x + p.y, offset.y + p.x};
-            *d_first++ = point_t{offset.x + p.y, offset.y - p.x};
-            *d_first++ = point_t{offset.x - p.y, offset.y + p.x};
-            *d_first++ = point_t{offset.x - p.y, offset.y - p.x};
+        auto translate_mirror_points = [this, &d_first](point_t p) {
+            *d_first++ = point_t{center.x + p.x, center.y + p.y};
+            *d_first++ = point_t{center.x + p.x, center.y - p.y};
+            *d_first++ = point_t{center.x - p.x, center.y + p.y};
+            *d_first++ = point_t{center.x - p.x, center.y - p.y};
+            *d_first++ = point_t{center.x + p.y, center.y + p.x};
+            *d_first++ = point_t{center.x + p.y, center.y - p.x};
+            *d_first++ = point_t{center.x - p.y, center.y + p.x};
+            *d_first++ = point_t{center.x - p.y, center.y - p.x};
         };
-        std::ptrdiff_t iteration_distance = point_count(radius) / 8;
+        std::ptrdiff_t iteration_distance = point_count() / 8;
         std::ptrdiff_t y_current = radius;
         std::ptrdiff_t r_squared = radius * radius;
         translate_mirror_points({0, y_current});
@@ -122,7 +149,30 @@ struct midpoint_circle_rasterizer
             translate_mirror_points({x, y_current});
         }
     }
+
+    point_t center;
+    std::ptrdiff_t radius;
 };
+
+namespace detail {
+
+template <typename View, typename Rasterizer, typename Pixel>
+struct apply_rasterizer_op<View, Rasterizer, Pixel, circle_rasterizer_t>
+{
+    void operator()(
+        View const& view, Rasterizer const& rasterizer, Pixel const& pixel)
+    {
+        std::vector<point_t> trajectory(rasterizer.point_count());
+        rasterizer(std::begin(trajectory));
+
+        for (auto const& point : trajectory)
+        {
+            view(point) = pixel;
+        }
+    }
+};
+
+} //namespace detail
 
 }} // namespace boost::gil
 

--- a/test/extension/image_processing/hough_circle_transform.cpp
+++ b/test/extension/image_processing/hough_circle_transform.cpp
@@ -23,8 +23,8 @@ namespace gil = boost::gil;
 template <typename Rasterizer>
 void exact_fit_test(std::ptrdiff_t radius, gil::point_t offset, Rasterizer rasterizer)
 {
-    std::vector<gil::point_t> circle_points(rasterizer.point_count(radius));
-    rasterizer(radius, offset, circle_points.begin());
+    std::vector<gil::point_t> circle_points(rasterizer.point_count());
+    rasterizer(circle_points.begin());
     // const std::ptrdiff_t diameter = radius * 2 - 1;
     const std::ptrdiff_t width = offset.x + radius + 1;
     const std::ptrdiff_t height = offset.y + radius + 1;
@@ -54,12 +54,12 @@ void exact_fit_test(std::ptrdiff_t radius, gil::point_t offset, Rasterizer raste
                    });
     gil::hough_circle_transform_brute(input, radius_parameter, x_parameter, y_parameter,
                                       output_views.begin(), rasterizer);
-    if (output_views[0](0, 0) != rasterizer.point_count(radius))
+    if (output_views[0](0, 0) != rasterizer.point_count())
     {
         std::cout << "accumulated value: " << static_cast<int>(output_views[0](0, 0))
-                  << " expected value: " << rasterizer.point_count(radius) << "\n\n";
+                  << " expected value: " << rasterizer.point_count() << "\n\n";
     }
-    BOOST_TEST(output_views[0](0, 0) == rasterizer.point_count(radius));
+    BOOST_TEST(output_views[0](0, 0) == rasterizer.point_count());
 }
 
 int main()
@@ -72,9 +72,10 @@ int main()
             for (std::ptrdiff_t y_offset = radius; y_offset < radius + test_dim_length; ++y_offset)
             {
 
-                exact_fit_test(radius, {x_offset, y_offset}, gil::midpoint_circle_rasterizer{});
                 exact_fit_test(radius, {x_offset, y_offset},
-                               gil::trigonometric_circle_rasterizer{});
+                                gil::midpoint_circle_rasterizer{{x_offset, y_offset}, radius});
+                exact_fit_test(radius, {x_offset, y_offset},
+                               gil::trigonometric_circle_rasterizer{{x_offset, y_offset}, radius});
             }
         }
     }

--- a/test/extension/image_processing/hough_line_transform.cpp
+++ b/test/extension/image_processing/hough_line_transform.cpp
@@ -36,11 +36,12 @@ void translate(std::vector<gil::point_t>& points, std::ptrdiff_t intercept)
 
 void hough_line_test(std::ptrdiff_t height, std::ptrdiff_t intercept)
 {
-    const auto rasterizer = gil::bresenham_line_rasterizer{};
     gil::gray8_image_t image(width, width, gil::gray8_pixel_t(0));
     auto input = gil::view(image);
-    std::vector<gil::point_t> line_points(rasterizer.point_count(width, height));
-    rasterizer({0, 0}, {width - 1, height - 1}, line_points.begin());
+
+    const auto rasterizer = gil::bresenham_line_rasterizer{{0, 0}, {width - 1, height - 1}};
+    std::vector<gil::point_t> line_points(rasterizer.point_count());
+    rasterizer(line_points.begin());
     translate(line_points, intercept);
     for (const auto& p : line_points)
     {

--- a/test/extension/rasterization/circle.cpp
+++ b/test/extension/rasterization/circle.cpp
@@ -15,13 +15,13 @@
 namespace gil = boost::gil;
 
 template <typename Rasterizer>
-void test_rasterizer_follows_equation(std::ptrdiff_t radius, Rasterizer rasterizer)
+void test_rasterizer_follows_equation(Rasterizer rasterizer)
 {
-
-    std::vector<gil::point_t> circle_points(rasterizer.point_count(radius));
+    const std::ptrdiff_t radius = rasterizer.radius;
+    std::vector<gil::point_t> circle_points(rasterizer.point_count());
     std::ptrdiff_t const r_squared = radius * radius;
-    rasterizer(radius, {0, 0}, circle_points.begin());
-    std::vector<gil::point_t> first_octant(rasterizer.point_count(radius) / 8);
+    rasterizer(circle_points.begin());
+    std::vector<gil::point_t> first_octant(rasterizer.point_count() / 8);
 
     for (std::size_t i = 0, octant_index = 0; i < circle_points.size(); i += 8, ++octant_index)
     {
@@ -38,10 +38,10 @@ void test_rasterizer_follows_equation(std::ptrdiff_t radius, Rasterizer rasteriz
 }
 
 template <typename Rasterizer>
-void test_connectivity(std::ptrdiff_t radius, Rasterizer rasterizer)
+void test_connectivity(Rasterizer rasterizer)
 {
-    std::vector<gil::point_t> circle_points(rasterizer.point_count(radius));
-    rasterizer(radius, {radius, radius}, circle_points.begin());
+    std::vector<gil::point_t> circle_points(rasterizer.point_count());
+    rasterizer(circle_points.begin());
     for (std::size_t i = 0; i < 8; ++i)
     {
         std::vector<gil::point_t> octant(circle_points.size() / 8);
@@ -65,11 +65,11 @@ int main()
 {
     for (std::ptrdiff_t radius = 5; radius <= 512; ++radius)
     {
-        test_rasterizer_follows_equation(radius, gil::midpoint_circle_rasterizer{});
+        test_rasterizer_follows_equation(gil::midpoint_circle_rasterizer{{0, 0}, radius});
         // TODO: find out a new testing procedure for trigonometric rasterizer
         // test_equation_following(radius, gil::trigonometric_circle_rasterizer{});
-        test_connectivity(radius, gil::midpoint_circle_rasterizer{});
-        test_connectivity(radius, gil::trigonometric_circle_rasterizer{});
+        test_connectivity(gil::midpoint_circle_rasterizer{{radius, radius}, radius});
+        test_connectivity(gil::trigonometric_circle_rasterizer{{radius, radius}, radius});
     }
 
     return boost::report_errors();

--- a/test/extension/rasterization/ellipse.cpp
+++ b/test/extension/rasterization/ellipse.cpp
@@ -72,9 +72,9 @@ int main()
     {
         for (float b = 1; b < 101; ++b)
         {
-            auto rasterizer = gil::midpoint_ellipse_rasterizer{};
-            std::vector<gil::point_t> points = rasterizer.obtain_trajectory(
-                {static_cast<unsigned int>(a), static_cast<unsigned int>(b)});
+            auto rasterizer = gil::midpoint_ellipse_rasterizer{{},
+                {static_cast<unsigned int>(a), static_cast<unsigned int>(b)}};
+            std::vector<gil::point_t> points = rasterizer.obtain_trajectory();
             test_rasterizer_follows_equation(points, a, b);
             test_connectivity(points);
         }

--- a/test/extension/rasterization/line.cpp
+++ b/test/extension/rasterization/line.cpp
@@ -49,9 +49,9 @@ endpoints create_endpoints(std::mt19937& twister,
 
 line_type create_line(endpoints points)
 {
-    gil::bresenham_line_rasterizer rasterizer;
-    line_type forward_line(rasterizer.point_count(points.start, points.end));
-    rasterizer(points.start, points.end, forward_line.begin());
+    gil::bresenham_line_rasterizer rasterizer(points.start, points.end);
+    line_type forward_line(rasterizer.point_count());
+    rasterizer(forward_line.begin());
     return forward_line;
 }
 


### PR DESCRIPTION
### Description

This PR implements the `gil::apply_rasterizer()` free function mentioned in #680.

However, I had to change the API of all three rasterizers quite considerably in order to squeeze them through this common interface. I am not sure if all those API changes are still debatable if we consider the deadline for Boost 1.80 in three days on 29th of June.

If you look at the updated examples, the usability is improved considerable (in my opinion) and it is still worth it (in my opinion) to discuss the PR, but I also understand that it might be too late for these kind of major API changes.


### References

#680

### Tasklist

- [x] Ensure all CI builds pass
- [x] Review and approve
