### PR TITLE
ci: replace Ubuntu 18.04 on GHA with Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,14 +28,16 @@ jobs:
           - toolset: gcc
             compiler: g++-8
             cxxstd: "14"
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             install: g++-8
           - toolset: gcc-9
             cxxstd: "14,17"
-            os: ubuntu-18.04
+            os: ubuntu-20.04
+            install: g++-9
           - toolset: gcc-10
             cxxstd: "14,17"
-            os: ubuntu-18.04
+            os: ubuntu-20.04
+            install: g++-10
           - toolset: clang
             compiler: clang++-3.9
             cxxstd: "14"
@@ -54,12 +56,12 @@ jobs:
           - toolset: clang
             compiler: clang++-6.0
             cxxstd: "14,17"
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             install: clang-6.0
           - toolset: clang
             compiler: clang++-7
             cxxstd: "14,17"
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             install: clang-7
           - toolset: clang
             compiler: clang++-8


### PR DESCRIPTION
### Description

GitHub started the deprecation process for Ubuntu 18.04 Action runners on 2022-08-08, and Ubuntu 18.04 will be completely unsupported by 2022-12-01 (if things proceed as planned).

So this PR tries to replace all Ubuntu 18.04 runners with the next newest Ubuntu 20.04 runner. I don't think this will work on first try, but we need to start somewhere.

So this commit replace those Ubuntu 18.04 jobs with the next newest Ubuntu 20.04 runner that have shown to still work with the newer version. The other five GHA jobs with Ubuntu 18.04 (gcc-6, gcc-7, clang++-3.9, clang++-4.0, clang++-5.0) still need to be dealt with separately later.

### References

See <https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/> for the deprecation announcement and more information on that.

### Tasklist

- [x] Ensure all CI builds pass
- [x] Review and approve
