### PR TITLE
Support newer version of Sphinx

### DIFF
--- a/doc/_static/boost.css
+++ b/doc/_static/boost.css
@@ -714,3 +714,22 @@ span.purple { color: purple; }
 span.gold { color: gold; }
 span.silver { color: silver; } /* lighter gray */
 span.gray { color: #808080; } /* light gray */
+
+/* 2022 fix */
+
+ol.simple ol p,
+ol.simple ul p,
+ul.simple ol p,
+ul.simple ul p {
+    margin-top: 0;
+}
+
+ol.simple > li:not(:first-child) > p,
+ul.simple > li:not(:first-child) > p {
+    margin-top: 0;
+}
+
+ol.simple p,
+ul.simple p {
+    margin-bottom: 0;
+}

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -49,6 +49,9 @@
     {%- for scriptfile in script_files %}
     <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>
     {%- endfor %}
+    <script data-url_root="{{ pathto('', 1) }}" id="documentation_options" src="{{ pathto('', 1) }}_static/documentation_options.js"></script>
+    <script src="{{ pathto('', 1) }}_static/searchtools.js"></script>
+    <script src={{ pathto('', 1) }}"_static/language_data.js"></script>
     {%- if use_opensearch %}
     <link rel="search" type="application/opensearchdescription+xml"
           title="{% trans docstitle=docstitle|e %}Search within {{ docstitle }}{% endtrans %}"


### PR DESCRIPTION
Hi,

The current boostorg/boost bundle has been created using Sphinx version 1.5.6 

If upgrading _all_ packages and Sphinx changes to 5.2.1 , the gil docs are slightly broken. 

- Search doesn't work  
- bullet lists are widely spaced   

Researched the problems in https://github.com/sphinx-doc/sphinx/issues . After some experimentation, it looks like the fix in this pull request solves the issues. 
