### PR TITLE
ci: move GitHub Action's Windows builds to supported OS version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,14 +156,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - toolset: msvc-14.2
-            cxxstd: "14,17"
-            addrmd: 32,64
-            os: windows-2019
           - toolset: gcc
             cxxstd: "14,17"
             addrmd: 64
-            os: windows-2019
+            os: windows-2022
           - toolset: msvc-14.3
             cxxstd: "14,17"
             addrmd: 32,64


### PR DESCRIPTION
### Description

The Windows Server 2019 runner image has been removed as of 2025-06-30, so it's not available anymore. For further information on that see <https://github.com/actions/runner-images/issues/12045>.

However, we can test on the newer Windows Server 2022 image instead.

Unfortunately, the Windows Server 2019 image was the last one to have Visual Studio 2019, so from now on only Visual Studio 2022 can be used in the CI workflows for MSVC.

We _could_ also use the Windows Server 2025 image, but it has Visual Studio 2022, too, just like the Windows Server 2022 image. So this would probably not make any difference.

### References

https://github.com/actions/runner-images/issues/12045

### Tasklist

- [x] Ensure all CI builds for Windows OS pass
- [x] Review and approve
