### PR TITLE
fix wrong buffer size in path string conversion functions

### DIFF
--- a/include/boost/gil/io/path_spec.hpp
+++ b/include/boost/gil/io/path_spec.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright 2007-2008 Andreas Pokorny, Christian Henning
+// Copyright 2024 Dirk Stolle (minor fixes)
 //
 // Distributed under the Boost Software License, Version 1.0
 // See accompanying file LICENSE_1_0.txt or copy at
@@ -41,9 +42,11 @@ inline std::string convert_to_string( std::string const& obj)
 
 inline std::string convert_to_string( std::wstring const& s )
 {
-    std::size_t len = wcslen( s.c_str() );
-    char* c = reinterpret_cast<char*>( alloca( len ));
-    wcstombs( c, s.c_str(), len );
+    std::mbstate_t state = std::mbstate_t();
+    const wchar_t* str = s.c_str();
+    const std::size_t len = std::wcsrtombs(nullptr, &str, 0, &state);
+    char* c = reinterpret_cast<char*>( alloca( len + 1));
+    wcstombs( c, s.c_str(), len + 1 );
 
     return std::string( c, c + len );
 }
@@ -80,7 +83,8 @@ inline char const* convert_to_native_string( const std::string& str )
 
 inline char const* convert_to_native_string( const wchar_t* str )
 {
-    std::size_t len = wcslen( str ) + 1;
+    std::mbstate_t state = std::mbstate_t();
+    const std::size_t len = std::wcsrtombs(nullptr, &str, 0, &state) + 1;
     char* c = new char[len];
     wcstombs( c, str, len );
 
@@ -89,7 +93,9 @@ inline char const* convert_to_native_string( const wchar_t* str )
 
 inline char const* convert_to_native_string( std::wstring const& str )
 {
-    std::size_t len = wcslen( str.c_str() ) + 1;
+    std::mbstate_t state = std::mbstate_t();
+    const wchar_t* wstr = str.c_str();
+    const std::size_t len = std::wcsrtombs(nullptr, &wstr, 0, &state) + 1;
     char* c = new char[len];
     wcstombs( c, str.c_str(), len );
 

--- a/include/boost/gil/io/path_spec.hpp
+++ b/include/boost/gil/io/path_spec.hpp
@@ -45,10 +45,10 @@ inline std::string convert_to_string( std::wstring const& s )
     std::mbstate_t state = std::mbstate_t();
     const wchar_t* str = s.c_str();
     const std::size_t len = std::wcsrtombs(nullptr, &str, 0, &state);
-    char* c = reinterpret_cast<char*>( alloca( len + 1));
-    wcstombs( c, s.c_str(), len + 1 );
+    std::string result(len, '\0');
+    wcstombs( &result[0], s.c_str(), len );
 
-    return std::string( c, c + len );
+    return result;
 }
 
 inline std::string convert_to_string( char const* str )

--- a/include/boost/gil/io/path_spec.hpp
+++ b/include/boost/gil/io/path_spec.hpp
@@ -1,6 +1,6 @@
 //
 // Copyright 2007-2008 Andreas Pokorny, Christian Henning
-// Copyright 2024 Dirk Stolle (minor fixes)
+// Copyright 2024 Dirk Stolle
 //
 // Distributed under the Boost Software License, Version 1.0
 // See accompanying file LICENSE_1_0.txt or copy at
@@ -12,6 +12,7 @@
 #include <boost/gil/io/detail/filesystem.hpp>
 
 #include <cstdlib>
+#include <cwchar>
 #include <string>
 #include <type_traits>
 
@@ -46,7 +47,7 @@ inline std::string convert_to_string( std::wstring const& s )
     const wchar_t* str = s.c_str();
     const std::size_t len = std::wcsrtombs(nullptr, &str, 0, &state);
     std::string result(len, '\0');
-    wcstombs( &result[0], s.c_str(), len );
+    std::wcstombs( &result[0], s.c_str(), len );
 
     return result;
 }
@@ -86,7 +87,7 @@ inline char const* convert_to_native_string( const wchar_t* str )
     std::mbstate_t state = std::mbstate_t();
     const std::size_t len = std::wcsrtombs(nullptr, &str, 0, &state) + 1;
     char* c = new char[len];
-    wcstombs( c, str, len );
+    std::wcstombs( c, str, len );
 
     return c;
 }
@@ -97,7 +98,7 @@ inline char const* convert_to_native_string( std::wstring const& str )
     const wchar_t* wstr = str.c_str();
     const std::size_t len = std::wcsrtombs(nullptr, &wstr, 0, &state) + 1;
     char* c = new char[len];
-    wcstombs( c, str.c_str(), len );
+    std::wcstombs( c, str.c_str(), len );
 
     return c;
 }


### PR DESCRIPTION
### Description

Fixes #733.

Issue:
The length calculation of the destination buffers for conversions from `std::wstring` to `std::string` or `wchar_t*` to `char*` is incorrect, causing a buffer overflow in some cases.

Explanation:
The current code uses `wcslen()` to "calculate" the length of the converted destination string buffer. However, `wcslen()` is just a `strlen()` for `wchar_t*` strings. So it returns the number of wide characters in a `wchar_t*` string, but this does not need to be the same as the number of narrow characters (that is: `char`) in the converted string (`char*` or `std::string`). It just happens to be the same, if the wide character string only uses characters of the English alphabet where each wide character is converted to exactly one narrow character.

So the length has to be calculated properly. There are (at least) two possibilities:
* Use `wcstombs()`'s POSIX extension to calculate the length before doing the conversion.

  > POSIX specifies a common extension: if `dst` is a null pointer, this function returns the number of bytes that would be written to `dst`, if converted.

  But that is an extension and cannot be relied upon to be present.
* We should use [`wcsrtombs()`](https://en.cppreference.com/w/cpp/string/multibyte/wcsrtombs) instead, where that behaviour is not an extension but part of the function and we do not need to rely on the presence of an extension. This is what this pull request does.

### References

* https://github.com/boostorg/gil/issues/733#issuecomment-2094864132
* [wcsrtombs() on cppreference.com](https://en.cppreference.com/w/cpp/string/multibyte/wcsrtombs)

### Tasklist

- [ ] Ensure all CI builds pass
- [ ] Review and approve
