### PR TITLE
[doc] Fix Doxygen parameter names that do not match the declarations

### DIFF
--- a/include/boost/gil/algorithm.hpp
+++ b/include/boost/gil/algorithm.hpp
@@ -1518,8 +1518,8 @@ void extend_row_impl(
 /// Image padding introduces new pixels around the edges of an image.
 /// The border provides space for annotations or acts as a boundary when using advanced filtering techniques.
 /// \tparam SrcView Models ImageViewConcept
-/// \tparam extend_count number of rows to be added each side
-/// \tparam option - TODO
+/// \param extend_count number of rows to be added each side
+/// \param option - TODO
 template <typename SrcView>
 auto extend_row(
     SrcView const& src_view,
@@ -1540,8 +1540,8 @@ auto extend_row(
 /// Image padding introduces new pixels around the edges of an image.
 /// The border provides space for annotations or acts as a boundary when using advanced filtering techniques.
 /// \tparam SrcView Models ImageViewConcept
-/// \tparam extend_count number of columns to be added each side
-/// \tparam option - TODO
+/// \param extend_count number of columns to be added each side
+/// \param option - TODO
 template <typename SrcView>
 auto extend_col(
     SrcView const& src_view,
@@ -1563,8 +1563,8 @@ auto extend_col(
 /// Image padding introduces new pixels around the edges of an image.
 /// The border provides space for annotations or acts as a boundary when using advanced filtering techniques.
 /// \tparam SrcView Models ImageViewConcept
-/// \tparam extend_count number of rows/column to be added each side
-/// \tparam option - TODO
+/// \param extend_count number of rows/column to be added each side
+/// \param option - TODO
 template <typename SrcView>
 auto extend_boundary(
     SrcView const& src_view,

--- a/include/boost/gil/channel.hpp
+++ b/include/boost/gil/channel.hpp
@@ -476,14 +476,15 @@ private:
 /// \endcode
 
 /// \tparam BitField A type that holds the bits of the pixel from which the channel is referenced. Typically an integral type, like std::uint16_t
-/// \tparam Defines the sequence of bits in the data value that contain the channel
-/// \tparam true if the reference is mutable
+/// \tparam FirstBit Defines, with NumBits, the sequence of bits in the data value that contain the channel
+/// \tparam NumBits Defines, with FirstBit, the sequence of bits in the data value that contain the channel
+/// \tparam IsMutable true if the reference is mutable
 template <typename BitField, int FirstBit, int NumBits, bool IsMutable>
 class packed_channel_reference;
 
-/// \tparam A type that holds the bits of the pixel from which the channel is referenced. Typically an integral type, like std::uint16_t
-/// \tparam Defines the sequence of bits in the data value that contain the channel
-/// \tparam true if the reference is mutable
+/// \tparam BitField A type that holds the bits of the pixel from which the channel is referenced. Typically an integral type, like std::uint16_t
+/// \tparam NumBits Defines the sequence of bits in the data value that contain the channel
+/// \tparam IsMutable true if the reference is mutable
 template <typename BitField, int NumBits, bool IsMutable>
 class packed_dynamic_channel_reference;
 

--- a/include/boost/gil/extension/rasterization/ellipse.hpp
+++ b/include/boost/gil/extension/rasterization/ellipse.hpp
@@ -33,9 +33,9 @@ struct midpoint_ellipse_rasterizer
     using type = ellipse_rasterizer_t;
 
     /// \brief Creates a midpoint ellipse rasterizer
-    /// \param center - Point containing positive integer x co-ordinate and y co-ordinate of the
+    /// \param center_point - Point containing positive integer x co-ordinate and y co-ordinate of the
     /// center respectively.
-    /// \param semi_axes - Point containing positive integer lengths of horizontal semi-axis
+    /// \param semi_axes_values - Point containing positive integer lengths of horizontal semi-axis
     /// and vertical semi-axis respectively.
     midpoint_ellipse_rasterizer(point<unsigned int> center_point,
         point<unsigned int> semi_axes_values)

--- a/include/boost/gil/image_processing/morphology.hpp
+++ b/include/boost/gil/image_processing/morphology.hpp
@@ -93,7 +93,7 @@ void morph_impl(SrcView const& src_view, DstView const& dst_view, Kernel const& 
 /// input image.
 /// \param src_view - Source/Input image view.
 /// \param dst_view - View which stores the final result of operations performed by this function.
-/// \param kernel - Kernel matrix/structuring element containing 0's and 1's
+/// \param ker_mat - Kernel matrix/structuring element containing 0's and 1's
 /// which will be used for applying the required morphological operation.
 /// \param identifier - Indicates the type of morphological operation to be applied.
 /// \tparam SrcView type of source image.

--- a/include/boost/gil/image_processing/threshold.hpp
+++ b/include/boost/gil/image_processing/threshold.hpp
@@ -102,7 +102,7 @@ enum class threshold_adaptive_method
 /// \param dst_view - TODO
 /// \param threshold_value - TODO
 /// \param max_value - TODO
-/// \param threshold_direction - if regular, values greater than threshold_value are
+/// \param direction - if regular, values greater than threshold_value are
 /// set to max_value else set to 0; if inverse, values greater than threshold_value are
 /// set to 0 else set to max_value.
 template <typename SrcView, typename DstView>


### PR DESCRIPTION
Six places where a Doxygen tag names something the declaration does not have. Comments only, no code touched.

**`channel.hpp`, the interesting one.** `packed_channel_reference` and `packed_dynamic_channel_reference` currently read:

```
/// \tparam BitField A type that holds the bits of the pixel from which the channel is referenced...
/// \tparam Defines the sequence of bits in the data value that contain the channel
/// \tparam true if the reference is mutable
template <typename BitField, int FirstBit, int NumBits, bool IsMutable>
class packed_channel_reference;
```

so Doxygen reads "Defines" and "true" as parameter names. That happened in 5611bd58 (Replace Boost.MPL with Boost.MP11, #274), which turned trailing `//` comments into `\tparam` lines. Before it:

```cpp
template <typename BitField,        // A type that holds the bits of the pixel...
          int FirstBit, int NumBits,// Defines the sequence of bits in the data value that contain the channel
          bool Mutable>             // true if the reference is mutable
```

The names were to the left of each comment, so they were dropped. Nothing had to be guessed here: the old form says exactly which description belongs to which parameter. `FirstBit` and `NumBits` shared one comment, so I split that sentence across the two rather than write something new for each. If you would rather have separate descriptions, say the word.

The second class lost the name on the first line too, and `Mutable` was renamed to `IsMutable` in the same commit.

**`algorithm.hpp`** — `extend_row`, `extend_col` and `extend_boundary` document `extend_count` and `option` with `\tparam`, but both are function arguments; the only template parameter is `SrcView`. Changed to `\param`. I left the `- TODO` text alone, that is yours to fill in.

**`ellipse.hpp`** — `midpoint_ellipse_rasterizer` documents `center` and `semi_axes`; the constructor takes `center_point` and `semi_axes_values`. `center` and `semi_axes` are the members it assigns to, which is presumably where the names came from.

**`threshold.hpp`** — `threshold_binary` documents `threshold_direction`; the argument is `direction`, and `threshold_direction` is its type.

**`morphology.hpp`** — `morph` documents `kernel`; the argument is `ker_mat`. `morph_impl` above it really does take `kernel`, and is untouched.

## Not included

The same sweep flags more of these that I did not verify closely enough to send: four in `io/read_and_convert_view.hpp` and one in `io/read_and_convert_image.hpp` (`\param file` / `file_name` against `device`), two in `io/read_image_info.hpp`, one in `extension/io/png/tags.hpp`, and two `\tparam` ones in `extension/dynamic_image`. The 16 hits in `channel_numeric_operations.hpp` are a false alarm from my parser tripping over `operator()`, those docs are fine.

**If you want the io ones done too, say so here and I will send a follow-up** — the reason I held them back is that the `read_and_convert_*` overloads differ in whether they take a device or a file name, so each needs reading rather than a blanket rename.
