### PR TITLE
Make locator.hpp self contained

### DIFF
--- a/include/boost/gil/locator.hpp
+++ b/include/boost/gil/locator.hpp
@@ -8,8 +8,7 @@
 #ifndef BOOST_GIL_LOCATOR_HPP
 #define BOOST_GIL_LOCATOR_HPP
 
-#include <boost/gil/dynamic_step.hpp>
-#include <boost/gil/pixel_iterator.hpp>
+#include <boost/gil/step_iterator.hpp>
 #include <boost/gil/point.hpp>
 
 #include <boost/assert.hpp>


### PR DESCRIPTION
### Description

`locator` implementation uses `make_step_iterator()` but `step_iterator.hpp` is not included.

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Ensure all CI builds pass
- [x] Review and approve
