### PR TITLE
Fix is_floating_point symbol is not a class template

### DIFF
--- a/include/boost/gil/io/typedefs.hpp
+++ b/include/boost/gil/io/typedefs.hpp
@@ -29,7 +29,7 @@ using byte_vector_t = std::vector<byte_t>;
 
 }} // namespace boost::gil
 
-namespace boost {
+namespace std {
 
 template<> struct is_floating_point<gil::float32_t> : std::true_type {};
 template<> struct is_floating_point<gil::float64_t> : std::true_type {};


### PR DESCRIPTION
Closes https://github.com/boostorg/gil/issues/760

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [ ] Add test case(s)
- [ ] Ensure all CI builds pass
- [ ] Review and approve
