### PR TITLE
fix: Broken build of test project for gcc-5

### DIFF
--- a/test/extension/toolbox/color_convert_hsl.cpp
+++ b/test/extension/toolbox/color_convert_hsl.cpp
@@ -35,14 +35,14 @@ void test_colors_hsl_to_rgb()
 {
     using color_t = std::tuple<float, float, float, std::uint8_t, std::uint8_t, std::uint8_t>;
     std::vector<color_t> colors = {
-        {0, 0, 0, 0, 0, 0},               // black
-        {0, 0, 1, 255, 255, 255},         // white
-        {0, 1, 0.5, 255, 0, 0},           // red
-        {2 / 6.f, 1, 0.5, 0, 255, 0},     // lime
-        {4 / 6.f, 1, 0.5, 0, 0, 255},     // blue
-        {5 / 6.f, 1, 0.25, 128, 0, 128},  // purple
-        {3 / 6.f, 1, 0.25, 0, 128, 128},  // teal
-        {4 / 6.f, 1, 0.25, 0, 0, 128},    // navy
+        color_t{0, 0, 0, 0, 0, 0},               // black
+        color_t{0, 0, 1, 255, 255, 255},         // white
+        color_t{0, 1, 0.5, 255, 0, 0},           // red
+        color_t{2 / 6.f, 1, 0.5, 0, 255, 0},     // lime
+        color_t{4 / 6.f, 1, 0.5, 0, 0, 255},     // blue
+        color_t{5 / 6.f, 1, 0.25, 128, 0, 128},  // purple
+        color_t{3 / 6.f, 1, 0.25, 0, 128, 128},  // teal
+        color_t{4 / 6.f, 1, 0.25, 0, 0, 128},    // navy
     };
 
     for (auto&& color : colors)

--- a/test/extension/toolbox/color_convert_rgb.cpp
+++ b/test/extension/toolbox/color_convert_rgb.cpp
@@ -35,22 +35,22 @@ void test_colors_rgb_to_hsl()
 {
     using color_t = std::tuple<std::uint8_t, std::uint8_t, std::uint8_t, float, float, float>;
     std::vector<color_t> colors = {
-        {0, 0, 0, 0, 0, 0},               // black
-        {255, 255, 255, 0, 0, 1},         // white
-        {255, 0, 0, 0, 1, 0.5},           // red
-        {0, 255, 0, 2 / 6.f, 1, 0.5},     // lime
-        {0, 0, 255, 4 / 6.f, 1, 0.5},     // blue
-        {255, 255, 0, 1 / 6.f, 1, 0.5},   // yellow
-        {0, 255, 255, 3 / 6.f, 1, 0.5},   // cyan
-        {255, 0, 255, 5 / 6.f, 1, 0.5},   // magenta
-        {191, 191, 191, 0, 0, 0.75},      // silver
-        {128, 128, 128, 0, 0, 0.5},       // gray
-        {128, 0, 0, 0, 1, 0.25},          // maroon
-        {128, 128, 0, 1 / 6.f, 1, 0.25},  // olive
-        {0, 128, 0, 2 / 6.f, 1, 0.25},    // green
-        {128, 0, 128, 5 / 6.f, 1, 0.25},  // purple
-        {0, 128, 128, 3 / 6.f, 1, 0.25},  // teal
-        {0, 0, 128, 4 / 6.f, 1, 0.25},    // navy
+        color_t{0, 0, 0, 0, 0, 0},               // black
+        color_t{255, 255, 255, 0, 0, 1},         // white
+        color_t{255, 0, 0, 0, 1, 0.5},           // red
+        color_t{0, 255, 0, 2 / 6.f, 1, 0.5},     // lime
+        color_t{0, 0, 255, 4 / 6.f, 1, 0.5},     // blue
+        color_t{255, 255, 0, 1 / 6.f, 1, 0.5},   // yellow
+        color_t{0, 255, 255, 3 / 6.f, 1, 0.5},   // cyan
+        color_t{255, 0, 255, 5 / 6.f, 1, 0.5},   // magenta
+        color_t{191, 191, 191, 0, 0, 0.75},      // silver
+        color_t{128, 128, 128, 0, 0, 0.5},       // gray
+        color_t{128, 0, 0, 0, 1, 0.25},          // maroon
+        color_t{128, 128, 0, 1 / 6.f, 1, 0.25},  // olive
+        color_t{0, 128, 0, 2 / 6.f, 1, 0.25},    // green
+        color_t{128, 0, 128, 5 / 6.f, 1, 0.25},  // purple
+        color_t{0, 128, 128, 3 / 6.f, 1, 0.25},  // teal
+        color_t{0, 0, 128, 4 / 6.f, 1, 0.25},    // navy
     };
 
     for (auto&& color : colors)


### PR DESCRIPTION
### Description

This PR fixes the broken build of the test project for gcc-5 and closes thereby #709 and #710.

Maybe this PR will also close #711. I had difficulties to reproduce the bug, as using godbolt [does not reproduce this bug using clang 3.9](https://godbolt.org/z/PxcTEEWq1).

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Ensure all CI builds pass
- [x] Review and approve
