### PR TITLE
Portable minmax Win32-API workaround #744

### DIFF
--- a/include/boost/gil/extension/histogram/std.hpp
+++ b/include/boost/gil/extension/histogram/std.hpp
@@ -59,7 +59,7 @@ void fill_histogram(SrcView const& srcview, std::vector<T>& histogram, bool accu
 
     if (!accumulate)
         histogram.clear();
-    histogram.resize(std::numeric_limits<channel_t>::max() + 1);
+    histogram.resize((std::numeric_limits<channel_t>::max)() + 1);
 
     for_each_pixel(color_converted_view<pixel_t>(srcview), [&](pixel_t const& p) {
         ++histogram[static_cast<std::size_t>(p)];
@@ -81,7 +81,7 @@ void fill_histogram(SrcView const& srcview, std::array<T, N>& histogram, bool ac
     using channel_t = typename channel_type<SrcView>::type;
     using pixel_t   = pixel<channel_t, gray_layout_t>;
 
-    const size_t pixel_max = std::numeric_limits<channel_t>::max();
+    const size_t pixel_max = (std::numeric_limits<channel_t>::max)();
     const float scale      = (histogram.size() - 1.0f) / pixel_max;
 
     if (!accumulate)

--- a/include/boost/gil/extension/io/tiff/detail/read.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/read.hpp
@@ -663,9 +663,9 @@ private:
 
         std::size_t element_size = sizeof( Pixel );
 
-        std::size_t ret = std::max( width
-                                  , (( scanline_size_in_bytes + element_size - 1 ) / element_size )
-                                  );
+        std::size_t ret = (std::max)( width
+                                    , (( scanline_size_in_bytes + element_size - 1 ) / element_size )
+                                    );
 
         return ret;
     }

--- a/include/boost/gil/histogram.hpp
+++ b/include/boost/gil/histogram.hpp
@@ -136,11 +136,11 @@ bool tuple_compare(Tuple const& t1, Tuple const& t2)
 template <typename Tuple>
 struct tuple_limit
 {
-    static constexpr Tuple min()
+    static constexpr Tuple (min)()
     {
         return min_impl(boost::mp11::make_index_sequence<std::tuple_size<Tuple>::value>{});
     }
-    static constexpr Tuple max()
+    static constexpr Tuple (max)()
     {
         return max_impl(boost::mp11::make_index_sequence<std::tuple_size<Tuple>::value>{});
     }
@@ -150,14 +150,14 @@ private:
     static constexpr Tuple min_impl(boost::mp11::index_sequence<I...>)
     {
         return std::make_tuple(
-            std::numeric_limits<typename std::tuple_element<I, Tuple>::type>::min()...);
+            (std::numeric_limits<typename std::tuple_element<I, Tuple>::type>::min)()...);
     }
 
     template <std::size_t... I>
     static constexpr Tuple max_impl(boost::mp11::index_sequence<I...>)
     {
         return std::make_tuple(
-            std::numeric_limits<typename std::tuple_element<I, Tuple>::type>::max()...);
+            (std::numeric_limits<typename std::tuple_element<I, Tuple>::type>::max)()...);
     }
 };
 
@@ -638,9 +638,9 @@ void fill_histogram(
     bool applymask                      = false,
     std::vector<std::vector<bool>> mask = {},
     typename histogram<T...>::key_type lower =
-        detail::tuple_limit<typename histogram<T...>::key_type>::min(),
+        (detail::tuple_limit<typename histogram<T...>::key_type>::min)(),
     typename histogram<T...>::key_type upper =
-        detail::tuple_limit<typename histogram<T...>::key_type>::max(),
+        (detail::tuple_limit<typename histogram<T...>::key_type>::max)(),
     bool setlimits = false)
 {
     if (!accumulate)

--- a/include/boost/gil/image_processing/histogram_equalization.hpp
+++ b/include/boost/gil/image_processing/histogram_equalization.hpp
@@ -70,8 +70,8 @@ auto histogram_equalization(histogram<SrcKeyType> const& src_hist, histogram<Dst
     using value_t = typename histogram<SrcKeyType>::value_type;
     dst_hist.clear();
     double sum          = src_hist.sum();
-    SrcKeyType min_key  = std::numeric_limits<DstKeyType>::min();
-    SrcKeyType max_key  = std::numeric_limits<DstKeyType>::max();
+    SrcKeyType min_key  = (std::numeric_limits<DstKeyType>::min)();
+    SrcKeyType max_key  = (std::numeric_limits<DstKeyType>::max)();
     auto cumltv_srchist = cumulative_histogram(src_hist);
     std::map<SrcKeyType, DstKeyType> color_map;
     std::for_each(cumltv_srchist.begin(), cumltv_srchist.end(), [&](value_t const& v) {
@@ -120,8 +120,8 @@ void histogram_equalization(
     std::size_t const channels = num_channels<SrcView>::value;
     coord_t const width        = src_view.width();
     coord_t const height       = src_view.height();
-    std::size_t pixel_max      = std::numeric_limits<dst_channel_t>::max();
-    std::size_t pixel_min      = std::numeric_limits<dst_channel_t>::min();
+    std::size_t pixel_max      = (std::numeric_limits<dst_channel_t>::max)();
+    std::size_t pixel_min      = (std::numeric_limits<dst_channel_t>::min)();
 
     for (std::size_t i = 0; i < channels; i++)
     {

--- a/include/boost/gil/image_processing/histogram_matching.hpp
+++ b/include/boost/gil/image_processing/histogram_matching.hpp
@@ -166,10 +166,10 @@ void histogram_matching(
     std::size_t const channels     = num_channels<SrcView>::value;
     coord_t const width            = src_view.width();
     coord_t const height           = src_view.height();
-    source_channel_t src_pixel_min = std::numeric_limits<source_channel_t>::min();
-    source_channel_t src_pixel_max = std::numeric_limits<source_channel_t>::max();
-    ref_channel_t ref_pixel_min    = std::numeric_limits<ref_channel_t>::min();
-    ref_channel_t ref_pixel_max    = std::numeric_limits<ref_channel_t>::max();
+    source_channel_t src_pixel_min = (std::numeric_limits<source_channel_t>::min)();
+    source_channel_t src_pixel_max = (std::numeric_limits<source_channel_t>::max)();
+    ref_channel_t ref_pixel_min    = (std::numeric_limits<ref_channel_t>::min)();
+    ref_channel_t ref_pixel_max    = (std::numeric_limits<ref_channel_t>::max)();
 
     for (std::size_t i = 0; i < channels; i++)
     {


### PR DESCRIPTION
### Description

The purpose of this PR is to work around min/max macro conflicts with windows.h when using Win32-API programming on MSVC (in Windows). Unfortunately windows.h defines min() and max() macros that conflict with the standard C++ ones.

### Tasklist

- [x] Ensure all CI builds pass
- [x] Review and approve
