### PR TITLE
Fix clang compilation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
             install: clang-4.0
           - toolset: clang
             compiler: clang++-5.0
-            cxxstd: "14,1z"
+            cxxstd: "14"
             os: ubuntu-latest
             container: ubuntu:18.04
             install: clang-5.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,8 +171,11 @@ jobs:
             container: ubuntu:25.04
             install: clang-20
           - toolset: clang
-            cxxstd: "14,17"
-            os: macos-13
+            cxxstd: "14,17,20"
+            os: macos-14
+          - toolset: clang
+            cxxstd: "14,17,20"
+            os: macos-15
 
     runs-on: ${{matrix.os}}
     container:

--- a/test/core/image/test_fixture.hpp
+++ b/test/core/image/test_fixture.hpp
@@ -35,7 +35,12 @@ using image_types = std::tuple
     gil::rgba32_image_t
 >;
 
-#if defined(BOOST_NO_CXX17_HDR_MEMORY_RESOURCE)
+// Workaround until we have the proper defect test in Boost.Config
+#if defined(__APPLE__) && (__clang_major__ ==  15)
+#define BOOST_NO_CXX17_DEFAULT_RESOURCE
+#endif
+
+#if defined(BOOST_NO_CXX17_HDR_MEMORY_RESOURCE) || defined(BOOST_NO_CXX17_DEFAULT_RESOURCE)
     using pmr_image_types = std::tuple<>;
 #else
     using pmr_image_types = std::tuple


### PR DESCRIPTION
## Description

Two CI jobs are currently failing. Investigate if they can be fixed or if they are deprecated and can be removed.

### References

[posix (clang, clang++-5.0, 14,1z, ubuntu-latest, ubuntu:18.04, clang-5.0)](https://github.com/boostorg/gil/actions/runs/17262406016/job/48986725091#logs)

[posix (clang, 14,17, macos-13)](https://github.com/boostorg/gil/actions/runs/17262406016/job/48986725166#logs)

<!-- Any links related to this PR: issues, other PRs, mailing list threads, StackOverflow questions, etc. -->

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [ ] Ensure all CI builds pass
- [ ] Review and approve
