### PR TITLE
ci: add jobs for newer GCC versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,32 @@ jobs:
             cxxstd: "14,17"
             os: ubuntu-24.04
             install: g++-10
+          - toolset: gcc
+            compiler: g++-11
+            cxxstd: "14,17"
+            os: ubuntu-24.04
+            install: g++-11
+          - toolset: gcc
+            compiler: g++-12
+            cxxstd: "14,17,20"
+            os: ubuntu-24.04
+            install: g++-12
+          - toolset: gcc
+            compiler: g++-13
+            cxxstd: "14,17,20"
+            os: ubuntu-24.04
+            install: g++-13
+          - toolset: gcc
+            compiler: g++-14
+            cxxstd: "14,17,20"
+            os: ubuntu-24.04
+            install: g++-14
+          - toolset: gcc
+            compiler: g++-15
+            cxxstd: "14,17,20"
+            os: ubuntu-latest
+            container: ubuntu:25.04
+            install: g++-15
           - toolset: clang
             compiler: clang++-3.9
             cxxstd: "14"


### PR DESCRIPTION
### Description

Add CI jobs for newer versions of GCC, from GCC 11 to GCC 15.


_~Currently a draft only, because there may be some new errors popping up.~
Not a draft anymore, because none of the new builds failed._

### References

None.

### Tasklist

- [x] Ensure all new CI builds pass
- [ ] Review and approve
