### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/.ci/get-boost.sh
+++ b/.ci/get-boost.sh
@@ -72,7 +72,6 @@ git submodule --quiet update --init $GIT_SUBMODULE_OPTS \
     libs/ratio \
     libs/rational \
     libs/regex \
-    libs/static_assert \
     libs/smart_ptr \
     libs/system \
     libs/throw_exception \


### PR DESCRIPTION
### Description

Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.

### References

https://github.com/boostorg/config/pull/531
https://github.com/boostorg/static_assert/pull/18
