### PR TITLE
docs: Bump C++11 to C++14 as current required

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ please follow the workflow explained in this document.
 
 ## Prerequisites
 
-- C++11 compiler
+- C++14 compiler
 - Build and run-time dependencies for tests and examples:
   - Boost.Filesystem
   - Boost.Test
@@ -359,25 +359,25 @@ Run core tests only specifying location of directory with tests:
 
 ```shell
 cd libs/gil
-b2 cxxstd=11 test/core
+b2 cxxstd=14 test/core
 ```
 
 Run all tests for selected extension (from Boost root directory, as alternative):
 
 ```shell
-b2 cxxstd=11 libs/gil/test/extension/dynamic_image
-b2 cxxstd=11 libs/gil/test/extension/io
-b2 cxxstd=11 libs/gil/test/extension/numeric
-b2 cxxstd=11 libs/gil/test/extension/toolbox
+b2 cxxstd=14 libs/gil/test/extension/dynamic_image
+b2 cxxstd=14 libs/gil/test/extension/io
+b2 cxxstd=14 libs/gil/test/extension/numeric
+b2 cxxstd=14 libs/gil/test/extension/toolbox
 ```
 
 Run I/O extension tests bundled in target called `simple`:
 
 ```shell
-b2 cxxstd=11 libs/gil/test/io//simple
+b2 cxxstd=14 libs/gil/test/io//simple
 ```
 
-**TIP:** Pass `b2` feature `cxxstd=11,14,17,2a` to request compilation for
+**TIP:** Pass `b2` feature `cxxstd=14,17,2a` to request compilation for
 multiple C++ standard versions in single build run.
 
 ### Using CMake
@@ -405,17 +405,17 @@ The provided CMake configuration allows a couple of ways to develop Boost.GIL:
 
 For CMake, you only need to build Boost libraries required by Boost.Test library
 which is used to run GIL tests. Since the `CMAKE_CXX_STANDARD` option in the current
-[CMakeLists.txt](CMakeLists.txt) defaults to C++11, pass the default `cxxstd=11` to `b2`:
+[CMakeLists.txt](CMakeLists.txt) defaults to C++14, pass the default `cxxstd=14` to `b2`:
 
   ```shell
   ./b2 headers
-  ./b2 variant=debug,release cxxstd=11 --with-filesystem stage
+  ./b2 variant=debug,release cxxstd=14 --with-filesystem stage
   ```
 
   or, depending on specific requirements, more complete build:
 
   ```shell
-  ./b2 variant=debug,release address-model=32,64 cxxstd=11 --layout=versioned --with-filesystem stage
+  ./b2 variant=debug,release address-model=32,64 cxxstd=14 --layout=versioned --with-filesystem stage
   ```
 
 If you wish to build tests using different C++ standard version, then adjust the `cxxstd` accordingly.
@@ -447,50 +447,52 @@ Here is an example of such lightweight workflow in Linux environment (Debian-bas
 - Configure build with CMake
 
     ```shell
-    mkdir _build
-    cd _build/
-    cmake ..
+    cmake -S . -B _build -DBoost_ADDITIONAL_VERSIONS=1.80 -DBoost_COMPILER=-gcc11 -DBoost_ARCHITECTURE=-x64
     ```
 
-    **TIP:** By default, tests and [examples](example/README.md) are compiled using
-    the minimum required C++11.
-    Specify `-DCMAKE_CXX_STANDARD=14|17|20` to use newer version.
+    By default, tests and [examples](example/README.md) are compiled using
+    the minimum required C++14.
+    Specify `-DCMAKE_CXX_STANDARD=17|20` to use newer version.
     For more CMake options available for GIL, check `option`-s defined
     in the top-level `CMakeLists.txt`.
 
-    **TIP:** If CMake is failing to find Boost libraries, especially built
-    with `--layout=versioned`, you can try a few hacks:
-      - option `-DBoost_ARCHITECTURE=-x64` to help CMake find Boost 1.66 and above
-        add an architecture tag to the library file names in versioned build
-        The option added in CMake 3.13.0.
+    CMake is failing to find Boost libraries, especially built with `--layout=versioned`,
+    you can try a few hacks as displayed in the command above:
       - option `-DBoost_COMPILER=-gcc5` or `-DBoost_COMPILER=-vc141` to help CMake earlier
         than 3.13 match your compiler with toolset used in the Boost library file names
         (i.e. `libboost_filesystem-gcc5-mt-x64-1_69` and not `-gcc55-`).
         Fixed in CMake 3.13.0.
+      - option `-DBoost_ARCHITECTURE=-x64` to help CMake find Boost 1.66 and above
+        add an architecture tag to the library file names in versioned build
+        The option added in CMake 3.13.0.
+      - option `-DDBoost_ADDITIONAL_VERSIONS=<unreleased Boost version>` is especially usefull
+        when testing GIL with staged build of Boost from its `develop` branch.
       - if CMake is still failing to find Boost, you may try `-DBoost_DEBUG=ON` to
         get detailed diagnostics output from `FindBoost.cmake` module.
 
 - List available CMake targets
 
     ```shell
-    cmake --build . --target help
+    cmake --build _build --target help
     ```
 
 - Build selected target with CMake
 
     ```shell
-    cmake --build . --target gil_test_pixel
+    cmake --build _build --target gil_test_pixel
     ```
 
 - List available CTest targets
 
     ```shell
+    cd __build
     ctest --show-only | grep Test
     ```
 
 - Run selected test with CTest
 
     ```shell
+    cd __build
     ctest -R gil.tests.core.pixel
     ```
 
@@ -567,10 +569,10 @@ Thus, below a few basic guidelines are listed.
 First and foremost, make sure you are familiar with the official
 [Boost Library Requirements and Guidelines](https://www.boost.org/development/requirements.html).
 
-Second, strive for writing idiomatic C++11, clean and elegant code.
+Second, strive for writing idiomatic C++14, clean and elegant code.
 
 **NOTE:** *The Boost.GIL source code does not necessary represent clean and elegant
-code to look up to. The library has recently entered the transition to C++11.
+code to look up to. The library has recently entered the transition to C++14.
 Major refactoring overhaul is ongoing.*
 
 Maintain structure your source code files according to the following guidelines:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Documentation | GitHub Actions | AppVeyor | Azure Pipelines | Regression | Codec
 
 Boost.GIL is a part of the [Boost C++ Libraries](http://github.com/boostorg).
 
-The Boost Generic Image Library (GIL) is a **C++11** header-only library that abstracts image
+The Boost Generic Image Library (GIL) is a **C++14** header-only library that abstracts image
 representations from algorithms and allows writing code that can work on a
 variety of images with performance similar to hand-writing for a specific image type.
 
@@ -52,11 +52,9 @@ See [example/cmake/README.md](example/cmake/README.md) for CMake configuration e
 
 ## Requirements
 
-**NOTE:** The library source code is currently being modernized for C++11.
-
 The Boost Generic Image Library (GIL) requires:
 
-- C++11 compiler (GCC 4.9, clang 3.3, MSVC++ 14.0 (1900) or any later version)
+- C++14 compiler (GCC 6, clang 3.9, MSVC++ 14.1 (1910) or any later version)
 - Boost header-only libraries
 
 Optionally, in order to build and run tests and examples:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,7 +1,7 @@
 Boost Generic Image Library
 ===========================
 
-The Generic Image Library (GIL) is a C++11 header-only library that abstracts image
+The Generic Image Library (GIL) is a C++14 header-only library that abstracts image
 representations from algorithms and allows writing code that can work on
 a variety of images with performance similar to hand-writing for a specific
 image type.

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -20,13 +20,11 @@ Compiling
 ---------
 
 The Boost.GIL library source code should successfully compile with any
-compiler with complete C++11 support.
+compiler with complete C++14 support.
 
 .. note::
 
-   We are planning to drop support for require C++14 support in Boost 1.76 or later,
-   or selectively drop support for GCC 5 due to its issues with inheriting constructors,
-   see `discussion for PR #526 <https://github.com/boostorg/gil/pull/526>`_.
+    Boost.GIL requires C++14 compiler since ince Boost 1.80.
 
 For the actual list of currently tested compilers, check results of the library CI
 builds linked from the `README.md <https://github.com/boostorg/gil/blob/develop/README.md>`_

--- a/example/adaptive_histogram_equalization.md
+++ b/example/adaptive_histogram_equalization.md
@@ -3,6 +3,7 @@
 Adaptive Histogram Equalization (AHE) capabilities in GIL are demonstrated by the program `adaptive_histogram_equalization`, compiled from the sources `example/adaptive_histogram_equalization.cpp`.
 
 ## Synopsis
+
 `adaptive_histogram_equalization`
 
 The program doesn't take any argument on the command line.
@@ -12,9 +13,11 @@ The program doesn't take any argument on the command line.
 ## Specific requirements
 
 ### Build requirements
-- A C++ compiler compliant with C++11 or above
+
+- A C++ compiler compliant with C++14 or above
 - The PNG library installed and configured.
 
 ### Execution requirements
+
 - `adaptive_histogram_equalization` expects to find an image called `test_adaptive.png` in the current directory.
 

--- a/example/adaptive_threshold.md
+++ b/example/adaptive_threshold.md
@@ -3,6 +3,7 @@
 Adaptive Thresholding capabilities in GIL are demonstrated by the program `adaptive_threshold`, compiled from the sources `example/adaptive_threshold.cpp`.
 
 ## Synopsis
+
 `adaptive_threshold`
 
 The program doesn't take any argument on the command line.
@@ -16,8 +17,10 @@ The program doesn't take any argument on the command line.
 ## Specific requirements
 
 ### Build requirements
-- A C++ compiler compliant with C++11 or above
+
+- A C++ compiler compliant with C++14 or above
 - The PNG library installed and configured.
 
 ### Execution requirements
+
 - `adaptive_threshold` expects to find an image called `test_adaptive.png` in the current directory.

--- a/example/affine.md
+++ b/example/affine.md
@@ -3,6 +3,7 @@
 Affine transformation capabilities in GIL are demonstrated by the program `affine`, compiled from the sources `example/affine.cpp`.
 
 ## Synopsis
+
 `affine`
 
 The program doesn't take any argument on the command line.
@@ -12,8 +13,10 @@ The program doesn't take any argument on the command line.
 ## Specific requirements
 
 ### Build requirements
-- A C++ compiler compliant with C++11 or above
+
+- A C++ compiler compliant with C++14 or above
 - The JPEG library installed and configured.
 
 ### Execution requirements
+
 - `affine` expects to find an image called `test.jpg` in the current directory.

--- a/example/anisotropic_diffusion.md
+++ b/example/anisotropic_diffusion.md
@@ -3,6 +3,7 @@
 Anisotropic diffusion capabilities in GIL are demonstrated by the program `anisotropic_diffusion`, compiled from the sources `example/anisotropic_diffusion.cpp`.
 
 ## Synopsis
+
 `anisoptropic_diffusion input.png output.png gray|rgb iterations kappa`
 - The first parameter must be the full path to an existing image in the JPEG format for `anisoptropic_diffusion` to process
 - The second parameter is the full path to the output image of `anisotropic_diffusion`. The directory will *not* be created and must exist.
@@ -15,8 +16,10 @@ Note that both the input and the ouput images must be in the PNG format.
 ## Specific requirements
 
 ### Build requirements
-- A C++ compiler compliant with C++11 or above
+
+- A C++ compiler compliant with C++14 or above
 - The PNG library installed and configured.
 
 ### Execution requirements
+
 `anisotropic_diffusion` has no specific execution requirements.

--- a/example/convolution.md
+++ b/example/convolution.md
@@ -3,6 +3,7 @@
 Convolution capabilities in GIL are demonstrated by the program `convolution`, compiled from the sources `example/convolution.cpp`.
 
 ## Synopsis
+
 `convolution`
 
 The program doesn't take any argument on the command line.
@@ -12,8 +13,10 @@ The program doesn't take any argument on the command line.
 ## Specific requirements
 
 ### Build requirements
-- A C++ compiler compliant with C++11 or above
+
+- A C++ compiler compliant with C++14 or above
 - The JPEG library installed and configured.
 
 ### Execution requirements
+
 - `convolution` expects to find an image called `test.jpg` in the current directory.

--- a/example/convolve2d.md
+++ b/example/convolve2d.md
@@ -3,6 +3,7 @@
 2d kernel convolution capabilities in GIL are demonstrated by the program `convolve2d`, compiled from the sources `example/convolve2d.cpp`.
 
 ## Synopsis
+
 `convolve2d`
 
 The program doesn't take any argument on the command line.
@@ -14,9 +15,11 @@ Note that the user is expected to press a key to end the program.
 ## Specific requirements
 
 ### Build requirements
-- A C++ compiler compliant with C++11 or above
+
+- A C++ compiler compliant with C++14 or above
 - The JPEG library installed and configured
 - The PNG library installed and configured.
 
 ### Execution requirements
+
 - `convolve2d` expects to find an image called `src_view.png` in the current directory.

--- a/example/dynamic_image.md
+++ b/example/dynamic_image.md
@@ -3,6 +3,7 @@
 Dynamic image manipulation capabilities in GIL are demonstrated by the program `dynamic_image`, compiled from the sources `example/dynamic_image.cpp`.
 
 ## Synopsis
+
 `dynamic_image`
 
 The program doesn't take any argument on the command line.
@@ -12,8 +13,10 @@ The program doesn't take any argument on the command line.
 ## Specific requirements
 
 ### Build requirements
-- A C++ compiler compliant with C++11 or above
+
+- A C++ compiler compliant with C++14 or above
 - The JPEG library installed and configured
 
 ### Execution requirements
+
 - `dynamic_image` expects to find an image called `test.jpg` in the current directory.

--- a/example/harris.md
+++ b/example/harris.md
@@ -3,6 +3,7 @@
 Harris corner detection capabilities in GIL are demonstrated by the program `harris`, compiled from the sources `example/harris.cpp` and `hvstack.hpp`.
 
 ## Synopsis
+
 `harris input.png window-size discriminant harris-threshold output.png`
 
 - The first parameter must be the full path to an existing image in the PNG format for `harris` to process
@@ -14,8 +15,10 @@ Harris corner detection capabilities in GIL are demonstrated by the program `har
 ## Specific requirements
 
 ### Build requirements
-- A C++ compiler compliant with C++11 or above
+
+- A C++ compiler compliant with C++14 or above
 - The PNG library installed and configured
 
 ### Execution requirements
+
 - `harris` has no specific execution requirements.

--- a/example/hessian.md
+++ b/example/hessian.md
@@ -13,7 +13,7 @@ Hessian feature detection capabilities in GIL are demonstrated by the program `h
 ## Specific requirements
 
 ### Build requirements
-- A C++ compiler compliant with C++11 or above
+- A C++ compiler compliant with C++14 or above
 - The PNG library installed and configured
 
 ### Execution requirements

--- a/example/histogram.md
+++ b/example/histogram.md
@@ -3,6 +3,7 @@
 Histogram capabilities in GIL are demonstrated by the program `histogram`, compiled from the sources `example/histogram.cpp`.
 
 ## Synopsis
+
 `histogram`
 
 The program doesn't take any argument on the command line.
@@ -13,8 +14,10 @@ The program doesn't produce any output.
 ## Specific requirements
 
 ### Build requirements
-- A C++ compiler compliant with C++11 or above
+
+- A C++ compiler compliant with C++14 or above
 - The PNG library installed and configured.
 
 ### Execution requirements
+
 - `histogram` expects to find an image called `test_adaptive.png` in the current directory.

--- a/example/histogram_equalization.md
+++ b/example/histogram_equalization.md
@@ -3,6 +3,7 @@
 Histogram equalization capabilities in GIL are demonstrated by the program `histogram_equalization`, compiled from the sources `example/histogram_equalization.cpp`.
 
 ## Synopsis
+
 `histogram_equalization`
 
 The program doesn't take any argument on the command line.
@@ -58,8 +59,10 @@ and is a hypotenuse! Using trivial trigonometry we know that the length we are s
 ## Specific requirements
 
 ### Build requirements
-- A C++ compiler compliant with C++11 or above
+
+- A C++ compiler compliant with C++14 or above
 - The PNG library installed and configured.
 
 ### Execution requirements
+
 - `histogram_equalization` expects to find an image called `test_adaptive.png` in the current directory.

--- a/example/histogram_matching.md
+++ b/example/histogram_matching.md
@@ -12,7 +12,7 @@ The program doesn't take any argument on the command line.
 ## Specific requirements
 
 ### Build requirements
-- A C++ compiler compliant with C++11 or above
+- A C++ compiler compliant with C++14 or above
 - The PNG library installed and configured.
 
 ### Execution requirements

--- a/example/hough_transform_circle.md
+++ b/example/hough_transform_circle.md
@@ -3,6 +3,7 @@
 Hough circle transform capabilities in GIL are demonstrated by the program `hough_transform_circle`, compiled from the sources `example/hough_transform_circle.cpp`.
 
 ## Synopsis
+
 `hough_transform_circle`
 
 The program doesn't take any argument on the command line.
@@ -12,7 +13,9 @@ The program outputs the voting cell of the centre of a circle drawn programatica
 ## Specific requirements
 
 ### Build requirements
-- A C++ compiler compliant with C++11 or above.
+
+- A C++ compiler compliant with C++14 or above.
 
 ### Execution requirements
+
 `hough_transform_circle` doesn't have any specific execution requirements.

--- a/example/hough_transform_line.md
+++ b/example/hough_transform_line.md
@@ -3,6 +3,7 @@
 Hough line transform capabilities in GIL are demonstrated by the program `hough_transform_line`, compiled from the sources `example/hough_transform_line.cpp`.
 
 ## Synopsis
+
 `hough_transform_line`
 
 The program doesn't take any argument on the command line.
@@ -12,7 +13,9 @@ The program outputs the expected theta and radius, followed by every step of the
 ## Specific requirements
 
 ### Build requirements
-- A C++ compiler compliant with C++11 or above.
+
+- A C++ compiler compliant with C++14 or above.
 
 ### Execution requirements
+
 `hough_transform_line` doesn't have any specific execution requirements.

--- a/example/interleaved_ptr.md
+++ b/example/interleaved_ptr.md
@@ -3,6 +3,7 @@
 Definition of custom pixel reference and iterator capabilities in GIL are demonstrated by the program `interleaved_ptr`, compiled from the sources `example/interleaved_ptr.cpp`, `interleaved_ptr.hpp` and `interleaved_ref.hpp`.
 
 ## Synopsis
+
 `interleaved_ptr`
 
 The program doesn't take any argument on the command line.
@@ -12,8 +13,10 @@ The program expects to find an image, `test.jpg` in the current directory, and p
 ## Specific requirements
 
 ### Build requirements
-- A C++ compiler compliant with C++11 or above
+
+- A C++ compiler compliant with C++14 or above
 - The JPEG library installed and configured.
 
 ### Execution requirements
+
 `interleaved_ptr` expects to find an image, `test.jpg` in the current directory.

--- a/example/mandelbrot.md
+++ b/example/mandelbrot.md
@@ -3,6 +3,7 @@
 Pixel iteration using `virtual_2d_locators` capabilities in GIL are demonstrated by the program `mandelbrot`, compiled from the sources `example/mandelbrot.cpp`.
 
 ## Synopsis
+
 `mandelbrot`
 
 The program doesn't take any argument on the command line.
@@ -12,8 +13,10 @@ The program produces the image `out-mandelbrot.jpg` that has been generated usin
 ## Specific requirements
 
 ### Build requirements
-- A C++ compiler compliant with C++11 or above
+
+- A C++ compiler compliant with C++14 or above
 - The JPEG library installed and configured.
 
 ### Execution requirements
+
 `mandelbrot` has no specific execution requirements.

--- a/example/morphology.md
+++ b/example/morphology.md
@@ -3,6 +3,7 @@
 Morphological operations capabilities in GIL are demonstrated by the program `morphology`, compiled from the sources `example/morphology.cpp`.
 
 ## Synopsis
+
 `morphology input.png output-image-template operation1 [operation2 ... operationN]`
 
 - The first parameter must be the full path to an existing image in the PNG format for `morphology` to process
@@ -24,8 +25,10 @@ The operations can be provided in any order, only note that if `binary` is suppl
 ## Specific requirements
 
 ### Build requirements
-- A C++ compiler compliant with C++11 or above
+
+- A C++ compiler compliant with C++14 or above
 - The PNG library installed and configured.
 
 ### Execution requirements
+
 `morphology` has no specific execution requirements.

--- a/example/packed_pixel.md
+++ b/example/packed_pixel.md
@@ -3,6 +3,7 @@
 Packed pixel formats capabilities in GIL are demonstrated by the program `packed_pixel`, compiled from the sources `example/packed_pixel.cpp`.
 
 ## Synopsis
+
 `packed_pixel`
 
 The program doesn't take any argument on the command line.
@@ -12,8 +13,10 @@ The program doesn't take any argument on the command line.
 ## Specific requirements
 
 ### Build requirements
-- A C++ compiler compliant with C++11 or above
+
+- A C++ compiler compliant with C++14 or above
 - The JPEG library installed and configured.
 
 ### Execution requirements
+
 `packed_pixel` expects to find an image called `input.jpg` in the current directory in JPEG format.

--- a/example/rasterizer_circle.md
+++ b/example/rasterizer_circle.md
@@ -3,6 +3,7 @@
 Circle rasterization capabilities in GIL are demonstrated by the program `rasterizer_circle`, compiled from the sources `example/rasterizer_circle.cpp`.
 
 ## Synopsis
+
 `rasterizer_circle`
 
 The program doesn't take any argument on the command line.
@@ -12,8 +13,10 @@ The program doesn't take any argument on the command line.
 ## Specific requirements
 
 ### Build requirements
-- A C++ compiler compliant with C++11 or above
+
+- A C++ compiler compliant with C++14 or above
 - The PNG library installed and configured.
 
 ### Execution requirements
+
 `rasterizer_circle` doesn't have any specific execution requirements.

--- a/example/rasterizer_ellipse.md
+++ b/example/rasterizer_ellipse.md
@@ -3,6 +3,7 @@
 Ellipse rasterization capabilities in GIL are demonstrated by the program `rasterizer_ellipse`, compiled from the sources `example/rasterizer_ellipse.cpp`.
 
 ## Synopsis
+
 `rasterizer_ellipse`
 
 The program doesn't take any argument on the command line.
@@ -15,8 +16,10 @@ The program doesn't take any argument on the command line.
 ## Specific requirements
 
 ### Build requirements
-- A C++ compiler compliant with C++11 or above
+
+- A C++ compiler compliant with C++14 or above
 - The JPEG library installed and configured.
 
 ### Execution requirements
+
 `rasterizer_ellipse` doesn't have any specific execution requirements.

--- a/example/rasterizer_line.md
+++ b/example/rasterizer_line.md
@@ -3,6 +3,7 @@
 Line rasterization capabilities in GIL are demonstrated by the program `rasterizer_line`, compiled from the sources `example/rasterizer_line.cpp`.
 
 ## Synopsis
+
 `rasterizer_line`
 
 The program doesn't take any argument on the command line.
@@ -16,8 +17,10 @@ The program doesn't take any argument on the command line.
 ## Specific requirements
 
 ### Build requirements
-- A C++ compiler compliant with C++11 or above
+
+- A C++ compiler compliant with C++14 or above
 - The PNG library installed and configured.
 
 ### Execution requirements
+
 `rasterizer_line` doesn't have any specific execution requirements.

--- a/example/resize.md
+++ b/example/resize.md
@@ -3,6 +3,7 @@
 Resizing capabilities in GIL are demonstrated by the program `resize`, compiled from the sources `example/resize.cpp`.
 
 ## Synopsis
+
 `resize`
 
 This program expects to find an image called `test.jpg`, in JPEG format, in the current directory, and produces a scaled down version of this image, called `out-resize.jpg`, in JPEG format in the current directory.
@@ -12,8 +13,10 @@ The program doesn't take any argument on the command line.
 ## Specific requirements
 
 ### Build requirements
-- A C++ compiler compliant with C++11 or above
+
+- A C++ compiler compliant with C++14 or above
 - The JPEG library installed and configured.
 
 ### Execution requirements
+
 `resize` expects to find an image called `test.jpg`, in JPEG format, in the current directory.

--- a/example/sobel_scharr.md
+++ b/example/sobel_scharr.md
@@ -3,6 +3,7 @@
 Edge detection via Sobel and Scharr filters capabilities in GIL are demonstrated by the program `sobel_scharr`, compiled from the sources `example/sobel_scharr.cpp`.
 
 ## Synopsis
+
 `sobel_scharr input.png sobel|scharr output-x.png output-y.png`
 
 - The first argument must be the full path to an existing image in PNG format
@@ -13,8 +14,10 @@ Edge detection via Sobel and Scharr filters capabilities in GIL are demonstrated
 ## Specific requirements
 
 ### Build requirements
-- A C++ compiler compliant with C++11 or above
+
+- A C++ compiler compliant with C++14 or above
 - The PNG library installed and configured.
 
 ### Execution requirements
+
 `sobek_scharr` doesn't have any specific execution requirements.

--- a/example/threshold.md
+++ b/example/threshold.md
@@ -3,6 +3,7 @@
 Thresholding capabilities in GIL are demonstrated by the program `threshold`, compiled from the sources `example/threshold.cpp`.
 
 ## Synopsis
+
 `threshold`
 
 The program expects to find an image in the JPEG format in the current directory named `input.jpg`, and produces two images in JPEG format in the current directory in return, named `out-threshold-binary.jpg` and `out-threshold-binary-inv.jpg`, where a thresholding and an inverse thresholding, respectively, has been applied.
@@ -12,8 +13,10 @@ The program doesn't take any command line arguments.
 ## Specific requirements
 
 ### Build requirements
-- A C++ compiler compliant with C++11 or above
+
+- A C++ compiler compliant with C++14 or above
 - The JPEG library installed and configured.
 
 ### Execution requirements
+
 `threshold` expects to find an image in the JPEG format in the current directory.

--- a/example/tutorial_histogram.md
+++ b/example/tutorial_histogram.md
@@ -3,6 +3,7 @@
 Histogram computation capabilities in GIL are demonstrated by the program `tutorial_histogram`, compiled from the sources `example/tutorial_histogram.cpp`.
 
 ## Synopsis
+
 `tutorial_histogram`
 
 The program expects to find an image in the JPEG format in the current directory named `input.jpg`, and produces a text file named `out-histogram.txt`, in the current direction, where the histogram has been calculated..
@@ -12,8 +13,10 @@ The program doesn't take any command line arguments.
 ## Specific requirements
 
 ### Build requirements
-- A C++ compiler compliant with C++11 or above
+
+- A C++ compiler compliant with C++14 or above
 - The JPEG library installed and configured.
 
 ### Execution requirements
+
 `tutorial_histogram` expects to find an image in the JPEG format in the current directory.

--- a/example/x_gradient.md
+++ b/example/x_gradient.md
@@ -3,6 +3,7 @@
 Gradients calculations capabilities in GIL are demonstrated by the program `x_gradient`, compiled from the sources `example/x_gradient.cpp`.
 
 ## Synopsis
+
 `x_gradient`
 
 The program expects to find an image in the JPEG format in the current directory named `input.jpg`, and produces an image in JPEG format in the current directory in return, named `out-x_gradient.jpg`, where the gradients have been captured.
@@ -12,8 +13,10 @@ The program doesn't take any command line arguments.
 ## Specific requirements
 
 ### Build requirements
-- A C++ compiler compliant with C++11 or above
+
+- A C++ compiler compliant with C++14 or above
 - The JPEG library installed and configured.
 
 ### Execution requirements
+
 `x_gradient` expects to find an image in the JPEG format in the current directory.


### PR DESCRIPTION
### References

Related to:
- #677
- #698
- #699

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Ensure all CI builds pass
