### PR TITLE
fix: Make locator.hpp self contained (#729)

### DIFF
--- a/include/boost/gil/locator.hpp
+++ b/include/boost/gil/locator.hpp
@@ -8,8 +8,7 @@
 #ifndef BOOST_GIL_LOCATOR_HPP
 #define BOOST_GIL_LOCATOR_HPP
 
-#include <boost/gil/dynamic_step.hpp>
-#include <boost/gil/pixel_iterator.hpp>
+#include <boost/gil/step_iterator.hpp>
 #include <boost/gil/point.hpp>
 
 #include <boost/assert.hpp>


### PR DESCRIPTION
On Mar 21, 2023, at 8:59 AM, Samuel DEBIONNE via Boost [<boost@lists.boost.org>](mailto:boost@lists.boost.org) wrote:
>
> Hello,
> I would like to merge a "missing include" fix from Boost.GIL to master:
>
> https://github.com/boostorg/gil/pull/729

Go ahead

— Marshall
