### PR TITLE
ci: fix Python package in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,7 @@ jobs:
       - name: install packages
         run: |
           sudo apt update
-          sudo apt install g++ libpng-dev libjpeg-dev libtiff5-dev libraw-dev lcov python -y
+          sudo apt install g++ libpng-dev libjpeg-dev libtiff5-dev libraw-dev lcov python-is-python3 -y
 
       - name: Setup Boost
         run: |


### PR DESCRIPTION
### Description

This pull request fixes the `E: Package 'python' has no installation candidate` error in the coverage workflow by providing an existing package.

The Python package in Ubuntu 22.04 is `python3`, but I decided to go for [`python-is-python3`](https://packages.ubuntu.com/jammy/python-is-python3) instead, because that makes sure that `python3` is installed (as dependency) and also creates a symlink from `/usr/bin/python` to `python3` as a way to make sure that commands with just `python` (instead of `python3`) also invoke the installed version of Python 3.

### References

See https://github.com/boostorg/gil/actions/runs/7317309558/job/19932692704 for an example of a currently failing coverage job.

### Tasklist

- [ ] Ensure all CI builds pass
- [ ] Review and approve
