### PR TITLE
Update Boost.Filesystem usage

### DIFF
--- a/test/extension/io/png/png_file_format_test.cpp
+++ b/test/extension/io/png/png_file_format_test.cpp
@@ -42,14 +42,14 @@ void test_file_format()
         fs::directory_iterator end_iter;
         for (fs::directory_iterator dir_itr(in_path); dir_itr != end_iter; ++dir_itr)
         {
-            if (fs::is_regular(dir_itr->status()) && (fs::extension(dir_itr->path()) == ".PNG"))
+            if (fs::is_regular_file(dir_itr->status()) && (dir_itr->path().extension().string() == ".PNG"))
             {
                 gil::rgb8_image_t img;
-                std::string filename = in + dir_itr->path().leaf().string();
+                std::string filename = in + dir_itr->path().filename().string();
                 gil::read_and_convert_image(filename, img, gil::png_tag());
 
 #ifdef BOOST_GIL_IO_TEST_ALLOW_WRITING_IMAGES
-                gil::write_view(png_out + fs::basename(dir_itr->path()) + ".png",
+                gil::write_view(png_out + dir_itr->path().stem().string() + ".png",
                     gil::view(img), gil::png_tag());
 #endif  // BOOST_GIL_IO_TEST_ALLOW_WRITING_IMAGES
             }


### PR DESCRIPTION
### Description

Removed usage of Boost.Filesystem APIs that were deprecated and then removed.
