### PR TITLE
Guard boost::filesystem usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,12 @@ option(BOOST_GIL_ENABLE_EXT_RASTERIZATION "Enable Rasterization extension and te
 option(BOOST_GIL_ENABLE_EXT_IMAGE_PROCESSING "Enable Image Processing extension (!) and tests" ON)
 option(BOOST_GIL_USE_CONAN "Use Conan to install dependencies" OFF)
 option(BOOST_GIL_USE_CLANG_TIDY "Set CMAKE_CXX_CLANG_TIDY property on targets to enable clang-tidy linting" OFF)
+option(BOOST_GIL_USE_BOOST_FILESYSTEM "Use boost::filesystem, disabling requires CMAKE_CXX_STANDARD >= 17" ON)
 set(CMAKE_CXX_STANDARD 14 CACHE STRING "C++ standard version to use (default is 14)")
+
+if (NOT BOOST_GIL_USE_BOOST_FILESYSTEM AND CMAKE_CXX_STANDARD LESS 17)
+  message(FATAL_ERROR "Using std::filesystem requires CMAKE_CXX_STANDARD >= 17")
+endif()
 
 #-----------------------------------------------------------------------------
 # Project
@@ -105,13 +110,20 @@ target_compile_options(gil_compile_options
     $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-fstrict-aliasing>
     $<$<AND:$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>,$<NOT:$<BOOL:${BOOST_GIL_BUILD_CI}>>>:-Wall -Wconversion -Wextra -Wfloat-equal -Wshadow -Wsign-promo -Wstrict-aliasing -Wunused-parameter -pedantic>)
 
+
+if (BOOST_GIL_USE_BOOST_FILESYSTEM)
+  set(filesystem_definition "BOOST_GIL_USE_BOOST_FILESYSTEM")
+else()
+  set(filesystem_definition "BOOST_GIL_IO_USE_STD_FILESYSTEM")
+endif()
 target_compile_definitions(gil_compile_options
   INTERFACE
     $<$<CXX_COMPILER_ID:MSVC>:_CRT_NONSTDC_NO_DEPRECATE>
     $<$<CXX_COMPILER_ID:MSVC>:_SCL_SECURE_NO_DEPRECATE>
     $<$<CXX_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS>
     $<$<CXX_COMPILER_ID:MSVC>:NOMINMAX>
-    $<$<CXX_COMPILER_ID:MSVC>:BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE>)
+    $<$<CXX_COMPILER_ID:MSVC>:BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE>
+    ${filesystem_definition})
 
 #-----------------------------------------------------------------------------
 # Dependency target
@@ -140,12 +152,18 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   set(Boost_USE_STATIC_RUNTIME OFF)
 endif()
 
-find_package(Boost 1.80.0 REQUIRED COMPONENTS filesystem)
+set(Boost_required_components headers)
+if (BOOST_GIL_USE_BOOST_FILESYSTEM)
+  list(APPEND Boost_required_components filesystem)
+endif()
+find_package(Boost 1.80.0 REQUIRED COMPONENTS ${Boost_required_components})
 message(STATUS "Boost.GIL: Using Boost_INCLUDE_DIRS=${Boost_INCLUDE_DIRS}")
 message(STATUS "Boost.GIL: Using Boost_LIBRARY_DIRS=${Boost_LIBRARY_DIRS}")
 
-target_link_libraries(gil_dependencies INTERFACE Boost::filesystem)
-
+target_link_libraries(gil_dependencies INTERFACE Boost::headers)
+if (BOOST_GIL_USE_BOOST_FILESYSTEM)
+  target_link_libraries(gil_dependencies INTERFACE Boost::filesystem)
+endif()
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   target_link_libraries(gil_dependencies INTERFACE Boost::disable_autolinking)
 endif()


### PR DESCRIPTION
### Description

CMake was unopinionated about what filesystem is used and required excessive flag setting. Now it clarifies that boost::filesystem is default and std::filesystem is used in case
BOOST_GIL_USE_BOOST_FILESYSTEM is off and CMAKE_CXX_STANDARD>=17.

Apparently we did not explicitly linked to boost libraries anyway. Either that, or I overlooked it.

### References

https://github.com/boostorg/gil/issues/742

### Tasklist

- [ ] Add test case(s)
- [ ] Ensure all CI builds pass
- [ ] Review and approve
