### PR TITLE
ci: update codecov/codecov-action in GitHub Actions workflow to v4

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -49,6 +49,6 @@ jobs:
           lcov --list coverage.info
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v1.2.1
+        uses: codecov/codecov-action@v4
         with:
           files: ../boost-root/coverage.info


### PR DESCRIPTION
### Description

This PR updates [`codecov/codecov-action`](https://github.com/codecov/codecov-action) to v4, it's current version.

### References

* It get's rid of the warning in CI due to outdated Node versions used by the older versions of the actions, e.g. as seen here: https://github.com/boostorg/gil/actions/runs/10054788474

  > The following actions uses node12 which is deprecated and will be forced to run on node16: codecov/codecov-action@v1.2.1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

  Version 4 of the action [uses Node 20](https://github.com/codecov/codecov-action/blob/e28ff129e5465c2c0dcc6f003fc735cb6ae0c673/action.yml#L120).

* As far as I understand, version 1.x of the action has been deprecated: https://about.codecov.io/blog/codecov-uploader-deprecation-plan/

### Tasklist

- [ ] Ensure all CI builds pass
- [ ] Review and approve
