### PR TITLE
fix: broken build for midpoint_ellipse_rasterizer::draw_curve

### DIFF
--- a/include/boost/gil/extension/rasterization/ellipse.hpp
+++ b/include/boost/gil/extension/rasterization/ellipse.hpp
@@ -183,7 +183,7 @@ struct midpoint_ellipse_rasterizer
     template<typename View, typename Pixel>
     void operator()(View& view, Pixel const& pixel) const
     {
-        draw_curve(view, obtain_trajectory());
+        draw_curve(view, pixel, obtain_trajectory());
     }
 
     point<unsigned int> center;

--- a/test/core/point/test_fixture.hpp
+++ b/test/core/point/test_fixture.hpp
@@ -1,0 +1,22 @@
+//
+// Copyright 2022 Marco Langer <langer.m86@gmail.com>
+//
+// Use, modification and distribution are subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/gil/point.hpp>
+
+#include <ostream>
+
+namespace boost { namespace gil {
+
+// necessary to use point directly with boost test macros
+template <typename T>
+auto operator<<(std::ostream& os, point<T> const& p) -> std::ostream&
+{
+    return os << "{x=" << p.x << ", y=" << p.y << "}";
+}
+
+}} // namespace boost::gil

--- a/test/extension/rasterization/Jamfile
+++ b/test/extension/rasterization/Jamfile
@@ -8,6 +8,7 @@
 #
 import testing ;
 
+run apply_rasterizer.cpp ;
 run line.cpp ;
 run circle.cpp ;
 run ellipse.cpp ;

--- a/test/extension/rasterization/apply_rasterizer.cpp
+++ b/test/extension/rasterization/apply_rasterizer.cpp
@@ -1,0 +1,35 @@
+//
+// Copyright 2022 Marco Langer <langer.m86@gmail.com>
+//
+// Use, modification and distribution are subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/gil.hpp>
+#include <boost/gil/extension/rasterization/circle.hpp>
+#include <boost/gil/extension/rasterization/ellipse.hpp>
+#include <boost/gil/extension/rasterization/line.hpp>
+
+#include <boost/core/lightweight_test.hpp>
+
+namespace gil = boost::gil;
+
+template <typename Rasterizer>
+void test_apply_rasterizers(Rasterizer const& rasterizer)
+{
+    gil::rgb8_image_t image(200, 200);
+    gil::rgb8_pixel_t pixel{255, 0, 0};
+
+    apply_rasterizer(view(image), rasterizer, pixel);
+}
+
+int main()
+{
+    test_apply_rasterizers(gil::midpoint_circle_rasterizer{{50, 50}, 30});
+    test_apply_rasterizers(gil::trigonometric_circle_rasterizer{{50, 50}, 30});
+    test_apply_rasterizers(gil::midpoint_ellipse_rasterizer{{50, 50}, {30, 20}});
+    test_apply_rasterizers(gil::bresenham_line_rasterizer{{50, 50}, {30, 20}});
+
+    return boost::report_errors();
+}

--- a/test/extension/rasterization/circle.cpp
+++ b/test/extension/rasterization/circle.cpp
@@ -1,4 +1,3 @@
-// Boost.GIL (Generic Image Library) - tests
 //
 // Copyright 2020 Olzhas Zhumabek <anonymous.from.applecity@gmail.com>
 //
@@ -7,9 +6,13 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //
 
+#include <boost/gil/point.hpp>
+#include <boost/gil/extension/rasterization/circle.hpp>
+
 #include <boost/core/lightweight_test.hpp>
-#include "boost/gil/extension/rasterization/circle.hpp"
-#include <cstddef>
+
+#include <cmath>
+#include <cstdint>
 #include <vector>
 
 namespace gil = boost::gil;
@@ -17,7 +20,7 @@ namespace gil = boost::gil;
 template <typename Rasterizer>
 void test_rasterizer_follows_equation(Rasterizer rasterizer)
 {
-    const std::ptrdiff_t radius = rasterizer.radius;
+    std::ptrdiff_t const radius = rasterizer.radius;
     std::vector<gil::point_t> circle_points(rasterizer.point_count());
     std::ptrdiff_t const r_squared = radius * radius;
     rasterizer(circle_points.begin());
@@ -28,9 +31,9 @@ void test_rasterizer_follows_equation(Rasterizer rasterizer)
         first_octant[octant_index] = circle_points[i];
     }
 
-    for (const auto& point : first_octant)
+    for (auto const& point : first_octant)
     {
-        double y_exact = std::sqrt(r_squared - point.x * point.x);
+        double const y_exact = std::sqrt(r_squared - point.x * point.x);
         std::ptrdiff_t lower_result = static_cast<std::ptrdiff_t>(std::floor(y_exact));
         std::ptrdiff_t upper_result = static_cast<std::ptrdiff_t>(std::ceil(y_exact));
         BOOST_TEST(point.y >= lower_result && point.y <= upper_result);

--- a/test/extension/rasterization/ellipse.cpp
+++ b/test/extension/rasterization/ellipse.cpp
@@ -5,10 +5,14 @@
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
+
+#include <boost/gil/point.hpp>
+#include <boost/gil/extension/rasterization/ellipse.hpp>
+
 #include <boost/core/lightweight_test.hpp>
-#include <boost/gil.hpp>
 
 #include <cmath>
+#include <cstdint>
 #include <vector>
 
 namespace gil = boost::gil;

--- a/test/extension/rasterization/line.cpp
+++ b/test/extension/rasterization/line.cpp
@@ -1,4 +1,3 @@
-// Boost.GIL (Generic Image Library) - tests
 //
 // Copyright 2020 Olzhas Zhumabek <anonymous.from.applecity@gmail.com>
 //
@@ -7,24 +6,24 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //
 
-#include <algorithm>
-#include <boost/core/lightweight_test.hpp>
-#include "boost/gil/point.hpp"
-#include "boost/gil/extension/rasterization/line.hpp"
+#include <boost/gil/point.hpp>
+#include <boost/gil/extension/rasterization/line.hpp>
 
+#include <boost/core/lightweight_test.hpp>
+
+#include <algorithm>
 #include <cmath>
-#include <cstddef>
+#include <cstdint>
 #include <iterator>
 #include <random>
 #include <vector>
 
 namespace gil = boost::gil;
 
-namespace boost
-{
-namespace gil
-{
-std::ostream& operator<<(std::ostream& os, const point_t p)
+// TODO move into separate file to make it accessible also for other tests
+// operator<< overload is needed to use points directly with boost test macros
+namespace boost { namespace gil {
+std::ostream& operator<<(std::ostream& os, point_t const& p)
 {
     os << "{x=" << p.x << ", y=" << p.y << "}";
     return os;
@@ -55,7 +54,7 @@ line_type create_line(endpoints points)
     return forward_line;
 }
 
-void test_start_end(const line_type& line_points, endpoints points)
+void test_start_end(line_type const& line_points, endpoints points)
 {
     BOOST_TEST_EQ(line_points.front(), points.start);
     BOOST_TEST_EQ(line_points.back(), points.end);

--- a/test/extension/rasterization/line.cpp
+++ b/test/extension/rasterization/line.cpp
@@ -6,6 +6,8 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //
 
+#include "core/point/test_fixture.hpp"
+
 #include <boost/gil/point.hpp>
 #include <boost/gil/extension/rasterization/line.hpp>
 
@@ -19,16 +21,6 @@
 #include <vector>
 
 namespace gil = boost::gil;
-
-// TODO move into separate file to make it accessible also for other tests
-// operator<< overload is needed to use points directly with boost test macros
-namespace boost { namespace gil {
-std::ostream& operator<<(std::ostream& os, point_t const& p)
-{
-    os << "{x=" << p.x << ", y=" << p.y << "}";
-    return os;
-}
-}} // namespace boost::gil
 
 using line_type = std::vector<gil::point_t>;
 


### PR DESCRIPTION
### Description

This PR fixes a bug in `midpoint_ellipse_rasterizer::draw_curve()`, [which I have introduced in my other PR](https://github.com/boostorg/gil/pull/695) while working on the `apply_rasterizer` function. I have also added missing test cases to cover these invocations.

### Tasklist
- [x] Add test case(s)
- [x] Ensure all CI builds pass
- [x] Review and approve
