### PR TITLE
[doc] Document the format tag without a \param

### DIFF
--- a/include/boost/gil/io/read_image_info.hpp
+++ b/include/boost/gil/io/read_image_info.hpp
@@ -42,8 +42,11 @@ auto read_image_info(Device& file, image_read_settings<FormatTag> const& setting
 }
 
 /// \brief Returns the image format backend. Backend is format specific.
+///
+/// The unnamed FormatTag argument defines the image format and must satisfy
+/// the is_format_tag metafunction.
+///
 /// \param file It's a device. Must satisfy is_adaptable_input_device metafunction.
-/// \param tag  Defines the image format. Must satisfy is_format_tag metafunction.
 /// \return image_read_info object dependent on the image format.
 /// \throw std::ios_base::failure
 template <typename Device, typename FormatTag>
@@ -85,8 +88,11 @@ auto read_image_info(
 }
 
 /// \brief Returns the image format backend. Backend is format specific.
+///
+/// The unnamed FormatTag argument defines the image format and must satisfy
+/// the is_format_tag metafunction.
+///
 /// \param file_name File name. Must satisfy is_supported_path_spec metafunction.
-/// \param tag       Defines the image format. Must satisfy is_format_tag metafunction.
 /// \return image_read_info object dependent on the image format.
 /// \throw std::ios_base::failure
 template <typename String, typename FormatTag>


### PR DESCRIPTION
Both `read_image_info` overloads document a `tag` parameter, and the argument it refers to has no name:

```cpp
/// \param file It's a device. Must satisfy is_adaptable_input_device metafunction.
/// \param tag  Defines the image format. Must satisfy is_format_tag metafunction.
template <typename Device, typename FormatTag>
auto read_image_info(Device& file, FormatTag const&, ...)
```

Doxygen cannot attach a `\param` to an unnamed argument, so it reports `tag` as a parameter that does not exist and the format tag ends up undocumented either way.

Two ways to fix it, and I picked the second:

- **name the argument** `tag`. It is never used in the body, so this would produce an unused-parameter warning, and every other `FormatTag` argument across `io/` is unnamed as well, so it would also break with the surrounding style;
- **keep the declaration and move the sentence into the description.** That is what this does.

The wording is the same as before, only the position changed.
