### PR TITLE
ci: Remove C++11 build jobs after C++14 switch

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,7 @@
 #
 version: 1.0.{build}-{branch}
 
-# Current Boost.GIL develop branch (future Boost 1.68) requires C++11
+# Current Boost.GIL develop branch requires C++14
 # Since VS2017, MSVC default is /std:c++14, so no explicit switch is required.
 image: Visual Studio 2017
 
@@ -17,18 +17,6 @@ shallow_clone: true
 
 environment:
   matrix:
-    - TOOLSET: msvc-14.0
-      ARCH: x86_64
-      VARIANT: debug
-      CXXSTD: 11
-      TEST_HEADERS: 1
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    - TOOLSET: msvc-14.0
-      ARCH: x86_64
-      VARIANT: release
-      CXXSTD: 11
-      TEST_HEADERS: 1
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     - TOOLSET: msvc-14.1
       ARCH: x86_64
       VARIANT: debug

--- a/.ci/azure-pipelines/steps-cmake-build-and-test.yml
+++ b/.ci/azure-pipelines/steps-cmake-build-and-test.yml
@@ -7,7 +7,7 @@
 parameters:
   # defaults, if not specified
   configuration: 'Release'
-  cxxver: '11'
+  cxxver: '14'
   enable_ext_io: 'OFF'
   enable_ext_numeric: 'ON'
   enable_ext_toolbox: 'ON'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,64 +19,64 @@ jobs:
       matrix:
         include:
           - toolset: gcc-6
-            cxxstd: "11,14,1z"
+            cxxstd: "14,1z"
             os: ubuntu-18.04
             install: g++-6
           - toolset: gcc-7
-            cxxstd: "11,14,17"
+            cxxstd: "14,17"
             os: ubuntu-18.04
           - toolset: gcc
             compiler: g++-8
-            cxxstd: "11,14"
+            cxxstd: "14"
             os: ubuntu-18.04
             install: g++-8
           - toolset: gcc-9
-            cxxstd: "11,14,17"
+            cxxstd: "14,17"
             os: ubuntu-18.04
           - toolset: gcc-10
-            cxxstd: "11,14,17"
+            cxxstd: "14,17"
             os: ubuntu-18.04
           - toolset: clang
             compiler: clang++-3.9
-            cxxstd: "11,14"
+            cxxstd: "14"
             os: ubuntu-18.04
             install: clang-3.9
           - toolset: clang
             compiler: clang++-4.0
-            cxxstd: "11,14"
+            cxxstd: "14"
             os: ubuntu-18.04
             install: clang-4.0
           - toolset: clang
             compiler: clang++-5.0
-            cxxstd: "11,14,1z"
+            cxxstd: "14,1z"
             os: ubuntu-18.04
             install: clang-5.0
           - toolset: clang
             compiler: clang++-6.0
-            cxxstd: "11,14,17"
+            cxxstd: "14,17"
             os: ubuntu-18.04
             install: clang-6.0
           - toolset: clang
             compiler: clang++-7
-            cxxstd: "11,14,17"
+            cxxstd: "14,17"
             os: ubuntu-18.04
             install: clang-7
           - toolset: clang
             compiler: clang++-8
-            cxxstd: "11,14,17"
+            cxxstd: "14,17"
             os: ubuntu-20.04
             install: clang-8
           - toolset: clang
             compiler: clang++-9
-            cxxstd: "11,14,17"
+            cxxstd: "14,17"
             os: ubuntu-20.04
             install: clang-9
           - toolset: clang
             compiler: clang++-10
-            cxxstd: "11,14,17"
+            cxxstd: "14,17"
             os: ubuntu-20.04
           - toolset: clang
-            cxxstd: "11,14,17"
+            cxxstd: "14,17"
             os: macos-10.15
 
     runs-on: ${{matrix.os}}
@@ -129,7 +129,7 @@ jobs:
             addrmd: 32,64
             os: windows-2019
           - toolset: gcc
-            cxxstd: "11,14,17"
+            cxxstd: "14,17"
             addrmd: 64
             os: windows-2019
           - toolset: msvc-14.3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Run tests
         run: |
           cd ../boost-root
-          ./b2 -j3 libs/$LIBRARY/test coverage=on toolset=gcc cxxstd=11 variant=debug
+          ./b2 -j3 libs/$LIBRARY/test coverage=on toolset=gcc cxxstd=14 variant=debug
           lcov --directory bin.v2 --capture --no-external --directory $(pwd) --output-file coverage.info > /dev/null 2>&1
           lcov --extract coverage.info $(pwd)'/boost/gil/*' --output-file coverage.info > /dev/null
           lcov --list coverage.info

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -21,7 +21,7 @@ import testing ;
 # <filesystem> header providing std::filesystem.
 # You can define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
 # to acknowledge that you have received this warning.
-local msvc-cxxs-with-experimental-fs = 11 14 ;
+local msvc-cxxs-with-experimental-fs = 14 ;
 
 project
   :
@@ -32,6 +32,8 @@ project
         cxx11_template_aliases
         cxx11_trailing_result_types  # implies decltype and auto
         cxx11_variadic_templates
+        cxx14_constexpr
+        cxx14_return_type_deduction
     ]
     <include>.
     # TODO: Enable concepts check for all, not just test/core


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

<!-- What does this pull request do? -->

We have switched to C++14 for Boost 1.80

### References

-  Closes #696
- Related to #699

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Ensure all CI builds pass
