### PR TITLE
feat: add tell() and error() functions to istream + ostream devices

### DIFF
--- a/include/boost/gil/io/device.hpp
+++ b/include/boost/gil/io/device.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright 2007-2012 Christian Henning, Andreas Pokorny
+// Copyright 2024 Dirk Stolle
 //
 // Distributed under the Boost Software License, Version 1.0
 // See accompanying file LICENSE_1_0.txt or copy at
@@ -409,12 +410,28 @@ public:
                  );
     }
 
+    long int tell()
+    {
+        auto pos = _in.tellg();
+
+        io_error_if( pos == std::istream::pos_type(-1)
+                   , "istream_device: file position error"
+                   );
+
+        return static_cast<long int>(pos);
+    }
+
     void write(const byte_t*, std::size_t)
     {
         io_error( "istream_device: Bad io error." );
     }
 
     void flush() {}
+
+    int error()
+    {
+        return _in.fail();
+    }
 
 private:
 
@@ -448,6 +465,17 @@ public:
                         ?std::ios::cur
                         :std::ios::end )
                   );
+    }
+
+    long int tell()
+    {
+        auto pos = _out.tellp();
+
+        io_error_if( pos == std::ostream::pos_type(-1)
+                   , "ostream_device: file position error"
+                   );
+
+        return static_cast<long int>(pos);
     }
 
     void write( const byte_t* data
@@ -509,7 +537,10 @@ public:
         _out << line;
     }
 
-
+    int error()
+    {
+        return _out.fail();
+    }
 
 private:
 


### PR DESCRIPTION
### Description

Adds `tell()` and `error()` functions to `istream_device` and `ostream_device` classes.

The class `file_stream_device` already has such functions, and now both `istream_device` and `ostream_device` have them, too, making the device classes more consistent.

Closes #724.

### References

See #724.

### Tasklist

- [ ] Ensure all CI builds pass
- [ ] Review and approve
