### PR TITLE
docs: Updated readme language badge to C++14

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Boost Generic Image Library (GIL)](https://raw.githubusercontent.com/boostorg/gil/develop/doc/_static/gil.png)
 
-[![Language](https://img.shields.io/badge/C%2B%2B-11-blue.svg)](https://en.wikipedia.org/wiki/C%2B%2B#Standardization)
+[![Language](https://img.shields.io/badge/C%2B%2B-14-blue.svg)](https://en.wikipedia.org/wiki/C%2B%2B#Standardization)
 [![License](https://img.shields.io/badge/license-BSL-blue.svg)](https://opensource.org/licenses/BSL-1.0)
 [![Documentation](https://img.shields.io/badge/gil-documentation-blue.svg)](http://boostorg.github.com/gil/)
 [![Wiki](https://img.shields.io/badge/gil-wiki-blue.svg)](https://github.com/boostorg/gil/wiki)


### PR DESCRIPTION
### Description

This PR updates the README.md language badge from C++11 to C++14.

Also still needed: change the topic in the about section from "cplusplus-11" to "cplusplus-14".