### PR TITLE
Fixed custom color converter in dynamic_factory and added corresponding

### DIFF
--- a/test/extension/dynamic_image/image_view_factory.cpp
+++ b/test/extension/dynamic_image/image_view_factory.cpp
@@ -83,10 +83,77 @@ struct test_flipped_up_down_view
     }
 };
 
+template<typename V1, typename V2>
+bool equal_pixels_values(V1&& v1, 
+    V2&& v2,
+    float threshold = 1e-3f)
+{
+// convert both images to rgba32f and compare with threshold
+   return boost::variant2::visit([=](auto const& v1, auto const& v2) {
+        auto it1 = v1.begin();
+        auto it2 = v2.begin();
+        while(it1 != v1.end() && it2 != v2.end()) {
+            using pixel_t = gil::rgba32f_pixel_t;
+            static constexpr std::size_t num_channels = gil::num_channels<pixel_t>::value;
+            pixel_t p1{};
+            gil::color_convert(*it1++, p1);
+            pixel_t p2{};
+            gil::color_convert(*it2++, p2);
+            for(size_t i = 0; i < num_channels; ++i) {
+                if(std::abs(p1[i] - p2[i]) > threshold){
+                    return false;
+                }
+            }
+        }
+        return true;
+    }, 
+    std::forward<V1>(v1), 
+    std::forward<V2>(v2));
+}
+
+struct test_color_converted_view
+{
+    static void run()
+    {
+        using dynamic_image_t = gil::any_image<gil::gray8_image_t, gil::gray16_image_t>;
+        using src_image_t = gil::gray8_image_t;
+        using dst_image_t = gil::gray16_image_t;
+        using dst_pixel_t = typename dst_image_t::value_type;
+        static constexpr std::size_t num_channels = 1;
+        auto color_converter = [](auto const& src, auto& dst) { dst = 2 * src; };
+        std::array<int, 9> pixel_data =
+        {
+            0, 1, 2,
+            3, 4, 5,
+            6, 7, 8
+        };
+        std::array<int, 9> expected_pixel_data;
+        std::transform(std::begin(expected_pixel_data), 
+            std::end(expected_pixel_data), 
+            std::begin(expected_pixel_data), 
+            [](auto v) { return 2 * v; });
+
+        dynamic_image_t source_image =
+        fixture::generate_image<src_image_t>(
+                3, 3, generator<num_channels>{pixel_data.data()});
+
+        dynamic_image_t expected_image =
+            fixture::generate_image<dst_image_t>(
+                3, 3, generator<num_channels>{expected_pixel_data.data()});
+
+        auto result_view = gil::color_converted_view<dst_pixel_t>(gil::const_view(source_image), color_converter);
+             
+        BOOST_TEST(equal_pixels_values(result_view, 
+            gil::const_view(expected_image), 
+            1e-3f)); 
+    }
+};
 
 int main()
 {
     test_flipped_up_down_view::run();
+
+    test_color_converted_view::run();
 
     return ::boost::report_errors();
 }

--- a/test/extension/dynamic_image/image_view_factory.cpp
+++ b/test/extension/dynamic_image/image_view_factory.cpp
@@ -86,10 +86,10 @@ struct test_flipped_up_down_view
 template<typename V1, typename V2>
 bool equal_pixels_values(V1&& v1, 
     V2&& v2,
-    float threshold = 1e-3f)
+    float threshold = 1e-6f)
 {
 // convert both images to rgba32f and compare with threshold
-   return boost::variant2::visit([=](auto const& v1, auto const& v2) {
+   return boost::variant2::visit([=](auto const& v1, auto const& v2) -> bool {
         auto it1 = v1.begin();
         auto it2 = v2.begin();
         while(it1 != v1.end() && it2 != v2.end()) {
@@ -128,8 +128,8 @@ struct test_color_converted_view
             6, 7, 8
         };
         std::array<int, 9> expected_pixel_data;
-        std::transform(std::begin(expected_pixel_data), 
-            std::end(expected_pixel_data), 
+        std::transform(std::begin(pixel_data), 
+            std::end(pixel_data), 
             std::begin(expected_pixel_data), 
             [](auto v) { return 2 * v; });
 
@@ -145,7 +145,7 @@ struct test_color_converted_view
              
         BOOST_TEST(equal_pixels_values(result_view, 
             gil::const_view(expected_image), 
-            1e-3f)); 
+            1e-6f)); 
     }
 };
 


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

The function color_converted_view for dynamic views with a custom color converter ignores the provided color converter. 
This pr fixes this issue as well as some compilation failures related to it. A corresponding test is included


