### PR TITLE
Switched from sprintf to snprintf

### DIFF
--- a/include/boost/gil/extension/io/tiff/detail/log.hpp
+++ b/include/boost/gil/extension/io/tiff/detail/log.hpp
@@ -45,7 +45,7 @@ private:
                      )
     {
         char buf[1000];
-        sprintf(buf, fmt, ap);
+        snprintf(buf, 1000, fmt, ap);
         std::cout << "error: " << buf << std::endl;
     }
 
@@ -55,7 +55,7 @@ private:
                        )
     {
         char buf[1000];
-        sprintf(buf, fmt, ap);
+        snprintf(buf, 1000, fmt, ap);
         std::cout << "warning: " << fmt << std::endl;
     }
 };


### PR DESCRIPTION
### Description

This pull request replaced the usage of sprintf to snprintf in the TIFF Logger according to #771 in order to prevent compiler warnings.

### References

Issue #771 
