### PR TITLE
fix compile error on clang

### DIFF
--- a/include/boost/gil/algorithm.hpp
+++ b/include/boost/gil/algorithm.hpp
@@ -1238,7 +1238,7 @@ struct inner_product_k_t
         BinaryOperation2 binary_op2)
     {
         init = binary_op1(init, binary_op2(*first1, *first2));
-        return inner_product_k_t<Size - 1>::template apply(
+        return inner_product_k_t<Size - 1>::apply(
             first1 + 1, first2 + 1, init, binary_op1, binary_op2);
     }
 };
@@ -1285,7 +1285,7 @@ T inner_product_k(
     BinaryOperation1 binary_op1,
     BinaryOperation2 binary_op2)
 {
-    return detail::inner_product_k_t<Size>::template apply(
+    return detail::inner_product_k_t<Size>::apply(
         first1, first2, init, binary_op1, binary_op2);
 }
 


### PR DESCRIPTION
Reopen pull request #766.

Source:
```cpp
#include <boost/gil.hpp>
```

Compilation (clang++ 20.1.7)
```text
clang++ -std=c++26 ./test.cpp -o test
./bin/debug/third_party/install/include/boost/gil/algorithm.hpp:1241:54: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
 1241 |         return inner_product_k_t<Size - 1>::template apply(
      |                                                      ^
./bin/debug/third_party/install/include/boost/gil/algorithm.hpp:1288:54: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
 1288 |     return detail::inner_product_k_t<Size>::template apply(
      |                                                      ^
2 errors generated.
```

File changed:
- Remove these 2 `template`.

**Thank you.**
