### PR TITLE
[doc] Fix Doxygen parameter names in io and the extensions

### DIFF
--- a/include/boost/gil/extension/dynamic_image/algorithm.hpp
+++ b/include/boost/gil/extension/dynamic_image/algorithm.hpp
@@ -152,7 +152,7 @@ void copy_and_convert_pixels(View const& src, any_image_view<Types...> const& ds
 
 /// \ingroup ImageViewSTLAlgorithmsCopyAndConvertPixels
 /// \tparam View Model ImageViewConcept
-/// \tparam Type Model Boost.MP11-compatible list of models of MutableImageViewConcept
+/// \tparam Types Model Boost.MP11-compatible list of models of MutableImageViewConcept
 template <typename View, typename ...Types>
 void copy_and_convert_pixels(View const& src, any_image_view<Types...> const& dst)
 {

--- a/include/boost/gil/extension/dynamic_image/any_image.hpp
+++ b/include/boost/gil/extension/dynamic_image/any_image.hpp
@@ -159,7 +159,7 @@ auto view(any_image<Images...>& img) -> typename any_image<Images...>::view_t
 }
 
 /// \brief Returns the constant-pixel view of any image. The returned view is any view.
-/// \tparam Types Models ImageVectorConcept
+/// \tparam Images Models ImageVectorConcept
 template <typename ...Images>
 BOOST_FORCEINLINE
 auto const_view(any_image<Images...> const& img) -> typename any_image<Images...>::const_view_t

--- a/include/boost/gil/extension/io/png/tags.hpp
+++ b/include/boost/gil/extension/io/png/tags.hpp
@@ -678,7 +678,7 @@ struct image_read_settings< png_tag > : public image_read_settings_base
     /// Constructor
     /// \param top_left Top left coordinate for reading partial image.
     /// \param dim      Dimensions for reading partial image.
-    /// \param gamma    Screen gamma value.
+    /// \param screen_gamma Screen gamma value.
     image_read_settings( point_t const&         top_left
                        , point_t const&         dim
                        , const bool             apply_screen_gamma = false

--- a/include/boost/gil/io/read_and_convert_image.hpp
+++ b/include/boost/gil/io/read_and_convert_image.hpp
@@ -239,7 +239,7 @@ void read_and_convert_image(
 }
 
 /// \brief Reads and color-converts an image. Image memory is allocated. Default color converter is used.
-/// \param file_name File name. Must satisfy is_supported_path_spec metafunction.
+/// \param device    It's a device. Must satisfy is_input_device metafunction or is_adaptable_input_device.
 /// \param img       The image in which the data is read into.
 /// \param tag       Defines the image format. Must satisfy is_format_tag metafunction.
 /// \throw std::ios_base::failure

--- a/include/boost/gil/io/read_and_convert_view.hpp
+++ b/include/boost/gil/io/read_and_convert_view.hpp
@@ -45,7 +45,7 @@ void read_and_convert_view(Reader& reader, View const& view,
 }
 
 /// \brief Reads and color-converts an image view. No memory is allocated.
-/// \param file      It's a device. Must satisfy is_input_device metafunction.
+/// \param device    It's a device. Must satisfy is_input_device metafunction.
 /// \param view      The image view in which the data is read into.
 /// \param settings  Specifies read settings depending on the image format.
 /// \param cc        Color converter function object.
@@ -132,7 +132,7 @@ void read_and_convert_view(
 }
 
 /// \brief Reads and color-converts an image view. No memory is allocated.
-/// \param file It's a device. Must satisfy is_input_device metafunction or is_adaptable_input_device.
+/// \param device It's a device. Must satisfy is_input_device metafunction or is_adaptable_input_device.
 /// \param view The image view in which the data is read into.
 /// \param cc   Color converter function object.
 /// \param tag  Defines the image format. Must satisfy is_format_tag metafunction.
@@ -188,7 +188,7 @@ void read_and_convert_view(
 }
 
 /// \brief Reads and color-converts an image view. No memory is allocated.
-/// \param file      It's a device. Must satisfy is_input_device metafunction or is_adaptable_input_device.
+/// \param device    It's a device. Must satisfy is_input_device metafunction or is_adaptable_input_device.
 /// \param view      The image view in which the data is read into.
 /// \param settings  Specifies read settings depending on the image format.
 /// \throw std::ios_base::failure
@@ -242,7 +242,7 @@ void read_and_convert_view(
 }
 
 /// \brief Reads and color-converts an image view. No memory is allocated.
-/// \param file It's a device. Must satisfy is_input_device metafunction or is_adaptable_input_device.
+/// \param device It's a device. Must satisfy is_input_device metafunction or is_adaptable_input_device.
 /// \param view The image view in which the data is read into.
 /// \param tag  Defines the image format. Must satisfy is_format_tag metafunction.
 /// \throw std::ios_base::failure

--- a/include/boost/gil/io/reader_base.hpp
+++ b/include/boost/gil/io/reader_base.hpp
@@ -47,8 +47,8 @@ public:
     ///
     /// @tparam Image Image which implements boost::gil's ImageConcept.
     ///
-    /// @param img  The image.
-    /// @param info The image read info.
+    /// @param img      The image.
+    /// @param settings The image read settings.
     template< typename Image >
     void init_image( Image&                                  img
                    , const image_read_settings< FormatTag >& settings


### PR DESCRIPTION
Follow-up to #792, covering the parts of the library that PR deliberately left out. I said there I would send these if wanted; Marshall Clow also suggested it in boostorg/algorithm#131 after merging the same kind of fix there. If you would rather not have them, close this and nothing is lost.

Nine `\param` / `\tparam` names that do not match the declaration below them.

### io

**`read_and_convert_view.hpp`** — all four `Device` overloads document `\param file`, the argument is `device`. The descriptions already read "It's a device", so only the names were wrong.

**`read_and_convert_image.hpp:241`** — the `Device` overload documents `file_name File name. Must satisfy is_supported_path_spec metafunction.`, which is the string overload's line copied down. The three other `Device` overloads in the same file (47, 134, 189) already say `device`, and I followed the one at 189 word for word.

**`reader_base.hpp:50`** — `init_image` documents `@param info`, the argument is `settings`.

### extensions

**`extension/io/png/tags.hpp:681`** — the `image_read_settings` constructor documents `\param gamma`, the argument is `screen_gamma`.

**`extension/dynamic_image/algorithm.hpp:155`** — the two-argument `copy_and_convert_pixels` documents `\tparam Type`, the pack is `Types`. The three-argument overload eleven lines above spells it correctly, so the two overloads describe the same pack differently.

**`extension/dynamic_image/any_image.hpp:162`** — `const_view` documents `\tparam Types`, the pack is `Images`. `view()` directly above it is correct.

### Checked and left alone

`read_view.hpp`, `read_image.hpp` and the remaining `Device` overloads genuinely name the argument `file`, so their `\param file` is right. GIL uses both spellings and I did not touch that.

### Two I did not fix, and why

`io/read_image_info.hpp:46` and `:89` document `\param tag` on overloads whose second parameter is unnamed (`FormatTag const&`). So the name really is absent, but the fix would mean naming a parameter in the signature rather than editing a comment, and that is your call rather than mine.

My checker also gets these two wrong in a way worth stating: it reports the parameter list as `file, const, dummy`, reading `const` in `FormatTag const&` as an argument name. So treat the two counts above as nine verified by hand, not eleven from a tool.

One more, not a mismatch so not included: the same png constructor never documents `apply_screen_gamma` at all.

### Checks

Comments only, the diff has no non-comment lines. Re-running the same check on this branch reports 0 remaining in `io` and the extensions, down from 11 on `develop` at dcfcc69.